### PR TITLE
feat: one-shot dev quickstart with auto-verify and invite gate toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,5 +144,10 @@ RATE_LIMIT_BURST=30
 # open public registration. Accepts: true/false, 1/0, yes/no, on/off.
 # INVITE_CODE_REQUIRED=true
 
+# ─── Dev convenience ───
+# When true, newly registered users are auto-verified (no email step).
+# Only use in local development. Defaults to false.
+# AUTO_VERIFY_EMAIL=false
+
 # ─── Logging ───
 RUST_LOG=nyxid=debug,tower_http=debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,9 @@ CHANNEL_EVENT_DEDUP_TTL_SECS=300         # Dedup entry TTL (default: 300 = 5 min
 # Registration gate (issue #179)
 INVITE_CODE_REQUIRED=true              # Gate new-user registration behind invite codes (default: true). Set to false for public launch.
 
+# Dev convenience
+AUTO_VERIFY_EMAIL=false                # When true, skip email verification on registration (default: false). Dev only.
+
 # Optional
 GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET
 GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET

--- a/README.md
+++ b/README.md
@@ -103,19 +103,26 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
 
-This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes. Copy-paste the entire block:
+This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
+
+**Step 1 — Check prerequisites** (paste this first):
 
 ```bash
-bash << 'SETUP'
-# ── Preflight checks ──
+bash << 'CHECK'
 err=0
 for cmd in git docker openssl curl; do
   if ! command -v "$cmd" >/dev/null 2>&1; then echo "Missing: $cmd"; err=1; fi
 done
 if ! docker compose version >/dev/null 2>&1; then echo "Missing: docker compose (v2 plugin)"; err=1; fi
 if ! docker info >/dev/null 2>&1; then echo "Docker is not running. Start Docker Desktop and re-run."; err=1; fi
-if [ "$err" -eq 1 ]; then echo "Fix the above and re-run."; exit 1; fi
+if [ "$err" -eq 1 ]; then exit 1; fi
+echo "All good — proceed to Step 2."
+CHECK
+```
 
+**Step 2 — Install and start** (paste after Step 1 passes):
+
+```bash
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
 
 # ── Generate .env.dev (dev config) and link for Docker ──
@@ -143,7 +150,7 @@ openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/n
 # ── Pull images and start the stack ──
 echo "Downloading NyxID (this may take a few minutes on first run)..."
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  --env-file .env.production pull
+  --env-file .env.production pull &&
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \
   --env-file .env.production up -d
 
@@ -152,13 +159,10 @@ echo "Waiting for NyxID to start..."
 n=0
 until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
   n=$((n+1))
-  if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker compose logs backend"; exit 1; fi
+  if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker compose logs backend"; break; fi
   sleep 2
-done
-echo ""
-echo "NyxID is running at http://localhost:3000"
+done && echo "NyxID is running at http://localhost:3000" &&
 echo "Save your encryption key (needed if you reset the database): $EK"
-SETUP
 ```
 
 **Open `http://localhost:3000` and register your account.** No email verification needed — accounts are auto-verified in dev mode.

--- a/README.md
+++ b/README.md
@@ -101,30 +101,71 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 ### Self-host
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) installed.
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
+
+This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes. Copy-paste the entire block:
 
 ```bash
+bash << 'SETUP'
+# ── Preflight checks ──
+err=0
+for cmd in git docker openssl curl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then echo "Missing: $cmd"; err=1; fi
+done
+if ! docker compose version >/dev/null 2>&1; then echo "Missing: docker compose (v2 plugin)"; err=1; fi
+if ! docker info >/dev/null 2>&1; then echo "Docker is not running. Start Docker Desktop and re-run."; err=1; fi
+if [ "$err" -eq 1 ]; then echo "Fix the above and re-run."; exit 1; fi
+
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
-cp .env.production.example .env.production
 
-# Generate and paste these values into .env.production:
-openssl rand -hex 32    # → ENCRYPTION_KEY (keep this safe)
-openssl rand -hex 24    # → MONGO_ROOT_PASSWORD
+# ── Generate .env.dev (dev config) and link for Docker ──
+EK=$(openssl rand -hex 32)
+cat > .env.dev << EOF
+MONGO_ROOT_PASSWORD=$(openssl rand -hex 24)
+ENCRYPTION_KEY=$EK
+BASE_URL=http://localhost:3001
+FRONTEND_URL=http://localhost:3000
+ENVIRONMENT=development
+JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
+JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
+INVITE_CODE_REQUIRED=false
+AUTO_VERIFY_EMAIL=true
+RUST_LOG=nyxid=info,tower_http=info
+EOF
+ln -sf .env.dev .env.production
 
-# Generate JWT signing keys
+# ── Generate JWT signing keys (PKCS#1 format) ──
 mkdir -p keys
 openssl genrsa -out keys/private.pem 4096 2>/dev/null
-openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
+openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
+  || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
 
-# Start the stack
+# ── Pull images and start the stack ──
+echo "Downloading NyxID (this may take a few minutes on first run)..."
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  --env-file .env.production pull
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \
   --env-file .env.production up -d
 
-# Wait for the server to be ready
-until curl -sf http://localhost:3001/health > /dev/null 2>&1; do sleep 2; done && echo "NyxID is running"
+# ── Wait for the server (up to 90s) ──
+echo "Waiting for NyxID to start..."
+n=0
+until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
+  n=$((n+1))
+  if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker compose logs backend"; exit 1; fi
+  sleep 2
+done
+echo ""
+echo "NyxID is running at http://localhost:3000"
+echo "Save your encryption key (needed if you reset the database): $EK"
+SETUP
 ```
 
