### PR TITLE
fix: hide unconfigured social login providers

### DIFF
--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -180,8 +180,13 @@ export function AuthFlow({
   const strength = getPasswordStrength(regPassword);
   const isInviteValid = INVITE_PATTERN.test(inviteCode.trim().toUpperCase());
 
-  // Always show all social providers — backend errors if not configured
-  const enabledRegisterProviders = REGISTER_PROVIDERS;
+  // Hide social providers whose backend credentials are not configured.
+  // While publicConfig is loading, render none rather than flashing buttons
+  // that may immediately disappear once the config arrives.
+  const enabledProviders = REGISTER_PROVIDERS.filter(
+    (p) => publicConfig?.social_providers.includes(p.id) ?? false,
+  );
+  const hasSocialProviders = enabledProviders.length > 0;
 
   // -- Slide helpers --
   const FADE_MS = 200;
@@ -412,17 +417,18 @@ export function AuthFlow({
                 </form>
               </Form>
 
-              {/* Divider */}
-              <div className="my-6 flex items-center gap-4">
-                <div className="h-px flex-1 bg-border" />
-                <span className="text-xs text-text-tertiary">or</span>
-                <div className="h-px flex-1 bg-border" />
-              </div>
+              {hasSocialProviders && (
+                <div className="my-6 flex items-center gap-4">
+                  <div className="h-px flex-1 bg-border" />
+                  <span className="text-xs text-text-tertiary">or</span>
+                  <div className="h-px flex-1 bg-border" />
+                </div>
+              )}
             </>
           )}
 
           <div className="flex flex-col gap-2">
-            {REGISTER_PROVIDERS.map((provider) => (
+            {enabledProviders.map((provider) => (
               <button
                 key={provider.id}
                 type="button"
@@ -585,7 +591,7 @@ export function AuthFlow({
             </p>
 
             <div className="flex flex-col gap-2">
-              {enabledRegisterProviders.map((provider) => (
+              {enabledProviders.map((provider) => (
                 <button
                   key={provider.id}
                   type="button"


### PR DESCRIPTION
## Summary

- Filters Google / GitHub / Apple buttons on `/login` and `/register` by `publicConfig.social_providers`, so users only see providers that actually work in the current environment.
- The `/api/v1/public/config` endpoint already exposes which providers have credentials and `usePublicConfig` was already fetching it — `auth-flow.tsx:184` had a comment `// Always show all social providers — backend errors if not configured` and explicitly bypassed the fetched value. This wires it through.
- Also hides the "or" divider on the login view when no providers are configured, so we don't render an "or" with nothing below it.
- During the brief loading window the filter resolves to empty, so we don't flash buttons that may immediately disappear once the config arrives.

## Test plan

- [x] `npm run build` (frontend) — clean (tsc -b + vite build)
- [x] `npm run lint` — 0 errors (7 unrelated pre-existing warnings)
- [x] Verified in headless Chrome against a mock backend in three configurations:
  - [x] `social_providers: []` → email-only on both `/login` and `/register`, no "or" divider, no social buttons
  - [x] `social_providers: ["google", "github", "apple"]` → email + divider + all 3 social buttons
  - [x] `social_providers: ["google"]` → email + divider + Google button only (per-provider filter, not all-or-nothing)
- [ ] Reviewer to verify in a real Quickstart environment with no provider env vars set.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)