### PR TITLE
chore: bump version to 0.2.0 + fix MCP setup copy in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
       label: Environment
       description: Relevant version info and environment details.
       placeholder: |
-        - NyxID version: v0.1.0
+        - NyxID version: v0.2.0
         - OS: macOS 15.3 / Ubuntu 24.04 / Windows 11
         - Browser: Chrome 131 (if frontend)
         - Rust: 1.93.0 (if backend)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ The hook runs `cargo fmt --check`, `cargo clippy`, and `eslint` on staged files.
 
 ```bash
 curl http://localhost:3001/health
-# {"status":"ok","version":"0.1.0"}
+# {"status":"ok","version":"0.2.0"}
 ```
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "nyxid"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "nyxid-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ There are two ways to use NyxID — pick the one that fits your situation:
 
 ### Option A: Hosted (closed beta)
 
-Sign up at the [NyxID console](https://nyx.chrono-ai.fun), add your API credentials through the dashboard, and copy the MCP config from **Settings > MCP** into your AI tool. Currently invitation-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist).
+Sign up at the [NyxID console](https://nyx.chrono-ai.fun), then use the `nyxid` CLI — or point your AI agent at it — to connect your services. Currently invitation-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist).
 
 ### Option B: Self-host
 
@@ -138,7 +138,7 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste this pro
 > 2. Clone the repo into the current directory, generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, and `AUTO_VERIFY_EMAIL=true` so I don't get stuck on email verification), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker compose logs backend`. Show me the generated `ENCRYPTION_KEY` so I can back it up.
 > 3. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
 > 4. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
-> 5. Finish by helping me copy the MCP config from **Settings > MCP** in the web console into my AI tool.
+> 5. Finish by connecting my AI tool to NyxID's MCP endpoint at `http://localhost:3001/mcp`. For Claude Code: `claude mcp add --transport http nyxid http://localhost:3001/mcp`. For Codex: `codex mcp add nyxid --url http://localhost:3001/mcp`. For Cursor: open **Settings > MCP** in the web console and click **Install to Cursor**.
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI + web console on each release -->
 
@@ -253,7 +253,11 @@ nyxid proxy request llm-openai models
 
 If the proxy returns data, the full chain works: credential stored, injected, downstream accepted.
 
-For MCP setup, open **Settings > MCP** in the web console (`http://localhost:3000`) to copy the correct config for Claude Code, Cursor, or VS Code.
+To connect your AI tool to NyxID's MCP endpoint (`http://localhost:3001/mcp`):
+
+- **Claude Code** — `claude mcp add --transport http nyxid http://localhost:3001/mcp`
+- **Codex** — `codex mcp add nyxid --url http://localhost:3001/mcp`
+- **Cursor** — open **Settings > MCP** in the web console (`http://localhost:3000`) and click **Install to Cursor** for a one-click deeplink install
 
 > Already have Rust? You can also install with: `cargo install --git https://github.com/ChronoAIProject/NyxID.git nyxid-cli`
 
@@ -262,7 +266,7 @@ For MCP setup, open **Settings > MCP** in the web console (`http://localhost:300
 Prefer a GUI (Graphical User Interface)? Everything above can also be done through the web console at `http://localhost:3000`:
 
 - **AI Services** — add API credentials (OpenAI, Anthropic, GitHub, etc.)
-- **Settings > MCP** — copy MCP config snippets for Claude Code, Cursor, or VS Code
+- **Settings > MCP** — one-click install for Cursor, or grab the `claude mcp add` / `codex mcp add` command for Claude Code and Codex
 
 ---
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyxid"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyxid-cli"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license.workspace = true
 repository.workspace = true

--- a/docs/API.md
+++ b/docs/API.md
@@ -143,7 +143,7 @@ Returns service health status. No authentication required.
 ```json
 {
   "status": "ok",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -93,7 +93,7 @@ The frontend starts on `http://localhost:3000`.
 
 ```bash
 curl http://localhost:3001/health
-# {"status":"ok","version":"0.1.0"}
+# {"status":"ok","version":"0.2.0"}
 ```
 
 ---
@@ -196,11 +196,11 @@ a specific version by exporting `NYXID_VERSION=v1.2.3` before running compose.
 
 ```bash
 # Tag and push to your container registry
-docker tag nyxid-backend registry.example.com/nyxid/backend:v0.1.0
-docker tag nyxid-frontend registry.example.com/nyxid/frontend:v0.1.0
+docker tag nyxid-backend registry.example.com/nyxid/backend:v0.2.0
+docker tag nyxid-frontend registry.example.com/nyxid/frontend:v0.2.0
 
-docker push registry.example.com/nyxid/backend:v0.1.0
-docker push registry.example.com/nyxid/frontend:v0.1.0
+docker push registry.example.com/nyxid/backend:v0.2.0
+docker push registry.example.com/nyxid/frontend:v0.2.0
 ```
 
 ---
@@ -271,8 +271,8 @@ Edit `k8s/ingress.yaml` and replace `auth.example.com` / `app.example.com` with 
 Edit `k8s/backend-deployment.yaml` and `k8s/frontend-deployment.yaml` to reference your registry:
 
 ```yaml
-image: registry.example.com/nyxid/backend:v0.1.0  # replace
-image: registry.example.com/nyxid/frontend:v0.1.0  # replace
+image: registry.example.com/nyxid/backend:v0.2.0  # replace
+image: registry.example.com/nyxid/frontend:v0.2.0  # replace
 ```
 
 ### Step 5: Apply All Manifests
@@ -652,7 +652,7 @@ npm run build
 
 ```bash
 curl https://auth.example.com/health
-# {"status":"ok","version":"0.1.0"}
+# {"status":"ok","version":"0.2.0"}
 ```
 
 Use this for:

--- a/docs/NODE_PROXY_PROTOCOL.md
+++ b/docs/NODE_PROXY_PROTOCOL.md
@@ -72,7 +72,7 @@ The node sends a `register` message with the one-time registration token:
   "type": "register",
   "token": "nyx_nreg_<64_hex_chars>",
   "metadata": {
-    "agent_version": "0.1.0",
+    "agent_version": "0.2.0",
     "os": "linux",
     "arch": "x86_64"
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "engines": {
     "node": ">=20.0.0"

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,29 +1,18 @@
 {
   "name": "openclaw-plugin-nyxid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-plugin-nyxid",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^24.5.2",
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
+        "node": ">=22"
       }
     },
     "node_modules/typescript": {
@@ -39,13 +28,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-plugin-nyxid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenClaw plugin and skill for NyxID credential brokering",
   "type": "module",
   "main": "./dist/src/index.js",

--- a/sdk/demo-react/package.json
+++ b/sdk/demo-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nyxids/oauth-react-demo",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nyxids/oauth-react": "^0.1.0",
+    "@nyxids/oauth-react": "^0.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/sdk/oauth-core/package.json
+++ b/sdk/oauth-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nyxids/oauth-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "NyxID OAuth core SDK with PKCE and token handling",
   "type": "module",
   "main": "./dist/index.js",

--- a/sdk/oauth-react/package.json
+++ b/sdk/oauth-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nyxids/oauth-react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React bindings for NyxID OAuth SDK",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,7 +35,7 @@
     "react": ">=18"
   },
   "dependencies": {
-    "@nyxids/oauth-core": "^0.1.0"
+    "@nyxids/oauth-core": "^0.2.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.13",

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -13,9 +13,9 @@
     },
     "demo-react": {
       "name": "@nyxids/oauth-react-demo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@nyxids/oauth-react": "^0.1.0",
+        "@nyxids/oauth-react": "^0.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -1720,7 +1720,7 @@
     },
     "oauth-core": {
       "name": "@nyxids/oauth-core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3"
@@ -1728,10 +1728,10 @@
     },
     "oauth-react": {
       "name": "@nyxids/oauth-react",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@nyxids/oauth-core": "^0.1.0"
+        "@nyxids/oauth-core": "^0.2.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.13",


### PR DESCRIPTION
## Summary

- Unify versions across the repo at **0.2.0**: backend, CLI, node-agent, frontend, SDK packages (`oauth-core`, `oauth-react`, `demo-react`), and the OpenClaw integration. `mobile` intentionally stays at `1.0.0`.
- Doc examples updated to match (`/health` responses, Docker tags in DEPLOYMENT, bug report template placeholder, node proxy protocol example).
- Fix misleading MCP setup instructions in `README.md`:
  - Rewrite hosted **Option A** flow to focus on service connection via the `nyxid` CLI or AI agent, instead of the vague "copy MCP config from Settings > MCP" wording.
  - Replace three other "copy MCP config" references with the working CLI commands (`claude mcp add --transport http nyxid <url>` / `codex mcp add nyxid --url <url>`) and the Cursor one-click install.
  - Drop **VS Code** from the Settings > MCP listings — the tab doesn't actually have a VS Code card (only Cursor, Claude Code, Codex). The separate `nyxid mcp config --tool vscode` CLI path still works and is unchanged.

## Test plan

- [ ] `cargo build` succeeds; `nyxid`, `nyxid-cli`, `nyxid-node` report **v0.2.0**
- [ ] `cd frontend && npm run build` succeeds
- [ ] `cd sdk && npm run build` succeeds for `@nyxids/oauth-core`, `@nyxids/oauth-react`, `@nyxids/oauth-react-demo`
- [ ] `GET /health` returns `"version": "0.2.0"`
- [ ] `mobile/package.json` still at `1.0.0`
- [ ] Read the rendered README on GitHub and confirm the four updated MCP sections are clear and accurate:
  - Option A (hosted)
  - AI-assisted quickstart prompt, Step 5
  - Manual CLI tail (MCP setup block)
  - Web console bullet list

## Known issues (not fixed in this PR)

The frontend **Settings > MCP** tab's Claude Code *manual JSON fallback* (not the primary `claude mcp add` command button, which works) has pre-existing bugs: it labels the file as `~/.claude/settings.json` (the real file is `~/.claude.json` or project `.mcp.json`), uses a non-existent `@anthropic-ai/mcp-proxy` npm package, and emits a stdio-transport config when the server actually supports native HTTP. This is duplicated across `settings.tsx`, `guide.tsx`, `mcp-connection-info.tsx`, and `lib/ai-tool-configs.ts`. Out of scope here — this PR is a pure README + version-bump pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)