-**Open `http://localhost:3000` and register your account.** For production hardening (TLS, domain), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+**Open `http://localhost:3000` and register your account.** No email verification needed — accounts are auto-verified in dev mode.
+
+To stop NyxID: `docker compose -f docker-compose.yml -f docker-compose.prod.yml down`
+
+For production deployment (TLS, domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Now connect your AI agent — pick one approach:
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -186,6 +186,11 @@ pub struct AppConfig {
     /// `INVITE_CODE_REQUIRED=false` to open public registration — used once
     /// the product launches publicly. See issue #179.
     pub invite_code_required: bool,
+
+    // Dev convenience
+    /// When `true`, newly registered users are marked as email-verified
+    /// immediately. Only intended for local development — defaults to `false`.
+    pub auto_verify_email: bool,
 }
 
 impl std::fmt::Debug for AppConfig {
@@ -347,6 +352,17 @@ impl std::fmt::Debug for AppConfig {
                 &self.channel_event_dedup_ttl_secs,
             )
             .finish()
+    }
+}
+
+/// Parse a boolean env var with a default value.
+fn parse_bool_env(name: &str, default: bool) -> bool {
+    match env::var(name).ok().as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => default,
+        Some(v) => matches!(
+            v.to_ascii_lowercase().as_str(),
+            "true" | "1" | "yes" | "on"
+        ),
     }
 }
 
@@ -584,6 +600,7 @@ impl AppConfig {
                 .unwrap_or(300),
 
             invite_code_required: parse_invite_code_required(env::var("INVITE_CODE_REQUIRED").ok()),
+            auto_verify_email: parse_bool_env("AUTO_VERIFY_EMAIL", false),
         }
     }
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -337,6 +337,7 @@ pub async fn register(
         &body.password,
         body.display_name.as_deref(),
         invite_code_id.as_deref(),
+        state.config.auto_verify_email,
     )
     .await;
 
@@ -384,9 +385,15 @@ pub async fn register(
         "Email verification token (dev only)"
     );
 
+    let message = if state.config.auto_verify_email {
+        "Registration successful. Email auto-verified (dev mode). You can now sign in.".to_string()
+    } else {
+        "Registration successful. Please verify your email.".to_string()
+    };
+
     Ok(Json(RegisterResponse {
         user_id: result.user_id,
-        message: "Registration successful. Please verify your email.".to_string(),
+        message,
     }))
 }
 
@@ -784,6 +791,7 @@ pub async fn setup(
         &body.password,
         body.display_name.as_deref(),
         None,
+        true, // Admin setup always auto-verifies
     )
     .await?;
 

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -39,6 +39,7 @@ pub struct PublicConfigResponse {
     pub node_ws_url: String,
     pub version: String,
     pub social_providers: Vec<String>,
+    pub invite_code_required: bool,
 }
 
 /// GET /api/v1/public/config
@@ -68,5 +69,6 @@ pub async fn public_config(State(state): State<AppState>) -> Json<PublicConfigRe
         node_ws_url: format!("{ws_base}/api/v1/nodes/ws"),
         version: env!("CARGO_PKG_VERSION").to_string(),
         social_providers,
