### PR TITLE
fix(frontend): split api-key scope from credential overrides

### DIFF
--- a/frontend/src/components/dashboard/api-key-detail/bindings-card.tsx
+++ b/frontend/src/components/dashboard/api-key-detail/bindings-card.tsx
@@ -4,13 +4,11 @@ import {
   useCreateBinding,
   useDeleteBinding,
 } from "@/hooks/use-agent-bindings";
-import { useUpdateApiKey } from "@/hooks/use-api-keys";
 import { useKeys } from "@/hooks/use-keys";
 import { ApiError } from "@/lib/api-client";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import {
   Card,
   CardContent,
@@ -70,18 +68,15 @@ function invalidReasonLabel(reason: string | undefined): string {
 
 export function BindingsCard({
   keyId,
-  allowAllServices,
   apiKeySource,
 }: {
   readonly keyId: string;
-  readonly allowAllServices: boolean;
   readonly apiKeySource?: CredentialSource;
 }) {
   const { data: bindings, isLoading } = useAgentBindings(keyId);
   const { data: allKeys } = useKeys();
   const createBinding = useCreateBinding();
   const deleteBinding = useDeleteBinding();
-  const updateApiKey = useUpdateApiKey();
   const [adding, setAdding] = useState(false);
   const [selectedServiceId, setSelectedServiceId] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<AgentServiceBinding | null>(
@@ -161,7 +156,7 @@ export function BindingsCard({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Link2 className="h-4 w-4 text-primary" />
-            <CardTitle className="text-sm">Service Bindings</CardTitle>
+            <CardTitle className="text-sm">Credential Overrides</CardTitle>
           </div>
           <Button
             size="sm"
@@ -169,61 +164,16 @@ export function BindingsCard({
             onClick={() => setAdding(true)}
             disabled={adding || availableServices.length === 0}
           >
-            Add Service
+            Add Override
           </Button>
         </div>
         <CardDescription>
-          {allowAllServices
-            ? "This agent can access all services. Add bindings to override credentials for specific services."
-            : "This agent can only access services listed below."}
+          Override the default credentials for specific services. Services
+          without an override use the default credential configured on the
+          service itself.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="flex items-center justify-between rounded-lg border border-border p-3">
-          <div className="space-y-0.5">
-            <Label htmlFor="allow-all-toggle" className="text-sm font-medium">
-              Allow all services
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              {allowAllServices
-                ? "Agent uses default credentials; bindings are overrides"
-                : "Agent can only access services with bindings below"}
-            </p>
-          </div>
-          <Switch
-            id="allow-all-toggle"
-            checked={allowAllServices}
-            disabled={updateApiKey.isPending}
-            onCheckedChange={(checked) => {
-              // When restricting, seed allowed_service_ids from current bindings
-              // so the agent doesn't lose access to already-bound services.
-              const boundIds = checked
-                ? undefined
-                : (bindings ?? []).map((b) => b.user_service_id);
-              updateApiKey.mutate(
-                {
-                  keyId,
-                  allow_all_services: checked,
-                  allowed_service_ids: boundIds,
-                },
-                {
-                  onSuccess: () =>
-                    toast.success(
-                      checked
-                        ? "Agent can now access all services"
-                        : "Agent restricted to bound services only",
-                    ),
-                  onError: (err) =>
-                    toast.error(
-                      err instanceof ApiError
-                        ? err.message
-                        : "Failed to update",
-                    ),
-                },
-              );
-            }}
-          />
-        </div>
         {adding && (
           <div className="rounded-lg border border-border p-3 space-y-3">
             <div className="space-y-1.5">
@@ -320,8 +270,8 @@ export function BindingsCard({
           </div>
         ) : (
           <p className="text-xs text-muted-foreground">
-            No credential overrides. This agent uses default credentials for
-            all services.
+            No overrides. This agent uses the default credential configured on
+            each allowed service.
           </p>
         )}
       </CardContent>

--- a/frontend/src/components/dashboard/api-key-detail/service-scope-card.tsx
+++ b/frontend/src/components/dashboard/api-key-detail/service-scope-card.tsx
@@ -105,14 +105,15 @@ export function ServiceScopeCard({
   }
 
   return (
-    <Card>
+    <Card className="md:col-span-2">
       <CardHeader className="pb-3">
         <div className="flex items-center gap-2">
           <Shield className="h-4 w-4 text-primary" />
           <CardTitle className="text-sm">Service Scope</CardTitle>
         </div>
         <CardDescription>
-          Which external services this key can access via proxy
+          Which external services this key can access via proxy. Credential
+          overrides for specific services are managed below.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">

--- a/frontend/src/pages/api-key-detail.tsx
+++ b/frontend/src/pages/api-key-detail.tsx
@@ -111,14 +111,6 @@ export function ApiKeyDetailPage() {
         <PlatformCard keyId={apiKey.id} platform={apiKey.platform} />
         <CallbackUrlCard keyId={apiKey.id} callbackUrl={apiKey.callback_url} />
 
-        <ServiceScopeCard
-          keyId={apiKey.id}
-          allowAllServices={apiKey.allow_all_services}
-          allowedServiceIds={apiKey.allowed_service_ids}
-          allowedServices={apiKey.allowed_services}
-          apiKeySource={apiKey.credential_source}
-        />
-
         <NodeScopeCard
           keyId={apiKey.id}
           allowAllNodes={apiKey.allow_all_nodes}
@@ -132,12 +124,20 @@ export function ApiKeyDetailPage() {
           rateLimitBurst={apiKey.rate_limit_burst}
         />
 
-        <BindingsCard
+        <UsageStatsCard keyId={apiKey.id} />
+
+        <ServiceScopeCard
           keyId={apiKey.id}
           allowAllServices={apiKey.allow_all_services}
+          allowedServiceIds={apiKey.allowed_service_ids}
+          allowedServices={apiKey.allowed_services}
           apiKeySource={apiKey.credential_source}
         />
-        <UsageStatsCard keyId={apiKey.id} />
+
+        <BindingsCard
+          keyId={apiKey.id}
+          apiKeySource={apiKey.credential_source}
+        />
       </div>
 
       <RotateKeyDialog

--- a/frontend/src/pages/api-key-detail.tsx
+++ b/frontend/src/pages/api-key-detail.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "@/components/shared/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { RefreshCw, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, RefreshCw, Trash2 } from "lucide-react";
 import { DetailsCard } from "@/components/dashboard/api-key-detail/details-card";
 import { ServiceScopeCard } from "@/components/dashboard/api-key-detail/service-scope-card";
 import { NodeScopeCard } from "@/components/dashboard/api-key-detail/node-scope-card";
@@ -24,6 +24,7 @@ export function ApiKeyDetailPage() {
   const { data: apiKey, isLoading, error } = useApiKey(keyId);
   const [rotateOpen, setRotateOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   if (isLoading) {
     return (
@@ -109,22 +110,6 @@ export function ApiKeyDetailPage() {
         />
 
         <PlatformCard keyId={apiKey.id} platform={apiKey.platform} />
-        <CallbackUrlCard keyId={apiKey.id} callbackUrl={apiKey.callback_url} />
-
-        <NodeScopeCard
-          keyId={apiKey.id}
-          allowAllNodes={apiKey.allow_all_nodes}
-          allowedNodeIds={apiKey.allowed_node_ids}
-          allowedNodes={apiKey.allowed_nodes}
-        />
-
-        <RateLimitCard
-          keyId={apiKey.id}
-          rateLimitPerSecond={apiKey.rate_limit_per_second}
-          rateLimitBurst={apiKey.rate_limit_burst}
-        />
-
-        <UsageStatsCard keyId={apiKey.id} />
 
         <ServiceScopeCard
           keyId={apiKey.id}
@@ -134,10 +119,58 @@ export function ApiKeyDetailPage() {
           apiKeySource={apiKey.credential_source}
         />
 
-        <BindingsCard
-          keyId={apiKey.id}
-          apiKeySource={apiKey.credential_source}
-        />
+        <div className="md:col-span-2">
+          <UsageStatsCard keyId={apiKey.id} />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <button
+          type="button"
+          onClick={() => setAdvancedOpen((v) => !v)}
+          aria-expanded={advancedOpen}
+          aria-controls="api-key-advanced"
+          className="flex w-full items-center justify-between rounded-lg border border-border bg-card px-4 py-3 text-left text-sm font-medium hover:bg-muted/40"
+        >
+          <span className="flex items-center gap-2">
+            {advancedOpen ? (
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            )}
+            Advanced
+          </span>
+          <span className="text-xs font-normal text-muted-foreground">
+            Callback URL, Node Scope, Rate Limits, Credential Overrides
+          </span>
+        </button>
+
+        {advancedOpen && (
+          <div id="api-key-advanced" className="grid gap-4 md:grid-cols-2">
+            <CallbackUrlCard
+              keyId={apiKey.id}
+              callbackUrl={apiKey.callback_url}
+            />
+
+            <NodeScopeCard
+              keyId={apiKey.id}
+              allowAllNodes={apiKey.allow_all_nodes}
+              allowedNodeIds={apiKey.allowed_node_ids}
+              allowedNodes={apiKey.allowed_nodes}
+            />
+
+            <RateLimitCard
+              keyId={apiKey.id}
+              rateLimitPerSecond={apiKey.rate_limit_per_second}
+              rateLimitBurst={apiKey.rate_limit_burst}
+            />
+
+            <BindingsCard
+              keyId={apiKey.id}
+              apiKeySource={apiKey.credential_source}
+            />
+          </div>
+        )}
       </div>
 
       <RotateKeyDialog

--- a/frontend/src/pages/api-key-detail.tsx
+++ b/frontend/src/pages/api-key-detail.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { RefreshCw, Trash2 } from "lucide-react";
 import { DetailsCard } from "@/components/dashboard/api-key-detail/details-card";
+import { ServiceScopeCard } from "@/components/dashboard/api-key-detail/service-scope-card";
 import { NodeScopeCard } from "@/components/dashboard/api-key-detail/node-scope-card";
 import { RotateKeyDialog } from "@/components/dashboard/api-key-detail/rotate-key-dialog";
 import { DeleteKeyDialog } from "@/components/dashboard/api-key-detail/delete-key-dialog";
@@ -109,6 +110,14 @@ export function ApiKeyDetailPage() {
 
         <PlatformCard keyId={apiKey.id} platform={apiKey.platform} />
         <CallbackUrlCard keyId={apiKey.id} callbackUrl={apiKey.callback_url} />
+
+        <ServiceScopeCard
+          keyId={apiKey.id}
+          allowAllServices={apiKey.allow_all_services}
+          allowedServiceIds={apiKey.allowed_service_ids}
+          allowedServices={apiKey.allowed_services}
+          apiKeySource={apiKey.credential_source}
+        />
 
         <NodeScopeCard
           keyId={apiKey.id}


### PR DESCRIPTION
## Context

On the API key detail page, the "Service Bindings" card was doing three jobs at once: hosting the **Allow all services** toggle, describing access scope (*"This agent can only access services listed below"*), and listing `AgentServiceBinding` credential-override records. When a user picked specific allowed services at creation, the detail page had no surface for them — the card's copy talked about scope while its list showed overrides.

There was also a latent data-loss trap at `bindings-card.tsx:200–202`: toggling "Allow all services" off rewrote `allowed_service_ids` to the current bindings' service ids, silently discarding whatever the user had originally selected at creation.

Separately, the detail page was rendering eight cards of equal visual weight, but four are niche: **Callback URL** (only for channel-bot keys), **Node Scope** (only for users with registered credential nodes), **Rate Limits** (only when overriding user defaults), and **Credential Overrides** (advanced per-agent credential segregation). For typical users these all render empty *"Not set / User default / All"* states, making the page feel noisier than the actual configuration warrants.

Diagnostic verified the backend round-trip is correct:
- `backend/src/services/key_service.rs:184` — `validate_service_ids` runs before insert, so if a key exists its `allowed_service_ids` are real.
- `backend/src/handlers/api_keys.rs:397–408` — `enrich_api_keys_batch` hydrates `allowed_services` from `user_services` by `_id`. Data was fine; the detail page just never rendered it.

## Summary

**Split scope from overrides:**
- **`ServiceScopeCard`** renders the hydrated `allowed_services` as badges and owns the allow-all toggle via its existing edit mode. Empty states: *All services* / *No services (auth-only)*.
- **`BindingsCard`** retitled to **Credential Overrides**. Allow-all toggle, `updateApiKey` dependency, and the silent-rewrite logic removed. Copy reworded to describe what the card actually does ("Override the default credentials for specific services…"). Add/delete override flow unchanged.

**Group advanced cards under a collapsed-by-default toggle:**
- **Always visible:** Details, Platform, Service Scope, Usage Stats.
- **Advanced (click to expand):** Callback URL, Node Scope, Rate Limits, Credential Overrides.
- Inline toggle button with `ChevronRight/ChevronDown`, `aria-expanded` / `aria-controls` wired for a11y. No new UI primitive added — `components/ui/` has no Accordion/Collapsible, and `useState` is sufficient here.

No backend, type, hook, or schema changes — pure frontend restructuring.

## Before / after

Before (from user screenshot): user ticks `llm-openai-codex` at creation → detail page shows *"Service Bindings — This agent can only access services listed below"* followed by *"No credential overrides…"*. The picked service is invisible. Eight cards all at equal weight, most empty.

After: detail page shows Details + Platform on top, a **Service Scope** card displaying the `llm-openai-codex` badge, and Usage Stats. An **Advanced ▸** toggle at the bottom expands to reveal Callback URL, Node Scope, Rate Limits, and **Credential Overrides** whose empty state honestly says *"No overrides. This agent uses the default credential configured on each allowed service."*

## Test plan

- [x] `npm run build` (type-check + Vite build) passes
- [x] `npm run lint` passes (pre-existing warnings only; nothing new on touched files)
- [x] Pre-commit hook (eslint) passes
- [ ] Manual: create an agent key, tick one allowed service, open detail page → Service Scope shows that service as a badge; Advanced is collapsed by default
- [ ] Manual: expand Advanced → Callback URL, Node Scope, Rate Limits, Credential Overrides render; collapse works
- [ ] Manual: toggle "Allow all services" in Scope's edit dialog → badge becomes "All services"; toggle back, pick different services → badges update; original selection is **not** silently rewritten to the bindings list
- [ ] Manual: Credential Overrides card add/remove still works; empty state copy reads correctly
- [ ] Manual: empty case — no allowed services, allow-all off → Scope shows `No services (auth-only)` destructive badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)