### PR TITLE
fix: add chunk error boundary for post-deployment lazy load failures

### DIFF
--- a/frontend/src/components/chunk-error-boundary.tsx
+++ b/frontend/src/components/chunk-error-boundary.tsx
@@ -68,8 +68,19 @@ export class ChunkErrorBoundary extends Component<Props, State> {
             textAlign: "center",
           }}
         >
-          <p style={{ fontSize: "1.125rem", marginBottom: "1.5rem" }}>
+          <p style={{ fontSize: "1.125rem", marginBottom: "0.5rem" }}>
             A new version has been deployed.
+          </p>
+          <p
+            style={{
+              fontSize: "0.875rem",
+              color: "#a1a1aa",
+              marginBottom: "1.5rem",
+              maxWidth: "24rem",
+            }}
+          >
+            Your browser has cached an older version of the app. Please reload
+            to get the latest update.
           </p>
           <button
             type="button"

--- a/frontend/src/components/chunk-error-boundary.tsx
+++ b/frontend/src/components/chunk-error-boundary.tsx
@@ -1,0 +1,94 @@
+import { Component, type ReactNode } from "react";
+
+const RELOAD_KEY = "nyxid_chunk_reload";
+
+function isChunkLoadError(error: Error): boolean {
+  const msg = error.message || "";
+  return (
+    msg.includes("Failed to fetch dynamically imported module") ||
+    msg.includes("Importing a module script failed") ||
+    msg.includes("ChunkLoadError") ||
+    /Loading chunk .+ failed/.test(msg)
+  );
+}
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  chunkError: boolean;
+}
+
+export class ChunkErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { chunkError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State | null {
+    if (isChunkLoadError(error)) {
+      return { chunkError: true };
+    }
+    return null;
+  }
+
+  componentDidCatch(error: Error): void {
+    if (!isChunkLoadError(error)) {
+      throw error;
+    }
+
+    // First attempt: auto-reload (guard prevents infinite loop)
+    if (!sessionStorage.getItem(RELOAD_KEY)) {
+      sessionStorage.setItem(RELOAD_KEY, "1");
+      window.location.reload();
+    }
+    // Second attempt: guard is set, so we show the fallback UI
+  }
+
+  render(): ReactNode {
+    if (this.state.chunkError && sessionStorage.getItem(RELOAD_KEY)) {
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            background: "#09090b",
+            color: "#e4e4e7",
+            fontFamily: "system-ui, sans-serif",
+            padding: "1rem",
+            textAlign: "center",
+          }}
+        >
+          <p style={{ fontSize: "1.125rem", marginBottom: "1.5rem" }}>
+            A new version has been deployed.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              sessionStorage.removeItem(RELOAD_KEY);
+              window.location.reload();
+            }}
+            style={{
+              padding: "0.625rem 1.25rem",
+              fontSize: "0.875rem",
+              fontWeight: 500,
+              color: "#09090b",
+              background: "#e4e4e7",
+              border: "none",
+              borderRadius: "0.375rem",
+              cursor: "pointer",
+            }}
+          >
+            Reload page
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/chunk-error-boundary.tsx
+++ b/frontend/src/components/chunk-error-boundary.tsx
@@ -27,27 +27,32 @@ export class ChunkErrorBoundary extends Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error): State | null {
-    if (isChunkLoadError(error)) {
+    if (!isChunkLoadError(error)) {
+      return null;
+    }
+
+    // First chunk error: auto-reload to pick up new assets.
+    // The sessionStorage guard prevents an infinite reload loop.
+    if (!sessionStorage.getItem(RELOAD_KEY)) {
+      sessionStorage.setItem(RELOAD_KEY, "1");
+      window.location.reload();
+      // Return chunkError so React doesn't try to render stale children
+      // while the reload is in progress.
       return { chunkError: true };
     }
-    return null;
+
+    // Reload already happened and chunks still fail — show fallback UI.
+    return { chunkError: true };
   }
 
   componentDidCatch(error: Error): void {
     if (!isChunkLoadError(error)) {
       throw error;
     }
-
-    // First attempt: auto-reload (guard prevents infinite loop)
-    if (!sessionStorage.getItem(RELOAD_KEY)) {
-      sessionStorage.setItem(RELOAD_KEY, "1");
-      window.location.reload();
-    }
-    // Second attempt: guard is set, so we show the fallback UI
   }
 
   render(): ReactNode {
-    if (this.state.chunkError && sessionStorage.getItem(RELOAD_KEY)) {
+    if (this.state.chunkError) {
       return (
         <div
           style={{

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,10 @@ import { router } from "./router";
 import { useAuthStore } from "./stores/auth-store";
 import "./app.css";
 
+// Clear the chunk-reload guard on successful app bootstrap.
+// This ensures future deploys can auto-reload again.
+sessionStorage.removeItem("nyxid_chunk_reload");
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-router";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toast";
+import { ChunkErrorBoundary } from "@/components/chunk-error-boundary";
 import { AuthLayout } from "@/components/layout/auth-layout";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { useAuthStore } from "@/stores/auth-store";
@@ -71,9 +72,11 @@ import {
 const rootRoute = createRootRoute({
   component: () => (
     <TooltipProvider>
-      <Suspense>
-        <Outlet />
-      </Suspense>
+      <ChunkErrorBoundary>
+        <Suspense>
+          <Outlet />
+        </Suspense>
+      </ChunkErrorBoundary>
       <Toaster />
     </TooltipProvider>
   ),


### PR DESCRIPTION
## Summary
- Adds a `ChunkErrorBoundary` React error boundary that catches dynamic import failures (stale chunk hashes after deployment) and auto-reloads the page once to pick up new assets
- Uses a `sessionStorage` guard to prevent infinite reload loops — if the reload doesn't resolve the issue, a fallback UI with a manual "Reload page" button is shown instead of a white screen
- Clears the reload guard on successful app bootstrap so future deploys can auto-reload again

## Test plan
- [ ] Deploy a new frontend build while a tab is open on the old version
- [ ] Navigate to a lazy-loaded route — verify auto-reload picks up new chunks
- [ ] Simulate a broken deploy (e.g. missing chunk) — verify fallback UI appears with reload button instead of white screen
- [ ] Verify normal navigation works without triggering the boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)