### PR TITLE
fix: align Vite dev server port to 3000 (#229)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # ─── Server ───
 PORT=3001
 BASE_URL=http://localhost:3001
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=http://localhost:3000
 
 # ─── Database ───
 DATABASE_URL=mongodb://nyxid:nyxid_dev_password@localhost:27018/nyxid?authSource=admin

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: 3000,
     proxy: {
       "/api": "http://localhost:3001",
       "^/oauth(?:/.*)?$": "http://localhost:3001",
@@ -40,7 +40,7 @@ export default defineConfig({
     },
   },
   preview: {
-    port: 5173,
+    port: 3000,
   },
   appType: "spa",
   test: {


### PR DESCRIPTION
## Summary
- Set Vite `server.port` and `preview.port` to `3000` in `frontend/vite.config.ts` (was `5173`)
- Update `FRONTEND_URL` in `.env.example` to `http://localhost:3000` (was `http://localhost:5173`)
- Local dev now matches the production Docker mapping (`3000:8080`) and all quickstart documentation

Closes #229

## Test plan
- [ ] Run `cd frontend && npm run dev` and confirm terminal shows `http://localhost:3000`
- [ ] Verify backend CORS accepts requests from `http://localhost:3000` (default in `config.rs`)
- [ ] Confirm no port conflict with other dev services (MongoDB 27018, Mailpit 1025/8025, backend 3001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)