### PR TITLE
fix: teach AI Services empty state about the verify-before-MCP gate (#298)

### DIFF
--- a/frontend/src/pages/keys.tsx
+++ b/frontend/src/pages/keys.tsx
@@ -265,10 +265,19 @@ function ServicesEmptyState({ onAdd }: { readonly onAdd: () => void }) {
         <div className="flex h-14 w-14 items-center justify-center rounded-full border border-border">
           <KeyRound className="h-6 w-6 text-muted-foreground" />
         </div>
-        <div className="text-center">
+        <div className="max-w-md space-y-2 text-center">
           <p className="text-sm font-medium">No AI services yet</p>
           <p className="text-xs text-muted-foreground">
-            Add an AI service to connect to external APIs through NyxID.
+            Connect a downstream service (OpenAI, GitHub, Anthropic, etc.) so your
+            AI agents can call it through NyxID without ever seeing the raw key.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Connect a service <span className="font-medium">before</span> wiring
+            up MCP &mdash; otherwise your AI agent will only see NyxID&apos;s{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-[0.7rem]">
+              nyx__&hellip;
+            </code>{" "}
+            meta-tools and proxy requests will look broken.
           </p>
         </div>
         <Button size="sm" onClick={onAdd}>


### PR DESCRIPTION
Companion to docs PR #307.

## Problem

During Codex review of issue #298, it flagged that the dashboard's "no AI services yet" empty state at `frontend/src/pages/keys.tsx:261` is the exact UX surface where new users get trapped:

> The UI empty state at frontend/src/pages/keys.tsx:261 says "Add an AI service" but does not itself teach "verify proxy before MCP".

So even after #307 lands the docs fix, a user who lands directly on the AI Services page (skipping the README) hits the same wall: they click **Add Service**, paste a credential, then go wire MCP and end up wondering why their AI agent only sees `nyx__discover_services`, `nyx__connect_service`, and `nyx__call_tool`.

The empty state is the right place to put the warning — it's the literal first thing a new user sees on the page.

## Change

Single file, copy-only (no behavior change):

`frontend/src/pages/keys.tsx` — `ServicesEmptyState` now leads with what the feature does in plain English ("Connect a downstream service so your AI agents can call it through NyxID without ever seeing the raw key") and then explicitly states the verify-before-MCP gate ("Connect a service **before** wiring up MCP — otherwise your AI agent will only see NyxID's `nyx__...` meta-tools and proxy requests will look broken"). Text container constrained to `max-w-md` so the longer copy still reads cleanly inside the centered card.

The `nyx__...` token name is kept on purpose — it's what users will actually see in their MCP client when they hit the trap, so naming it lets them recognize the symptom and trace it back to "oh, this is the page that warned me about that."

## Why a separate PR from #307

Two reasons:
1. **Independent landing.** Either PR can merge first; neither blocks the other. Together they close the loop on #298 across both the docs and the dashboard.
2. **Different reviewers.** #307 is docs-only; this one touches frontend code. Splitting them lets the right people focus on the right diff without having to scroll past unrelated changes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint -- src/pages/keys.tsx` clean (the 7 warnings on the full repo lint are all pre-existing in unrelated files)
- [x] Pre-commit hook passed
- [ ] **Visual QA needed:** I did not spin up the dev server to render the empty state in a browser, because reaching it requires a fresh account with zero connected services and the worktree didn't have a running backend. Reviewer should verify the centered layout still looks right at common viewport widths (mobile 375px, desktop 1280px+) and that the longer copy doesn't push the **Add Service** button off-card.
- [ ] (Followup, lower priority) Once a service IS added, the post-add success state and the service detail page also don't have a "Test request" / "Verify proxy" affordance. That's a bigger UX change and out of scope here, but worth filing as a separate issue if anyone agrees it's missing.

## Related

- Closes the dashboard half of [#298](https://github.com/ChronoAIProject/NyxID/issues/298)
- Companion to docs PR #307
- Codex consult session: `019d8ab2` (raised the original concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)