### PR TITLE
docs: tighten self-host quickstart — prereqs, disk estimates, optional CLI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
 
+Copy and paste this entire block into your terminal:
+
 ```bash
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
 

--- a/README.md
+++ b/README.md
@@ -12,57 +12,55 @@ public or private, and handles all the credentials so your agent never sees
 a raw key.
 
 ```mermaid
-flowchart TD
-    %% Top clients
-    A[Claude Code]
-    B[Cursor]
-    C[n8n]
+flowchart LR
+    subgraph Agents["AI Agents"]
+        CC[Claude Code]
+        CU[Cursor]
+        N8[n8n]
+    end
 
-    %% Gateway
-    G[NyxID<br/>Cloud Gateway]
+    subgraph NyxID["NyxID Gateway"]
+        AUTH[OIDC and API Key Auth]
+        PROXY[Credential Injection Proxy]
+        MCP[MCP Tool Wrapping]
+    end
 
-    %% Node
-    N[Node]
+    subgraph Connectivity["Private Reach"]
+        NODE[Credential Node]
+    end
 
-    %% Destinations
-    P[Public APIs]
-    I[Internal APIs]
-    L[Localhost Services]
+    subgraph Targets["Connected Services"]
+        PUB[Public APIs]
+        INT[Internal APIs]
+        LOC[Localhost Services]
+    end
 
-    %% Flows
-    A --> G
-    B --> G
-    C --> G
+    CC --> AUTH
+    CU --> AUTH
+    N8 --> AUTH
 
-    G --> P
-    G --> I
-    G --> N --> L
+    AUTH --> PROXY
+    PROXY --> MCP
+    PROXY -->|Direct proxy| PUB
+    PROXY -->|Private network| INT
+    PROXY -->|NAT traversal| NODE
+    NODE --> LOC
 
-    %% Styling
-    classDef client fill:#eef2ff,stroke:#6366f1,color:#111827,stroke-width:1.5px;
-    classDef gateway fill:#0f172a,stroke:#38bdf8,color:#ffffff,stroke-width:2px;
+    classDef agents fill:#eef2ff,stroke:#4f46e5,color:#111827,stroke-width:1.5px;
+    classDef gateway fill:#111827,stroke:#22d3ee,color:#ffffff,stroke-width:2px;
+    classDef tooling fill:#e0f2fe,stroke:#0284c7,color:#0f172a,stroke-width:1.5px;
     classDef node fill:#fef3c7,stroke:#f59e0b,color:#111827,stroke-width:1.5px;
-    classDef public fill:#eff6ff,stroke:#3b82f6,color:#111827,stroke-width:1.5px;
-    classDef internal fill:#ecfdf5,stroke:#10b981,color:#111827,stroke-width:1.5px;
-    classDef local fill:#fff7ed,stroke:#f97316,color:#111827,stroke-width:1.5px;
+    classDef targets fill:#ecfeff,stroke:#14b8a6,color:#0f172a,stroke-width:1.5px;
 
-    class A,B,C client;
-    class G gateway;
-    class N node;
-    class P public;
-    class I internal;
-    class L local;
+    class CC,CU,N8 agents;
+    class AUTH,PROXY gateway;
+    class MCP tooling;
+    class NODE node;
+    class PUB,INT,LOC targets;
 ```
 
 NyxID proxies requests, injects credentials automatically, punches through
 NAT to reach your local services, and wraps any REST API as MCP tools.
-
-<!-- TODO: Product screenshot
-     Replace the ASCII diagram above with a polished architecture diagram or dashboard screenshot.
-     <p align="center">
-       <img src="assets/screenshot.png" alt="NyxID Dashboard" width="80%">
-     </p>
--->
 
 ## What NyxID Does
 
@@ -101,7 +99,13 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 ### Self-host
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
+**Prerequisites:**
+
+- [Docker](https://docs.docker.com/get-docker/) — required for the server stack (backend, frontend, MongoDB). ~2 GB disk for images on first pull.
+- A bash-compatible terminal — macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows.
+- [Rust / Cargo](https://www.rust-lang.org/tools/install) — **optional**, only needed if you install the `nyxid` CLI (see [Manual CLI](#manual-cli) below). The installer will set this up automatically if missing. Budget ~1.5 GB disk (~300 MB for the toolchain plus ~1 GB for the build cache) and 3–10 minutes for the first compile.
+
+Total disk footprint: ~2 GB for the server only, ~3.5 GB if you also install the CLI from source.
 
 Copy and paste this entire block into your terminal:
 
@@ -139,15 +143,31 @@ echo "ENCRYPTION_KEY=$EK  ← save this somewhere safe"
 
 **Open `http://localhost:3000` and register your account.** For production hardening (TLS, domain), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