+        invite_code_required: state.config.invite_code_required,
     })
 }

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -38,6 +38,7 @@ pub async fn register_user(
     password_raw: &str,
     display_name: Option<&str>,
     invite_code_id: Option<&str>,
+    auto_verify_email: bool,
 ) -> AppResult<RegisterResult> {
     // Validate password length
     if password_raw.len() < 8 {
@@ -87,8 +88,8 @@ pub async fn register_user(
         password_hash: Some(password_hash),
         display_name: display_name.map(String::from),
         avatar_url: None,
-        email_verified: false,
-        email_verification_token: Some(verification_token_hash),
+        email_verified: auto_verify_email,
+        email_verification_token: if auto_verify_email { None } else { Some(verification_token_hash) },
         password_reset_token: None,
         password_reset_expires_at: None,
         is_active: true,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -163,6 +163,9 @@ dev `docker-compose.override.yml` is intentionally NOT auto-loaded when
 `-f` is used explicitly.
 
 ```bash
+# If you previously ran the quickstart, remove the dev symlink first
+[ -L .env.production ] && rm .env.production
+
 # Create a production env file from the template
 cp .env.production.example .env.production
 $EDITOR .env.production

--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -22,6 +22,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import { usePublicConfig } from "@/hooks/use-public-config";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,6 +135,9 @@ export function AuthFlow({
   returnTo,
   socialError,
 }: AuthFlowProps) {
+  const { data: publicConfig } = usePublicConfig();
+  const inviteRequired = publicConfig?.invite_code_required ?? true;
+
   const [panel, setPanel] = useState<AuthPanel>(initialPanel);
   const [inviteError, setInviteError] = useState(false);
   const [fadeOpacity, setFadeOpacity] = useState(1);
@@ -263,6 +267,7 @@ export function AuthFlow({
 
   // -- Invite code gate for Step 2 --
   function requireInviteCode(): boolean {
+    if (!inviteRequired) return true;
     const code = inviteCode.trim();
     if (!code) {
       setInviteError(true);
@@ -474,7 +479,8 @@ export function AuthFlow({
             </p>
           </div>
 
-          {/* Step 1: Invite Code */}
+          {/* Step 1: Invite Code (only when invite gate is enabled) */}
+          {inviteRequired && (
           <Form {...registerForm}>
             <div className="relative mb-6 pl-9">
               <div className="absolute left-[11px] top-7 bottom-[-12px] w-px bg-gradient-to-b from-violet-500/10 to-transparent" />
@@ -558,12 +564,15 @@ export function AuthFlow({
               </p>
             </div>
           </Form>
+          )}
 
-          {/* Step 2: Choose Method */}
-          <div className="relative pl-9">
+          {/* Step 2: Choose Method (becomes Step 1 when invite not required) */}
+          <div className={`relative ${inviteRequired ? "pl-9" : ""}`}>
+            {inviteRequired && (
             <div className="absolute left-0 top-0 flex h-6 w-6 items-center justify-center rounded-full border border-violet-500/15 bg-violet-500/10 text-[11px] font-semibold text-violet-400">
               2
             </div>
+            )}
             <p className="mb-3 text-[13px] font-medium leading-6 text-muted-foreground">
               Choose how to sign up
             </p>
@@ -663,7 +672,8 @@ export function AuthFlow({
             </div>
           </div>
 
-          {/* Invite code mirror */}
+          {/* Invite code mirror (only when invite gate is enabled) */}
+          {inviteRequired && (
           <div className="mb-5 flex items-center gap-2.5 rounded-lg border border-violet-500/10 bg-violet-500/10 px-3.5 py-2.5">
             <svg
               className="h-3.5 w-3.5 shrink-0 text-violet-400"
@@ -688,6 +698,7 @@ export function AuthFlow({
               Edit
             </button>
           </div>
+          )}
 
           {/* Email registration form */}
           <Form {...registerForm}>

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -14,8 +14,7 @@ export const registerSchema = z
     inviteCode: z
       .string()
       .trim()
-      .transform((s) => s.toUpperCase())
-      .pipe(z.string().min(1, "Invite code is required")),
+      .transform((s) => s.toUpperCase()),
     name: z
       .string()
       .min(1, "Name is required")

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -359,6 +359,7 @@ export interface PublicConfig {
   readonly node_ws_url: string;
   readonly version: string;
   readonly social_providers: readonly string[];
+  readonly invite_code_required: boolean;
 }
 
 export type CredentialMode = "admin" | "user" | "both";


### PR DESCRIPTION
## Summary

- Rewrites the self-host quickstart as a single copy-paste block that non-tech users can run without manual edits
- Adds `AUTO_VERIFY_EMAIL` env var to skip email verification in dev (defaults `false`, safe for prod)
- Exposes `invite_code_required` in public config API so the frontend conditionally hides the invite code step
- Uses `.env.dev` symlinked to `.env.production` so Docker compose works without modifying compose files

## What changed

**Backend (4 files):**
- `config.rs` — new `auto_verify_email` field + `parse_bool_env` helper
- `handlers/health.rs` — `invite_code_required` added to `PublicConfigResponse`
- `handlers/auth.rs` — passes auto-verify flag, conditional toast message
- `services/auth_service.rs` — `register_user()` accepts `auto_verify_email` param

**Frontend (3 files):**
- `auth-flow.tsx` — conditionally hides invite code step/mirror based on public config
- `schemas/auth.ts` — invite code validation no longer enforced client-side
- `types/api.ts` — `invite_code_required` added to `PublicConfig`

**Docs (4 files):**
- `README.md` — one-shot quickstart with preflight checks, auto-generated secrets, teardown
- `DEPLOYMENT.md` — symlink cleanup note for prod setup
- `.env.example` / `CLAUDE.md` — document `AUTO_VERIFY_EMAIL`

**No changes to docker-compose files.**

Supersedes #247.

## Test plan

- [ ] Copy-paste full quickstart block from README into a fresh terminal on a clean machine
- [ ] All three containers start (mongodb, backend, frontend)
- [ ] `curl localhost:3001/health` returns ok
- [ ] `curl localhost:3001/api/v1/public/config` includes `invite_code_required: false`
- [ ] Frontend at localhost:3000 shows registration without invite code step
- [ ] Registration succeeds, toast says "Email auto-verified (dev mode)"
- [ ] Login works immediately without email verification
- [ ] Preflight check reports missing tools and stops cleanly
- [ ] Teardown command stops all containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)