### PR TITLE
feat: one-shot dev quickstart with auto-verify and invite gate toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,5 +144,10 @@ RATE_LIMIT_BURST=30
 # open public registration. Accepts: true/false, 1/0, yes/no, on/off.
 # INVITE_CODE_REQUIRED=true
 
+# ─── Dev convenience ───
+# When true, newly registered users are auto-verified (no email step).
+# Only use in local development. Defaults to false.
+# AUTO_VERIFY_EMAIL=false
+
 # ─── Logging ───
 RUST_LOG=nyxid=debug,tower_http=debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,9 @@ CHANNEL_EVENT_DEDUP_TTL_SECS=300         # Dedup entry TTL (default: 300 = 5 min
 # Registration gate (issue #179)
 INVITE_CODE_REQUIRED=true              # Gate new-user registration behind invite codes (default: true). Set to false for public launch.
 
+# Dev convenience
+AUTO_VERIFY_EMAIL=false                # When true, skip email verification on registration (default: false). Dev only.
+
 # Optional
 GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET
 GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET

--- a/README.md
+++ b/README.md
@@ -103,39 +103,73 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
 
+This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
+
+**Step 1 — Check prerequisites** (paste this first):
+
+```bash
+bash << 'CHECK'
+err=0
+for cmd in git docker openssl curl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then echo "Missing: $cmd"; err=1; fi
+done
+if ! docker compose version >/dev/null 2>&1; then echo "Missing: docker compose (v2 plugin)"; err=1; fi
+if ! docker info >/dev/null 2>&1; then echo "Docker is not running. Start Docker Desktop and re-run."; err=1; fi
+if [ "$err" -eq 1 ]; then exit 1; fi
+echo "All good — proceed to Step 2."
+CHECK
+```
+
+**Step 2 — Install and start** (paste after Step 1 passes):
+
 ```bash
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
 
-# Generate .env.production with fresh secrets
+# ── Generate .env.dev (dev config) and link for Docker ──
 EK=$(openssl rand -hex 32)
-cat > .env.production << EOF
+cat > .env.dev << EOF
 MONGO_ROOT_PASSWORD=$(openssl rand -hex 24)
 ENCRYPTION_KEY=$EK
 BASE_URL=http://localhost:3001
 FRONTEND_URL=http://localhost:3000
-ENVIRONMENT=production
+ENVIRONMENT=development
 JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
 JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
 INVITE_CODE_REQUIRED=false
+AUTO_VERIFY_EMAIL=true
 RUST_LOG=nyxid=info,tower_http=info
 EOF
+ln -sf .env.dev .env.production
 
-# Generate JWT signing keys (PKCS#1 format)
+# ── Generate JWT signing keys (PKCS#1 format) ──
 mkdir -p keys
 openssl genrsa -out keys/private.pem 4096 2>/dev/null
-openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null
+openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
+  || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
 
-# Start the stack
+# ── Pull images and start the stack ──
+echo "Downloading NyxID (this may take a few minutes on first run)..."
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  --env-file .env.production pull &&
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \
   --env-file .env.production up -d
 
-# Wait for the server to be ready
-until curl -sf http://localhost:3001/health > /dev/null 2>&1; do sleep 2; done
-echo "NyxID is running at http://localhost:3000"
-echo "ENCRYPTION_KEY=$EK  ← save this somewhere safe"
+# ── Wait for the server (up to 90s) ──
+echo "Waiting for NyxID to start..."
+n=0
+until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
+  n=$((n+1))
+  if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker compose logs backend"; break; fi
+  sleep 2
+done && echo "NyxID is running at http://localhost:3000" &&
+echo "Save your encryption key (needed if you reset the database): $EK"
 ```
 