+#### Optional: Install the `nyxid` CLI
+
+The server stack above is fully usable from the web console — the CLI is only needed if you want to script credential setup, manage credential nodes, or drive NyxID from your terminal. Skip this section if you'd rather stay in the browser.
+
+> **Heads-up:** the installer builds from source via Cargo. It will install Rust automatically if you don't already have it (~300 MB) and then compile the CLI (~1 GB build cache, 3–10 minutes on first run). Make sure you have ~1.5 GB free.
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh)"
+source ~/.cargo/env                               # make nyxid available in current shell
+nyxid --version                                   # verify
+```
+
+Once installed, jump to [Manual CLI](#manual-cli) below for login and first-credential setup.
+
+---
+
 Now connect your AI agent — pick one approach:
 
 #### AI-assisted
 
 Paste this into Claude Code, Cursor, or any AI coding assistant:
 
-> I have NyxID self-hosted. The web console is at http://localhost:3000 and the backend API is at http://localhost:3001. Help me install the NyxID CLI (install script: https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh), then run source ~/.cargo/env to load it, log in with nyxid login --base-url http://localhost:3001, add my OpenAI API key with nyxid service add llm-openai, and verify with nyxid proxy request llm-openai models. Then help me copy the MCP config from Settings > MCP in the web console.
+> I have NyxID self-hosted and the Docker stack is up and healthy. The web console is at http://localhost:3000 and the backend API is at http://localhost:3001. Before doing anything, **ask me whether I want to install the `nyxid` CLI** — explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't already have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using this script: https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then run `source ~/.cargo/env`, log in with `nyxid login --base-url http://localhost:3001`, add my OpenAI API key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through doing the same thing in the web console at http://localhost:3000 instead. Either way, finish by helping me copy the MCP config from **Settings > MCP** in the web console.
 
