### PR TITLE
fix(ui): smooth modal motion and align api-key scope picker with AI Services

### DIFF
--- a/frontend/src/components/dashboard/api-key-create-dialog.tsx
+++ b/frontend/src/components/dashboard/api-key-create-dialog.tsx
@@ -399,6 +399,8 @@ export function ApiKeyCreateDialog() {
                           // `watchTargetOrg` is undefined.
                           const visibleServices = (services ?? []).filter(
                             (s) => {
+                              if (s.auto_connected) return false;
+                              if (!s.is_active) return false;
                               const source = s.credential_source;
                               if (watchTargetOrg) {
                                 return (

--- a/frontend/src/components/dashboard/api-key-detail/service-scope-card.tsx
+++ b/frontend/src/components/dashboard/api-key-detail/service-scope-card.tsx
@@ -59,7 +59,12 @@ export function ServiceScopeCard({
   // filter here is to avoid offering options that would 400 on save.
   const personalKeys = useMemo(
     () =>
-      (allKeys ?? []).filter((k) => sameOwner(k.credential_source, apiKeySource)),
+      (allKeys ?? []).filter(
+        (k) =>
+          !k.auto_connected &&
+          k.is_active &&
+          sameOwner(k.credential_source, apiKeySource),
+      ),
     [allKeys, apiKeySource],
   );
   const updateApiKey = useUpdateApiKey();

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -16,7 +16,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm duration-300 ease-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -33,7 +33,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-6 border border-border bg-surface p-7 shadow-xl shadow-primary/5 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-[14px]",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-6 border border-border bg-surface p-7 shadow-xl shadow-primary/5 duration-300 ease-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 rounded-[14px]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- **Modal motion** — drop the `slide-in-from-left-1/2` / `slide-in-from-top-[48%]` classes on `Dialog` so modals no longer fly in/out from the top-left corner. Keeps fade + zoom-95, bumps duration to `300ms` with `ease-out` (matches DESIGN.md "medium" range and "enter ease-out" guidance). Applies to overlay too so the backdrop fade tracks the panel.
- **API-key Access Scope picker** — filter `useKeys()` results to hide `auto_connected` and inactive services in both the Create dialog (`api-key-create-dialog.tsx`) and the Edit Scope card (`service-scope-card.tsx`). The picker now mirrors what's visible on the AI Services tab; the prior version leaked auto-connected/inactive entries that the user never explicitly added (16+ items in QA).

No backend changes — `useKeys()` already returns the user's own UserService rows and `key_service::validate_service_ids` already validates against `user_services`.

## Test plan
- [ ] `cd frontend && npm install && npm run build` (clean)
- [ ] `npm run test` — 395/395 pass
- [ ] `/keys` → *Add Service* — modal scales gently from center
- [ ] `/keys` → *NyxID API Keys* → *Create API Key* → uncheck *Allow all services* — option count matches the AI Services tab (with *Show auto-connected* off)
- [ ] `/api-keys/{id}` → *Edit Scope* — same filter applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)