### PR TITLE
feat: gate email auth UI behind EMAIL_AUTH_ENABLED flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,5 +149,13 @@ RATE_LIMIT_BURST=30
 # Only use in local development. Defaults to false.
 # AUTO_VERIFY_EMAIL=false
 
+# Email/password auth UI and signup API. Defaults to false (SSO-only: the
+# email form is hidden on /login and /register, and POST /auth/register
+# returns 1009). The self-host quickstart in README.md writes this to true
+# automatically; for plain `cargo run`, uncomment the line below if you want
+# to test the email signup flow locally. The login API is not gated either
+# way — existing users can always authenticate via direct API call.
+# EMAIL_AUTH_ENABLED=true
+
 # ─── Logging ───
 RUST_LOG=nyxid=debug,tower_http=debug

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste this pro
 
 > I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively:
 > 1. Confirm Docker is installed and running before touching anything (check `git`, `docker`, `openssl`, `curl`, `docker compose` v2, and `docker info`).
-> 2. Clone the repo into the current directory, generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, and `AUTO_VERIFY_EMAIL=true` so I don't get stuck on email verification), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker compose logs backend`. Show me the generated `ENCRYPTION_KEY` so I can back it up.
+> 2. Clone the repo into the current directory, generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker compose logs backend`. Show me the generated `ENCRYPTION_KEY` so I can back it up.
 > 3. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
 > 4. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
 > 5. Finish by helping me copy the MCP config from **Settings > MCP** in the web console into my AI tool.
@@ -178,6 +178,7 @@ JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
 JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
 INVITE_CODE_REQUIRED=false
 AUTO_VERIFY_EMAIL=true
+EMAIL_AUTH_ENABLED=true
 RUST_LOG=nyxid=info,tower_http=info
 EOF
 ln -sf .env.dev .env.production

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -187,6 +187,16 @@ pub struct AppConfig {
     /// the product launches publicly. See issue #179.
     pub invite_code_required: bool,
 
+    /// When `true`, email/password auth UI is shown on `/login` and
+    /// `/register`, and `POST /api/v1/auth/register` accepts new accounts.
+    /// Defaults to `false` — the self-host quickstart in `README.md` is the
+    /// only path that opts in by writing `EMAIL_AUTH_ENABLED=true` to
+    /// `.env.dev`. Production, stock local `cargo run`, and any other
+    /// environment without the flag get SSO-only signup. The login endpoint
+    /// is NOT gated — existing users can still authenticate via direct API
+    /// call even when the UI is hidden.
+    pub email_auth_enabled: bool,
+
     // Dev convenience
     /// When `true`, newly registered users are marked as email-verified
     /// immediately. Only intended for local development — defaults to `false`.
@@ -602,6 +612,7 @@ impl AppConfig {
                 .unwrap_or(300),
 
             invite_code_required: parse_invite_code_required(env::var("INVITE_CODE_REQUIRED").ok()),
+            email_auth_enabled: parse_bool_env("EMAIL_AUTH_ENABLED", false),
             auto_verify_email: parse_bool_env("AUTO_VERIFY_EMAIL", false),
         }
     }
@@ -901,6 +912,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         }
     }

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -759,6 +759,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         }
     }

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -193,6 +193,7 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         }
     }

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -729,6 +729,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         };
 

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -338,6 +338,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         };
 

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -120,6 +120,9 @@ pub enum AppError {
     #[error("Social auth: registration closed — invite code required")]
     SocialAuthRegistrationClosed,
 
+    #[error("Email signup is disabled on this instance")]
+    EmailSignupDisabled,
+
     #[error("Consent required")]
     ConsentRequired { consent_url: String },
 
@@ -234,6 +237,7 @@ impl AppError {
             Self::SocialAuthConflict => StatusCode::CONFLICT,
             Self::SocialAuthDeactivated => StatusCode::FORBIDDEN,
             Self::SocialAuthRegistrationClosed => StatusCode::FORBIDDEN,
+            Self::EmailSignupDisabled => StatusCode::FORBIDDEN,
             Self::ConsentRequired { .. } => StatusCode::FORBIDDEN,
             Self::UnsupportedGrantType(_) => StatusCode::BAD_REQUEST,
             Self::ApprovalRequired { .. } => StatusCode::FORBIDDEN,
@@ -277,6 +281,7 @@ impl AppError {
             Self::Internal(_) => 1006,
             Self::DatabaseError(_) => 1007,
             Self::ValidationError(_) => 1008,
+            Self::EmailSignupDisabled => 1009,
             Self::AuthenticationFailed(_) => 2000,
             Self::TokenExpired => 2001,
             Self::MfaRequired { .. } => 2002,
@@ -370,6 +375,7 @@ impl AppError {
             Self::Internal(_) => "internal_error",
             Self::DatabaseError(_) => "database_error",
             Self::ValidationError(_) => "validation_error",
+            Self::EmailSignupDisabled => "email_signup_disabled",
             Self::AuthenticationFailed(_) => "authentication_failed",
             Self::TokenExpired => "token_expired",
             Self::MfaRequired { .. } => "mfa_required",
@@ -708,6 +714,7 @@ mod tests {
             AppError::RateLimited.error_code(),
             AppError::Internal("".into()).error_code(),
             AppError::ValidationError("".into()).error_code(),
+            AppError::EmailSignupDisabled.error_code(),
             AppError::AuthenticationFailed("".into()).error_code(),
             AppError::TokenExpired.error_code(),
             AppError::MfaRequired {
@@ -782,6 +789,15 @@ mod tests {
         assert_eq!(
             AppError::ValidationError("".into()).error_key(),
             "validation_error"
+        );
+        assert_eq!(
+            AppError::EmailSignupDisabled.error_key(),
+            "email_signup_disabled"
+        );
+        assert_eq!(AppError::EmailSignupDisabled.error_code(), 1009);
+        assert_eq!(
+            AppError::EmailSignupDisabled.status_code(),
+            StatusCode::FORBIDDEN
         );
         assert_eq!(
             AppError::AuthenticationFailed("".into()).error_key(),

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -312,6 +312,10 @@ pub async fn register(
     headers: HeaderMap,
     Json(body): Json<RegisterRequest>,
 ) -> AppResult<Json<RegisterResponse>> {
+    if !state.config.email_auth_enabled {
+        return Err(AppError::EmailSignupDisabled);
+    }
+
     body.validate()
         .map_err(|e| AppError::ValidationError(e.to_string()))?;
 

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -40,6 +40,7 @@ pub struct PublicConfigResponse {
     pub version: String,
     pub social_providers: Vec<String>,
     pub invite_code_required: bool,
+    pub email_auth_enabled: bool,
 }
 
 /// GET /api/v1/public/config
@@ -70,5 +71,6 @@ pub async fn public_config(State(state): State<AppState>) -> Json<PublicConfigRe
         version: env!("CARGO_PKG_VERSION").to_string(),
         social_providers,
         invite_code_required: state.config.invite_code_required,
+        email_auth_enabled: state.config.email_auth_enabled,
     })
 }

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -696,6 +696,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         }
     }

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -802,6 +802,7 @@ mod tests {
             channel_event_dedup_capacity: 32_768,
             channel_event_dedup_ttl_secs: 300,
             invite_code_required: true,
+            email_auth_enabled: false,
             auto_verify_email: false,
         }
     }

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -178,6 +178,7 @@ For development, Mailpit is provided via Docker Compose (SMTP on `localhost:1025
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `INVITE_CODE_REQUIRED` | `true` | Gate new-user registration behind invite codes. Set to `false` for public registration. Accepts: `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`. |
+| `EMAIL_AUTH_ENABLED` | `false` | Show the email/password auth UI on `/login` and `/register` and accept `POST /api/v1/auth/register`. Defaults to **false** (SSO-only). The self-host quickstart in `README.md` writes this to `true` automatically. The login API is never gated — existing users can always authenticate via direct API call even when the UI is hidden. Accepts: `true`/`1`/`yes`/`on` → enabled; anything else → disabled. |
 
 ## Channel Bot Relay (Deprecated)
 

