### PR TITLE
feat: include RBAC data in identity assertion JWT

### DIFF
--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -933,7 +933,8 @@ async fn execute_proxy_inner(
                     &state.config,
                     user,
                     &target.service,
-                ) {
+                    &state.db,
+                ).await {
                     Ok(assertion) => {
                         identity_headers.push(("X-NyxID-Identity-Token".to_string(), assertion));
                     }

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -934,7 +934,9 @@ async fn execute_proxy_inner(
                     user,
                     &target.service,
                     &state.db,
-                ).await {
+                )
+                .await
+                {
                     Ok(assertion) => {
                         identity_headers.push(("X-NyxID-Identity-Token".to_string(), assertion));
                     }

--- a/backend/src/services/identity_service.rs
+++ b/backend/src/services/identity_service.rs
@@ -23,6 +23,12 @@ pub struct IdentityAssertionClaims {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub nyx_service_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub groups: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Vec<String>>,
 }
 
 /// SEC-M1: Sanitize a string for use as an HTTP header value.
@@ -81,11 +87,16 @@ pub fn build_identity_headers(user: &User, service: &DownstreamService) -> Vec<(
 
 /// Generate a short-lived signed JWT identity assertion.
 /// Used when service.identity_propagation_mode is "jwt" or "both".
-pub fn generate_identity_assertion(
+///
+/// Resolves the user's RBAC data (roles, groups, permissions) from the
+/// database and includes them in the assertion. This allows downstream
+/// services to make authorization decisions without calling back to NyxID.
+pub async fn generate_identity_assertion(
     jwt_keys: &JwtKeys,
     config: &AppConfig,
     user: &User,
     service: &DownstreamService,
+    db: &mongodb::Database,
 ) -> AppResult<String> {
     let now = Utc::now().timestamp();
 
@@ -93,6 +104,8 @@ pub fn generate_identity_assertion(
         .identity_jwt_audience
         .as_deref()
         .unwrap_or(&service.base_url);
+
+    let rbac = super::rbac_helpers::resolve_user_rbac(db, &user.id).await?;
 
     let claims = IdentityAssertionClaims {
         sub: user.id.clone(),
@@ -112,6 +125,9 @@ pub fn generate_identity_assertion(
             None
         },
         nyx_service_id: service.id.clone(),
+        roles: Some(rbac.role_slugs),
+        groups: Some(rbac.group_slugs),
+        permissions: Some(rbac.permissions),
     };
 
     let mut header = Header::new(Algorithm::RS256);

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -1853,7 +1853,9 @@ pub async fn execute_tool(
                     user,
                     &target.service,
                     db,
-                ).await {
+                )
+                .await
+                {
                     Ok(assertion) => {
                         identity_headers.push(("X-NyxID-Identity-Token".to_string(), assertion));
                     }

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -1852,7 +1852,8 @@ pub async fn execute_tool(
                     config,
                     user,
                     &target.service,
-                ) {
+                    db,
+                ).await {
                     Ok(assertion) => {
                         identity_headers.push(("X-NyxID-Identity-Token".to_string(), assertion));
                     }


### PR DESCRIPTION
## Summary
- Add `roles`, `groups`, `permissions` fields to identity assertion JWT claims
- Downstream services can now read user RBAC data by decoding the `X-NyxID-Identity-Token` header, no callback to NyxID needed

## Why
When NyxID proxy forwards requests to downstream services (like ornn-api), the identity assertion JWT only contains `sub`, `email`, and `name`. Downstream services that need to check user permissions currently have no way to get roles/permissions without calling back to NyxID admin APIs, which requires admin credentials and adds latency.

The user's original access token already has roles/permissions (when `roles` scope is requested), but the proxy intentionally does not forward the `Authorization` header to downstream services (security allowlist). The identity assertion is the designed channel for passing user identity, so it should include RBAC data.

## Changes
- `IdentityAssertionClaims`: added `roles`, `groups`, `permissions` (all `Option<Vec<String>>`, skipped if None)
- `generate_identity_assertion()`: now async, accepts `&mongodb::Database`, calls `resolve_user_rbac()` to populate RBAC claims
- Updated call sites in `handlers/proxy.rs` and `services/mcp_service.rs` to pass `db` and `.await`

## Impact
- Identity assertion JWT size increases slightly (RBAC data added to payload)
- One additional DB query per proxied request (`resolve_user_rbac` does up to 3 MongoDB queries)
- All downstream services using JWT identity propagation mode automatically receive RBAC data

## Test plan
- [x] `cargo check` passes
- [ ] Verify identity assertion JWT contains roles/permissions after service registration with JWT propagation mode
- [ ] Verify downstream service can decode and use RBAC claims