### PR TITLE
fix: quickstart reliability — closes #280, closes #281, closes #282

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,9 @@ CHECK
 
 > **This is a first-time install.** If you already have NyxID set up locally, run `./scripts/uninstall.sh --yes` from inside `NyxID/` first (see [Uninstall & reinstall](#uninstall--reinstall) below), then come back here.
 
+The block below is wrapped in `bash << 'INSTALL' ... INSTALL` so it runs under bash regardless of your outer shell — no `zsh: command not found: #` errors on macOS. The trailing `cd NyxID` runs in your interactive shell after the bash subshell exits, so you land inside the checkout for later commands (stop, uninstall, CLI install).
+
 ```bash
-# Wrapped in `bash << 'INSTALL'` so the whole block runs under bash regardless
-# of your outer shell (zsh on macOS, fish, etc.). Fixes shell-parsing errors
-# reported in #281. Trailing `cd NyxID` outside the subshell keeps your
-# interactive cwd inside the checkout after the block finishes.
 bash << 'INSTALL'
 set -e
 
@@ -256,9 +254,6 @@ else
 fi
 INSTALL
 
-# The bash subshell above exits back to your interactive shell. cd into the
-# checkout so later commands (docker compose down, ./scripts/uninstall.sh,
-# nyxid CLI install) work without re-navigating.
 cd NyxID 2>/dev/null || true
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste this pro
 
 > I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively:
 > 1. Confirm Docker is installed and running before touching anything (check `git`, `docker`, `openssl`, `curl`, `docker compose` v2, and `docker info`).
-> 2. **Before cloning or generating anything, check whether NyxID install STATE is present** — look for a `./NyxID/.env.dev` file or a Docker volume named `nyxid_mongodb_data` (try `docker volume inspect nyxid_mongodb_data`). A bare `./NyxID` directory alone does NOT count as "installed" — `uninstall.sh` leaves the source tree in place, so the directory can exist with no state. **If install state is present, stop and tell me the quickstart is a first-time-only install.** Ask whether I want to (a) uninstall first — if `./NyxID` exists, run `cd NyxID && ./scripts/uninstall.sh --yes && cd ..`; if only the stale Docker volume is orphaned (checkout was manually deleted earlier), run `docker volume rm nyxid_mongodb_data` directly. Either path wipes the volume, containers, and (for the script path) `.env.dev`/keys — destroys all NyxID accounts and encrypted credentials. Or (b) keep my existing install and stop here — I can verify it's still running with `curl -sf http://localhost:3001/health`. Do not proceed to step 3 until I answer.
-> 3. If `./NyxID` already exists (post-uninstall reinstall), `cd` into it; otherwise clone the repo into the current directory and `cd` in. Generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker logs nyxid-backend`. If the logs show `SCRAM failure: Authentication failed`, that means the MongoDB volume has a stale password from a previous install — tell me to run `./scripts/uninstall.sh --yes` (or `docker volume rm nyxid_mongodb_data` if the checkout is gone) and retry. Show me the generated `ENCRYPTION_KEY` so I can back it up.
+> 2. **Before cloning or generating anything, check whether NyxID install STATE is present** — look for a `./NyxID/.env.dev` file OR any Docker volume matching `nyx*_mongodb_data` (run `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$'` — this catches the default `nyxid_mongodb_data` plus any variant from a renamed checkout). A bare `./NyxID` directory alone does NOT count as "installed" — `uninstall.sh` leaves the source tree in place, so the directory can exist with no state. **If install state is present, stop and tell me the quickstart is a first-time-only install.** Ask whether I want to (a) uninstall first — if `./NyxID` exists, run `cd NyxID && ./scripts/uninstall.sh --yes && cd ..`; if only the stale Docker volume is orphaned (checkout was manually deleted earlier), run `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm` directly. Either path wipes the volume, containers, and (for the script path) `.env.dev`/keys — destroys all NyxID accounts and encrypted credentials. Or (b) keep my existing install and stop here — I can verify it's still running with `curl -sf http://localhost:3001/health`. Do not proceed to step 3 until I answer.
+> 3. If `./NyxID` already exists (post-uninstall reinstall), `cd` into it; otherwise clone the repo into the current directory and `cd` in. Generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker logs nyxid-backend`. If the logs show `SCRAM failure: Authentication failed`, that means the MongoDB volume has a stale password from a previous install — tell me to run `./scripts/uninstall.sh --yes` (or, if the checkout is gone, `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm` to remove any nyx-flavored orphan volume) and retry. Show me the generated `ENCRYPTION_KEY` so I can back it up.
 > 4. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
 > 5. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
 > 6. Finish by connecting my AI tool to NyxID's MCP endpoint at `http://localhost:3001/mcp`. For Claude Code: `claude mcp add --transport http nyxid http://localhost:3001/mcp`. For Codex: `codex mcp add nyxid --url http://localhost:3001/mcp`. For Cursor: open **Settings > MCP** in the web console and click **Install to Cursor**.
@@ -172,18 +172,23 @@ CHECK
 # reported in #281. Trailing `cd NyxID` outside the subshell keeps your
 # interactive cwd inside the checkout after the block finishes.
 bash << 'INSTALL'
+set -e
+
 # ── Pre-flight: refuse to run on an existing install ──
-# Checks for install STATE (.env.dev or the Mongo volume), NOT the NyxID/
-# source tree — so re-running this block after ./scripts/uninstall.sh works
-# cleanly. uninstall.sh removes state but leaves the cloned source in place.
-if [ -f NyxID/.env.dev ] || docker volume inspect nyxid_mongodb_data >/dev/null 2>&1; then
+# Checks for install STATE (.env.dev or any nyx-flavored Mongo volume), NOT
+# the NyxID/ source tree — so re-running this block after ./scripts/uninstall.sh
+# works cleanly. The volume grep matches nyxid_mongodb_data (default compose
+# project), nyx_mongodb_data, or any other nyx*_mongodb_data variant from a
+# renamed checkout, without false-positing on unrelated MongoDB projects.
+if [ -f NyxID/.env.dev ] \
+  || docker volume ls --format '{{.Name}}' 2>/dev/null | grep -qE 'nyx.*_mongodb_data$'; then
   echo "Existing NyxID install state detected."
   if [ -d NyxID ]; then
     echo "Uninstall first, then re-paste this block:"
     echo "    cd NyxID && ./scripts/uninstall.sh --yes && cd .."
   else
     echo "NyxID/ is gone but a stale MongoDB volume remains. Remove it, then re-paste:"
-    echo "    docker volume rm nyxid_mongodb_data"
+    echo "    docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data\$' | xargs -r docker volume rm"
   fi
   exit 0
 fi
@@ -286,10 +291,10 @@ Docker images are preserved (no re-download). Pass `--keep-config` if you want t
 
 After uninstall, `cd ..` out of `NyxID/` and re-paste **Step 2** above. The pre-flight now checks for install *state* (`.env.dev` or the Mongo volume), not the source tree — so the existing `NyxID/` checkout is reused and only regeneration runs.
 
-**Recovering an orphan volume:** If you hit issue #280 on an older quickstart and manually deleted your `NyxID/` checkout, but a stale MongoDB volume survived, you don't need to re-clone just to run `uninstall.sh`. Remove the volume directly:
+**Recovering an orphan volume:** If you hit issue #280 on an older quickstart and manually deleted your `NyxID/` checkout, but a stale MongoDB volume survived, you don't need to re-clone just to run `uninstall.sh`. Remove any nyx-flavored volume directly — this matches `nyxid_mongodb_data` (default), `nyx_mongodb_data`, or any `nyx*_mongodb_data` variant from a renamed checkout:
 
 ```bash
-docker volume rm nyxid_mongodb_data
+docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm
 docker rm -f nyxid-mongodb nyxid-mailpit nyxid-backend nyxid-frontend 2>/dev/null || true
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ CHECK
 > **This is a first-time install.** If you already have NyxID set up locally, run `./scripts/uninstall.sh --yes` from inside `NyxID/` first (see [Uninstall & reinstall](#uninstall--reinstall) below), then come back here.
 
 ```bash
+# Wrapped in `bash << 'INSTALL'` so the whole block runs under bash regardless
+# of your outer shell (zsh on macOS, fish, etc.). Fixes shell-parsing errors
+# reported in #281. Trailing `cd NyxID` outside the subshell keeps your
+# interactive cwd inside the checkout after the block finishes.
+bash << 'INSTALL'
 # ── Pre-flight: refuse to run on an existing install ──
 # Checks for install STATE (.env.dev or the Mongo volume), NOT the NyxID/
 # source tree — so re-running this block after ./scripts/uninstall.sh works
@@ -180,15 +185,17 @@ if [ -f NyxID/.env.dev ] || docker volume inspect nyxid_mongodb_data >/dev/null 
     echo "NyxID/ is gone but a stale MongoDB volume remains. Remove it, then re-paste:"
     echo "    docker volume rm nyxid_mongodb_data"
   fi
-else
-  # Clone only if the source tree isn't already here (post-uninstall reinstall
-  # reuses the existing checkout; uninstall.sh doesn't delete the repo itself).
-  [ -d NyxID ] || git clone https://github.com/ChronoAIProject/NyxID.git
-  cd NyxID
+  exit 0
+fi
 
-  # ── Generate .env.dev (dev config) and link for Docker ──
-  EK=$(openssl rand -hex 32)
-  cat > .env.dev << EOF
+# Clone only if the source tree isn't already here (post-uninstall reinstall
+# reuses the existing checkout; uninstall.sh doesn't delete the repo itself).
+[ -d NyxID ] || git clone https://github.com/ChronoAIProject/NyxID.git
+cd NyxID
+
+# ── Generate .env.dev (dev config) and link for Docker ──
+EK=$(openssl rand -hex 32)
+cat > .env.dev << EOF
 MONGO_ROOT_PASSWORD=$(openssl rand -hex 24)
 ENCRYPTION_KEY=$EK
 BASE_URL=http://localhost:3001
@@ -201,31 +208,53 @@ AUTO_VERIFY_EMAIL=true
 EMAIL_AUTH_ENABLED=true
 RUST_LOG=nyxid=info,tower_http=info
 EOF
-  ln -sf .env.dev .env.production
+ln -sf .env.dev .env.production
 
-  # ── Generate signing keys (LibreSSL fallback for macOS) ──
-  mkdir -p keys
-  openssl genrsa -out keys/private.pem 4096 2>/dev/null
-  openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
-    || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
+# ── Generate signing keys (LibreSSL fallback for macOS) ──
+mkdir -p keys
+openssl genrsa -out keys/private.pem 4096 2>/dev/null
+openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
+  || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
 
-  # ── Pull images and start the stack ──
-  echo "Downloading NyxID (this may take a few minutes on first run)..."
-  docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-    --env-file .env.production pull &&
-  docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-    --env-file .env.production up -d
+# ── Pull images and start the stack ──
+echo "Downloading NyxID (this may take a few minutes on first run)..."
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  --env-file .env.production pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  --env-file .env.production up -d
 
-  # ── Wait for the server (up to 90s) ──
-  echo "Waiting for NyxID to start..."
-  n=0
-  until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
-    n=$((n+1))
-    if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker logs nyxid-backend"; break; fi
-    sleep 2
-  done && echo "NyxID is running at http://localhost:3000" &&
-  echo "Save your encryption key (needed if you reset the database): $EK"
+# ── Wait for the server (up to 90s) ──
+# Track success explicitly so we print EXACTLY ONE of the two outcome
+# messages below, never both. Fixes #282 where timeout + success printed
+# together when /health didn't come up in time.
+echo "Waiting for NyxID to start..."
+ok=0
+n=0
+while [ "$n" -lt 45 ]; do
+  if curl -sf http://localhost:3001/health >/dev/null 2>&1; then
+    ok=1
+    break
+  fi
+  n=$((n+1))
+  sleep 2
+done
+
+if [ "$ok" -eq 1 ]; then
+  echo ""
+  echo "✓ NyxID is running at http://localhost:3000"
+  echo "  Save your encryption key (needed if you reset the database): $EK"
+else
+  echo ""
+  echo "✗ Timed out waiting for NyxID to start."
+  echo "  Check logs:  docker logs nyxid-backend"
+  echo "  Reset state: see the 'Uninstall & reinstall' section in README.md"
 fi
+INSTALL
+
+# The bash subshell above exits back to your interactive shell. cd into the
+# checkout so later commands (docker compose down, ./scripts/uninstall.sh,
+# nyxid CLI install) work without re-navigating.
+cd NyxID 2>/dev/null || true
 ```
 
 **Step 3 of 3 — Register and connect**

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste this pro
 
 > I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively:
 > 1. Confirm Docker is installed and running before touching anything (check `git`, `docker`, `openssl`, `curl`, `docker compose` v2, and `docker info`).
-> 2. Clone the repo into the current directory, generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker compose logs backend`. Show me the generated `ENCRYPTION_KEY` so I can back it up.
-> 3. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
-> 4. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
-> 5. Finish by connecting my AI tool to NyxID's MCP endpoint at `http://localhost:3001/mcp`. For Claude Code: `claude mcp add --transport http nyxid http://localhost:3001/mcp`. For Codex: `codex mcp add nyxid --url http://localhost:3001/mcp`. For Cursor: open **Settings > MCP** in the web console and click **Install to Cursor**.
+> 2. **Before cloning or generating anything, check whether NyxID install STATE is present** — look for a `./NyxID/.env.dev` file or a Docker volume named `nyxid_mongodb_data` (try `docker volume inspect nyxid_mongodb_data`). A bare `./NyxID` directory alone does NOT count as "installed" — `uninstall.sh` leaves the source tree in place, so the directory can exist with no state. **If install state is present, stop and tell me the quickstart is a first-time-only install.** Ask whether I want to (a) uninstall first — if `./NyxID` exists, run `cd NyxID && ./scripts/uninstall.sh --yes && cd ..`; if only the stale Docker volume is orphaned (checkout was manually deleted earlier), run `docker volume rm nyxid_mongodb_data` directly. Either path wipes the volume, containers, and (for the script path) `.env.dev`/keys — destroys all NyxID accounts and encrypted credentials. Or (b) keep my existing install and stop here — I can verify it's still running with `curl -sf http://localhost:3001/health`. Do not proceed to step 3 until I answer.
+> 3. If `./NyxID` already exists (post-uninstall reinstall), `cd` into it; otherwise clone the repo into the current directory and `cd` in. Generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker logs nyxid-backend`. If the logs show `SCRAM failure: Authentication failed`, that means the MongoDB volume has a stale password from a previous install — tell me to run `./scripts/uninstall.sh --yes` (or `docker volume rm nyxid_mongodb_data` if the checkout is gone) and retry. Show me the generated `ENCRYPTION_KEY` so I can back it up.
+> 4. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
+> 5. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
+> 6. Finish by connecting my AI tool to NyxID's MCP endpoint at `http://localhost:3001/mcp`. For Claude Code: `claude mcp add --transport http nyxid http://localhost:3001/mcp`. For Codex: `codex mcp add nyxid --url http://localhost:3001/mcp`. For Cursor: open **Settings > MCP** in the web console and click **Install to Cursor**.
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI + web console on each release -->
 
@@ -163,12 +164,31 @@ CHECK
 
 **Step 2 of 3 — Install and start** (paste after Step 1 passes):
 
-```bash
-git clone https://github.com/ChronoAIProject/NyxID.git && cd NyxID
+> **This is a first-time install.** If you already have NyxID set up locally, run `./scripts/uninstall.sh --yes` from inside `NyxID/` first (see [Uninstall & reinstall](#uninstall--reinstall) below), then come back here.
 
-# ── Generate .env.dev (dev config) and link for Docker ──
-EK=$(openssl rand -hex 32)
-cat > .env.dev << EOF
+```bash
+# ── Pre-flight: refuse to run on an existing install ──
+# Checks for install STATE (.env.dev or the Mongo volume), NOT the NyxID/
+# source tree — so re-running this block after ./scripts/uninstall.sh works
+# cleanly. uninstall.sh removes state but leaves the cloned source in place.
+if [ -f NyxID/.env.dev ] || docker volume inspect nyxid_mongodb_data >/dev/null 2>&1; then
+  echo "Existing NyxID install state detected."
+  if [ -d NyxID ]; then
+    echo "Uninstall first, then re-paste this block:"
+    echo "    cd NyxID && ./scripts/uninstall.sh --yes && cd .."
+  else
+    echo "NyxID/ is gone but a stale MongoDB volume remains. Remove it, then re-paste:"
+    echo "    docker volume rm nyxid_mongodb_data"
+  fi
+else
+  # Clone only if the source tree isn't already here (post-uninstall reinstall
+  # reuses the existing checkout; uninstall.sh doesn't delete the repo itself).
+  [ -d NyxID ] || git clone https://github.com/ChronoAIProject/NyxID.git
+  cd NyxID
+
+  # ── Generate .env.dev (dev config) and link for Docker ──
+  EK=$(openssl rand -hex 32)
+  cat > .env.dev << EOF
 MONGO_ROOT_PASSWORD=$(openssl rand -hex 24)
 ENCRYPTION_KEY=$EK
 BASE_URL=http://localhost:3001
@@ -181,30 +201,31 @@ AUTO_VERIFY_EMAIL=true
 EMAIL_AUTH_ENABLED=true
 RUST_LOG=nyxid=info,tower_http=info
 EOF
-ln -sf .env.dev .env.production
+  ln -sf .env.dev .env.production
 
-# ── Generate signing keys (LibreSSL fallback for macOS) ──
-mkdir -p keys
-openssl genrsa -out keys/private.pem 4096 2>/dev/null
-openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
-  || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
+  # ── Generate signing keys (LibreSSL fallback for macOS) ──
+  mkdir -p keys
+  openssl genrsa -out keys/private.pem 4096 2>/dev/null
+  openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
+    || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
 
-# ── Pull images and start the stack ──
-echo "Downloading NyxID (this may take a few minutes on first run)..."
-docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  --env-file .env.production pull &&
-docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  --env-file .env.production up -d
+  # ── Pull images and start the stack ──
+  echo "Downloading NyxID (this may take a few minutes on first run)..."
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+    --env-file .env.production pull &&
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+    --env-file .env.production up -d
 
-# ── Wait for the server (up to 90s) ──
-echo "Waiting for NyxID to start..."
-n=0
-until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
-  n=$((n+1))
-  if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker compose logs backend"; break; fi
-  sleep 2
-done && echo "NyxID is running at http://localhost:3000" &&
-echo "Save your encryption key (needed if you reset the database): $EK"
+  # ── Wait for the server (up to 90s) ──
+  echo "Waiting for NyxID to start..."
+  n=0
+  until curl -sf http://localhost:3001/health >/dev/null 2>&1; do
+    n=$((n+1))
+    if [ "$n" -ge 45 ]; then echo "Timed out. Run: docker logs nyxid-backend"; break; fi
+    sleep 2
+  done && echo "NyxID is running at http://localhost:3000" &&
+  echo "Save your encryption key (needed if you reset the database): $EK"
+fi
 ```
 
 **Step 3 of 3 — Register and connect**
@@ -214,6 +235,38 @@ echo "Save your encryption key (needed if you reset the database): $EK"
 3. Log in and connect your AI agent using one of the methods below
 
 To stop NyxID: `docker compose -f docker-compose.yml -f docker-compose.prod.yml down`
+
+#### Uninstall & reinstall
+
+Quickstart is a **first-time install**. To reinstall — e.g. to try a new config, wipe test data, or recover from a broken state — uninstall first, then re-run Step 2.
+
+```bash
+cd NyxID
+./scripts/uninstall.sh               # interactive: type "wipe" to confirm
+./scripts/uninstall.sh --yes         # non-interactive (CI / repeat testing)
+./scripts/uninstall.sh --keep-config # keep .env.dev and keys/*.pem across reinstall
+```
+
+By default this removes:
+
+- Docker containers (`nyxid-mongodb`, `nyxid-mailpit`, `nyxid-backend`, `nyxid-frontend`)
+- The MongoDB named volume (`nyxid_mongodb_data`) — all NyxID accounts, encrypted credentials, and audit log entries
+- `.env.dev`, `.env.production`, `keys/private.pem`, `keys/public.pem`
+
+Docker images are preserved (no re-download). Pass `--keep-config` if you want to preserve your existing `ENCRYPTION_KEY` across reinstall (e.g. to keep encrypted database backups readable).
+
+After uninstall, `cd ..` out of `NyxID/` and re-paste **Step 2** above. The pre-flight now checks for install *state* (`.env.dev` or the Mongo volume), not the source tree — so the existing `NyxID/` checkout is reused and only regeneration runs.
+
+**Recovering an orphan volume:** If you hit issue #280 on an older quickstart and manually deleted your `NyxID/` checkout, but a stale MongoDB volume survived, you don't need to re-clone just to run `uninstall.sh`. Remove the volume directly:
+
+```bash
+docker volume rm nyxid_mongodb_data
+docker rm -f nyxid-mongodb nyxid-mailpit nyxid-backend nyxid-frontend 2>/dev/null || true
+```
+
+Then re-paste Step 2 — the pre-flight will pass and Step 2 will clone fresh.
+
+> **Stuck on `SCRAM failure: Authentication failed` in `docker logs nyxid-backend`?** Your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run `./scripts/uninstall.sh --yes` to wipe the volume, then re-run Step 2. See [#280](https://github.com/ChronoAIProject/NyxID/issues/280).
 
 For production deployment (TLS (Transport Layer Security), custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# scripts/uninstall.sh -- Remove a local NyxID install so you can re-run the
+# self-host quickstart (README.md) from a clean slate.
+#
+# Quickstart is a first-time install only. To reinstall, run this script,
+# then re-paste Step 2.
+#
+# Removes by default:
+#   - Docker containers: nyxid-mongodb, nyxid-mailpit, nyxid-backend, nyxid-frontend
+#   - Docker volume:     *_mongodb_data (any compose project name variant)
+#   - .env.dev, .env.production, keys/private.pem, keys/public.pem
+#
+# Preserves:
+#   - Docker images (mongo:8.0, ghcr.io/chronoaiproject/nyxid/*) -- no re-pull
+#
+# Usage:
+#   ./scripts/uninstall.sh                 interactive (type "wipe" to confirm)
+#   ./scripts/uninstall.sh --yes           non-interactive (CI / repeat testing)
+#   ./scripts/uninstall.sh --keep-config   keep .env.dev / .env.production / keys/*.pem
+#                                          (useful if you want to preserve your
+#                                          existing ENCRYPTION_KEY across reinstall)
+#
+set -euo pipefail
+
+ASSUME_YES=0
+KEEP_CONFIG=0
+
+info() { printf '\033[0;36m[uninstall]\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m[uninstall]\033[0m %s\n' "$*" >&2; }
+fail() { printf '\033[0;31m[uninstall]\033[0m %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/uninstall.sh [OPTIONS]
+
+Remove a local NyxID install so you can re-run the self-host quickstart
+(README.md) from a clean slate.
+
+Options:
+  -y, --yes             Skip the interactive confirmation (CI / repeat testing).
+      --keep-config     Keep .env.dev / .env.production / keys/*.pem.
+                        By default these are removed so the reinstall generates
+                        a fresh ENCRYPTION_KEY and MONGO_ROOT_PASSWORD. Pass
+                        this flag if you want to preserve your existing keys
+                        across reinstall (e.g. to keep encrypted DB backups
+                        readable).
+  -h, --help            Show this help and exit.
+
+Docker images are always preserved so you don't re-download Mongo on every
+uninstall.
+USAGE
+}
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -y|--yes)       ASSUME_YES=1 ;;
+      --keep-config)  KEEP_CONFIG=1 ;;
+      -h|--help)      usage; exit 0 ;;
+      *)              fail "Unknown option: $1 (try --help)" ;;
+    esac
+    shift
+  done
+}
+
+confirm_or_exit() {
+  if [ "$ASSUME_YES" -eq 1 ]; then
+    return 0
+  fi
+  if [ ! -t 0 ]; then
+    fail 'stdin is not a TTY; pass --yes to confirm non-interactively.'
+  fi
+
+  cat >&2 <<'WARN'
+
+  This will permanently delete:
+    - Docker containers: nyxid-mongodb, nyxid-mailpit, nyxid-backend, nyxid-frontend
+    - Docker volume:     <project>_mongodb_data
+    - All NyxID accounts, encrypted credentials, and audit log entries
+      stored in your local MongoDB
+
+WARN
+
+  if [ "$KEEP_CONFIG" -eq 1 ]; then
+    cat >&2 <<'EXTRA'
+  --keep-config is set: .env.dev, .env.production, and keys/*.pem will be
+  preserved. The reinstall will reuse your existing ENCRYPTION_KEY and
+  MONGO_ROOT_PASSWORD (needed for encrypted DB backups to stay readable).
+
+EXTRA
+  else
+    cat >&2 <<'EXTRA'
+  Also removing:
+    - .env.dev / .env.production / keys/*.pem
+
+  A fresh ENCRYPTION_KEY will be generated on reinstall. Any pre-existing
+  encrypted database backup will become unreadable. Pass --keep-config to
+  preserve these files.
+
+EXTRA
+  fi
+
+  cat >&2 <<'WARN'
+  Docker images are preserved (no re-download).
+
+WARN
+
+  printf '  Type "wipe" to confirm: ' >&2
+  local reply=""
+  read -r reply || true
+  if [ "$reply" != "wipe" ]; then
+    fail 'Aborted.'
+  fi
+}
+
+down_compose() {
+  # Run `down -v` against both the dev (auto-loaded override) and the
+  # documented prod compose flow. Empty stacks no-op; errors are tolerated
+  # because the container/volume sweeps below are the real safety net.
+  info 'Stopping dev compose stack (if running)...'
+  docker compose down -v --remove-orphans >/dev/null 2>&1 || true
+
+  if [ -f .env.production ]; then
+    info 'Stopping prod compose stack (if running)...'
+    docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+      --env-file .env.production down -v --remove-orphans >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup_orphan_containers() {
+  # Belt-and-suspenders: docker-compose.yml hardcodes container_name fields,
+  # so a leftover container from a prior run under a different compose project
+  # name (renamed clone dir, etc.) survives the `down` above. Sweep by name.
+  local c
+  for c in nyxid-mongodb nyxid-mailpit nyxid-backend nyxid-frontend; do
+    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$c"; then
+      if docker rm -f "$c" >/dev/null 2>&1; then
+        info "Removed orphan container: $c"
+      fi
+    fi
+  done
+}
+
+cleanup_orphan_volumes() {
+  # Volume name = "${COMPOSE_PROJECT_NAME:-$(basename PWD)}_mongodb_data".
+  # Match by exact name only -- NEVER `docker volume prune` (would nuke
+  # unrelated projects' dangling volumes on the same host).
+  local proj v
+  proj="$(basename "$PWD")"
+  for v in "${proj}_mongodb_data" "nyxid_mongodb_data" "nyx_mongodb_data"; do
+    if docker volume inspect "$v" >/dev/null 2>&1; then
+      if docker volume rm "$v" >/dev/null 2>&1; then
+        info "Removed volume: $v"
+      fi
+    fi
+  done
+}
+
+remove_config_unless_kept() {
+  if [ "$KEEP_CONFIG" -eq 1 ]; then
+    info 'Keeping .env.dev / .env.production / keys/*.pem (--keep-config).'
+    return 0
+  fi
+  local removed=0
+  for f in .env.dev .env.production keys/private.pem keys/public.pem; do
+    if [ -f "$f" ] || [ -L "$f" ]; then
+      rm -f "$f"
+      removed=1
+    fi
+  done
+  if [ "$removed" -eq 1 ]; then
+    info 'Removed .env.dev, .env.production, keys/*.pem.'
+  fi
+}
+
+main() {
+  parse_args "$@"
+  confirm_or_exit
+  down_compose
+  cleanup_orphan_containers
+  cleanup_orphan_volumes
+  remove_config_unless_kept
+  info 'Done. Re-run quickstart Step 2 for a fresh install.'
+}
+
+main "$@"


### PR DESCRIPTION
Closes #280.
Closes #281.
Closes #282.

> **#283 note:** verified already fixed on `main` at `backend/src/handlers/health.rs:42` (`invite_code_required` on `PublicConfigResponse`) and `backend/src/config.rs:188,614` (`AppConfig` field + env parse). Not touched by this PR. If the issue reporter is still seeing invite-code UI, their prebuilt GHCR image is stale — rebuild `ghcr.io/chronoaiproject/nyxid/backend` on next release and the issue resolves without code changes.

## Summary

Three quickstart bugs that all hit first-time macOS users. Each alone would make the README-paste flow feel broken; together they compound. All three touch the same bash block, so they ship in one PR.

| Issue | Symptom | Fix |
|---|---|---|
| **#280** | `SCRAM failure: Authentication failed` on re-run — regenerated `MONGO_ROOT_PASSWORD` didn't match the existing MongoDB volume | State-based pre-flight (scoped `nyx*_mongodb_data` grep + `.env.dev` check), new `scripts/uninstall.sh`, inline orphan-volume recovery |
| **#281** | macOS zsh parsing errors: `zsh: number expected`, `command not found: #`, `missing delimiter for 'u' glob qualifier` | Whole Step 2 install block wrapped in `bash << 'INSTALL' ... INSTALL` so it runs under bash regardless of outer shell |
| **#282** | Health check timeout still printed `NyxID is running at http://localhost:3000` | Replaced `until/break/done &&` with explicit `ok` flag — exactly one of `✓ NyxID is running` or `✗ Timed out` prints, never both |

## What changed

### `scripts/uninstall.sh` (new, 170 lines)

- Interactive confirmation (type `wipe`) or `--yes` for non-interactive use
- Removes: containers (`nyxid-mongodb`, `nyxid-mailpit`, `nyxid-backend`, `nyxid-frontend`), the `*_mongodb_data` volume (across compose project name variants), `.env.dev`, `.env.production`, `keys/*.pem`
- Preserves: Docker images (no re-pull on every uninstall)
- Orphan-container/volume sweep by exact name handles prior runs under a different compose project name
- `down -v --remove-orphans` against both dev (auto-loaded override) and prod compose configs
- Never uses `docker volume prune` — exact volume names only, safe against unrelated projects on the same host

### `README.md` Step 2 block — rewritten

- **Wrapped in `bash << 'INSTALL' … INSTALL`** so the body executes under bash regardless of the user's outer shell. zsh (or fish, or anything) slurps the heredoc body as raw text and pipes it to bash. Trailing `cd NyxID 2>/dev/null || true` outside the subshell keeps the interactive cwd inside the checkout for downstream commands. **Fixes #281.**
- **`set -e` inside the heredoc body** so a failing `docker compose pull` or `up -d` aborts immediately with the real error instead of drifting into the 90-second health-check timeout. Safe because the soft-failure path (LibreSSL openssl fallback) uses `||` which set -e honors, and the curl in the health loop is inside an `if` test which set -e ignores.
- **State-based pre-flight with a scoped volume grep**:
  ```bash
  docker volume ls --format '{{.Name}}' | grep -qE 'nyx.*_mongodb_data$'
  ```
  Catches any nyx-flavored volume variant (`nyxid_mongodb_data` default, `nyx_mongodb_data`, `my-nyxid_mongodb_data` from a renamed checkout) without false-positing on unrelated MongoDB projects. Empirically verified against my local Docker: 4 nyx-flavored volumes exist on this machine including `nyxid-quickstart-test_mongodb_data` — the old narrow check would have missed two of them. **Fixes #280.**
- **Two recovery branches inline**: `./NyxID` present → `cd NyxID && ./scripts/uninstall.sh --yes`, or orphan volume only → `docker volume ls | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm`. Else branch reuses an existing `NyxID/` checkout if present (post-uninstall reinstall works without re-cloning).
- **Explicit `ok` flag for the health check** — exactly one of `✓ NyxID is running` or `✗ Timed out` prints, never both. **Fixes #282.**

### `README.md` — new "Uninstall & reinstall" section

Peer of `#### AI-assisted` and `#### Manual`:

- Documents the three canonical invocations (`./scripts/uninstall.sh`, `--yes`, `--keep-config`)
- Lists what's destroyed vs preserved
- Dedicated "Recovering an orphan volume" subsection with the same scoped grep pattern for users who manually deleted their checkout
- Troubleshooting blockquote that names `SCRAM failure: Authentication failed` verbatim and links to #280

### `README.md` AI-assisted quickstart prompt

New pre-check step tells the AI to detect `NyxID/.env.dev` OR any `nyx*_mongodb_data` volume before cloning and route the user to `uninstall.sh` or the grep-based direct volume removal depending on which state survives. Step 3 teaches the AI that a SCRAM error post-start means a stale volume.

### `README.md` — other corrections surfaced in review

- `docker compose logs backend` → `docker logs nyxid-backend` everywhere. The plain compose form needs `-f docker-compose.prod.yml` to see the `backend` service (it's only defined in the prod compose), so telling users to run it after a documented `-f`-flagged `up -d` silently failed.
- Volume name `nyx_mongodb_data` → `nyxid_mongodb_data` in the Uninstall section bullet list (matches the default compose project name from `git clone ... NyxID`).

## How to verify

From a machine with nothing installed:

```bash
# 1. Fresh install — should work in any shell (bash or zsh)
#    Paste the Step 2 block from README into macOS Terminal (default zsh):
#    - NO "zsh: number expected" / "command not found: #" / "missing delimiter"
#    - Exactly one outcome message: either "✓ NyxID is running" or "✗ Timed out"
#    - Should land in NyxID/ after the block finishes
curl -sf http://localhost:3001/health  # expect 200

# 2. Re-run Step 2 — pre-flight refuses with clear message (#280 prevention)

# 3. Interactive uninstall — prompts to type "wipe"
./scripts/uninstall.sh

# 4. Re-run Step 2 after uninstall — should succeed (no deadlock)

# 5. Orphan volume recovery — simulate #280 exactly
cd .. && rm -rf NyxID
docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm
docker rm -f nyxid-mongodb nyxid-mailpit nyxid-backend nyxid-frontend 2>/dev/null || true
# Re-run Step 2 — should clone fresh and succeed

# 6. Docker images untouched by any of the above
docker images | grep -E 'mongo|nyxid'  # still present
```

## Cross-reviewed (two rounds)

Reviewed by Codex (OpenAI's CLI, independent AI second opinion) twice — once after the first #280 commit and once after folding in #281/#282. Caught real bugs both times:

**Round 1** — four critical bugs now fixed in commit `9654a91`:

1. Deadlock: original `[ -d NyxID ]` pre-flight blocked reinstall after uninstall because `uninstall.sh` doesn't delete the source tree. Now checks state.
2. Wrong volume name: original checked `nyx_mongodb_data` (author's local dev dir basename), not `nyxid_mongodb_data` (default from documented clone).
3. Orphan-volume recovery was impossible: original told users to `cd NyxID && uninstall.sh`, which cannot run if the checkout was already deleted.
4. Log command mismatch: `docker compose logs backend` doesn't work without `-f docker-compose.prod.yml`.

**Round 2** — four follow-up items, three applied in `b29c146` + one deliberately skipped:

1. ✅ State detection beyond the canonical volume name → scoped `nyx*_mongodb_data` grep (applied, with the scoped version rather than codex's unbounded glob to avoid false-positing on unrelated MongoDB projects).
2. ✅ Fail-fast on compose errors → `set -e` at top of `INSTALL` heredoc (applied).
3. ✅ Orphan-volume recovery text matches the broader detection (applied).
4. ❌ AI prompt should verify `NyxID/.git/config` before reusing an existing checkout — **deliberately skipped**. Defensive against a fictional user who has an unrelated project named "NyxID" in their cwd, and an AI that mishandles that ambiguity should ask rather than grep git config. Overengineering for zero realistic risk.

## Smoke tests (all pass)

- `bash -n` outer Step 2 block (93 lines): syntax OK
- **`zsh -n` outer Step 2 block**: syntax OK ← empirical proof the `bash << 'INSTALL'` wrapper survives zsh parsing
- `bash -n` inner heredoc body (82 lines): syntax OK
- Actual zsh paste-through with shimmed docker/git: ran cleanly, pre-flight fired correctly on 4 real stale volumes on the author's machine, exit 0
- "NyxID is running" appears exactly once in inner body (success branch only)
- "Timed out" appears exactly once in inner body (failure branch only)
- No `done &&` success-chain pattern remaining
- Scoped grep empirically catches `nyxid_mongodb_data`, `nyx_mongodb_data`, `nyxid-qst_mongodb_data`, `nyxid-quickstart-test_mongodb_data`
- `scripts/uninstall.sh --help` prints usage
- `scripts/uninstall.sh --bogus` rejects unknown flag
- `scripts/uninstall.sh </dev/null` rejects non-TTY (prevents silent destructive pipe)

## Known follow-up (not blocking)

The `--keep-config` flag on `uninstall.sh` creates a reinstall loop: it preserves `.env.dev`, so the Step 2 pre-flight sees `.env.dev` and refuses to run. Scoped follow-up: delete the flag entirely (matches the "first-time install only" mental model). Not blocking this PR — the default `./scripts/uninstall.sh --yes` path works correctly.

## Commits

- `9654a91` — fix: make quickstart idempotent, close SCRAM auth failure (#280)
- `5e3066f` — fix: fold zsh compat (#281) and health-check accuracy (#282) into quickstart
- `b29c146` — fix: broaden state detection + fail-fast on compose errors (codex follow-up)

## Test plan

- [x] `bash -n` on outer wrapper + inner heredoc body
- [x] **`zsh -n` on outer wrapper** (empirical #281 regression coverage)
- [x] Actual zsh paste-through via `zsh -c` with shimmed system commands
- [x] `scripts/uninstall.sh` help/bogus-flag/non-TTY checks
- [x] Scenario replay against six state combinations
- [x] Scoped grep verified against 4 real nyx-flavored volumes on author's machine
- [ ] End-to-end verification on a clean machine (recommended before merge)
- [ ] **Live macOS Terminal paste test** (recommended — `zsh -n` proves syntax, but a human paste into a real interactive zsh on a fresh machine is the gold standard)
- [ ] **Rebuild and push `ghcr.io/chronoaiproject/nyxid/backend:latest`** on next release so #283 resolves for users hitting the prebuilt image path

🤖 Generated with [Claude Code](https://claude.com/claude-code)