### PR TITLE
introspect endpoint resolves RBAC from database instead of JWT claim

### DIFF
--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -1130,15 +1130,11 @@ pub async fn introspect(
     // This ensures introspection returns correct roles/permissions even when
     // the access token was issued without them (e.g., after token refresh
     // with a scope that didn't include "roles").
-    let (roles, groups, permissions) =
-        match crate::services::rbac_helpers::resolve_user_rbac(&state.db, &claims.sub).await {
-            Ok(rbac) => (
-                Some(rbac.role_slugs),
-                Some(rbac.group_slugs),
-                Some(rbac.permissions),
-            ),
-            Err(_) => (claims.roles, claims.groups, claims.permissions),
-        };
+    let rbac = match crate::services::rbac_helpers::resolve_user_rbac(&state.db, &claims.sub).await
+    {
+        Ok(rbac) => rbac,
+        Err(_) => return Json(inactive),
+    };
 
     Json(IntrospectResponse {
         active: true,
@@ -1151,9 +1147,9 @@ pub async fn introspect(
         sub: Some(claims.sub),
         iss: Some(claims.iss),
         jti: Some(claims.jti),
-        roles,
-        groups,
-        permissions,
+        roles: Some(rbac.role_slugs),
+        groups: Some(rbac.group_slugs),
+        permissions: Some(rbac.permissions),
     })
 }
 


### PR DESCRIPTION
refreshed access token doesn't contain role claim. update introspect endpoint logic to read user role directly from db instead of from access token itself.