-Your AI agent will install the CLI (including Rust if needed), walk you through login and credential setup, and verify your connection — all interactively.
+Your AI agent will confirm the CLI install with you first, then walk you through login and credential setup (or the web-console equivalent), and verify your connection — all interactively.
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI on each release -->
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 ### Self-host
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) installed.
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal (macOS Terminal, Linux shell, or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows).
 
 ```bash
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID

--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credenti
 
 Total disk footprint: ~2 GB for the server only, ~3.5 GB if you also install the CLI from source.
 
+#### Option A: AI-assisted (recommended)
+
+If you have Claude Code, Cursor, or any AI coding assistant open, paste this prompt and it will drive the entire self-host flow for you — clone, env generation, Docker stack, health check, optional CLI install, login, first credential, and MCP config:
+
+> I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively:
+> 1. Confirm Docker is installed and running before touching anything.
+> 2. Clone the repo into the current directory, generate `.env.production` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD`, create the PKCS#1 JWT signing keys under `keys/`, then start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d` and wait until `http://localhost:3001/health` returns 200. Show me the generated `ENCRYPTION_KEY` so I can back it up.
+> 3. Tell me to open http://localhost:3000 and register my account, and wait until I confirm I've done that.
+> 4. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
+> 5. Finish by helping me copy the MCP config from **Settings > MCP** in the web console into my AI tool.
+
+<!-- AI quickstart maintenance: validate this prompt against actual CLI + web console on each release -->
+
+Prefer to do it yourself? Use Option B below.
+
+#### Option B: Manual
+
 Copy and paste this entire block into your terminal:
 
 ```bash
@@ -159,17 +176,7 @@ Once installed, jump to [Manual CLI](#manual-cli) below for login and first-cred
 
 ---
 
-Now connect your AI agent — pick one approach:
-
-#### AI-assisted
-
-Paste this into Claude Code, Cursor, or any AI coding assistant:
-
-> I have NyxID self-hosted and the Docker stack is up and healthy. The web console is at http://localhost:3000 and the backend API is at http://localhost:3001. Before doing anything, **ask me whether I want to install the `nyxid` CLI** — explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't already have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using this script: https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then run `source ~/.cargo/env`, log in with `nyxid login --base-url http://localhost:3001`, add my OpenAI API key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through doing the same thing in the web console at http://localhost:3000 instead. Either way, finish by helping me copy the MCP config from **Settings > MCP** in the web console.
-
-Your AI agent will confirm the CLI install with you first, then walk you through login and credential setup (or the web-console equivalent), and verify your connection — all interactively.
-
-<!-- AI quickstart maintenance: validate this prompt against actual CLI on each release -->
+If you went the manual route above, finish the connection by picking one of these:
 
 #### Manual CLI
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ flowchart TD
 ```
 
 NyxID proxies requests, injects credentials automatically, punches through
-NAT (Network Address Translation) to reach your local services, and wraps any REST (Representational State Transfer) API (Application Programming Interface) as MCP (Model Context Protocol) tools.
+NAT to reach your local services, and wraps any REST API as MCP tools.
 
 <!-- TODO: Product screenshot
      Replace the ASCII diagram above with a polished architecture diagram or dashboard screenshot.
@@ -66,11 +66,11 @@ NAT (Network Address Translation) to reach your local services, and wraps any RE
 
 ## What NyxID Does
 
-- **Reach anything** — public APIs, internal APIs, localhost services via credential nodes (`nyxid node`). SSH (Secure Shell) tunneling (`nyxid ssh`) reaches remote hosts. No VPN (Virtual Private Network), no port forwarding.
+- **Reach anything** — public APIs, internal APIs, localhost services via credential nodes (`nyxid node`). SSH tunneling (`nyxid ssh`) reaches remote hosts. No VPN, no port forwarding.
 - **Never expose keys** — the reverse proxy injects credentials automatically. Your agent talks to NyxID; NyxID talks to the API with the real key.
-- **MCP auto-wrap** — REST APIs with OpenAPI specs become [MCP](https://modelcontextprotocol.io/) tools. `nyxid mcp config --tool cursor` generates the config. Works with Claude Code, Cursor, VS Code, and any MCP client.
+- **MCP auto-wrap** — REST APIs with OpenAPI specs become [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) tools. `nyxid mcp config --tool cursor` generates the config. Works with Claude Code, Cursor, VS Code, and any MCP client.
 - **Per-agent isolation** — each agent gets a scoped token. Agent A accesses Slack and Gmail. Agent B only accesses your internal API. Revoke any session without touching the underlying credentials.
-- **Full identity layer** — OIDC (OpenID Connect) / OAuth 2.0 (Open Authorization) with PKCE (Proof Key for Code Exchange), RBAC (Role-Based Access Control), service accounts, transaction approval (Telegram + mobile push), LLM (Large Language Model) gateway for 7 providers.
+- **Full identity layer** — OIDC/OAuth 2.0 with PKCE, RBAC, service accounts, transaction approval (Telegram + mobile push), LLM gateway for 7 providers.
 
 ## Why NyxID
 
@@ -95,116 +95,51 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 ## Quick Start
 
-There are two ways to use NyxID — pick the one that fits your situation:
-
-| | Hosted | Self-host |
-|---|---|---|
-| **What it is** | We run NyxID for you in the cloud | You run NyxID on your own machine |
-| **Best for** | Getting started quickly, no setup | Full control, private networks, offline use |
-| **Status** | Closed beta (invitation only) | Open — anyone can run it |
-
-### Option A: Hosted (closed beta)
+### Hosted (closed beta)
 
 Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credentials through the dashboard, and copy the MCP config from **Settings > MCP** into your AI tool. Currently invitation-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist).
 
-### Option B: Self-host
+### Self-host
 
-Run NyxID on your own machine. This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
-
-```mermaid
-flowchart LR
-    A["1. Check prerequisites"] --> B["2. Clone & configure"]
-    B --> C["Start Docker stack"]
-    C --> D["3. Register account"]
-    D --> E{Connect AI agent}
-    E --> F[AI-assisted]
-    E --> G[Manual CLI]
-    E --> H[Web console]
-```
-
-#### Let AI do it
-
-Paste this into Claude Code, Cursor, or any AI coding assistant and it will handle the entire setup:
-
-> Read https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/README.md — go to "Option B: Self-host" and execute Step 1 (check prerequisites), Step 2 (clone the repo, generate .env.dev and RSA keys, pull Docker images, start the stack, wait for health check), and Step 3 (open the web console, register an account, install the NyxID CLI, log in, add my API credentials, and verify the proxy). Walk me through anything that needs my input (like email, password, or API keys).
-
-If you prefer to run each step yourself, follow the manual instructions below.
-
-**What you need installed before starting:**
-- [Docker Desktop](https://docs.docker.com/get-docker/) (includes Docker Compose)
-- A terminal — macOS Terminal, Linux shell, or [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows
-
-**Step 1 of 3 — Check your system** (paste this into your terminal):
-
-```bash
-bash << 'CHECK'
-err=0
-for cmd in git docker openssl curl; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then echo "Missing: $cmd"; err=1; fi
-done
-if ! docker compose version >/dev/null 2>&1; then echo "Missing: docker compose (v2 plugin)"; err=1; fi
-if ! docker info >/dev/null 2>&1; then echo "Docker is not running. Start Docker Desktop and re-run."; err=1; fi
-if [ "$err" -eq 1 ]; then exit 1; fi
-echo "All good — proceed to Step 2."
-CHECK
-```
-
-**Step 2 of 3 — Install and start** (paste after Step 1 passes):
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) installed.
 
 ```bash
 git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
 