-**Open `http://localhost:3000` and register your account.** For production hardening (TLS, domain), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+**Open `http://localhost:3000` and register your account.** No email verification needed — accounts are auto-verified in dev mode.
+
+To stop NyxID: `docker compose -f docker-compose.yml -f docker-compose.prod.yml down`
+
+For production deployment (TLS, domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Now connect your AI agent — pick one approach:
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ flowchart LR
 
 Paste this into Claude Code, Cursor, or any AI coding assistant and it will handle the entire setup:
 
-> Read the self-host section of https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/README.md and execute all three steps — check prerequisites, install and start the Docker stack, then register an account and connect me. Walk me through anything that needs my input (like credentials).
+> Read https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/README.md — go to "Option B: Self-host" and execute Step 1 (check prerequisites), Step 2 (clone the repo, generate .env.dev and RSA keys, pull Docker images, start the stack, wait for health check), and Step 3 (open the web console, register an account, install the NyxID CLI, log in, add my API credentials, and verify the proxy). Walk me through anything that needs my input (like email, password, or API keys).
 
 If you prefer to run each step yourself, follow the manual instructions below.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ flowchart TD
 ```
 
 NyxID proxies requests, injects credentials automatically, punches through
-NAT to reach your local services, and wraps any REST API as MCP tools.
+NAT (Network Address Translation) to reach your local services, and wraps any REST (Representational State Transfer) API (Application Programming Interface) as MCP (Model Context Protocol) tools.
 
 <!-- TODO: Product screenshot
      Replace the ASCII diagram above with a polished architecture diagram or dashboard screenshot.
@@ -66,11 +66,11 @@ NAT to reach your local services, and wraps any REST API as MCP tools.
 
 ## What NyxID Does
 
-- **Reach anything** — public APIs, internal APIs, localhost services via credential nodes (`nyxid node`). SSH tunneling (`nyxid ssh`) reaches remote hosts. No VPN, no port forwarding.
+- **Reach anything** — public APIs, internal APIs, localhost services via credential nodes (`nyxid node`). SSH (Secure Shell) tunneling (`nyxid ssh`) reaches remote hosts. No VPN (Virtual Private Network), no port forwarding.
 - **Never expose keys** — the reverse proxy injects credentials automatically. Your agent talks to NyxID; NyxID talks to the API with the real key.
-- **MCP auto-wrap** — REST APIs with OpenAPI specs become [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) tools. `nyxid mcp config --tool cursor` generates the config. Works with Claude Code, Cursor, VS Code, and any MCP client.
+- **MCP auto-wrap** — REST APIs with OpenAPI specs become [MCP](https://modelcontextprotocol.io/) tools. `nyxid mcp config --tool cursor` generates the config. Works with Claude Code, Cursor, VS Code, and any MCP client.
 - **Per-agent isolation** — each agent gets a scoped token. Agent A accesses Slack and Gmail. Agent B only accesses your internal API. Revoke any session without touching the underlying credentials.
-- **Full identity layer** — OIDC/OAuth 2.0 with PKCE, RBAC, service accounts, transaction approval (Telegram + mobile push), LLM gateway for 7 providers.
+- **Full identity layer** — OIDC (OpenID Connect) / OAuth 2.0 (Open Authorization) with PKCE (Proof Key for Code Exchange), RBAC (Role-Based Access Control), service accounts, transaction approval (Telegram + mobile push), LLM (Large Language Model) gateway for 7 providers.
 
 ## Why NyxID
 
@@ -95,17 +95,27 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 ## Quick Start
 
-### Hosted (closed beta)
+There are two ways to use NyxID — pick the one that fits your situation:
+
+| | Hosted | Self-host |
+|---|---|---|
+| **What it is** | We run NyxID for you in the cloud | You run NyxID on your own machine |
+| **Best for** | Getting started quickly, no setup | Full control, private networks, offline use |
+| **Status** | Closed beta (invitation only) | Open — anyone can run it |
+
+### Option A: Hosted (closed beta)
 
 Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credentials through the dashboard, and copy the MCP config from **Settings > MCP** into your AI tool. Currently invitation-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist).
 
-### Self-host
+### Option B: Self-host
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
+Run NyxID on your own machine. This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
 
-This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
+**What you need installed before starting:**
+- [Docker Desktop](https://docs.docker.com/get-docker/) (includes Docker Compose)
+- A terminal — macOS Terminal, Linux shell, or [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows
 
-**Step 1 — Check prerequisites** (paste this first):
+**Step 1 of 3 — Check your system** (paste this into your terminal):
 
 ```bash
 bash << 'CHECK'
@@ -120,7 +130,7 @@ echo "All good — proceed to Step 2."
 CHECK
 ```
 
-**Step 2 — Install and start** (paste after Step 1 passes):
+**Step 2 of 3 — Install and start** (paste after Step 1 passes):
 
 ```bash
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
@@ -141,7 +151,7 @@ RUST_LOG=nyxid=info,tower_http=info
 EOF
 ln -sf .env.dev .env.production
 
-# ── Generate JWT signing keys (PKCS#1 format) ──
+# ── Generate signing keys ──
 mkdir -p keys
 openssl genrsa -out keys/private.pem 4096 2>/dev/null
 openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
@@ -165,15 +175,17 @@ done && echo "NyxID is running at http://localhost:3000" &&
 echo "Save your encryption key (needed if you reset the database): $EK"
 ```
 
-**Open `http://localhost:3000` and register your account.** No email verification needed — accounts are auto-verified in dev mode.
+**Step 3 of 3 — Register and connect**
+
+1. Open `http://localhost:3000` in your browser
+2. Register with your name, email, and a password — no email verification needed (accounts are auto-verified in dev mode)
+3. Log in and connect your AI agent using one of the methods below
 
 To stop NyxID: `docker compose -f docker-compose.yml -f docker-compose.prod.yml down`
 
-For production deployment (TLS, domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+For production deployment (TLS (Transport Layer Security), custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
-Now connect your AI agent — pick one approach:
-
-#### AI-assisted
+#### Connect your AI agent — AI-assisted
 
 Paste this into Claude Code, Cursor, or any AI coding assistant:
 
@@ -183,7 +195,7 @@ Your AI agent will install the CLI (including Rust if needed), walk you through 
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI on each release -->
 
-#### Manual CLI
+#### Connect your AI agent — Manual CLI (Command Line Interface)
 
 ```bash
 # Install the CLI (installs Rust automatically if needed, takes a few minutes on first run)
@@ -202,13 +214,13 @@ nyxid proxy request llm-openai models
 
 If the proxy returns data, the full chain works: credential stored, injected, downstream accepted.
 
-For MCP setup, open **Settings > MCP** in the web console (`http://localhost:3000`) to copy the correct config for Claude Code, Cursor, or VS Code.
+For MCP setup, open **Settings > MCP** in the web console at `http://localhost:3000` to copy the correct config for Claude Code, Cursor, or VS Code.
 
 > Already have Rust? You can also install with: `cargo install --git https://github.com/ChronoAIProject/NyxID.git nyxid-cli`
 
-#### Web console
+#### Connect your AI agent — Web console
 
-Prefer a GUI? Everything above can also be done through the web console at `http://localhost:3000`:
+Prefer a GUI (Graphical User Interface)? Everything above can also be done through the web console at `http://localhost:3000`:
 
 - **AI Services** — add API credentials (OpenAI, Anthropic, GitHub, etc.)
 - **Settings > MCP** — copy MCP config snippets for Claude Code, Cursor, or VS Code

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ flowchart LR
     E --> H[Web console]
 ```
 
+#### Let AI do it
+
+Paste this into Claude Code, Cursor, or any AI coding assistant and it will handle the entire setup:
+
+> Read the self-host section of https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/README.md and execute all three steps — check prerequisites, install and start the Docker stack, then register an account and connect me. Walk me through anything that needs my input (like credentials).
+
+If you prefer to run each step yourself, follow the manual instructions below.
+
 **What you need installed before starting:**
 - [Docker Desktop](https://docs.docker.com/get-docker/) (includes Docker Compose)
 - A terminal — macOS Terminal, Linux shell, or [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 Run NyxID on your own machine. This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
 
+```mermaid
+flowchart LR
+    A["1. Check prerequisites"] --> B["2. Clone & configure"]
+    B --> C["Start Docker stack"]
+    C --> D["3. Register account"]
+    D --> E{Connect AI agent}
+    E --> F[AI-assisted]
+    E --> G[Manual CLI]
+    E --> H[Web console]
+```
+
 **What you need installed before starting:**
 - [Docker Desktop](https://docs.docker.com/get-docker/) (includes Docker Compose)
 - A terminal — macOS Terminal, Linux shell, or [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -357,12 +357,14 @@ impl std::fmt::Debug for AppConfig {
 
 /// Parse a boolean env var with a default value.
 fn parse_bool_env(name: &str, default: bool) -> bool {
-    match env::var(name).ok().as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+    match env::var(name)
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
         None => default,
-        Some(v) => matches!(
-            v.to_ascii_lowercase().as_str(),
-            "true" | "1" | "yes" | "on"
-        ),
+        Some(v) => matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "on"),
     }
 }
 
@@ -899,6 +901,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         }
     }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -186,6 +186,11 @@ pub struct AppConfig {
     /// `INVITE_CODE_REQUIRED=false` to open public registration — used once
     /// the product launches publicly. See issue #179.
     pub invite_code_required: bool,
+
+    // Dev convenience
+    /// When `true`, newly registered users are marked as email-verified
+    /// immediately. Only intended for local development — defaults to `false`.
+    pub auto_verify_email: bool,
 }
 
 impl std::fmt::Debug for AppConfig {
@@ -347,6 +352,17 @@ impl std::fmt::Debug for AppConfig {
                 &self.channel_event_dedup_ttl_secs,
             )
             .finish()
+    }
+}
+
+/// Parse a boolean env var with a default value.
+fn parse_bool_env(name: &str, default: bool) -> bool {
+    match env::var(name).ok().as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => default,
+        Some(v) => matches!(
+            v.to_ascii_lowercase().as_str(),
+            "true" | "1" | "yes" | "on"
+        ),
     }
 }
 
@@ -584,6 +600,7 @@ impl AppConfig {
                 .unwrap_or(300),
 
             invite_code_required: parse_invite_code_required(env::var("INVITE_CODE_REQUIRED").ok()),
+            auto_verify_email: parse_bool_env("AUTO_VERIFY_EMAIL", false),
         }
     }
 

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -759,6 +759,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         }
     }
 

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -193,6 +193,7 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         }
     }
 

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -729,6 +729,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         };
 
         (keys, config)

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -338,6 +338,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         };
 
         let provider = LocalKeyProvider::from_config(&config);

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -337,6 +337,7 @@ pub async fn register(
         &body.password,
         body.display_name.as_deref(),
         invite_code_id.as_deref(),
+        state.config.auto_verify_email,
     )
     .await;
 
@@ -384,9 +385,15 @@ pub async fn register(
         "Email verification token (dev only)"
     );
 
+    let message = if state.config.auto_verify_email {
+        "Registration successful. Email auto-verified (dev mode). You can now sign in.".to_string()
+    } else {
+        "Registration successful. Please verify your email.".to_string()
+    };
+
     Ok(Json(RegisterResponse {
         user_id: result.user_id,
-        message: "Registration successful. Please verify your email.".to_string(),
+        message,
     }))
 }
 
@@ -784,6 +791,7 @@ pub async fn setup(
         &body.password,
         body.display_name.as_deref(),
         None,
+        true, // Admin setup always auto-verifies
     )
     .await?;
 

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -39,6 +39,7 @@ pub struct PublicConfigResponse {
     pub node_ws_url: String,
     pub version: String,
     pub social_providers: Vec<String>,
+    pub invite_code_required: bool,
 }
 
 /// GET /api/v1/public/config
@@ -68,5 +69,6 @@ pub async fn public_config(State(state): State<AppState>) -> Json<PublicConfigRe
         node_ws_url: format!("{ws_base}/api/v1/nodes/ws"),
         version: env!("CARGO_PKG_VERSION").to_string(),
         social_providers,
+        invite_code_required: state.config.invite_code_required,
     })
 }

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -38,6 +38,7 @@ pub async fn register_user(
     password_raw: &str,
     display_name: Option<&str>,
     invite_code_id: Option<&str>,
+    auto_verify_email: bool,
 ) -> AppResult<RegisterResult> {
     // Validate password length
     if password_raw.len() < 8 {
@@ -87,8 +88,8 @@ pub async fn register_user(
         password_hash: Some(password_hash),
         display_name: display_name.map(String::from),
         avatar_url: None,
-        email_verified: false,
-        email_verification_token: Some(verification_token_hash),
+        email_verified: auto_verify_email,
+        email_verification_token: if auto_verify_email { None } else { Some(verification_token_hash) },
         password_reset_token: None,
         password_reset_expires_at: None,
         is_active: true,

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -89,7 +89,11 @@ pub async fn register_user(
         display_name: display_name.map(String::from),
         avatar_url: None,
         email_verified: auto_verify_email,
-        email_verification_token: if auto_verify_email { None } else { Some(verification_token_hash) },
+        email_verification_token: if auto_verify_email {
+            None
+        } else {
+            Some(verification_token_hash)
+        },
         password_reset_token: None,
         password_reset_expires_at: None,
         is_active: true,

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -696,6 +696,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         }
     }
 

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -793,6 +793,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            auto_verify_email: false,
         }
     }
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -163,6 +163,9 @@ dev `docker-compose.override.yml` is intentionally NOT auto-loaded when
 `-f` is used explicitly.
 
 ```bash
+# If you previously ran the quickstart, remove the dev symlink first
+[ -L .env.production ] && rm .env.production
+
 # Create a production env file from the template
 cp .env.production.example .env.production
 $EDITOR .env.production

--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -22,6 +22,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import { usePublicConfig } from "@/hooks/use-public-config";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -134,6 +135,9 @@ export function AuthFlow({
   returnTo,
   socialError,
 }: AuthFlowProps) {
+  const { data: publicConfig } = usePublicConfig();
+  const inviteRequired = publicConfig?.invite_code_required ?? true;
+
   const [panel, setPanel] = useState<AuthPanel>(initialPanel);
   const [inviteError, setInviteError] = useState(false);
   const [fadeOpacity, setFadeOpacity] = useState(1);
@@ -263,6 +267,7 @@ export function AuthFlow({
 
   // -- Invite code gate for Step 2 --
   function requireInviteCode(): boolean {
+    if (!inviteRequired) return true;
     const code = inviteCode.trim();
     if (!code) {
       setInviteError(true);
@@ -474,7 +479,8 @@ export function AuthFlow({
             </p>
           </div>
 
-          {/* Step 1: Invite Code */}
+          {/* Step 1: Invite Code (only when invite gate is enabled) */}
+          {inviteRequired && (
           <Form {...registerForm}>
             <div className="relative mb-6 pl-9">
               <div className="absolute left-[11px] top-7 bottom-[-12px] w-px bg-gradient-to-b from-violet-500/10 to-transparent" />
@@ -558,12 +564,15 @@ export function AuthFlow({
               </p>
             </div>
           </Form>
+          )}
 
-          {/* Step 2: Choose Method */}
-          <div className="relative pl-9">
+          {/* Step 2: Choose Method (becomes Step 1 when invite not required) */}
+          <div className={`relative ${inviteRequired ? "pl-9" : ""}`}>
+            {inviteRequired && (
             <div className="absolute left-0 top-0 flex h-6 w-6 items-center justify-center rounded-full border border-violet-500/15 bg-violet-500/10 text-[11px] font-semibold text-violet-400">
               2
             </div>
+            )}
             <p className="mb-3 text-[13px] font-medium leading-6 text-muted-foreground">
               Choose how to sign up
             </p>
@@ -663,7 +672,8 @@ export function AuthFlow({
             </div>
           </div>
 
-          {/* Invite code mirror */}
+          {/* Invite code mirror (only when invite gate is enabled) */}
+          {inviteRequired && (
           <div className="mb-5 flex items-center gap-2.5 rounded-lg border border-violet-500/10 bg-violet-500/10 px-3.5 py-2.5">
             <svg
               className="h-3.5 w-3.5 shrink-0 text-violet-400"
@@ -688,6 +698,7 @@ export function AuthFlow({
               Edit
             </button>
           </div>
+          )}
 
           {/* Email registration form */}
           <Form {...registerForm}>

--- a/frontend/src/schemas/auth.test.ts
+++ b/frontend/src/schemas/auth.test.ts
@@ -115,9 +115,9 @@ describe("registerSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects empty invite code", () => {
+  it("accepts empty invite code (backend enforces when required)", () => {
     const result = registerSchema.safeParse({ ...validData, inviteCode: "" });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it("normalizes invite code to trimmed uppercase", () => {
@@ -131,12 +131,12 @@ describe("registerSchema", () => {
     }
   });
 
-  it("rejects invite code that is only whitespace", () => {
+  it("accepts invite code that is only whitespace (trimmed to empty, backend enforces)", () => {
     const result = registerSchema.safeParse({
       ...validData,
       inviteCode: "   ",
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 });
 

--- a/frontend/src/schemas/auth.ts
+++ b/frontend/src/schemas/auth.ts
@@ -14,8 +14,7 @@ export const registerSchema = z
     inviteCode: z
       .string()
       .trim()
-      .transform((s) => s.toUpperCase())
-      .pipe(z.string().min(1, "Invite code is required")),
+      .transform((s) => s.toUpperCase()),
     name: z
       .string()
       .min(1, "Name is required")

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -359,6 +359,7 @@ export interface PublicConfig {
   readonly node_ws_url: string;
   readonly version: string;
   readonly social_providers: readonly string[];
+  readonly invite_code_required: boolean;
 }
 
 export type CredentialMode = "admin" | "user" | "both";


### PR DESCRIPTION
## Summary

- Rewrites the self-host quickstart as a clear 3-step copy-paste flow for non-tech users
- Adds `AUTO_VERIFY_EMAIL` env var to skip email verification in dev (defaults `false`, safe for prod)
- Exposes `invite_code_required` in public config API so the frontend conditionally hides the invite code step
- Uses `.env.dev` symlinked to `.env.production` so Docker Compose works without modifying compose files
- Expands all abbreviations at first mention for accessibility
- Adds comparison table between Hosted and Self-host options

## What changed

**README.md:**
- Split Quick Start into "Option A: Hosted" and "Option B: Self-host" with comparison table
- 3-step self-host flow: (1) check system, (2) install and start, (3) register and connect
- All abbreviations expanded at first mention (API, NAT, MCP, REST, SSH, VPN, OIDC, OAuth, PKCE, RBAC, LLM, CLI, GUI, TLS)
- Prerequisites spelled out as bullet list
- Preflight check in safe heredoc subshell, install step with full Docker output
- Teardown command included

**Backend (10 files):**
- `config.rs` — new `auto_verify_email` field + `parse_bool_env` helper + test constructor
- `handlers/health.rs` — `invite_code_required` added to `PublicConfigResponse`
- `handlers/auth.rs` — passes auto-verify flag, conditional toast message
- `services/auth_service.rs` — `register_user()` accepts `auto_verify_email` param
- `crypto/aes.rs`, `crypto/apple_client_secret.rs`, `crypto/jwt.rs`, `crypto/local_key_provider.rs`, `services/channel_relay_service.rs`, `services/social_auth_service.rs` — added `auto_verify_email: false` to test `AppConfig` constructors

**Frontend (4 files):**
- `auth-flow.tsx` — conditionally hides invite code step/mirror based on public config
- `schemas/auth.ts` — invite code validation no longer enforced client-side
- `schemas/auth.test.ts` — updated tests to match relaxed validation
- `types/api.ts` — `invite_code_required` added to `PublicConfig`

**Docs (3 files):**
- `DEPLOYMENT.md` — symlink cleanup note for prod setup
- `.env.example` / `CLAUDE.md` — document `AUTO_VERIFY_EMAIL`

**No changes to docker-compose files. All config flows through env vars with safe defaults.**

Supersedes #247.

## Test plan

- [ ] Paste Step 1 (preflight) — prints "All good" or lists missing tools and stops
- [ ] Paste Step 2 — Docker pull shows progress, all three containers start
- [ ] `curl localhost:3001/health` returns ok
- [ ] `curl localhost:3001/api/v1/public/config` includes `invite_code_required: false`
- [ ] Frontend at localhost:3000 shows registration without invite code step
- [ ] Registration succeeds, toast says "Email auto-verified (dev mode)"
- [ ] Login works immediately without email verification
- [ ] Teardown command stops all containers
- [ ] Existing prod deployments (without `AUTO_VERIFY_EMAIL`) behave identically
- [ ] All CI checks pass (Rust format, clippy, tests, frontend tests, SDK build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)