### PR TITLE
fix: remove stale DM Serif Text font preload causing 404

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,6 @@
     <meta name="description" content="Connect Claude, Cursor, or your own AI agents to public, internal, and localhost APIs with secure access control. Approve every connection from your phone." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" href="https://fonts.gstatic.com/s/dmseriftext/v12/rnCu-xZa_krGokauCeNq1wWyafOPXHIJErY.woff2" as="font" type="font/woff2" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Space+Grotesk:wght@600;700&family=Manrope:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Playfair+Display:ital,wght@0,400;0,600;1,400&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
## Summary

- Remove the `<link rel="preload">` for `DM Serif Text` woff2 in `frontend/index.html` which returned a 404 in the browser console
- The project uses **DM Serif Display**, not DM Serif Text — the preload URL pointed to a font that was never used
- The Google Fonts `<link>` CSS already handles loading the correct `DM Serif Display` font
- The two `<link rel="preconnect">` hints for `fonts.googleapis.com` and `fonts.gstatic.com` are kept for connection warmup

Closes #249

## Test plan

- [ ] Open the frontend in a browser and confirm no 404 errors in the Network/Console tabs for font resources
- [ ] Verify DM Serif Display still renders correctly (headings, display text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)