-# ── Generate .env.dev (dev config) and link for Docker ──
+# Generate .env.production with fresh secrets
 EK=$(openssl rand -hex 32)
-cat > .env.dev << EOF
+cat > .env.production << EOF
 MONGO_ROOT_PASSWORD=$(openssl rand -hex 24)
 ENCRYPTION_KEY=$EK
 BASE_URL=http://localhost:3001
 FRONTEND_URL=http://localhost:3000
-ENVIRONMENT=development
+ENVIRONMENT=production
 JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
 JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
 INVITE_CODE_REQUIRED=false
-AUTO_VERIFY_EMAIL=true
 RUST_LOG=nyxid=info,tower_http=info
 EOF
-ln -sf .env.dev .env.production
 
-# ── Generate signing keys ──
+# Generate JWT signing keys (PKCS#1 format)
 mkdir -p keys
 openssl genrsa -out keys/private.pem 4096 2>/dev/null
-openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
-  || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
+openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null
 
-# ── Pull images and start the stack ──
-echo "Downloading NyxID (this may take a few minutes on first run)..."
-docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  --env-file .env.production pull &&
+# Start the stack
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \
   --env-file .env.production up -d
 
-# ── Wait for the server (up to 90s) ──
-echo "Waiting for NyxID to start..."
-n=0
-until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
-  n=$((n+1))
-  if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker compose logs backend"; break; fi
-  sleep 2
-done && echo "NyxID is running at http://localhost:3000" &&
-echo "Save your encryption key (needed if you reset the database): $EK"
+# Wait for the server to be ready
+until curl -sf http://localhost:3001/health > /dev/null 2>&1; do sleep 2; done
+echo "NyxID is running at http://localhost:3000"
+echo "ENCRYPTION_KEY=$EK  ← save this somewhere safe"
 ```
 
-**Step 3 of 3 — Register and connect**
+**Open `http://localhost:3000` and register your account.** For production hardening (TLS, domain), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
-1. Open `http://localhost:3000` in your browser
-2. Register with your name, email, and a password — no email verification needed (accounts are auto-verified in dev mode)
-3. Log in and connect your AI agent using one of the methods below
+Now connect your AI agent — pick one approach:
 
