### PR TITLE
docs: explicit AI Services connect flow + new docs/CONNECTING_SERVICES.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,7 @@ There are two ways to use NyxID — pick the one that fits your situation:
 
 ### Option A: Hosted (closed beta)
 
-1. Sign up at the [NyxID console](https://nyx.chrono-ai.fun) — currently invite-only ([join the waitlist](https://nyx.chrono-ai.fun/#waitlist)).
-2. Use `https://nyx.chrono-ai.fun` as your `<BASE_URL>`.
-3. Follow **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** to connect your first AI Service and verify the proxy works before you wire up MCP — this is the step that the previous quickstart wording skipped over ([#298](https://github.com/ChronoAIProject/NyxID/issues/298)).
+Sign up at the [NyxID console](https://nyx.chrono-ai.fun) — currently invite-only ([join the waitlist](https://nyx.chrono-ai.fun/#waitlist)). Use `https://nyx.chrono-ai.fun` as your `<BASE_URL>`, then jump to [Connecting AI Services](#connecting-ai-services) below.
 
 ### Option B: Self-host
 
@@ -141,8 +139,9 @@ Prefer to run each step yourself, or need the full troubleshooting guide? The co
 - One paste-block install — [Step 2](docs/QUICKSTART.md#step-2-of-3--install-and-start)
 - Register your account — [Step 3](docs/QUICKSTART.md#step-3-of-3--register-and-connect)
 - Optional [CLI install](docs/QUICKSTART.md#optional-install-the-nyxid-cli)
-- [Connect your first AI Service](docs/CONNECTING_SERVICES.md) — verify the proxy works *before* wiring MCP, so your agent doesn't end up stuck with only `nyx__...` meta-tools
 - [Uninstall & reinstall](docs/QUICKSTART.md#uninstall--reinstall), [orphan volume recovery](docs/QUICKSTART.md#recovering-an-orphan-volume), and [SCRAM failure](docs/QUICKSTART.md#stuck-on-scram-failure) troubleshooting
+
+Once NyxID is running, jump to [Connecting AI Services](#connecting-ai-services) below to connect your first downstream API.
 
 For production deployment (TLS, custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
@@ -162,6 +161,21 @@ nyxid node credentials setup --service my-local-api --api-url http://localhost:8
 # Import endpoints as MCP tools (if the service has an OpenAPI spec)
 nyxid catalog endpoints my-local-api
 ```
+
+## Connecting AI Services
+
+After NyxID is running (hosted or self-host), the next step is to connect a downstream API — OpenAI, Anthropic, GitHub, your private API, anything — so your AI agents can call it through the proxy without ever seeing the raw key.
+
+> **Connect a service *before* wiring up MCP.** Otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken.
+
+The full walkthrough is at **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** — base-URL-agnostic, so the same guide works for hosted (`https://nyx.chrono-ai.fun`) and self-host (`http://localhost:3001`). It covers four paths in order of friction:
+
+- **AI-driven (recommended)** — paste a prompt into Claude Code / Codex / Cursor and let your agent use NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__connect_service`, `nyx__call_tool`) to add and verify your first service end-to-end.
+- **CLI** — `nyxid service add llm-openai --credential-env OPENAI_API_KEY` then `nyxid proxy request llm-openai models` to verify.
+- **Web UI** — dashboard click-through with a "Test request" verify step.
+- **Direct API** — curl examples for automation and CI.
+
+Whichever path you pick, the verification step (calling a real downstream tool and getting a real response back) is the gate everything hinges on. The doc also has an "Adding more services later" section, so the same guide covers your tenth service the same way it covers your first.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ There are two ways to use NyxID — pick the one that fits your situation:
 
 ### Option A: Hosted (closed beta)
 
-Sign up at the [NyxID console](https://nyx.chrono-ai.fun), then use the `nyxid` CLI — or point your AI agent at it — to connect your services. Currently invitation-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist).
+1. Sign up at the [NyxID console](https://nyx.chrono-ai.fun) — currently invite-only ([join the waitlist](https://nyx.chrono-ai.fun/#waitlist)).
+2. Use `https://nyx.chrono-ai.fun` as your `<BASE_URL>`.
+3. Follow **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** to connect your first AI Service and verify the proxy works before you wire up MCP — this is the step that the previous quickstart wording skipped over ([#298](https://github.com/ChronoAIProject/NyxID/issues/298)).
 
 ### Option B: Self-host
 
@@ -138,7 +140,8 @@ Prefer to run each step yourself, or need the full troubleshooting guide? The co
 - System preflight check — [Step 1](docs/QUICKSTART.md#step-1-of-3--check-your-system)
 - One paste-block install — [Step 2](docs/QUICKSTART.md#step-2-of-3--install-and-start)
 - Register your account — [Step 3](docs/QUICKSTART.md#step-3-of-3--register-and-connect)
-- Optional [CLI install](docs/QUICKSTART.md#optional-install-the-nyxid-cli) and [first credential / MCP wiring](docs/QUICKSTART.md#connect-your-ai-tool)
+- Optional [CLI install](docs/QUICKSTART.md#optional-install-the-nyxid-cli)
+- [Connect your first AI Service](docs/CONNECTING_SERVICES.md) — verify the proxy works *before* wiring MCP, so your agent doesn't end up stuck with only `nyx__...` meta-tools
 - [Uninstall & reinstall](docs/QUICKSTART.md#uninstall--reinstall), [orphan volume recovery](docs/QUICKSTART.md#recovering-an-orphan-volume), and [SCRAM failure](docs/QUICKSTART.md#stuck-on-scram-failure) troubleshooting
 
 For production deployment (TLS, custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
@@ -170,6 +173,7 @@ nyxid catalog endpoints my-local-api
 
 | Topic | Link | |
 |-------|------|---|
+| Connecting Services | [docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md) | Add your first (or Nth) AI Service — works for hosted + self-host |
 | Quickstart (manual) | [docs/QUICKSTART.md](docs/QUICKSTART.md) | Step-by-step self-host + troubleshooting |
 | Deployment | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Start here for production setup |
 | AI Agent Playbook | [docs/AI_AGENT_PLAYBOOK.md](docs/AI_AGENT_PLAYBOOK.md) | Start here for agent integration |

--- a/README.md
+++ b/README.md
@@ -166,21 +166,22 @@ nyxid catalog endpoints my-local-api
 
 After NyxID is running (hosted or self-host), the next step is to connect a downstream API — OpenAI, Anthropic, GitHub, your private API, anything — so your AI agents can call it through the proxy without ever seeing the raw key.
 
-> **Wiring MCP alone isn't enough.** Until you connect a real downstream service *and* verify the proxy works, your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken.
+> **Connect a service *before* wiring up MCP.** Otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken.
 
-### Recommended: let your AI agent drive it
+The full walkthrough is at **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** — base-URL-agnostic, so the same guide works for hosted (`https://nyx.chrono-ai.fun`) and self-host (`http://localhost:3001`). It covers four paths in order of friction:
 
-Once you're authenticated (`nyxid login --base-url <BASE_URL>`) and your AI tool is MCP-connected (`claude mcp add --transport http nyxid <BASE_URL>/mcp`, or the Codex / Cursor equivalents), paste this into your AI agent:
+- **AI-driven (recommended)** — paste a prompt into Claude Code / Codex / Cursor and let your agent use NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__connect_service`, `nyx__call_tool`) to add and verify your first service end-to-end.
+- **CLI** — `nyxid service add llm-openai --credential-env OPENAI_API_KEY` then `nyxid proxy request llm-openai models` to verify.
+- **Web UI** — dashboard click-through with a "Test request" verify step.
+- **Direct API** — curl examples for automation and CI.
 
-> Help me connect an AI Service in NyxID. Use `nyx__discover_services` to list what's available in the catalog and ask me which one I want (e.g. OpenAI, Anthropic, GitHub). Once I pick, ask me for the credential I want to use (API key, token, etc.), then call `nyx__connect_service` with the `service_id` from discover results and my credential. After it returns success, call `nyx__search_tools` to confirm the new service's tools are now exposed, then call `nyx__call_tool` on one of them (e.g. list models, list repos) to verify the proxy works end-to-end. Report back with the actual response so I know it's working — not just "looks good." If anything errors, tell me whether it's a credential problem or a service config problem.
+Whichever path you pick, the verification step (calling a real downstream tool and getting a real response back) is the gate everything hinges on. The doc also has an "Adding more services later" section, so the same guide covers your tenth service the same way it covers your first.
 
-The agent walks the full loop: `nyx__discover_services` → `nyx__connect_service` → `nyx__search_tools` → `nyx__call_tool`. The final call **is** the verify-gate — a real downstream response (a list of OpenAI models, a list of GitHub repos, etc.) means everything is wired end-to-end.
+For the AI-driven path: after `nyxid login --base-url <BASE_URL>` and `claude mcp add --transport http nyxid <BASE_URL>/mcp` (or Codex / Cursor equivalents), paste this into your agent:
+
+> Help me connect an AI Service in NyxID. Use `nyx__discover_services` to list what's available in the catalog and ask me which one I want (e.g. OpenAI, Anthropic, GitHub). Once I pick, ask me for the credential I want to use, then call `nyx__connect_service` with the `service_id` from discover results and my credential. After it returns success, call `nyx__search_tools` to confirm the new service's tools are now exposed, then call `nyx__call_tool` on one of them (e.g. list models, list repos) to verify the proxy works end-to-end. Report back with the actual response so I know it's working — not just "looks good." If anything errors, tell me whether it's a credential problem or a service config problem.
 
 <!-- Sync this prompt with docs/CONNECTING_SERVICES.md Path A on every release. -->
-
-### Other paths
-
-Don't have the CLI yet, want to drive it yourself, or need to script it from CI? **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** has the full base-URL-agnostic walkthrough — CLI (`nyxid service add ...`), web console click-through, and direct curl/API examples — plus the auth bootstrap for users without the CLI installed. The doc also covers adding more services later, so it's the canonical reference for both your first and your tenth.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ChronoAIProject/NyxID)](https://github.com/ChronoAIProject/NyxID)
+[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.com/channels/1422500823925264438/1485570725413650553)
 
 <p align="center">
   <img src="assets/banner.png" alt="NyxID — Connect AI agents to any API, anywhere. Securely." width="100%">
@@ -96,6 +97,12 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 | REST to MCP auto-wrap | Yes | No | No | No |
 | Per-agent isolation | Yes | No | No | No |
 | OIDC / OAuth 2.0 | Yes | No | No | Yes |
+
+## Use Cases
+
+- Give Claude Code access to your private APIs without sharing keys
+- Expose internal microservices to AI agents through a single MCP endpoint
+- Secure AI agent access to self-hosted tools (Grafana, Jenkins, n8n) behind your firewall
 
 ## Quick Start
 
@@ -194,12 +201,6 @@ nyxid node credentials setup --service my-local-api --api-url http://localhost:8
 # Import endpoints as MCP tools (if the service has an OpenAPI spec)
 nyxid catalog endpoints my-local-api
 ```
-
-## Use Cases
-
-- Give Claude Code access to your private APIs without sharing keys
-- Expose internal microservices to AI agents through a single MCP endpoint
-- Secure AI agent access to self-hosted tools (Grafana, Jenkins, n8n) behind your firewall
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ any REST API as MCP (Model Context Protocol) tools.
 - **Per-agent isolation** — each agent gets a scoped token. Agent A accesses Slack and Gmail. Agent B only accesses your internal API. Revoke any session without touching the underlying credentials.
 - **Full identity layer** — OIDC (OpenID Connect) / OAuth 2.0 with PKCE (Proof Key for Code Exchange), RBAC (Role-Based Access Control), service accounts, transaction approval (Telegram + mobile push), LLM (Large Language Model) gateway for 7 providers.
 
-## See it in action
+## See It in Action
 
 The end-to-end loop is short: connect a service to NyxID once, then any AI agent pointed at your NyxID MCP endpoint can use it — without ever seeing the raw API key.
 
@@ -107,7 +107,7 @@ There are two ways to use NyxID — pick the one that fits your situation:
 | **Best for** | Getting started quickly, no setup | Full control, private networks, offline use |
 | **Status** | Early access (invite code below) | Open — anyone can run it |
 
-### Option A: Hosted (recommended)
+### Option A: Hosted (Recommended)
 
 Start using NyxID in under a minute — no Docker, no setup:
 
@@ -118,13 +118,13 @@ Start using NyxID in under a minute — no Docker, no setup:
 
 Early access — limited to 20 users.
 
-### Option B: Self-host
+### Option B: Self-Host
 
 Run NyxID on your own machine. This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
 
 **Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal. The `nyxid` CLI is optional. Full prereqs and disk budgets in [docs/QUICKSTART.md](docs/QUICKSTART.md#prerequisites).
 
-#### AI-assisted (recommended)
+#### AI-Assisted (Recommended)
 
 If you have Claude Code, Cursor, or any AI coding assistant open, paste the prompt below into it and it will drive the entire self-host flow for you — preflight, clone, env generation, Docker stack, health check, optional CLI install, login, first credential, and MCP config.
 
@@ -143,7 +143,7 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste the prom
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI + web console on each release -->
 
-#### Manual setup
+#### Manual Setup
 
 Prefer to run each step yourself, or need the full troubleshooting guide? The complete manual flow lives in **[docs/QUICKSTART.md](docs/QUICKSTART.md)**:
 
@@ -178,7 +178,7 @@ For the AI-driven path: wire MCP first with `claude mcp add --transport http nyx
 
 <!-- Sync this prompt with docs/CONNECTING_SERVICES.md Path A on every release. -->
 
-### Reach local services (optional)
+## Reach Local Services (Optional)
 
 Services behind a firewall? Deploy a credential node to punch through NAT and expose them as MCP tools:
 
@@ -203,9 +203,9 @@ nyxid catalog endpoints my-local-api
 
 ## Resources
 
-| Topic | Link | |
-|-------|------|---|
-| Connecting Services | [docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md) | Add your first (or Nth) AI Service — works for hosted + self-host |
+| Topic | Link | Description |
+|-------|------|-------------|
+| Connecting AI Services | [docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md) | Add your first (or Nth) AI Service — works for hosted + self-host |
 | Quickstart (manual) | [docs/QUICKSTART.md](docs/QUICKSTART.md) | Step-by-step self-host + troubleshooting |
 | Deployment | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Start here for production setup |
 | AI Agent Playbook | [docs/AI_AGENT_PLAYBOOK.md](docs/AI_AGENT_PLAYBOOK.md) | Start here for agent integration |
@@ -213,10 +213,10 @@ nyxid catalog endpoints my-local-api
 | API Reference | [docs/API.md](docs/API.md) | Full endpoint documentation |
 | Credential Nodes | [docs/NODE_PROXY.md](docs/NODE_PROXY.md) | NAT traversal setup |
 | MCP Integration | [docs/MCP_DELEGATION_FLOW.md](docs/MCP_DELEGATION_FLOW.md) | MCP protocol details |
-| SSH Tunneling | [docs/SSH_TUNNELING.md](docs/SSH_TUNNELING.md) | |
-| Security | [docs/SECURITY.md](docs/SECURITY.md) | |
-| Environment Variables | [docs/ENV.md](docs/ENV.md) | |
-| Developer Guide | [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md) | |
+| SSH Tunneling | [docs/SSH_TUNNELING.md](docs/SSH_TUNNELING.md) | Remote host access over WebSocket |
+| Security | [docs/SECURITY.md](docs/SECURITY.md) | Threat model and hardening |
+| Environment Variables | [docs/ENV.md](docs/ENV.md) | Full config reference |
+| Developer Guide | [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md) | Local development setup |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -166,16 +166,21 @@ nyxid catalog endpoints my-local-api
 
 After NyxID is running (hosted or self-host), the next step is to connect a downstream API — OpenAI, Anthropic, GitHub, your private API, anything — so your AI agents can call it through the proxy without ever seeing the raw key.
 
-> **Connect a service *before* wiring up MCP.** Otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken.
+> **Wiring MCP alone isn't enough.** Until you connect a real downstream service *and* verify the proxy works, your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken.
 
-The full walkthrough is at **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** — base-URL-agnostic, so the same guide works for hosted (`https://nyx.chrono-ai.fun`) and self-host (`http://localhost:3001`). It covers four paths in order of friction:
+### Recommended: let your AI agent drive it
 
-- **AI-driven (recommended)** — paste a prompt into Claude Code / Codex / Cursor and let your agent use NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__connect_service`, `nyx__call_tool`) to add and verify your first service end-to-end.
-- **CLI** — `nyxid service add llm-openai --credential-env OPENAI_API_KEY` then `nyxid proxy request llm-openai models` to verify.
-- **Web UI** — dashboard click-through with a "Test request" verify step.
-- **Direct API** — curl examples for automation and CI.
+Once you're authenticated (`nyxid login --base-url <BASE_URL>`) and your AI tool is MCP-connected (`claude mcp add --transport http nyxid <BASE_URL>/mcp`, or the Codex / Cursor equivalents), paste this into your AI agent:
 
-Whichever path you pick, the verification step (calling a real downstream tool and getting a real response back) is the gate everything hinges on. The doc also has an "Adding more services later" section, so the same guide covers your tenth service the same way it covers your first.
+> Help me connect an AI Service in NyxID. Use `nyx__discover_services` to list what's available in the catalog and ask me which one I want (e.g. OpenAI, Anthropic, GitHub). Once I pick, ask me for the credential I want to use (API key, token, etc.), then call `nyx__connect_service` with the `service_id` from discover results and my credential. After it returns success, call `nyx__search_tools` to confirm the new service's tools are now exposed, then call `nyx__call_tool` on one of them (e.g. list models, list repos) to verify the proxy works end-to-end. Report back with the actual response so I know it's working — not just "looks good." If anything errors, tell me whether it's a credential problem or a service config problem.
+
+The agent walks the full loop: `nyx__discover_services` → `nyx__connect_service` → `nyx__search_tools` → `nyx__call_tool`. The final call **is** the verify-gate — a real downstream response (a list of OpenAI models, a list of GitHub repos, etc.) means everything is wired end-to-end.
+
+<!-- Sync this prompt with docs/CONNECTING_SERVICES.md Path A on every release. -->
+
+### Other paths
+
+Don't have the CLI yet, want to drive it yourself, or need to script it from CI? **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** has the full base-URL-agnostic walkthrough — CLI (`nyxid service add ...`), web console click-through, and direct curl/API examples — plus the auth bootstrap for users without the CLI installed. The doc also covers adding more services later, so it's the canonical reference for both your first and your tenth.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ChronoAIProject/NyxID)](https://github.com/ChronoAIProject/NyxID)
-[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/MB5bRa4arr)
+[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/fQw5Nep9)
 
 <p align="center">
   <img src="assets/banner.png" alt="NyxID — Connect AI agents to any API, anywhere. Securely." width="100%">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ChronoAIProject/NyxID)](https://github.com/ChronoAIProject/NyxID)
-[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.com/channels/1422500823925264438/1485570725413650553)
+[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/MB5bRa4arr)
 
 <p align="center">
   <img src="assets/banner.png" alt="NyxID — Connect AI agents to any API, anywhere. Securely." width="100%">

--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ Run NyxID on your own machine. This sets up three Docker containers (database, b
 
 #### AI-assisted (recommended)
 
-If you have Claude Code, Cursor, or any AI coding assistant open, paste this prompt and it will drive the entire self-host flow for you — clone, env generation, Docker stack, health check, optional CLI install, login, first credential, and MCP config:
+If you have Claude Code, Cursor, or any AI coding assistant open, paste the prompt below into it and it will drive the entire self-host flow for you — preflight, clone, env generation, Docker stack, health check, optional CLI install, login, first credential, and MCP config.
+
+<details>
+<summary><strong>Click to expand the full AI-assisted self-host prompt</strong></summary>
 
 > I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively. If anything fails or I'd prefer to follow the manual steps myself, the full step-by-step with troubleshooting is at https://github.com/ChronoAIProject/NyxID/blob/main/docs/QUICKSTART.md.
 > 1. Confirm Docker is installed and running before touching anything (check `git`, `docker`, `openssl`, `curl`, `docker compose` v2, and `docker info`).
@@ -128,6 +131,8 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste this pro
 > 4. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
 > 5. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer will pull the Rust toolchain (~300 MB) if I don't have it, and that the first build takes 3–10 minutes and ~1.5 GB of disk. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh, then `source ~/.cargo/env`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, and verify with `nyxid proxy request llm-openai models`. If I say no, walk me through adding the same OpenAI credential in the web console instead.
 > 6. Finish by connecting my AI tool to NyxID's MCP endpoint at `http://localhost:3001/mcp`. For Claude Code: `claude mcp add --transport http nyxid http://localhost:3001/mcp`. For Codex: `codex mcp add nyxid --url http://localhost:3001/mcp`. For Cursor: open **Settings > MCP** in the web console and click **Install to Cursor**.
+
+</details>
 
 <!-- AI quickstart maintenance: validate this prompt against actual CLI + web console on each release -->
 
@@ -145,6 +150,27 @@ Once NyxID is running, jump to [Connecting AI Services](#connecting-ai-services)
 
 For production deployment (TLS, custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
+## Connecting AI Services
+
+After NyxID is running (hosted or self-host), the next step is to connect a downstream API — OpenAI, Anthropic, GitHub, your private API, anything — so your AI agents can call it through the proxy without ever seeing the raw key.
+
+> **Wiring MCP alone won't show real tools.** Until you also connect a real downstream service *and* verify the proxy works, your AI agent will only see NyxID's `nyx__...` meta-tools — that's the trap behind issue [#298](https://github.com/ChronoAIProject/NyxID/issues/298). The flow below does both steps in one paste; the manual paths in [docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md) make the connect-and-verify step explicit.
+
+The full walkthrough is at **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** — base-URL-agnostic, so the same guide works for hosted (`https://nyx.chrono-ai.fun`) and self-host (`http://localhost:3001`). It covers four paths in order of friction:
+
+- **AI-driven (recommended)** — paste a prompt into Claude Code / Codex / Cursor and let your agent use NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__connect_service`, `nyx__call_tool`) to add and verify your first service end-to-end.
+- **CLI** — `nyxid service add llm-openai --credential-env OPENAI_API_KEY` then `nyxid proxy request llm-openai models` to verify.
+- **Web UI** — dashboard click-through with a "Test request" verify step.
+- **Direct API** — curl + `x-api-key` header for automation and CI.
+
+Whichever path you pick, the verification step (calling a real downstream tool and getting a real response back) is the gate everything hinges on. The doc also has an "Adding more services later" section, so the same guide covers your tenth service the same way it covers your first.
+
+For the AI-driven path: wire MCP first with `claude mcp add --transport http nyxid <BASE_URL>/mcp` (or `codex mcp add nyxid --url <BASE_URL>/mcp`, or Cursor's one-click install) — the first run opens your browser to authenticate. Then paste this into your AI agent:
+
+> Help me connect an AI Service in NyxID. Use `nyx__discover_services` to list what's available in the catalog and ask me which one I want (e.g. OpenAI, Anthropic, GitHub). Once I pick, ask me for the credential I want to use, then call `nyx__connect_service` with the `service_id` from discover results and my credential. After it returns success, call `nyx__search_tools` to confirm the new service's tools are now exposed, then call `nyx__call_tool` on one of them (e.g. list models, list repos) to verify the proxy works end-to-end. Report back with the actual response so I know it's working — not just "looks good." If anything errors, tell me whether it's a credential problem or a service config problem.
+
+<!-- Sync this prompt with docs/CONNECTING_SERVICES.md Path A on every release. -->
+
 ### Reach local services (optional)
 
 Services behind a firewall? Deploy a credential node to punch through NAT and expose them as MCP tools:
@@ -161,27 +187,6 @@ nyxid node credentials setup --service my-local-api --api-url http://localhost:8
 # Import endpoints as MCP tools (if the service has an OpenAPI spec)
 nyxid catalog endpoints my-local-api
 ```
-
-## Connecting AI Services
-
-After NyxID is running (hosted or self-host), the next step is to connect a downstream API — OpenAI, Anthropic, GitHub, your private API, anything — so your AI agents can call it through the proxy without ever seeing the raw key.
-
-> **Connect a service *before* wiring up MCP.** Otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken.
-
-The full walkthrough is at **[docs/CONNECTING_SERVICES.md](docs/CONNECTING_SERVICES.md)** — base-URL-agnostic, so the same guide works for hosted (`https://nyx.chrono-ai.fun`) and self-host (`http://localhost:3001`). It covers four paths in order of friction:
-
-- **AI-driven (recommended)** — paste a prompt into Claude Code / Codex / Cursor and let your agent use NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__connect_service`, `nyx__call_tool`) to add and verify your first service end-to-end.
-- **CLI** — `nyxid service add llm-openai --credential-env OPENAI_API_KEY` then `nyxid proxy request llm-openai models` to verify.
-- **Web UI** — dashboard click-through with a "Test request" verify step.
-- **Direct API** — curl examples for automation and CI.
-
-Whichever path you pick, the verification step (calling a real downstream tool and getting a real response back) is the gate everything hinges on. The doc also has an "Adding more services later" section, so the same guide covers your tenth service the same way it covers your first.
-
-For the AI-driven path: after `nyxid login --base-url <BASE_URL>` and `claude mcp add --transport http nyxid <BASE_URL>/mcp` (or Codex / Cursor equivalents), paste this into your agent:
-
-> Help me connect an AI Service in NyxID. Use `nyx__discover_services` to list what's available in the catalog and ask me which one I want (e.g. OpenAI, Anthropic, GitHub). Once I pick, ask me for the credential I want to use, then call `nyx__connect_service` with the `service_id` from discover results and my credential. After it returns success, call `nyx__search_tools` to confirm the new service's tools are now exposed, then call `nyx__call_tool` on one of them (e.g. list models, list repos) to verify the proxy works end-to-end. Report back with the actual response so I know it's working — not just "looks good." If anything errors, tell me whether it's a credential problem or a service config problem.
-
-<!-- Sync this prompt with docs/CONNECTING_SERVICES.md Path A on every release. -->
 
 ## Use Cases
 

--- a/docs/CONNECTING_SERVICES.md
+++ b/docs/CONNECTING_SERVICES.md
@@ -23,20 +23,21 @@ If you're on hosted and don't have an account yet, sign up at [nyx.chrono-ai.fun
 
 ## The 5-second mental model
 
-NyxID stores your credentials encrypted, then proxies your AI agent's requests to the real downstream API and injects the credential server-side. Connecting a service is always:
+NyxID stores your credentials encrypted, then proxies your AI agent's requests to the real downstream API and injects the credential server-side. Connecting a service has three substeps that need to happen at some point:
 
 1. Pick a service from the catalog (or define a custom one)
 2. Provide its credential
-3. **Verify the proxy actually works** before you wire MCP
-4. Then your AI agent can use it
+3. **Verify the proxy actually works** — call a real downstream tool, get a real response back
 
-Step 3 is the gate everything hinges on. Skip it and you'll spend 20 minutes wondering why MCP only shows `nyx__...` tools.
+The trap from issue [#298](https://github.com/ChronoAIProject/NyxID/issues/298) is wiring MCP **without** doing the three substeps. Your AI agent then sees only NyxID's `nyx__...` meta-tools and there's nothing real to call.
+
+Below you have four paths that complete the substeps. The **AI-driven path** uses an MCP-connected agent to do them itself, so MCP must be wired first. The **manual paths** (CLI, web UI, curl) don't depend on MCP at all — you can wire MCP whenever, or never. Either way, all that matters is that the three substeps actually happen.
 
 ---
 
 ## Step 1 — Get authenticated
 
-You need NyxID auth before MCP or any of the manual paths will work. Pick the route that matches what you'll use in Step 2.
+You need NyxID auth before any of the steps below will work. Pick the route that matches what you'll use next.
 
 **Using Claude Code, Codex, or Cursor (most users):** skip ahead to Step 2. The `claude mcp add` / `codex mcp add` commands open a browser the first time and authenticate you interactively via OAuth — there's no separate login step.
 
@@ -170,18 +171,18 @@ Same flow, skip the steps you've already done:
 - **Web UI users:** **AI Services → Add Service** any time.
 - **Bulk setup:** the API path scales — loop `POST /api/v1/keys` over your credentials with a small script.
 
-You can also rotate credentials on existing services from the same surfaces — `nyxid service rotate <slug>`, **AI Services → \[service\] → Rotate Credential**, or `PUT /api/v1/keys/<id>`.
+You can also rotate credentials on existing services from the same surfaces — `nyxid service rotate-credential <id> --credential-env <NEW_ENV_VAR>` (use `nyxid service list` to find the service ID), **AI Services → \[service\] → Rotate Credential**, or `PUT /api/v1/keys/<id>`.
 
 ---
 
 ## Connecting custom (non-catalog) services
 
-Got a private API NyxID's catalog doesn't know about? You can still connect it:
+Got a private API NyxID's catalog doesn't know about? You can still connect it. The slug is positional and the URL flag is `--endpoint-url`:
 
 ```bash
-nyxid service add --custom \
-  --slug my-internal-api \
-  --endpoint https://internal.example.com \
+nyxid service add my-internal-api \
+  --custom \
+  --endpoint-url https://internal.example.com \
   --credential-env MY_API_KEY \
   --auth-method bearer
 ```

--- a/docs/CONNECTING_SERVICES.md
+++ b/docs/CONNECTING_SERVICES.md
@@ -34,32 +34,29 @@ Step 3 is the gate everything hinges on. Skip it and you'll spend 20 minutes won
 
 ---
 
-## Step 1 — Get authenticated (one-time, ~30 seconds)
+## Step 1 — Get authenticated
 
-Before anything else you need a NyxID auth credential. Two ways:
+You need NyxID auth before MCP or any of the manual paths will work. Pick the route that matches what you'll use in Step 2.
 
-**CLI (recommended)** — installs the `nyxid` CLI if you don't have it, then opens your browser to log in:
+**Using Claude Code, Codex, or Cursor (most users):** skip ahead to Step 2. The `claude mcp add` / `codex mcp add` commands open a browser the first time and authenticate you interactively via OAuth — there's no separate login step.
 
-```bash
-nyxid login --base-url <BASE_URL>
-```
-
-Don't have the CLI yet? One-line install:
+**Using the `nyxid` CLI:** install it if you don't have it, then run `nyxid login`:
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh)"
 source ~/.cargo/env
+nyxid login --base-url <BASE_URL>
 ```
 
-**Or** — if you'd rather not install anything: open `<BASE_URL>` in your browser, sign in, go to **Settings → API Keys → Create**, and copy the key. You'll paste it into your AI agent's MCP config in Step 2.
+The login command opens your browser and stores a session locally. The CLI and any subsequent `claude mcp add` / `codex mcp add` will reuse it.
 
-> Already logged in from a previous session? Skip to Step 2.
+**Using a headless HTTP client (curl, n8n, Zapier, custom code, CI/CD):** open the web console (`https://nyx.chrono-ai.fun` for hosted, `http://localhost:3000` for self-host), sign in, go to **AI Services → API Keys → Create**, and copy the raw key. You'll pass it as an `x-api-key` header on every request. There's no `claude mcp add` for this route — your tool talks to NyxID directly.
 
 ---
 
 ## Step 2 — Wire your AI agent to NyxID's MCP endpoint
 
-So your agent can see NyxID at all. Pick whichever AI tool you use:
+So your AI agent can see NyxID at all. Pick whichever AI tool you use:
 
 ```bash
 # Claude Code
@@ -68,12 +65,15 @@ claude mcp add --transport http nyxid <BASE_URL>/mcp
 # Codex
 codex mcp add nyxid --url <BASE_URL>/mcp
 
-# Cursor — open <BASE_URL> in browser, go to Settings → MCP, click "Install to Cursor"
+# Cursor — open the web console (https://nyx.chrono-ai.fun for hosted, http://localhost:3000
+# for self-host), go to Settings → MCP, click "Install to Cursor"
 ```
 
-The first run uses your credentials from Step 1. After this, your AI agent will see NyxID's `nyx__discover_services`, `nyx__connect_service`, `nyx__search_tools`, and `nyx__call_tool` meta-tools — but **not yet** any real downstream tools, because you haven't connected a real service yet. That's Step 3.
+The first run of `claude mcp add` / `codex mcp add` opens a browser to authenticate you (OAuth) and stores a session. If you already ran `nyxid login` from Step 1, the session is reused and there's no second prompt.
 
-> Already wired up from a previous session? Skip to Step 3.
+After this, your AI agent will see NyxID's `nyx__discover_services`, `nyx__connect_service`, `nyx__search_tools`, and `nyx__call_tool` meta-tools — but **not yet** any real downstream tools, because you haven't connected a real service yet. That's Step 3. **Don't stop here**, or you'll hit issue [#298](https://github.com/ChronoAIProject/NyxID/issues/298).
+
+> **Headless HTTP client?** There is no `mcp add` for n8n / Zapier / curl. Skip directly to Step 3 Path D and pass `x-api-key: <YOUR_KEY>` (from Step 1) on every request to `<BASE_URL>/api/v1/...` and `<BASE_URL>/mcp`.
 
 ---
 
@@ -112,7 +112,9 @@ If `proxy request` returns a real response, your service is connected and the cr
 
 If you'd rather click through:
 
-1. Open `<BASE_URL>:3000` in your browser (or just `<BASE_URL>` for hosted) and sign in.
+1. Open the **web console** in your browser and sign in. The console URL is **not the same as `<BASE_URL>`** — it's the dashboard, a separate port from the API:
+   - **Hosted:** `https://nyx.chrono-ai.fun`
+   - **Self-host:** `http://localhost:3000` (port 3000, while the API runs on 3001)
 2. Click **AI Services** in the sidebar → **Add Service**.
 3. Pick a service from the catalog (OpenAI, Anthropic, GitHub, etc.).
 4. Paste the credential it asks for.

--- a/docs/CONNECTING_SERVICES.md
+++ b/docs/CONNECTING_SERVICES.md
@@ -1,0 +1,197 @@
+# Connecting AI Services to NyxID
+
+How to connect a downstream API (OpenAI, GitHub, Anthropic, your private API, anything) to NyxID so your AI agents can call it through the proxy without ever seeing the raw credential.
+
+This guide works for both deployment modes — **hosted** (`https://nyx.chrono-ai.fun`) and **self-host** (`http://localhost:3001`). It also works for your **first service** and your **tenth**.
+
+> **If your MCP client only shows `nyx__...` tools and nothing else, you have not connected a real AI Service yet.** That's exactly what this guide fixes. Skip to [Step 3](#step-3--connect-your-first-service).
+
+---
+
+## Pick your base URL
+
+Substitute `<BASE_URL>` everywhere in this guide with whichever applies to you:
+
+| Deployment | `<BASE_URL>` |
+|---|---|
+| Hosted (closed beta) | `https://nyx.chrono-ai.fun` |
+| Self-host (default) | `http://localhost:3001` |
+
+If you're on hosted and don't have an account yet, sign up at [nyx.chrono-ai.fun](https://nyx.chrono-ai.fun) (currently invite-only — [join the waitlist](https://nyx.chrono-ai.fun/#waitlist)). If you're self-hosting and don't have NyxID running yet, see [docs/QUICKSTART.md](QUICKSTART.md) first.
+
+---
+
+## The 5-second mental model
+
+NyxID stores your credentials encrypted, then proxies your AI agent's requests to the real downstream API and injects the credential server-side. Connecting a service is always:
+
+1. Pick a service from the catalog (or define a custom one)
+2. Provide its credential
+3. **Verify the proxy actually works** before you wire MCP
+4. Then your AI agent can use it
+
+Step 3 is the gate everything hinges on. Skip it and you'll spend 20 minutes wondering why MCP only shows `nyx__...` tools.
+
+---
+
+## Step 1 — Get authenticated (one-time, ~30 seconds)
+
+Before anything else you need a NyxID auth credential. Two ways:
+
+**CLI (recommended)** — installs the `nyxid` CLI if you don't have it, then opens your browser to log in:
+
+```bash
+nyxid login --base-url <BASE_URL>
+```
+
+Don't have the CLI yet? One-line install:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/tools/install.sh)"
+source ~/.cargo/env
+```
+
+**Or** — if you'd rather not install anything: open `<BASE_URL>` in your browser, sign in, go to **Settings → API Keys → Create**, and copy the key. You'll paste it into your AI agent's MCP config in Step 2.
+
+> Already logged in from a previous session? Skip to Step 2.
+
+---
+
+## Step 2 — Wire your AI agent to NyxID's MCP endpoint
+
+So your agent can see NyxID at all. Pick whichever AI tool you use:
+
+```bash
+# Claude Code
+claude mcp add --transport http nyxid <BASE_URL>/mcp
+
+# Codex
+codex mcp add nyxid --url <BASE_URL>/mcp
+
+# Cursor — open <BASE_URL> in browser, go to Settings → MCP, click "Install to Cursor"
+```
+
+The first run uses your credentials from Step 1. After this, your AI agent will see NyxID's `nyx__discover_services`, `nyx__connect_service`, `nyx__search_tools`, and `nyx__call_tool` meta-tools — but **not yet** any real downstream tools, because you haven't connected a real service yet. That's Step 3.
+
+> Already wired up from a previous session? Skip to Step 3.
+
+---
+
+## Step 3 — Connect your first service
+
+This is the headline. Four paths, in order of how friction-free they are. Pick whichever you like — they all do the same thing and any of them satisfies issue #298's "verify before MCP" gate.
+
+### Path A — AI-driven (recommended)
+
+Paste this prompt into your AI agent (now MCP-connected from Step 2):
+
+> Help me connect an AI Service in NyxID. Use `nyx__discover_services` to list what's available in the catalog and ask me which one I want (e.g. OpenAI, Anthropic, GitHub). Once I pick, ask me for the credential I want to use (API key, token, etc.), then call `nyx__connect_service` with the `service_id` from discover results and my credential. After it returns success, call `nyx__search_tools` to confirm the new service's tools are now exposed, then call `nyx__call_tool` on one of them (e.g. list models, list repos) to verify the proxy works end-to-end. Report back with the actual response so I know it's working — not just "looks good." If anything errors, tell me whether it's a credential problem or a service config problem.
+
+That's it. The agent walks you through everything: discover → ask → connect → search → call. The final `nyx__call_tool` is your verify-gate — if it returns a real downstream response (a list of OpenAI models, a list of GitHub repos, etc.), the chain is working end-to-end.
+
+If the agent only manages to call `nyx__discover_services` and stops there, it doesn't have a tool problem — it has an instruction problem. Re-paste the prompt and tell it explicitly to keep going through all five steps.
+
+### Path B — CLI
+
+If you'd rather drive it yourself, three commands:
+
+```bash
+# 1. Connect a service from the catalog (e.g. OpenAI). Set OPENAI_API_KEY in your shell first.
+nyxid service add llm-openai --credential-env OPENAI_API_KEY
+
+# 2. Verify the proxy works end-to-end. You should see a real JSON list of models.
+nyxid proxy request llm-openai models
+
+# 3. (Optional) See what the catalog has if you want a different service.
+nyxid catalog list
+```
+
+If `proxy request` returns a real response, your service is connected and the credential is good. Done.
+
+### Path C — Web UI
+
+If you'd rather click through:
+
+1. Open `<BASE_URL>:3000` in your browser (or just `<BASE_URL>` for hosted) and sign in.
+2. Click **AI Services** in the sidebar → **Add Service**.
+3. Pick a service from the catalog (OpenAI, Anthropic, GitHub, etc.).
+4. Paste the credential it asks for.
+5. On the new service's detail page, click **Test request** (or use the "Try it" panel) to verify the proxy works. You should see a real downstream response, not an error.
+
+### Path D — Direct API (for automation)
+
+For scripting, CI/CD, or integrating with a config-management tool, hit the REST endpoints directly:
+
+```bash
+# Replace <TOKEN> with your bearer token (from `nyxid login`) or use x-api-key.
+
+# Connect a service from the catalog
+curl -X POST <BASE_URL>/api/v1/keys \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "catalog_slug": "llm-openai",
+    "credential": "sk-...",
+    "label": "production-openai"
+  }'
+
+# Verify the proxy works — should return a real OpenAI models response
+curl -X GET <BASE_URL>/api/v1/proxy/s/llm-openai/models \
+  -H "Authorization: Bearer <TOKEN>"
+```
+
+Same as the CLI path under the hood — these are the exact endpoints `nyxid service add` and `nyxid proxy request` call. Use this when you don't want a CLI dependency in your automation environment.
+
+---
+
+## Did it work?
+
+After connecting a service via any of the four paths above, reconnect your AI agent to MCP (some clients pick up new tools automatically; others need a restart). You should now see real downstream tools — `chat_completions`, `list_models`, `get_repo`, etc. — **alongside** the `nyx__...` meta-tools.
+
+If you only see `nyx__...` tools after reconnecting, the service didn't actually get connected. Common causes:
+
+- The credential was wrong (re-run with the correct value)
+- The catalog slug doesn't match (run `nyxid catalog list` to find the exact slug)
+- You connected the service to a different account than the one your MCP client is authenticated as
+- Your MCP client cached the old tool list — restart it
+
+Use `nyx__search_tools` from your AI agent (or `nyxid service list` from the CLI) to confirm what tools NyxID *thinks* it has exposed for you. If `nyx__search_tools` returns nothing, the service isn't connected on the NyxID side — the bug is upstream of MCP.
+
+---
+
+## Adding more services later
+
+Same flow, skip the steps you've already done:
+
+- **Already authenticated and MCP-wired?** Jump straight to [Step 3](#step-3--connect-your-first-service) and pick your favorite path. The AI prompt in Path A handles the Nth service the same way it handles the first.
+- **CLI users:** `nyxid service add <slug> --credential-env <ENV_VAR>` and you're done. `nyxid catalog list` to browse what's available.
+- **Web UI users:** **AI Services → Add Service** any time.
+- **Bulk setup:** the API path scales — loop `POST /api/v1/keys` over your credentials with a small script.
+
+You can also rotate credentials on existing services from the same surfaces — `nyxid service rotate <slug>`, **AI Services → \[service\] → Rotate Credential**, or `PUT /api/v1/keys/<id>`.
+
+---
+
+## Connecting custom (non-catalog) services
+
+Got a private API NyxID's catalog doesn't know about? You can still connect it:
+
+```bash
+nyxid service add --custom \
+  --slug my-internal-api \
+  --endpoint https://internal.example.com \
+  --credential-env MY_API_KEY \
+  --auth-method bearer
+```
+
+For services behind a firewall (localhost, internal-only), see [docs/NODE_PROXY.md](NODE_PROXY.md) for the credential node setup that punches through NAT.
+
+---
+
+## Related docs
+
+- [docs/QUICKSTART.md](QUICKSTART.md) — self-host setup (Docker, account creation)
+- [docs/MCP_DELEGATION_FLOW.md](MCP_DELEGATION_FLOW.md) — how MCP auth + delegation work under the hood
+- [docs/AI_AGENT_PLAYBOOK.md](AI_AGENT_PLAYBOOK.md) — patterns for using NyxID from agent code
+- [docs/NODE_PROXY.md](NODE_PROXY.md) — connecting localhost / private-network services via credential nodes
+- [docs/API.md](API.md) — full REST endpoint reference

--- a/docs/CONNECTING_SERVICES.md
+++ b/docs/CONNECTING_SERVICES.md
@@ -80,7 +80,7 @@ After this, your AI agent will see NyxID's `nyx__discover_services`, `nyx__conne
 
 ## Step 3 — Connect your first service
 
-This is the headline. Four paths, in order of how friction-free they are. Pick whichever you like — they all do the same thing and any of them satisfies issue #298's "verify before MCP" gate.
+This is the headline. Four paths, in order of how friction-free they are. Pick whichever you like — they all complete the three substeps from the mental model above and avoid the issue #298 trap (where MCP is wired but no real service is connected, so the agent only sees `nyx__...` meta-tools).
 
 ### Path A — AI-driven (recommended)
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -160,9 +160,9 @@ nyxid --version                                   # verify
 
 ## Connect your AI tool
 
-Once your stack is up and you've registered an account, the next step is to connect a real downstream AI Service (OpenAI, Anthropic, GitHub, etc.) and verify the proxy works **before** you wire MCP — otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and you'll wonder why nothing's working.
+Once your stack is up and you've registered an account, the next step is to connect a real downstream AI Service (OpenAI, Anthropic, GitHub, etc.) and verify the proxy actually works. **Wiring MCP alone won't show real tools** — until a real service is connected and verified, your AI agent will only see NyxID's `nyx__...` meta-tools and you'll wonder why nothing's working.
 
-That whole flow lives in **[docs/CONNECTING_SERVICES.md](CONNECTING_SERVICES.md)**. It's base-URL-agnostic and covers all four paths (AI-driven, CLI, web console, direct API). Use `http://localhost:3001` as your `<BASE_URL>` for self-host.
+The full flow lives in **[docs/CONNECTING_SERVICES.md](CONNECTING_SERVICES.md)**. It's base-URL-agnostic and covers all four paths (AI-driven, CLI, web console, direct API). Use `http://localhost:3001` as your `<BASE_URL>` for self-host.
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -160,35 +160,9 @@ nyxid --version                                   # verify
 
 ## Connect your AI tool
 
-Pick one of these:
+Once your stack is up and you've registered an account, the next step is to connect a real downstream AI Service (OpenAI, Anthropic, GitHub, etc.) and verify the proxy works **before** you wire MCP — otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and you'll wonder why nothing's working.
 
-### Manual CLI
-
-```bash
-# Log in (opens browser for authentication)
-nyxid login --base-url http://localhost:3001
-
-# Add your first API credential (e.g. OpenAI — make sure OPENAI_API_KEY is set in your shell)
-nyxid service add llm-openai --credential-env OPENAI_API_KEY
-
-# Verify — you should see a JSON response listing models
-nyxid proxy request llm-openai models
-```
-
-If the proxy returns data, the full chain works: credential stored, injected, downstream accepted.
-
-To connect your AI tool to NyxID's MCP endpoint (`http://localhost:3001/mcp`):
-
-- **Claude Code** — `claude mcp add --transport http nyxid http://localhost:3001/mcp`
-- **Codex** — `codex mcp add nyxid --url http://localhost:3001/mcp`
-- **Cursor** — open **Settings > MCP** in the web console (`http://localhost:3000`) and click **Install to Cursor** for a one-click deeplink install
-
-### Web console
-
-Prefer a GUI (Graphical User Interface)? Everything above can also be done through the web console at `http://localhost:3000`:
-
-- **AI Services** — add API credentials (OpenAI, Anthropic, GitHub, etc.)
-- **Settings > MCP** — one-click install for Cursor, or grab the `claude mcp add` / `codex mcp add` command for Claude Code and Codex
+That whole flow lives in **[docs/CONNECTING_SERVICES.md](CONNECTING_SERVICES.md)**. It's base-URL-agnostic and covers all four paths (AI-driven, CLI, web console, direct API). Use `http://localhost:3001` as your `<BASE_URL>` for self-host.
 
 ---
 

--- a/frontend/src/pages/keys.tsx
+++ b/frontend/src/pages/keys.tsx
@@ -265,10 +265,19 @@ function ServicesEmptyState({ onAdd }: { readonly onAdd: () => void }) {
         <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border">
           <KeyRound className="h-6 w-6 text-muted-foreground" />
         </div>
-        <div className="text-center">
+        <div className="max-w-md space-y-2 text-center">
           <p className="text-sm font-medium">No AI services yet</p>
           <p className="text-xs text-muted-foreground">
-            Add an AI service to connect to external APIs through NyxID.
+            Connect a downstream service (OpenAI, GitHub, Anthropic, etc.) so your
+            AI agents can call it through NyxID without ever seeing the raw key.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Connect a service <span className="font-medium">before</span> wiring
+            up MCP &mdash; otherwise your AI agent will only see NyxID&apos;s{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-[0.7rem]">
+              nyx__&hellip;
+            </code>{" "}
+            meta-tools and proxy requests will look broken.
           </p>
         </div>
         <Button size="sm" onClick={onAdd}>


### PR DESCRIPTION
Closes #298

## Summary

The README hosted quickstart told users to "add API credentials through the dashboard" without making it clear they had to first connect a real downstream service before MCP would surface anything beyond the `nyx__...` meta-tools. New users wired up MCP, saw only `nyx__discover_services` / `nyx__connect_service` / `nyx__call_tool`, and got stuck.

This PR fixes the trap on **both surfaces** the user actually touches — the docs and the dashboard empty state — in one change so issue #298 lands atomically.

## Changes

### Docs side

#### New: `docs/CONNECTING_SERVICES.md`

Base-URL-agnostic guide for connecting your first (or Nth) AI Service. Top-of-file callout warns about the "only `nyx__` tools" trap. Then:

- **Step 1 — Get authenticated (~30s)**: `nyxid login --base-url <BASE_URL>`, with a one-line CLI installer for first-time users, plus a no-CLI fallback (mint an API key in the dashboard).
- **Step 2 — Wire MCP**: `claude mcp add` / `codex mcp add` / Cursor one-click.
- **Step 3 — Connect your first service** (the headline): four paths, in order of friction:
  - **Path A — AI-driven (recommended)**: paste a prompt into your AI agent, it uses `nyx__discover_services` → `nyx__connect_service` → `nyx__search_tools` → `nyx__call_tool` to add and verify the service end-to-end. The final `nyx__call_tool` *is* the verify-gate — it returns a real downstream response or it errors loudly.
  - **Path B — CLI**: `nyxid service add llm-openai --credential-env OPENAI_API_KEY` then `nyxid proxy request llm-openai models` to verify.
  - **Path C — Web UI**: dashboard click-through with the "Test request" verify step.
  - **Path D — Direct API (curl)**: for automation/CI.
- **Did it work?** troubleshooting section listing the common causes of "I only see `nyx__...` tools."
- **Adding more services later**: skip the bootstrap, jump straight to Step 3 — works for the Nth service the same way it works for the first.
- **Connecting custom (non-catalog) services**: pointer at `nyxid service add --custom` and `docs/NODE_PROXY.md` for firewall-locked targets.

#### `README.md`

- **Option A: Hosted** — replaced the one-line vague blurb with an explicit 3-step list (sign up → use `https://nyx.chrono-ai.fun` as your `<BASE_URL>` → follow `docs/CONNECTING_SERVICES.md`), with a direct callout to issue #298.
- **Option B: Self-host → Manual setup** — split the old combined "first credential / MCP wiring" line into two items, the second pointing at `docs/CONNECTING_SERVICES.md` with explicit "verify proxy *before* wiring MCP" framing.
- **Resources table** — new "Connecting Services" row at the top, framed as "Add your first (or Nth) AI Service — works for hosted + self-host."

#### `docs/QUICKSTART.md`

- Gutted the duplicate **Manual CLI** and **Web console** subsections under `## Connect your AI tool`. Codex flagged that they had the same verify-gate bug as the README — they listed CLI service-add and MCP wiring as co-equal options without making "verify before MCP" mandatory. Replaced with a short pointer at the new `docs/CONNECTING_SERVICES.md`.
- The parent `## Connect your AI tool` heading is preserved so existing cross-doc links to `#connect-your-ai-tool` keep working.

### Dashboard side

#### `frontend/src/pages/keys.tsx`

`ServicesEmptyState` (the "no AI services yet" card on a fresh account) now leads with what the feature does in plain English ("Connect a downstream service so your AI agents can call it through NyxID without ever seeing the raw key") and then explicitly states the verify-before-MCP gate ("Connect a service **before** wiring up MCP — otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken").

The `nyx__...` token name is kept on purpose — it's what users will actually see in their MCP client when they hit the trap, so naming it lets them recognize the symptom and trace it back to the page that warned them.

Without this, a user who lands directly on `/keys` (skipping the README) hits the same wall the docs PR is trying to fix. Both surfaces need to teach the same thing.

## Codex consult

I asked Codex (session `019d8ab2`) to sanity-check the design before drafting. Two things it pushed back on, and how this PR handled them:

1. **"MCP-first is wrong order — `/mcp` is authenticated, you can't bootstrap from it."** Codex was right. The doc honors this: Steps 1+2 are explicit auth bootstrap (`nyxid login` or dashboard API key) *before* anything tries to talk to `/mcp`. AI-driven setup is then Step 3, framed as "after you're MCP-authenticated."
2. **"The same trap exists in `docs/QUICKSTART.md` and in `frontend/src/pages/keys.tsx:261`, not just the README."** Codex spotted that the just-merged QUICKSTART.md inherited the bug AND the dashboard empty state has it too. This PR fixes all three surfaces in the same change so we don't ship a fix that only papers over part of the problem.

Where this PR consciously diverges from Codex's recommendation: Codex argued for "CLI first, MCP marked advanced" in the path ordering. I kept AI-driven as the headline Step 3 path per @user instruction ("AI first should be clear"), but Codex's underlying concern is satisfied because the doc explicitly bootstraps auth via CLI in Step 1 — so by the time the user hits the AI prompt, they're already authenticated.

## Followup not in this PR

Once a service IS added, the post-add success state and service detail page also don't have a "Test request" / "Verify proxy" affordance. That's a bigger UX change separate from #298 — should be filed as its own issue if anyone agrees it's missing.

## Link audit

All 16 anchor + file links verified against GitHub's actual rendered HTML on this branch via `gh api` HTML render:

- 8 README → `docs/QUICKSTART.md` anchors ✓ (carried over from #304)
- 1 README → `docs/CONNECTING_SERVICES.md` (file link, no anchor) ✓
- 1 `docs/CONNECTING_SERVICES.md` self-anchor (`#step-3--connect-your-first-service`) ✓
- 1 QUICKSTART → README `#quick-start` ✓
- 4 QUICKSTART self-anchors (preserved from #304) ✓
- 1 QUICKSTART → CONNECTING_SERVICES (file link) ✓

All 15 referenced files exist.

## Test plan

- [ ] Render `docs/CONNECTING_SERVICES.md` on GitHub and confirm all four paths (A/B/C/D) read cleanly with no broken formatting
- [ ] Click each link from README's hosted section and from the Resources table
- [ ] Click the new link from `docs/QUICKSTART.md#connect-your-ai-tool` and confirm it resolves
- [ ] **Visual QA on the dashboard empty state** — render `/keys` on a fresh account with zero connected services. Confirm the longer copy still fits cleanly inside the centered card at common viewport widths (mobile 375px, desktop 1280px+) and doesn't push the **Add Service** button off-screen.
- [ ] **Hosted dogfood** — sign in to the hosted console, follow Path A end-to-end (paste the prompt into Claude Code with hosted MCP wired up) and confirm an AI agent can actually drive the discover → connect → verify loop without hand-holding. This is the issue #298 acceptance test.
- [ ] **Self-host dogfood** — same Path A flow with `http://localhost:3001` as BASE_URL
- [ ] Run Path B (CLI) on a fresh account and confirm `nyxid service add llm-openai --credential-env OPENAI_API_KEY && nyxid proxy request llm-openai models` returns a real model list

🤖 Generated with [Claude Code](https://claude.com/claude-code)