--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -137,8 +137,11 @@ export function AuthFlow({
 }: AuthFlowProps) {
   const { data: publicConfig } = usePublicConfig();
   const inviteRequired = publicConfig?.invite_code_required ?? true;
+  const emailAuthEnabled = publicConfig?.email_auth_enabled ?? false;
 
-  const [panel, setPanel] = useState<AuthPanel>(initialPanel);
+  const [panel, setPanel] = useState<AuthPanel>(
+    initialPanel === 2 && !emailAuthEnabled ? 1 : initialPanel,
+  );
   const [inviteError, setInviteError] = useState(false);
   const [fadeOpacity, setFadeOpacity] = useState(1);
   const fadingRef = useRef(false);
@@ -331,88 +334,92 @@ export function AuthFlow({
             </div>
           )}
 
-          <Form {...loginForm}>
-            <form
-              onSubmit={loginForm.handleSubmit(onLoginSubmit)}
-              className="flex flex-col gap-4"
-            >
-              {loginForm.formState.errors.root && (
-                <div
-                  role="alert"
-                  className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          {emailAuthEnabled && (
+            <>
+              <Form {...loginForm}>
+                <form
+                  onSubmit={loginForm.handleSubmit(onLoginSubmit)}
+                  className="flex flex-col gap-4"
                 >
-                  {loginForm.formState.errors.root.message}
-                </div>
-              )}
-
-              <FormField
-                control={loginForm.control}
-                name="email"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        placeholder="you@example.com"
-                        autoComplete="email"
-                        {...field}
-                        ref={(el) => {
-                          field.ref(el);
-                          (
-                            loginEmailRef as React.MutableRefObject<HTMLInputElement | null>
-                          ).current = el;
-                        }}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={loginForm.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <div className="flex items-center justify-between">
-                      <FormLabel>Password</FormLabel>
-                      <Link
-                        to={"/forgot-password" as string}
-                        className="text-xs font-medium text-violet-400 hover:text-violet-300"
-                      >
-                        Forgot password?
-                      </Link>
+                  {loginForm.formState.errors.root && (
+                    <div
+                      role="alert"
+                      className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                    >
+                      {loginForm.formState.errors.root.message}
                     </div>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        placeholder="Enter your password"
-                        autoComplete="current-password"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                  )}
 
-              <Button
-                type="submit"
-                className="h-11 w-full bg-gradient-to-br from-violet-400 via-violet-500 to-violet-600 text-sm font-medium shadow-[0_2px_12px_rgba(139,92,246,0.2)] hover:opacity-90 hover:shadow-[0_4px_20px_rgba(139,92,246,0.3)]"
-                isLoading={loginMutation.isPending}
-              >
-                Sign In
-              </Button>
-            </form>
-          </Form>
+                  <FormField
+                    control={loginForm.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder="you@example.com"
+                            autoComplete="email"
+                            {...field}
+                            ref={(el) => {
+                              field.ref(el);
+                              (
+                                loginEmailRef as React.MutableRefObject<HTMLInputElement | null>
+                              ).current = el;
+                            }}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
 
-          {/* Divider */}
-          <div className="my-6 flex items-center gap-4">
-            <div className="h-px flex-1 bg-border" />
-            <span className="text-xs text-text-tertiary">or</span>
-            <div className="h-px flex-1 bg-border" />
-          </div>
+                  <FormField
+                    control={loginForm.control}
+                    name="password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <div className="flex items-center justify-between">
+                          <FormLabel>Password</FormLabel>
+                          <Link
+                            to={"/forgot-password" as string}
+                            className="text-xs font-medium text-violet-400 hover:text-violet-300"
+                          >
+                            Forgot password?
+                          </Link>
+                        </div>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder="Enter your password"
+                            autoComplete="current-password"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <Button
+                    type="submit"
+                    className="h-11 w-full bg-gradient-to-br from-violet-400 via-violet-500 to-violet-600 text-sm font-medium shadow-[0_2px_12px_rgba(139,92,246,0.2)] hover:opacity-90 hover:shadow-[0_4px_20px_rgba(139,92,246,0.3)]"
+                    isLoading={loginMutation.isPending}
+                  >
+                    Sign In
+                  </Button>
+                </form>
+              </Form>
+
+              {/* Divider */}
+              <div className="my-6 flex items-center gap-4">
+                <div className="h-px flex-1 bg-border" />
+                <span className="text-xs text-text-tertiary">or</span>
+                <div className="h-px flex-1 bg-border" />
+              </div>
+            </>
+          )}
 
           <div className="flex flex-col gap-2">
             {REGISTER_PROVIDERS.map((provider) => (
@@ -595,30 +602,32 @@ export function AuthFlow({
                 </button>
               ))}
 
-              <button
-                type="button"
-                onClick={() => { if (requireInviteCode()) slideToPanel(2); }}
-                className="flex h-[46px] cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-4 text-[13.5px] font-medium text-foreground transition-colors hover:border-border/80 hover:bg-white/[0.03] active:scale-[0.99]"
-              >
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-violet-500/10">
-                  <svg
-                    className="h-4 w-4 text-violet-400"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <rect x="2" y="4" width="20" height="16" rx="2" />
-                    <path d="M22 7l-10 6L2 7" />
-                  </svg>
-                </span>
-                Continue with Email
-                <span className="ml-auto text-sm text-muted-foreground">
-                  &rsaquo;
-                </span>
-              </button>
+              {emailAuthEnabled && (
+                <button
+                  type="button"
+                  onClick={() => { if (requireInviteCode()) slideToPanel(2); }}
+                  className="flex h-[46px] cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-4 text-[13.5px] font-medium text-foreground transition-colors hover:border-border/80 hover:bg-white/[0.03] active:scale-[0.99]"
+                >
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-violet-500/10">
+                    <svg
+                      className="h-4 w-4 text-violet-400"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <rect x="2" y="4" width="20" height="16" rx="2" />
+                      <path d="M22 7l-10 6L2 7" />
+                    </svg>
+                  </span>
+                  Continue with Email
+                  <span className="ml-auto text-sm text-muted-foreground">
+                    &rsaquo;
+                  </span>
+                </button>
+              )}
             </div>
           </div>
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -368,6 +368,7 @@ export interface PublicConfig {
   readonly version: string;
   readonly social_providers: readonly string[];
   readonly invite_code_required: boolean;
+  readonly email_auth_enabled: boolean;
 }
 
 export type CredentialMode = "admin" | "user" | "both";


### PR DESCRIPTION
## Status: Draft — parked pending decision

We are uncertain whether to ship this. Keeping it as a draft so reviewers can look at the shape without a merge commitment.

## Summary

- New env var `EMAIL_AUTH_ENABLED` (**defaults to `false`**) hides the email/password auth UI on both `/login` and `/register` and rejects `POST /api/v1/auth/register` with a dedicated `EmailSignupDisabled` error (code `1009`, HTTP `403`).
- Self-host quickstart in `README.md` (both the AI-assisted prompt and the manual bash heredoc) explicitly writes `EMAIL_AUTH_ENABLED=true` into the generated `.env.dev`, so first-time self-hosters can still create their admin account without setting up an OAuth app.
- Production, stock local `cargo run`, and any other environment without the flag → SSO-only by default.

## What is NOT changed

The login API (`POST /api/v1/auth/login`) is intentionally **not** gated. Existing email/password users can still authenticate via direct API call even when the UI is hidden, so flipping the flag post-launch doesn't lock anyone out. Forgot-password, reset-password, and verify-email endpoints are also untouched.

## Backend

- `backend/src/config.rs` — `email_auth_enabled: bool` loaded via the existing `parse_bool_env("EMAIL_AUTH_ENABLED", false)` helper (same pattern as `auto_verify_email`). Seven test fixtures updated.
- `backend/src/errors/mod.rs` — new `EmailSignupDisabled` variant, error code **1009** (filling the gap between `ValidationError=1008` and `AuthenticationFailed=2000`), HTTP 403, `error_key = "email_signup_disabled"`. Added to the `error_codes_unique` HashSet test and the `error_keys` assertion block.
- `backend/src/handlers/auth.rs` — `register` handler short-circuits with `AppError::EmailSignupDisabled` before `body.validate()` when the flag is off.
- `backend/src/handlers/health.rs` — `PublicConfigResponse` surfaces `email_auth_enabled` on `/api/v1/public/config`.

## Frontend

- `frontend/src/types/api.ts` — `PublicConfig.email_auth_enabled: boolean` added.
- `frontend/src/components/auth/auth-flow.tsx`:
  - `emailAuthEnabled = publicConfig?.email_auth_enabled ?? false` (default matches backend — on initial render before the config fetch resolves, the email form stays hidden).
  - Login panel's `<Form>` + "or" divider wrapped in `{emailAuthEnabled && (...)}`.
  - Register panel's "Continue with Email" button wrapped in `{emailAuthEnabled && (...)}`.
  - `initialPanel=2` (the email signup form) deep-link guard: falls back to panel 1 when the flag is off.
  - Social providers, invite code field, and footer "Sign up / Log in" links unchanged.

## Docs

- `README.md` — quickstart manual heredoc + AI-assisted prompt both write `EMAIL_AUTH_ENABLED=true`.
- `.env.example` — commented hint near `AUTO_VERIFY_EMAIL` for developers running `cargo run` without the quickstart.
- `docs/ENV.md` — new row under "Registration Gate".

## Verification

- `cargo build` — clean
- `cargo test -p nyxid` — **1165 passed, 0 failed** (includes `error_codes_unique` + new `EmailSignupDisabled` assertions on code/key/status)
- `npm run build` — clean TypeScript + Vite build
- Pre-commit hook (cargo fmt, cargo clippy, eslint) — all passed
- Live API check on a second backend at port 3002 (to avoid disrupting the running dev server on 3001):
  - Default unset → `{"email_auth_enabled": false}` on `/public/config`; `POST /auth/register` → `403 {"error":"email_signup_disabled","error_code":1009,"message":"Email signup is disabled on this instance"}`
  - `EMAIL_AUTH_ENABLED=true` → `{"email_auth_enabled": true}` on `/public/config`

## Test plan

- [ ] Pull branch and `cargo test -p nyxid` (expect 1165 passing)
- [ ] `cargo build` clean
- [ ] `cd frontend && npm run build` clean
- [ ] Start backend with no `EMAIL_AUTH_ENABLED` set — confirm `/login` and `/register` show only social login buttons (no email form, no "Continue with Email" button)
- [ ] `curl -X POST .../api/v1/auth/register -d '{...}'` → HTTP 403 with error_code 1009
- [ ] `curl -X POST .../api/v1/auth/login -d '{existing user creds}'` → still succeeds (login intentionally not gated)
- [ ] Restart backend with `EMAIL_AUTH_ENABLED=true` — confirm email form reappears on `/login` and register flow works end-to-end
- [ ] Walk through the README self-host quickstart manual block — confirm the generated `.env.dev` contains `EMAIL_AUTH_ENABLED=true` and the first admin can register

## Open questions for reviewers

1. Do we want to ship this at all? (The reason this is a draft.)
2. Should we also gate the login API server-side, or keep it open for existing users?
3. `CONTRIBUTING.md` says to target `dev`, but recent PRs all merge to `main` and `origin/dev` is stale. This PR targets `main` to match actual practice — should we update the contributing guide?

🤖 Generated with [Claude Code](https://claude.com/claude-code)