-To stop NyxID: `docker compose -f docker-compose.yml -f docker-compose.prod.yml down`
-
-For production deployment (TLS (Transport Layer Security), custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
-
-#### Connect your AI agent — AI-assisted
+#### AI-assisted
 
 Paste this into Claude Code, Cursor, or any AI coding assistant:
 
@@ -214,7 +149,7 @@ Your AI agent will install the CLI (including Rust if needed), walk you through 
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI on each release -->
 
-#### Connect your AI agent — Manual CLI (Command Line Interface)
+#### Manual CLI
 
 ```bash
 # Install the CLI (installs Rust automatically if needed, takes a few minutes on first run)
@@ -233,13 +168,13 @@ nyxid proxy request llm-openai models
 
 If the proxy returns data, the full chain works: credential stored, injected, downstream accepted.
 
-For MCP setup, open **Settings > MCP** in the web console at `http://localhost:3000` to copy the correct config for Claude Code, Cursor, or VS Code.
+For MCP setup, open **Settings > MCP** in the web console (`http://localhost:3000`) to copy the correct config for Claude Code, Cursor, or VS Code.
 
 > Already have Rust? You can also install with: `cargo install --git https://github.com/ChronoAIProject/NyxID.git nyxid-cli`
 
-#### Connect your AI agent — Web console
+#### Web console
 
-Prefer a GUI (Graphical User Interface)? Everything above can also be done through the web console at `http://localhost:3000`:
+Prefer a GUI? Everything above can also be done through the web console at `http://localhost:3000`:
 
 - **AI Services** — add API credentials (OpenAI, Anthropic, GitHub, etc.)
 - **Settings > MCP** — copy MCP config snippets for Claude Code, Cursor, or VS Code


### PR DESCRIPTION
## Summary

- Expand **Prerequisites** in the self-host quickstart into a bulleted list: Docker (required, ~2 GB), bash terminal, and Rust/Cargo (**optional**, ~1.5 GB + 3–10 min first compile, only needed if installing the `nyxid` CLI). Adds a total-footprint line (~2 GB server-only, ~3.5 GB with CLI from source).
- Add a new **Optional: Install the `nyxid` CLI** subsection right after the health check with an honest cost warning (Rust toolchain download, disk, compile time) so users aren't surprised. The server stack is fully usable from the web console without the CLI.
- Rewrite the **AI-assisted** prompt so the agent *asks the user first* whether they want to install the CLI, explains the cost upfront, and falls back to walking them through the same steps in the web console if they decline. MCP config copy is the final step either way.
- Earlier commits on this branch (already on the branch before this push) ensure the quickstart is a single copy-pasteable block and add the `bash` prerequisite.

## Test plan

- [ ] Render README.md on GitHub and confirm the new Prerequisites bullets, Optional CLI subsection, and rewritten AI-assisted prompt display correctly.
- [ ] Copy-paste the self-host quickstart block on a clean macOS/Linux box with only Docker installed; confirm the stack comes up and `/health` passes without touching Rust.
- [ ] Separately run the Optional CLI install block on the same machine; confirm it installs Rust (if missing), builds `nyxid`, and `nyxid --version` works.
- [ ] Paste the AI-assisted prompt into Claude Code against a running stack; confirm the agent asks before installing the CLI and follows the web-console path if declined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)