### PR TITLE
docs: hosted quickstart with invite code

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,18 @@ There are two ways to use NyxID — pick the one that fits your situation:
 |---|---|---|
 | **What it is** | We run NyxID for you in the cloud | You run NyxID on your own machine |
 | **Best for** | Getting started quickly, no setup | Full control, private networks, offline use |
-| **Status** | Closed beta (invitation only) | Open — anyone can run it |
+| **Status** | Early access (invite code below) | Open — anyone can run it |
 
-### Option A: Hosted (closed beta)
+### Option A: Hosted (recommended)
 
-Sign up at the [NyxID console](https://nyx.chrono-ai.fun), then use the `nyxid` CLI — or point your AI agent at it — to connect your services. Currently invitation-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist).
+Start using NyxID in under a minute — no Docker, no setup:
+
+1. Go to **[nyx.chrono-ai.fun/register](https://nyx.chrono-ai.fun/register)**
+2. Enter invite code: **`NYX-FGNY85AF`**
+3. Sign in with Google, GitHub, or Apple
+4. Add your first service credential and connect your AI agent
+
+Early access — limited to 20 users.
 
 ### Option B: Self-host
 


### PR DESCRIPTION
## Summary
- Replace "closed beta / join waitlist" with direct registration flow
- Invite code `NYX-FGNY85AF` (20 users) in README Quick Start
- Direct link to nyx.chrono-ai.fun/register

## Why
M0 目标: 04-18 前首个外部用户注册并使用 NyxID。当前 README 写的是 "join the waitlist"，外部开发者走不通。改为直接给邀请码 + 注册链接。

🤖 Generated with [Claude Code](https://claude.com/claude-code)