### PR TITLE
feat(cli): wizard v3.1 — DisplayOnce for node register-token + api-key create

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -680,6 +680,11 @@ pub enum ApiKeyCommands {
         /// directly, and every org admin can rotate / delete it via this same CLI.
         #[arg(long, value_name = "ORG_ID")]
         org: Option<String>,
+        /// Skip the browser wizard and print the new key to the terminal.
+        /// The new key is shown ONCE — copy it before scrolling away.
+        /// Equivalent to setting `NYXID_NO_WIZARD=1` for a single invocation.
+        #[arg(long, alias = "no-wizard")]
+        terminal: bool,
         #[command(flatten)]
         auth: AuthArgs,
     },
@@ -950,6 +955,16 @@ pub enum NodeCommands {
     },
     /// Generate a registration token
     RegisterToken {
+        /// Node name (defaults to `my-node` if neither flag nor browser
+        /// wizard input is provided).
+        #[arg(long)]
+        name: Option<String>,
+        /// Skip the browser wizard and print the new token to the
+        /// terminal. The new token is shown ONCE — copy it before
+        /// scrolling away. Equivalent to setting `NYXID_NO_WIZARD=1`
+        /// for a single invocation.
+        #[arg(long, alias = "no-wizard")]
+        terminal: bool,
         #[command(flatten)]
         auth: AuthArgs,
     },

--- a/cli/src/commands/api_key.rs
+++ b/cli/src/commands/api_key.rs
@@ -20,8 +20,36 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
             platform,
             callback_url,
             org,
+            terminal,
             auth,
         } => {
+            use std::io::IsTerminal;
+            // Wizard gate — mirrors Rotate. Any of --terminal,
+            // --output json, piped stdout, SSH, or NYXID_NO_WIZARD
+            // falls through to the scripted path below with
+            // byte-identical behavior to pre-wizard.
+            let interactive_output = matches!(auth.output, OutputFormat::Table);
+            let wizard_eligible = !terminal
+                && interactive_output
+                && std::io::stdout().is_terminal()
+                && crate::wizard::is_wizard_eligible();
+
+            if wizard_eligible {
+                let prefill = crate::wizard::ApiKeyCreatePrefill {
+                    name: name.clone(),
+                    platform: platform.clone(),
+                    scopes: scopes.clone(),
+                    expires_in_days,
+                    allow_all_services,
+                    allow_all_nodes,
+                    allowed_services_csv: allowed_services.clone(),
+                    allowed_nodes_csv: allowed_nodes.clone(),
+                    callback_url: callback_url.clone(),
+                    org_id: org.clone(),
+                };
+                return crate::wizard::run_api_key_create_wizard(&auth, prefill).await;
+            }
+
             let mut api = ApiClient::from_auth(&auth)?;
 
             let key_name = match name {

--- a/cli/src/commands/node.rs
+++ b/cli/src/commands/node.rs
@@ -113,18 +113,47 @@ pub async fn run(command: NodeCommands) -> Result<()> {
             Ok(())
         }
 
-        NodeCommands::RegisterToken { auth } => {
+        NodeCommands::RegisterToken {
+            name,
+            terminal,
+            auth,
+        } => {
+            use std::io::IsTerminal;
+            // Wizard gate — mirrors RotateToken / api-key Rotate. Any of
+            // --terminal, --output json, piped stdout, SSH, or
+            // NYXID_NO_WIZARD falls through to the scripted path below
+            // with byte-identical behavior to pre-wizard.
+            let interactive_output = matches!(auth.output, OutputFormat::Table);
+            let wizard_eligible = !terminal
+                && interactive_output
+                && std::io::stdout().is_terminal()
+                && crate::wizard::is_wizard_eligible();
+
+            if wizard_eligible {
+                let prefill = crate::wizard::NodeRegisterPrefill { name: name.clone() };
+                return crate::wizard::run_node_register_token_wizard(&auth, prefill).await;
+            }
+
+            // Scripted / headless path — UNCHANGED from pre-wizard
+            // behavior. Still prompts from stdin when --name is absent
+            // so existing interactive-but-not-wizardable sessions (SSH)
+            // keep working the same way they always did.
             let mut api = ApiClient::from_auth(&auth)?;
 
-            eprint!("Node name: ");
-            std::io::stderr().flush()?;
-            let mut name_input = String::new();
-            std::io::stdin().read_line(&mut name_input)?;
-            let node_name = name_input.trim();
-            let node_name = if node_name.is_empty() {
-                "my-node"
-            } else {
-                node_name
+            let node_name = match name {
+                Some(n) if !n.trim().is_empty() => n.trim().to_string(),
+                _ => {
+                    eprint!("Node name: ");
+                    std::io::stderr().flush()?;
+                    let mut name_input = String::new();
+                    std::io::stdin().read_line(&mut name_input)?;
+                    let trimmed = name_input.trim();
+                    if trimmed.is_empty() {
+                        "my-node".to_string()
+                    } else {
+                        trimmed.to_string()
+                    }
+                }
             };
 
             let result: Value = api

--- a/cli/src/wizard/assets/wizard.css
+++ b/cli/src/wizard/assets/wizard.css
@@ -364,6 +364,37 @@ html, body {
   line-height: 1.4;
 }
 
+/* Standalone text input used outside the .wizard-field container (e.g. the
+   v3.1 node-register-token name input in the confirm panel's meta slot, and
+   the v3.1 api-key-create scope picker). Same visual language as
+   .wizard-field input[type="text"] but applies directly without needing a
+   wrapping <label class="wizard-field">. */
+.wizard-text-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.9375rem;
+  font-family: inherit;
+}
+.wizard-text-input:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 0;
+  border-color: transparent;
+}
+.wizard-text-input[type="number"] {
+  /* Firefox shows up/down spinners by default; drop them so numeric
+     inputs look like the rest of the form surface. */
+  -moz-appearance: textfield;
+}
+.wizard-text-input[type="number"]::-webkit-inner-spin-button,
+.wizard-text-input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 .wizard-input-row {
   display: flex;
   gap: 0.375rem;
@@ -382,6 +413,109 @@ html, body {
   cursor: pointer;
 }
 .wizard-input-toggle:hover { background: var(--ghost-hover); color: var(--fg); }
+
+/* ---- v3.1: api-key create scope picker ---- */
+
+/* Group fieldsets (service access, node access, rate limit). Mirrors the
+   .wizard-info-panel visual tier — subtle border, padding, no background
+   so they read as grouped-but-secondary to the top-of-form Name field. */
+.wizard-scope-group {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.wizard-scope-group > legend {
+  padding: 0 0.375rem;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Checkboxes and radios in the scope picker. The parent <label> owns
+   the click target so clicking the text toggles the input. */
+.wizard-checkbox,
+.wizard-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-right: 1.25rem;
+  cursor: pointer;
+  font-size: 0.9375rem;
+}
+.wizard-checkbox-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0;
+  margin-top: 0.25rem;
+}
+.wizard-radio {
+  display: flex;
+  margin: 0.25rem 0;
+}
+.wizard-radio input[type="radio"],
+.wizard-checkbox input[type="checkbox"] {
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
+/* Multi-select list shown when the user picks "Select specific". Fixed
+   max-height with overflow so a long services/nodes list doesn't push
+   the submit button off-screen. */
+.wizard-multi-wrap {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.wizard-multi-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+}
+.wizard-multi-toolbar .wizard-field-hint {
+  margin-left: auto;
+}
+.wizard-multi-list {
+  max-height: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.wizard-multi-list label.wizard-checkbox {
+  display: flex;
+  margin: 0;
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+}
+.wizard-multi-list label.wizard-checkbox:hover {
+  background: var(--ghost-hover);
+}
+.wizard-multi-item-meta {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+/* Two-column numeric inputs for the rate-limit row. */
+.wizard-rate-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+.wizard-field-inline {
+  margin: 0;
+}
+.wizard-field-inline label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--muted);
+}
 
 .wizard-info-panel {
   margin-top: 1rem;

--- a/cli/src/wizard/assets/wizard.html
+++ b/cli/src/wizard/assets/wizard.html
@@ -336,7 +336,8 @@
         </svg>
         <span>
           Once you click <strong>I have saved this</strong>, this page won't show
-          the value again. Your old key is already revoked on the server.
+          the value again.
+          <span id="display-once-warn-tail">Your old key is already revoked on the server.</span>
         </span>
       </div>
 

--- a/cli/src/wizard/assets/wizard.html
+++ b/cli/src/wizard/assets/wizard.html
@@ -93,6 +93,167 @@
       </div>
     </section>
 
+    <!-- v3.1: api-key create scope picker. Separate panel (rather than
+         reusing step-credential) because the field set, validation
+         rules, and data sources are unrelated to the ai-key catalog
+         form. Shown when FLOW=api-key-create. Title + owner row are
+         populated by wizard.js at init. -->
+    <section class="wizard-step-panel" id="step-scope-picker" data-step="scope-picker" hidden>
+      <h1 class="wizard-title">Create API key</h1>
+      <p class="wizard-body wizard-muted">
+        The key value will be minted on submit and shown once on the next
+        screen. Before that, pick a name and the scope — what this key is
+        allowed to do.
+      </p>
+
+      <div class="wizard-error-banner" id="scope-picker-error" role="alert" hidden></div>
+
+      <form id="scope-picker-form" autocomplete="off">
+        <div class="wizard-field">
+          <label for="scope-name">Name</label>
+          <input type="text" id="scope-name" class="wizard-text-input"
+                 placeholder="e.g. coding-agent" maxlength="128" required>
+          <span class="wizard-field-hint">
+            A short label so you can find this key in `nyxid api-key list`.
+          </span>
+        </div>
+
+        <div class="wizard-field" id="scope-owner-field" hidden>
+          <label for="scope-owner">Owner</label>
+          <select id="scope-owner" class="wizard-select">
+            <option value="">Personal (your account)</option>
+          </select>
+          <span class="wizard-field-hint">
+            Org-owned keys authenticate as the org — every org admin can
+            rotate or delete them. Services and nodes below filter to what
+            the chosen owner can see.
+          </span>
+        </div>
+
+        <div class="wizard-field">
+          <label for="scope-platform">Platform</label>
+          <select id="scope-platform" class="wizard-select">
+            <option value="">— none —</option>
+            <option value="claude-code">claude-code</option>
+            <option value="codex">codex</option>
+            <option value="openclaw">openclaw</option>
+            <option value="cursor">cursor</option>
+            <option value="generic">generic</option>
+          </select>
+          <span class="wizard-field-hint">
+            Tags this key with the AI agent it belongs to, for audit
+            attribution and per-agent rate limits.
+          </span>
+        </div>
+
+        <div class="wizard-field">
+          <label for="scope-scopes">Scopes</label>
+          <div class="wizard-checkbox-row">
+            <label class="wizard-checkbox">
+              <input type="checkbox" id="scope-read" checked> read
+            </label>
+            <label class="wizard-checkbox">
+              <input type="checkbox" id="scope-write" checked> write
+            </label>
+          </div>
+        </div>
+
+        <div class="wizard-field">
+          <label for="scope-expiry">Expiry</label>
+          <div class="wizard-input-row">
+            <input type="number" id="scope-expiry" class="wizard-text-input"
+                   placeholder="never" min="1" max="3650">
+            <span class="wizard-input-toggle" aria-hidden="true">days</span>
+          </div>
+          <span class="wizard-field-hint">
+            Leave blank for no expiry. After this many days, the key stops
+            authenticating.
+          </span>
+        </div>
+
+        <fieldset class="wizard-scope-group">
+          <legend>Service access</legend>
+          <label class="wizard-radio">
+            <input type="radio" name="scope-service-mode" value="all" checked>
+            All services
+          </label>
+          <label class="wizard-radio">
+            <input type="radio" name="scope-service-mode" value="specific">
+            Select specific services
+          </label>
+          <div class="wizard-multi-wrap" id="scope-services-wrap" hidden>
+            <div class="wizard-multi-toolbar">
+              <button type="button" class="wizard-btn-tiny" id="scope-services-all">select all</button>
+              <button type="button" class="wizard-btn-tiny" id="scope-services-none">clear</button>
+              <span class="wizard-field-hint" id="scope-services-count">0 selected</span>
+            </div>
+            <div class="wizard-multi-list" id="scope-services-list" role="list">
+              <div class="wizard-field-hint">Loading…</div>
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset class="wizard-scope-group">
+          <legend>Node access</legend>
+          <label class="wizard-radio">
+            <input type="radio" name="scope-node-mode" value="all" checked>
+            All nodes
+          </label>
+          <label class="wizard-radio">
+            <input type="radio" name="scope-node-mode" value="specific">
+            Select specific nodes
+          </label>
+          <div class="wizard-multi-wrap" id="scope-nodes-wrap" hidden>
+            <div class="wizard-multi-toolbar">
+              <button type="button" class="wizard-btn-tiny" id="scope-nodes-all">select all</button>
+              <button type="button" class="wizard-btn-tiny" id="scope-nodes-none">clear</button>
+              <span class="wizard-field-hint" id="scope-nodes-count">0 selected</span>
+            </div>
+            <div class="wizard-multi-list" id="scope-nodes-list" role="list">
+              <div class="wizard-field-hint">Loading…</div>
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset class="wizard-scope-group">
+          <legend>Rate limit (optional)</legend>
+          <div class="wizard-rate-row">
+            <div class="wizard-field wizard-field-inline">
+              <label for="scope-rate-per-second">Per second</label>
+              <input type="number" id="scope-rate-per-second" class="wizard-text-input"
+                     placeholder="server default" min="1" max="10000">
+            </div>
+            <div class="wizard-field wizard-field-inline">
+              <label for="scope-rate-burst">Burst</label>
+              <input type="number" id="scope-rate-burst" class="wizard-text-input"
+                     placeholder="server default" min="1" max="10000">
+            </div>
+          </div>
+          <span class="wizard-field-hint">
+            Leave blank to use the server defaults.
+          </span>
+        </fieldset>
+
+        <div class="wizard-field">
+          <label for="scope-callback-url">Callback URL (optional)</label>
+          <input type="text" id="scope-callback-url" class="wizard-text-input"
+                 placeholder="https://…" maxlength="2048">
+          <span class="wizard-field-hint">
+            Webhook URL for channel-bot relay. Most keys don't need this.
+          </span>
+        </div>
+      </form>
+
+      <div class="wizard-status" id="scope-picker-status" aria-live="polite"></div>
+
+      <div class="wizard-actions">
+        <button type="button" id="scope-cancel" class="wizard-btn wizard-btn-ghost">Cancel</button>
+        <button type="button" id="scope-submit" class="wizard-btn wizard-btn-primary">
+          Create key
+        </button>
+      </div>
+    </section>
+
     <!-- Step 3 — confirmation -->
     <section class="wizard-step-panel" id="step-confirm" data-step="3" hidden>
       <h1 class="wizard-title"><span aria-hidden="true">✓</span> Service created</h1>

--- a/cli/src/wizard/assets/wizard.js
+++ b/cli/src/wizard/assets/wizard.js
@@ -1556,6 +1556,18 @@
     containerEl.appendChild(row);
   }
 
+  // Set the tail sentence of the display-once warn banner. Split from
+  // the static prefix ("Once you click I have saved this, this page
+  // won't show the value again.") so rotate flows can keep the original
+  // "Your old key is already revoked on the server" wording while the
+  // v3.1 create flows can swap in flow-appropriate copy (there is no
+  // "old key" to revoke when the user is creating a key, not rotating
+  // one). textContent-only — no HTML injection path.
+  function setWarnTail(text) {
+    const el = document.getElementById("display-once-warn-tail");
+    if (el) el.textContent = text;
+  }
+
   // Attach visibilitychange + blur remask listeners. Call once per
   // DisplayOnce render, AFTER all rows have been appended via
   // renderSecretRow. Listeners stay attached for the life of the page
@@ -1577,6 +1589,13 @@
     const isApiKey = flow === "api-key-rotate";
     document.getElementById("display-once-title").textContent =
       isApiKey ? "Save the new API key" : "Save the new node credentials";
+
+    // Rotate flows: the POST /rotate call that preceded this render
+    // atomically revoked the old secret server-side, so the "already
+    // revoked" tail is factually correct by the time the panel is
+    // visible. (Create-shaped flows set a different tail — see
+    // renderNodeRegisterDisplayOnce / renderApiKeyCreateDisplayOnce.)
+    setWarnTail("Your old key is already revoked on the server.");
 
     const rowsEl = document.getElementById("display-once-rows");
     rowsEl.innerHTML = "";
@@ -1839,6 +1858,11 @@
   function renderNodeRegisterDisplayOnce(tokenId, nodeName, token) {
     document.getElementById("display-once-title").textContent =
       `Save the registration token for '${nodeName}'`;
+    // Create-flow wording: there is no old token to revoke, so the
+    // rotate-flow tail ("Your old key is already revoked…") would
+    // mislead here. The token is backend-stored as a hash only, so
+    // there is genuinely no way to retrieve it later.
+    setWarnTail("There is no way to retrieve this token later — save it before continuing.");
 
     const rowsEl = document.getElementById("display-once-rows");
     rowsEl.innerHTML = "";
@@ -2285,6 +2309,10 @@
   function renderApiKeyCreateDisplayOnce(apiKeyId, keyName, fullKey) {
     document.getElementById("display-once-title").textContent =
       `Save the API key for '${keyName}'`;
+    // Create-flow wording: nothing was revoked, nothing is pending.
+    // The backend stored only a SHA-256 of the key; the plaintext
+    // exists solely on this page right now.
+    setWarnTail("There is no way to retrieve this key later — save it before continuing.");
 
     const rowsEl = document.getElementById("display-once-rows");
     rowsEl.innerHTML = "";

--- a/cli/src/wizard/assets/wizard.js
+++ b/cli/src/wizard/assets/wizard.js
@@ -20,6 +20,18 @@
     // v3 rotation flows (api-key-rotate / node-rotate-token)
     resourceId: PARAMS.get("resource_id") || null,
     displayName: PARAMS.get("display_name") || null,
+    // v3.1 node-register-token
+    name: PARAMS.get("name") || null,
+    // v3.1 api-key-create (reuses `name` above)
+    platform: PARAMS.get("platform") || null,
+    scopes: PARAMS.get("scopes") || null,
+    expiresInDays: PARAMS.get("expires_in_days") || null,
+    allowAllServices: PARAMS.get("allow_all_services") === "1",
+    allowAllNodes: PARAMS.get("allow_all_nodes") === "1",
+    allowedServicesCsv: PARAMS.get("allowed_services") || null,
+    allowedNodesCsv: PARAMS.get("allowed_nodes") || null,
+    callbackUrl: PARAMS.get("callback_url") || null,
+    orgId: PARAMS.get("org_id") || null,
   };
 
   let postInFlight = false;   // swallow beforeunload cancel while a POST is open
@@ -1478,6 +1490,89 @@
     + '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>'
     + '</svg>';
 
+  // Secret values for display-once rows NEVER leave their row's
+  // closure — this module-level array just tracks "remask me" callbacks
+  // the blur / visibilitychange listeners can fan out to. Cleared
+  // per-flow by renderSecretRow's caller (which recreates the array
+  // implicitly by calling installRemaskHandlers before the first row).
+  let remaskCallbacks = [];
+
+  // Render a single "label · masked value · show · copy" row inside
+  // `containerEl`. Extracted out of renderDisplayOnce so v3.1 flows
+  // (node-register-token, api-key-create) share the identical masked
+  // UX — click to reveal, auto-remask on blur, copy button with a
+  // "copied!" flash — without reimplementing any of it. The secret
+  // `value` lives in the per-row closure (setRevealed) and never
+  // escapes. Caller MUST call `installRemaskHandlers` exactly once
+  // after all rows are rendered.
+  function renderSecretRow(containerEl, { label, value }) {
+    const row = document.createElement("div");
+    row.className = "wizard-secret-row";
+
+    const labelEl = document.createElement("span");
+    labelEl.className = "wizard-secret-row-label";
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+
+    const valueWrap = document.createElement("div");
+    valueWrap.className = "wizard-secret-row-value";
+
+    const code = document.createElement("code");
+    const maskLen = Math.min(48, Math.max(8, value.length));
+    const masked = "•".repeat(maskLen);
+    code.textContent = masked;
+    valueWrap.appendChild(code);
+
+    const reveal = document.createElement("button");
+    reveal.type = "button";
+    reveal.className = "wizard-btn-tiny";
+    reveal.textContent = "show";
+    let revealed = false;
+    const setRevealed = (v) => {
+      revealed = v;
+      if (v) {
+        code.textContent = value;
+        code.classList.add("is-revealed");
+        reveal.textContent = "hide";
+      } else {
+        code.textContent = masked;
+        code.classList.remove("is-revealed");
+        reveal.textContent = "show";
+      }
+    };
+    reveal.addEventListener("click", () => setRevealed(!revealed));
+    valueWrap.appendChild(reveal);
+    remaskCallbacks.push(() => { if (revealed) setRevealed(false); });
+
+    const copy = document.createElement("button");
+    copy.type = "button";
+    copy.className = "wizard-btn-tiny wizard-btn-tiny-icon";
+    copy.setAttribute("aria-label", `copy ${label}`);
+    copy.innerHTML = COPY_ICON_SVG + '<span class="wizard-btn-label">copy</span>';
+    copy.addEventListener("click", () => copyText(value, copy));
+    valueWrap.appendChild(copy);
+
+    row.appendChild(valueWrap);
+    containerEl.appendChild(row);
+  }
+
+  // Attach visibilitychange + blur remask listeners. Call once per
+  // DisplayOnce render, AFTER all rows have been appended via
+  // renderSecretRow. Listeners stay attached for the life of the page
+  // — we never transition back out of display-once — so redundant
+  // calls would stack duplicate handlers. Protect against that.
+  let remaskHandlersInstalled = false;
+  function installRemaskHandlers() {
+    if (remaskHandlersInstalled) return;
+    remaskHandlersInstalled = true;
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) remaskCallbacks.forEach(fn => fn());
+    });
+    window.addEventListener("blur", () => {
+      remaskCallbacks.forEach(fn => fn());
+    });
+  }
+
   function renderDisplayOnce(flow, resourceId, displayName, secrets) {
     const isApiKey = flow === "api-key-rotate";
     document.getElementById("display-once-title").textContent =
@@ -1485,82 +1580,14 @@
 
     const rowsEl = document.getElementById("display-once-rows");
     rowsEl.innerHTML = "";
-
-    // Track all reveal-toggle setters so visibility/blur can flip them
-    // all at once. Each setter is created per-row in its own closure
-    // so the secret value never escapes the row's scope.
-    const remaskAll = [];
-
+    // Reset the shared remask list for this flow's rows, then render
+    // each one via the shared helper. See renderSecretRow's doc comment
+    // for why the secret value never escapes the row's closure.
+    remaskCallbacks = [];
     for (const secret of secrets) {
-      const row = document.createElement("div");
-      row.className = "wizard-secret-row";
-
-      const label = document.createElement("span");
-      label.className = "wizard-secret-row-label";
-      label.textContent = secret.label;
-      row.appendChild(label);
-
-      const valueWrap = document.createElement("div");
-      valueWrap.className = "wizard-secret-row-value";
-
-      const code = document.createElement("code");
-      // Mask string is ALWAYS dots — never the real value, never a
-      // truncated prefix. Length capped so very long secrets don't
-      // produce a ridiculous mask.
-      const maskLen = Math.min(48, Math.max(8, secret.value.length));
-      const masked = "•".repeat(maskLen);
-      code.textContent = masked;
-      valueWrap.appendChild(code);
-
-      // Lowercase "show" / "hide" to match the v2 wizard-input-toggle
-      // password-field convention (keeps muscle memory consistent
-      // across both flows).
-      const reveal = document.createElement("button");
-      reveal.type = "button";
-      reveal.className = "wizard-btn-tiny";
-      reveal.textContent = "show";
-      let revealed = false;
-      const setRevealed = (v) => {
-        revealed = v;
-        if (v) {
-          code.textContent = secret.value;
-          code.classList.add("is-revealed");
-          reveal.textContent = "hide";
-        } else {
-          code.textContent = masked;
-          code.classList.remove("is-revealed");
-          reveal.textContent = "show";
-        }
-      };
-      reveal.addEventListener("click", () => setRevealed(!revealed));
-      valueWrap.appendChild(reveal);
-      remaskAll.push(() => { if (revealed) setRevealed(false); });
-
-      // Copy: SVG clipboard icon + label span. The label span lets
-      // copyText flip just the text ("copy" → "copied!") without
-      // nuking the icon.
-      const copy = document.createElement("button");
-      copy.type = "button";
-      copy.className = "wizard-btn-tiny wizard-btn-tiny-icon";
-      copy.setAttribute("aria-label", `copy ${secret.label}`);
-      copy.innerHTML = COPY_ICON_SVG + '<span class="wizard-btn-label">copy</span>';
-      copy.addEventListener("click", () => copyText(secret.value, copy));
-      valueWrap.appendChild(copy);
-
-      row.appendChild(valueWrap);
-      rowsEl.appendChild(row);
+      renderSecretRow(rowsEl, { label: secret.label, value: secret.value });
     }
-
-    // Auto-remask on visibility/blur. Codex P2: 60s timer was
-    // mis-targeted (annoying when present, too long when away).
-    // Remask immediately on the events that mean "user can't see
-    // the page anyway."
-    document.addEventListener("visibilitychange", () => {
-      if (document.hidden) remaskAll.forEach(fn => fn());
-    });
-    window.addEventListener("blur", () => {
-      remaskAll.forEach(fn => fn());
-    });
+    installRemaskHandlers();
 
     // (Download as .txt removed in this iteration — copy + reveal cover
     // the api-key case. If the node-rotate flow's two-secret + rekey
@@ -1696,17 +1723,637 @@
     });
   }
 
+  // ---- v3.1: nyxid node register-token ----
+  //
+  // Generate-and-display twin of `node rotate-token`. The backend mints
+  // a fresh `nyx_nreg_...` on confirm; the wizard renders it in the
+  // reusable DisplayOnce panel. Differs from rotation flows in three
+  // ways: (1) there is no existing resource to resolve — the CLI either
+  // prefills `name` or we collect it here; (2) the ack payload carries
+  // `token_id` instead of `resource_id`; (3) the confirm panel's "are
+  // you sure" copy is about creation, not destruction.
+  function initNodeRegisterFlow() {
+    const prefillName = (PREFILL.name || "").trim();
+    let nodeName = prefillName;
+
+    const titleEl = document.getElementById("rotate-confirm-title");
+    const bodyEl = document.getElementById("rotate-confirm-body");
+    const metaEl = document.getElementById("rotate-confirm-meta");
+    const goBtn = document.getElementById("rotate-go");
+    const cancelBtnLocal = document.getElementById("rotate-cancel");
+    const errBanner = document.getElementById("rotate-confirm-error");
+
+    if (stepLabel) stepLabel.textContent = "Step 1 of 2 · name this node";
+
+    titleEl.textContent = "Generate registration token";
+    bodyEl.textContent =
+      "A one-time registration token will be minted. The token value is shown "
+      + "once on the next screen — make sure you have somewhere to save it "
+      + "(password manager, vault, or the target host's clipboard) before "
+      + "continuing.";
+    goBtn.textContent = "Generate token";
+
+    // Replace the "ID" meta row with either a read-only name echo (when
+    // prefill is set) or an editable text input (when it isn't). Either
+    // way the DOM stays simple and the dispatcher reads the resolved
+    // name from the `nodeName` closure variable.
+    metaEl.innerHTML = "";
+    const dt = document.createElement("dt");
+    dt.textContent = "Node name";
+    metaEl.appendChild(dt);
+    const dd = document.createElement("dd");
+
+    let nameInput = null;
+    if (prefillName) {
+      const code = document.createElement("code");
+      code.textContent = prefillName;
+      dd.appendChild(code);
+    } else {
+      nameInput = document.createElement("input");
+      nameInput.type = "text";
+      nameInput.className = "wizard-text-input";
+      nameInput.placeholder = "e.g. edge-tokyo";
+      nameInput.autocomplete = "off";
+      nameInput.spellcheck = false;
+      nameInput.maxLength = 128;
+      dd.appendChild(nameInput);
+    }
+    metaEl.appendChild(dd);
+
+    showRotationPanel("step-confirm-rotate");
+    if (nameInput) nameInput.focus();
+
+    cancelBtnLocal.addEventListener("click", () => onCancelRotation());
+
+    goBtn.addEventListener("click", async () => {
+      if (postInFlight) return;
+      if (nameInput) {
+        const typed = nameInput.value.trim();
+        if (!typed) {
+          errBanner.textContent = "Node name is required.";
+          errBanner.hidden = false;
+          nameInput.focus();
+          return;
+        }
+        nodeName = typed;
+      }
+      errBanner.hidden = true;
+      postInFlight = true;
+      goBtn.disabled = true;
+      cancelBtnLocal.disabled = true;
+      setRotationStatus("rotate-confirm-status", "Minting registration token…");
+      try {
+        const resp = await proxyJson(
+          "POST",
+          "/api/proxy/api/v1/nodes/register-token",
+          { name: nodeName },
+        );
+        const token = resp?.token || "";
+        const tokenId = resp?.token_id || "";
+        if (!token || !tokenId) {
+          throw new Error(
+            "Backend returned an empty token. Check the server logs and re-run "
+              + "`nyxid node register-token`.",
+          );
+        }
+        renderNodeRegisterDisplayOnce(tokenId, nodeName, token);
+        showRotationPanel("step-display-once");
+        if (stepLabel) stepLabel.textContent = "Step 2 of 2 · save the value";
+      } catch (err) {
+        errBanner.textContent = err.message || String(err);
+        errBanner.hidden = false;
+        goBtn.disabled = false;
+        cancelBtnLocal.disabled = false;
+        setRotationStatus("rotate-confirm-status", "");
+      } finally {
+        postInFlight = false;
+      }
+    });
+  }
+
+  // Thin wrapper around the DisplayOnce panel for the node-register
+  // flow. Reuses the masked-code + reveal + copy + blur-remask
+  // machinery from renderDisplayOnce (rotation path), but posts a
+  // different typed ack payload (`{ acknowledged, token_id }` rather
+  // than `{ acknowledged, resource_id }`).
+  function renderNodeRegisterDisplayOnce(tokenId, nodeName, token) {
+    document.getElementById("display-once-title").textContent =
+      `Save the registration token for '${nodeName}'`;
+
+    const rowsEl = document.getElementById("display-once-rows");
+    rowsEl.innerHTML = "";
+    remaskCallbacks = [];
+    renderSecretRow(rowsEl, {
+      label: "Registration token",
+      value: token,
+    });
+
+    installRemaskHandlers();
+
+    const ackBtn = document.getElementById("display-once-ack");
+    ackBtn.onclick = async () => {
+      if (finished) return;
+      finished = true;
+      ackBtn.disabled = true;
+      const statusEl = document.getElementById("display-once-status");
+      if (statusEl) {
+        statusEl.textContent = "Signalling CLI…";
+        statusEl.className = "wizard-status";
+      }
+      try {
+        const res = await proxyFetch("POST", "/api/proxy/complete", {
+          acknowledged: true,
+          token_id: tokenId,
+        });
+        if (!res.ok) {
+          if (statusEl) {
+            statusEl.textContent = `CLI rejected the ack (HTTP ${res.status}).`;
+            statusEl.className = "wizard-status error";
+          }
+          finished = false;
+          ackBtn.disabled = false;
+          return;
+        }
+        showOverlay({
+          icon: "✓",
+          title: "Saved",
+          body: "It is safe to close the browser now.",
+          sub: "Your terminal has the post-creation summary.",
+        });
+      } catch (err) {
+        if (statusEl) {
+          statusEl.textContent =
+            "Couldn't reach the CLI: " + (err.message || String(err));
+          statusEl.className = "wizard-status error";
+        }
+        finished = false;
+        ackBtn.disabled = false;
+      }
+    };
+  }
+
+  // ---- v3.1: nyxid api-key create ----
+  //
+  // Unlike node-register-token (which has nothing to configure beyond
+  // a name) the api-key-create flow owns a full scope picker:
+  // name + owner + platform + scopes + expiry + per-service multi-
+  // select + per-node multi-select + rate limits + callback URL. The
+  // wizard.html #step-scope-picker panel holds the markup; this
+  // function wires prefill, list fetching, validation, and submission.
+  //
+  // Secret leak surface mirrors the other DisplayOnce flows: the
+  // server-issued `full_key` is rendered in the reusable
+  // renderSecretRow helper, and the ack payload on `/api/proxy/complete`
+  // carries only `{ acknowledged, api_key_id }` (typed
+  // `ApiKeyCreateAckPayload` with `deny_unknown_fields` on the Rust
+  // side). The browser NEVER round-trips `full_key` back to the CLI.
+  function initApiKeyCreateFlow() {
+    const form = document.getElementById("scope-picker-form");
+    const errBanner = document.getElementById("scope-picker-error");
+    const nameInput = document.getElementById("scope-name");
+    const ownerField = document.getElementById("scope-owner-field");
+    const ownerSelect = document.getElementById("scope-owner");
+    const platformSelect = document.getElementById("scope-platform");
+    const readChk = document.getElementById("scope-read");
+    const writeChk = document.getElementById("scope-write");
+    const expiryInput = document.getElementById("scope-expiry");
+    const callbackInput = document.getElementById("scope-callback-url");
+    const ratePerSecondInput = document.getElementById("scope-rate-per-second");
+    const rateBurstInput = document.getElementById("scope-rate-burst");
+    const cancelBtn2 = document.getElementById("scope-cancel");
+    const submitBtn = document.getElementById("scope-submit");
+    const statusEl = document.getElementById("scope-picker-status");
+
+    if (stepLabel) stepLabel.textContent = "Step 1 of 2 · configure scope";
+
+    // --- Prefill: any CLI-supplied flag goes straight into the form.
+    if (PREFILL.name) nameInput.value = PREFILL.name;
+    if (PREFILL.platform) platformSelect.value = PREFILL.platform;
+    if (PREFILL.scopes) {
+      const parts = PREFILL.scopes.split(/\s+/).filter(Boolean);
+      readChk.checked = parts.includes("read");
+      writeChk.checked = parts.includes("write");
+    }
+    if (PREFILL.expiresInDays) expiryInput.value = PREFILL.expiresInDays;
+    if (PREFILL.callbackUrl) callbackInput.value = PREFILL.callbackUrl;
+
+    // --- Scope-specific state for multi-selects.
+    let availableServices = [];
+    let availableNodes = [];
+    let servicesFetched = false;
+    let nodesFetched = false;
+
+    const serviceWrap = document.getElementById("scope-services-wrap");
+    const serviceList = document.getElementById("scope-services-list");
+    const serviceCount = document.getElementById("scope-services-count");
+    const nodeWrap = document.getElementById("scope-nodes-wrap");
+    const nodeList = document.getElementById("scope-nodes-list");
+    const nodeCount = document.getElementById("scope-nodes-count");
+
+    // --- Owner picker: fetch orgs once, populate selector if any.
+    // List is best-effort — failure hides the field entirely so the
+    // user still gets the personal-account default. Always safe to fail
+    // closed on an optional UI element.
+    (async () => {
+      try {
+        const resp = await proxyJson("GET", "/api/proxy/api/v1/orgs");
+        const orgs = Array.isArray(resp?.orgs)
+          ? resp.orgs
+          : Array.isArray(resp?.items)
+            ? resp.items
+            : Array.isArray(resp)
+              ? resp
+              : [];
+        if (orgs.length === 0) {
+          ownerField.hidden = true;
+          return;
+        }
+        for (const org of orgs) {
+          const opt = document.createElement("option");
+          opt.value = org.id || org._id || "";
+          const display = org.display_name || org.name || opt.value;
+          opt.textContent = `Org · ${display}`;
+          ownerSelect.appendChild(opt);
+        }
+        if (PREFILL.orgId) ownerSelect.value = PREFILL.orgId;
+        ownerField.hidden = false;
+      } catch (_) {
+        // Hide on any failure. The user keeps the personal-account
+        // default and can still submit without an owner.
+        ownerField.hidden = true;
+      }
+    })();
+
+    // --- Service / node multi-select machinery.
+    function updateSelectionCount(listEl, countEl) {
+      const checked = listEl.querySelectorAll('input[type="checkbox"]:checked').length;
+      const total = listEl.querySelectorAll('input[type="checkbox"]').length;
+      countEl.textContent = `${checked} of ${total} selected`;
+    }
+
+    function renderMultiList(listEl, items, idKey, labelFn, preselectCsv) {
+      listEl.innerHTML = "";
+      if (items.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "wizard-field-hint";
+        empty.textContent = "Nothing to select.";
+        listEl.appendChild(empty);
+        return;
+      }
+      const preselect = new Set(
+        (preselectCsv || "").split(",").map(s => s.trim()).filter(Boolean),
+      );
+      for (const item of items) {
+        const id = item[idKey] || item.id || item._id || "";
+        if (!id) continue;
+        const label = document.createElement("label");
+        label.className = "wizard-checkbox";
+        label.setAttribute("role", "listitem");
+        const cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.value = id;
+        if (preselect.has(id)) cb.checked = true;
+        label.appendChild(cb);
+        const text = document.createElement("span");
+        text.textContent = labelFn(item);
+        label.appendChild(text);
+        listEl.appendChild(label);
+      }
+    }
+
+    async function fetchServicesOnce() {
+      if (servicesFetched) return;
+      servicesFetched = true;
+      try {
+        const resp = await proxyJson("GET", "/api/proxy/api/v1/user-services");
+        availableServices = Array.isArray(resp?.services)
+          ? resp.services
+          : Array.isArray(resp)
+            ? resp
+            : [];
+        renderMultiList(
+          serviceList,
+          availableServices,
+          "id",
+          (s) => s.slug ? `${s.slug}${s.label ? " · " + s.label : ""}` : (s.label || s.id || ""),
+          PREFILL.allowedServicesCsv,
+        );
+        updateSelectionCount(serviceList, serviceCount);
+      } catch (err) {
+        serviceList.innerHTML = "";
+        const e = document.createElement("div");
+        e.className = "wizard-field-hint";
+        e.textContent = "Couldn't load services: " + (err.message || String(err));
+        serviceList.appendChild(e);
+      }
+    }
+
+    async function fetchNodesOnce() {
+      if (nodesFetched) return;
+      nodesFetched = true;
+      try {
+        const resp = await proxyJson("GET", "/api/proxy/api/v1/nodes");
+        availableNodes = Array.isArray(resp?.nodes)
+          ? resp.nodes
+          : Array.isArray(resp)
+            ? resp
+            : [];
+        renderMultiList(
+          nodeList,
+          availableNodes,
+          "id",
+          (n) => n.name ? `${n.name}${n.status ? " · " + n.status : ""}` : (n.id || ""),
+          PREFILL.allowedNodesCsv,
+        );
+        updateSelectionCount(nodeList, nodeCount);
+      } catch (err) {
+        nodeList.innerHTML = "";
+        const e = document.createElement("div");
+        e.className = "wizard-field-hint";
+        e.textContent = "Couldn't load nodes: " + (err.message || String(err));
+        nodeList.appendChild(e);
+      }
+    }
+
+    // Wire service/node mode radios. "Select specific" toggles the
+    // list visibility and triggers a one-shot fetch (subsequent toggles
+    // don't refetch — the data rarely changes mid-flow).
+    function wireScopeRadios(name, wrap, fetcher, listEl, countEl) {
+      const radios = form.querySelectorAll(`input[name="${name}"]`);
+      radios.forEach(r => r.addEventListener("change", async () => {
+        if (r.value === "specific" && r.checked) {
+          wrap.hidden = false;
+          await fetcher();
+        } else if (r.value === "all" && r.checked) {
+          wrap.hidden = true;
+        }
+      }));
+      listEl.addEventListener("change", (e) => {
+        if (e.target.matches('input[type="checkbox"]')) {
+          updateSelectionCount(listEl, countEl);
+        }
+      });
+    }
+    wireScopeRadios("scope-service-mode", serviceWrap, fetchServicesOnce, serviceList, serviceCount);
+    wireScopeRadios("scope-node-mode", nodeWrap, fetchNodesOnce, nodeList, nodeCount);
+
+    // "select all" / "clear" buttons for each multi-select.
+    function wireMultiToolbar(allBtn, noneBtn, listEl, countEl) {
+      allBtn.addEventListener("click", () => {
+        listEl.querySelectorAll('input[type="checkbox"]').forEach(c => { c.checked = true; });
+        updateSelectionCount(listEl, countEl);
+      });
+      noneBtn.addEventListener("click", () => {
+        listEl.querySelectorAll('input[type="checkbox"]').forEach(c => { c.checked = false; });
+        updateSelectionCount(listEl, countEl);
+      });
+    }
+    wireMultiToolbar(
+      document.getElementById("scope-services-all"),
+      document.getElementById("scope-services-none"),
+      serviceList, serviceCount,
+    );
+    wireMultiToolbar(
+      document.getElementById("scope-nodes-all"),
+      document.getElementById("scope-nodes-none"),
+      nodeList, nodeCount,
+    );
+
+    // Apply CLI-supplied allow-all / specific prefill AFTER the radios
+    // are wired so the change event fires and the list loads when
+    // "specific" is prefilled.
+    if (PREFILL.allowedServicesCsv) {
+      const specific = form.querySelector('input[name="scope-service-mode"][value="specific"]');
+      specific.checked = true;
+      specific.dispatchEvent(new Event("change"));
+    }
+    if (PREFILL.allowedNodesCsv) {
+      const specific = form.querySelector('input[name="scope-node-mode"][value="specific"]');
+      specific.checked = true;
+      specific.dispatchEvent(new Event("change"));
+    }
+    // `allowAll*` prefill is implicit: the default radio is already
+    // "all", so there's nothing to do beyond not overriding.
+
+    // --- Show the panel.
+    document.querySelectorAll(".wizard-step-panel").forEach(p => {
+      p.hidden = p.id !== "step-scope-picker";
+    });
+    nameInput.focus();
+
+    // --- Submit.
+    async function submitScopePicker() {
+      if (postInFlight) return;
+      errBanner.hidden = true;
+
+      // Validation. Backend enforces again but catching client-side
+      // avoids the round-trip on obvious mistakes.
+      const name = nameInput.value.trim();
+      if (!name) {
+        errBanner.textContent = "Name is required.";
+        errBanner.hidden = false;
+        nameInput.focus();
+        return;
+      }
+      const scopeParts = [];
+      if (readChk.checked) scopeParts.push("read");
+      if (writeChk.checked) scopeParts.push("write");
+      if (scopeParts.length === 0) {
+        errBanner.textContent = "Pick at least one of read / write.";
+        errBanner.hidden = false;
+        return;
+      }
+
+      // Build request body. Only keys in the wizard/server.rs
+      // allowlist for POST /api-keys are ever included; values
+      // follow the backend's CreateApiKeyRequest shape.
+      const body = {
+        name,
+        scopes: scopeParts.join(" "),
+      };
+
+      const expiry = expiryInput.value.trim();
+      if (expiry) {
+        const days = parseInt(expiry, 10);
+        if (!Number.isFinite(days) || days < 1 || days > 3650) {
+          errBanner.textContent = "Expiry must be a positive number of days.";
+          errBanner.hidden = false;
+          return;
+        }
+        // Same rfc3339 format the CLI emits — CLI-side calls chrono
+        // Duration::days and to_rfc3339; JS Date.toISOString produces
+        // the same shape.
+        const ts = new Date(Date.now() + days * 24 * 3600 * 1000);
+        body.expires_at = ts.toISOString();
+      }
+
+      const platform = platformSelect.value;
+      if (platform) body.platform = platform;
+
+      const callback = callbackInput.value.trim();
+      if (callback) body.callback_url = callback;
+
+      const rps = ratePerSecondInput.value.trim();
+      if (rps) {
+        const n = parseInt(rps, 10);
+        if (!Number.isFinite(n) || n < 1) {
+          errBanner.textContent = "Rate per second must be a positive integer.";
+          errBanner.hidden = false;
+          return;
+        }
+        body.rate_limit_per_second = n;
+      }
+      const burst = rateBurstInput.value.trim();
+      if (burst) {
+        const n = parseInt(burst, 10);
+        if (!Number.isFinite(n) || n < 1) {
+          errBanner.textContent = "Rate burst must be a positive integer.";
+          errBanner.hidden = false;
+          return;
+        }
+        body.rate_limit_burst = n;
+      }
+
+      const serviceMode = form.querySelector('input[name="scope-service-mode"]:checked').value;
+      if (serviceMode === "all") {
+        body.allow_all_services = true;
+      } else {
+        const ids = Array.from(
+          serviceList.querySelectorAll('input[type="checkbox"]:checked'),
+        ).map(c => c.value);
+        body.allow_all_services = false;
+        body.allowed_service_ids = ids;
+      }
+      const nodeMode = form.querySelector('input[name="scope-node-mode"]:checked').value;
+      if (nodeMode === "all") {
+        body.allow_all_nodes = true;
+      } else {
+        const ids = Array.from(
+          nodeList.querySelectorAll('input[type="checkbox"]:checked'),
+        ).map(c => c.value);
+        body.allow_all_nodes = false;
+        body.allowed_node_ids = ids;
+      }
+
+      const ownerId = ownerSelect?.value || "";
+      if (ownerId) body.target_org_id = ownerId;
+
+      postInFlight = true;
+      submitBtn.disabled = true;
+      cancelBtn2.disabled = true;
+      setStatus(statusEl, "Creating API key…");
+      try {
+        const resp = await proxyJson("POST", "/api/proxy/api/v1/api-keys", body);
+        const fullKey = resp?.full_key || "";
+        const apiKeyId = resp?.id || resp?._id || "";
+        if (!fullKey || !apiKeyId) {
+          throw new Error(
+            "Backend returned an empty key. Check the server logs and re-run `nyxid api-key create`.",
+          );
+        }
+        renderApiKeyCreateDisplayOnce(apiKeyId, name, fullKey);
+        document.querySelectorAll(".wizard-step-panel").forEach(p => {
+          p.hidden = p.id !== "step-display-once";
+        });
+        if (stepLabel) stepLabel.textContent = "Step 2 of 2 · save the value";
+      } catch (err) {
+        errBanner.textContent = err.message || String(err);
+        errBanner.hidden = false;
+        submitBtn.disabled = false;
+        cancelBtn2.disabled = false;
+        setStatus(statusEl, "");
+      } finally {
+        postInFlight = false;
+      }
+    }
+
+    cancelBtn2.addEventListener("click", () => onCancelRotation(
+      "No API key was created. It is safe to close the browser now.",
+    ));
+    submitBtn.addEventListener("click", submitScopePicker);
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      submitScopePicker();
+    });
+  }
+
+  // Thin wrapper around the DisplayOnce panel for the api-key-create
+  // flow. Same pattern as renderNodeRegisterDisplayOnce: resets the
+  // shared `remaskCallbacks` list, renders one row, installs the
+  // visibility/blur remask handlers, and binds ack → POST /complete
+  // with the typed `{ acknowledged, api_key_id }` payload.
+  function renderApiKeyCreateDisplayOnce(apiKeyId, keyName, fullKey) {
+    document.getElementById("display-once-title").textContent =
+      `Save the API key for '${keyName}'`;
+
+    const rowsEl = document.getElementById("display-once-rows");
+    rowsEl.innerHTML = "";
+    remaskCallbacks = [];
+    renderSecretRow(rowsEl, {
+      label: "API key",
+      value: fullKey,
+    });
+    installRemaskHandlers();
+
+    const ackBtn = document.getElementById("display-once-ack");
+    ackBtn.onclick = async () => {
+      if (finished) return;
+      finished = true;
+      ackBtn.disabled = true;
+      const statusEl = document.getElementById("display-once-status");
+      if (statusEl) {
+        statusEl.textContent = "Signalling CLI…";
+        statusEl.className = "wizard-status";
+      }
+      try {
+        const res = await proxyFetch("POST", "/api/proxy/complete", {
+          acknowledged: true,
+          api_key_id: apiKeyId,
+        });
+        if (!res.ok) {
+          if (statusEl) {
+            statusEl.textContent = `CLI rejected the ack (HTTP ${res.status}).`;
+            statusEl.className = "wizard-status error";
+          }
+          finished = false;
+          ackBtn.disabled = false;
+          return;
+        }
+        showOverlay({
+          icon: "✓",
+          title: "Saved",
+          body: "It is safe to close the browser now.",
+          sub: "Your terminal has the post-creation summary.",
+        });
+      } catch (err) {
+        if (statusEl) {
+          statusEl.textContent =
+            "Couldn't reach the CLI: " + (err.message || String(err));
+          statusEl.className = "wizard-status error";
+        }
+        finished = false;
+        ackBtn.disabled = false;
+      }
+    };
+  }
+
   // ---- init ----
   //
   // Per-flow dispatch. ai-key keeps the v2 boot sequence verbatim;
-  // rotation flows (v3) skip the catalog/credential machinery and
-  // jump straight into the confirm-rotate panel.
+  // DisplayOnce flows (v3 rotate + v3.1 create) skip the catalog/
+  // credential machinery and jump straight into the confirm panel.
   if (FLOW === "ai-key") {
     wire();
     if (!document.hidden) startHeartbeats();
     loadCatalog();
   } else if (FLOW === "api-key-rotate" || FLOW === "node-rotate-token") {
     initRotationFlow(FLOW);
+    if (!document.hidden) startHeartbeats();
+  } else if (FLOW === "node-register-token") {
+    initNodeRegisterFlow();
+    if (!document.hidden) startHeartbeats();
+  } else if (FLOW === "api-key-create") {
+    initApiKeyCreateFlow();
     if (!document.hidden) startHeartbeats();
   } else {
     // Unknown flow — show a minimal error and do nothing else.

--- a/cli/src/wizard/mod.rs
+++ b/cli/src/wizard/mod.rs
@@ -16,6 +16,15 @@
 //!     reads `id` / `name` / `message`,
 //!   - longer heartbeat-dead window for rotation flows so the user has
 //!     time to copy the secret into a password manager.
+//!
+//! v3.1 (`docs/CLI_WIZARD_V3.md` §2) adds the create-side of DisplayOnce:
+//! `nyxid node register-token` and `nyxid api-key create`. The backend
+//! still generates the one-time secret, but the trigger is a *create*
+//! call rather than a *rotate* call. The same narrow machinery applies:
+//! per-flow typed ack payloads (`NodeRegisterAckPayload`,
+//! `ApiKeyCreateAckPayload`), per-flow field-allowlist printer closures,
+//! and the same 60 s heartbeat-dead window (generalized from
+//! `is_rotation` → `is_display_once` on `FlowKind`).
 
 mod server;
 
@@ -60,6 +69,35 @@ pub struct RotatePrefill {
     pub display_name: String,
 }
 
+/// CLI-supplied prefill for `nyxid node register-token`. No resource to
+/// resolve up front — the backend mints a fresh token on confirm — so
+/// the only field is the optional node name. When the user didn't pass
+/// `--name` on the CLI, the wizard collects it in the browser instead
+/// of via an opaque stdin prompt.
+#[derive(Debug, Clone, Default)]
+pub struct NodeRegisterPrefill {
+    pub name: Option<String>,
+}
+
+/// CLI-supplied prefill for `nyxid api-key create`. Any field set here
+/// is encoded into the browser URL so the wizard opens with those
+/// values pre-populated. A user who types `nyxid api-key create --name
+/// coding-agent --platform claude-code` gets a wizard pre-filled with
+/// those two fields and the cursor on the "Create" button.
+#[derive(Debug, Clone, Default)]
+pub struct ApiKeyCreatePrefill {
+    pub name: Option<String>,
+    pub platform: Option<String>,
+    pub scopes: Option<String>,
+    pub expires_in_days: Option<u32>,
+    pub allow_all_services: bool,
+    pub allow_all_nodes: bool,
+    pub allowed_services_csv: Option<String>,
+    pub allowed_nodes_csv: Option<String>,
+    pub callback_url: Option<String>,
+    pub org_id: Option<String>,
+}
+
 /// Typed completion payload posted by the browser when the user clicks
 /// "I have saved this — close" on the DisplayOnce panel. Two guards live
 /// in this struct:
@@ -76,16 +114,43 @@ pub struct RotationAckPayload {
     pub resource_id: String,
 }
 
+/// Typed completion payload for `nyxid node register-token`. Same
+/// `deny_unknown_fields` guard as `RotationAckPayload`: the browser
+/// CANNOT smuggle the raw `nyx_nreg_...` token back through this path.
+/// `token_id` is the server-issued UUID for the registration token
+/// record (already visible to the user in the audit log and list
+/// endpoint); echoing it is safe and lets the CLI summary reference
+/// the row the user just created.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeRegisterAckPayload {
+    pub acknowledged: bool,
+    pub token_id: String,
+}
+
+/// Typed completion payload for `nyxid api-key create`. Shape and
+/// guards mirror the other ack payloads. `api_key_id` is the server-
+/// issued UUID for the created `ApiKey` record — non-secret, visible
+/// via `GET /api/v1/api-keys`, safe to print.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApiKeyCreateAckPayload {
+    pub acknowledged: bool,
+    pub api_key_id: String,
+}
+
 /// Outcome of a wizard run, returned to the caller for shaping terminal
 /// output. Variants are flow-specific so the leak surface stays narrow:
 /// the ai-key flow keeps its existing untyped body (a slug+label+url
-/// summary nobody calls a secret); rotation flows MUST go through the
-/// typed `RotationAckPayload` so the printer never sees raw bytes from
+/// summary nobody calls a secret); DisplayOnce flows MUST go through a
+/// typed per-flow ack payload so the printer never sees raw bytes from
 /// the browser.
 #[derive(Debug, Clone)]
 pub enum WizardOutcome {
     AiKeyCompleted(serde_json::Value),
     RotationAcknowledged(RotationAckPayload),
+    NodeRegisterAcknowledged(NodeRegisterAckPayload),
+    ApiKeyCreateAcknowledged(ApiKeyCreateAckPayload),
     Cancelled,
     TimedOut,
 }
@@ -137,12 +202,14 @@ pub async fn run_ai_key_wizard(auth: &crate::cli::AuthArgs, prefill: WizardPrefi
             print_wizard_summary(&body, &base_url);
             Ok(())
         }
-        WizardOutcome::RotationAcknowledged(_) => {
-            // Defensive: rotation outcome can't reach the ai-key handler
-            // (server::handle_complete dispatches by FlowKind), but if it
-            // ever did we'd refuse to print anything from it.
+        WizardOutcome::RotationAcknowledged(_)
+        | WizardOutcome::NodeRegisterAcknowledged(_)
+        | WizardOutcome::ApiKeyCreateAcknowledged(_) => {
+            // Defensive: a DisplayOnce outcome can't reach the ai-key
+            // handler (server::handle_complete dispatches by FlowKind),
+            // but if it ever did we'd refuse to print anything from it.
             Err(anyhow!(
-                "internal: ai-key wizard returned a rotation outcome (flow dispatch broken)"
+                "internal: ai-key wizard returned a display-once outcome (flow dispatch broken)"
             ))
         }
         WizardOutcome::Cancelled => {
@@ -157,6 +224,122 @@ pub async fn run_ai_key_wizard(auth: &crate::cli::AuthArgs, prefill: WizardPrefi
             eprintln!("       nyxid service add <slug> --credential-env VAR --label <label>");
             std::process::exit(1);
         }
+    }
+}
+
+/// Shared entry point for the `nyxid node register-token` wizard.
+/// Scripted / headless path lives in `commands::node` and stays
+/// byte-identical to pre-wizard behavior.
+pub async fn run_node_register_token_wizard(
+    auth: &crate::cli::AuthArgs,
+    prefill: NodeRegisterPrefill,
+) -> Result<()> {
+    let base_url = auth.resolved_base_url()?;
+    let access_token = crate::auth::resolve_access_token(auth)?;
+    let base_url_root = base_url.trim_end_matches('/').to_string();
+    let proxy = ProxyContext {
+        base_url_root,
+        access_token,
+        profile: auth.profile.clone(),
+    };
+
+    let outcome = server::run_flow(
+        server::FlowKind::NodeRegisterToken,
+        proxy,
+        server::PrefillData::NodeRegister(prefill),
+    )
+    .await?;
+
+    match outcome {
+        WizardOutcome::NodeRegisterAcknowledged(ack) => {
+            attract_terminal("NyxID wizard complete");
+            // Field allowlist: only `ack.token_id` (echoed from the
+            // browser, validated UUID-ish server-side). Never
+            // `format!("{ack:?}")`, never `serde_json::to_string(&ack)`.
+            eprintln!("✓ Registration token generated. New value was shown in the browser.");
+            eprintln!("  Token ID: {}", ack.token_id);
+            eprintln!("  Register a node with:");
+            eprintln!(
+                "    nyxid node register --token <token-from-browser> --url ws://<server>/api/v1/nodes/ws"
+            );
+            Ok(())
+        }
+        WizardOutcome::Cancelled => {
+            attract_terminal("NyxID wizard cancelled");
+            eprintln!("✗ Registration token wizard cancelled.");
+            eprintln!("  If the new token was shown in the browser, it was minted on the server.");
+            eprintln!(
+                "  If you saved it, you're done. If not, run `nyxid node register-token` again."
+            );
+            std::process::exit(1);
+        }
+        WizardOutcome::TimedOut => {
+            attract_terminal("NyxID wizard timed out");
+            eprintln!("✗ Registration token wizard timed out.");
+            eprintln!("  If the new token was shown in the browser, it was minted on the server.");
+            eprintln!(
+                "  If you didn't save it, run `nyxid node register-token` again to issue a fresh token."
+            );
+            std::process::exit(1);
+        }
+        _ => Err(anyhow!(
+            "internal: node-register-token wizard returned unexpected outcome"
+        )),
+    }
+}
+
+/// Shared entry point for the `nyxid api-key create` wizard. All CLI
+/// flags are plumbed through as `prefill` so a user who typed values on
+/// the command line sees them pre-selected in the browser.
+pub async fn run_api_key_create_wizard(
+    auth: &crate::cli::AuthArgs,
+    prefill: ApiKeyCreatePrefill,
+) -> Result<()> {
+    let base_url = auth.resolved_base_url()?;
+    let access_token = crate::auth::resolve_access_token(auth)?;
+    let base_url_root = base_url.trim_end_matches('/').to_string();
+    let proxy = ProxyContext {
+        base_url_root,
+        access_token,
+        profile: auth.profile.clone(),
+    };
+
+    let outcome = server::run_flow(
+        server::FlowKind::ApiKeyCreate,
+        proxy,
+        server::PrefillData::ApiKeyCreate(prefill),
+    )
+    .await?;
+
+    match outcome {
+        WizardOutcome::ApiKeyCreateAcknowledged(ack) => {
+            attract_terminal("NyxID wizard complete");
+            // Field allowlist: only `ack.api_key_id` (validated UUID-ish).
+            eprintln!("✓ API key created. New value was shown in the browser.");
+            eprintln!("  ID: {}", ack.api_key_id);
+            eprintln!("  Set as environment variable:");
+            eprintln!("    export NYXID_API_KEY=\"<value-from-browser>\"");
+            Ok(())
+        }
+        WizardOutcome::Cancelled => {
+            attract_terminal("NyxID wizard cancelled");
+            eprintln!("✗ API key wizard cancelled.");
+            eprintln!("  If the new key was shown in the browser, it was created on the server.");
+            eprintln!("  If you saved it, you're done. If not, run `nyxid api-key create` again.");
+            std::process::exit(1);
+        }
+        WizardOutcome::TimedOut => {
+            attract_terminal("NyxID wizard timed out");
+            eprintln!("✗ API key wizard timed out.");
+            eprintln!("  If the new key was shown in the browser, it was created on the server.");
+            eprintln!(
+                "  If you didn't save it, run `nyxid api-key create` again to issue a fresh key."
+            );
+            std::process::exit(1);
+        }
+        _ => Err(anyhow!(
+            "internal: api-key-create wizard returned unexpected outcome"
+        )),
     }
 }
 
@@ -250,11 +433,13 @@ async fn run_rotation_wizard(
             success_summary(&display_name_for_summary, &ack.resource_id);
             Ok(())
         }
-        WizardOutcome::AiKeyCompleted(_) => {
-            // Defensive: server dispatch shouldn't produce this for a
+        WizardOutcome::AiKeyCompleted(_)
+        | WizardOutcome::NodeRegisterAcknowledged(_)
+        | WizardOutcome::ApiKeyCreateAcknowledged(_) => {
+            // Defensive: server dispatch shouldn't produce these for a
             // rotation flow.
             Err(anyhow!(
-                "internal: rotation wizard returned an ai-key outcome (flow dispatch broken)"
+                "internal: rotation wizard returned a non-rotation outcome (flow dispatch broken)"
             ))
         }
         WizardOutcome::Cancelled => {

--- a/cli/src/wizard/server.rs
+++ b/cli/src/wizard/server.rs
@@ -30,25 +30,39 @@ use tokio::{
     sync::{Notify, oneshot},
 };
 
-use super::{ProxyContext, RotatePrefill, RotationAckPayload, WizardOutcome, WizardPrefill};
+use super::{
+    ApiKeyCreateAckPayload, ApiKeyCreatePrefill, NodeRegisterAckPayload, NodeRegisterPrefill,
+    ProxyContext, RotatePrefill, RotationAckPayload, WizardOutcome, WizardPrefill,
+};
 
 /// Which flow is running. Each flow gets its own allowlist and default
 /// page body. v2 shipped only `AiKey`; v3 added the two rotation
-/// (DisplayOnce-shaped) flows.
+/// (DisplayOnce-shaped) flows; v3.1 adds the create-side pair.
 #[derive(Debug, Clone, Copy)]
 pub enum FlowKind {
     AiKey,
     ApiKeyRotate,
     NodeRotateToken,
+    NodeRegisterToken,
+    ApiKeyCreate,
 }
 
 impl FlowKind {
-    /// True for flows whose Step 3 panel renders a one-time secret. The
-    /// heartbeat watchdog uses a longer dead-after window for these so
-    /// users have time to alt-tab into a password manager without the
-    /// CLI killing itself mid-save.
-    fn is_rotation(&self) -> bool {
-        matches!(self, FlowKind::ApiKeyRotate | FlowKind::NodeRotateToken)
+    /// True for flows whose terminal panel renders a one-time secret.
+    /// The heartbeat watchdog uses a longer dead-after window for these
+    /// so users have time to alt-tab into a password manager without
+    /// the CLI killing itself mid-save. (Previously named
+    /// `is_rotation`; v3.1 generalized since `register-token` and
+    /// `api-key create` have the same alt-tab risk despite not being
+    /// rotations.)
+    fn is_display_once(&self) -> bool {
+        matches!(
+            self,
+            FlowKind::ApiKeyRotate
+                | FlowKind::NodeRotateToken
+                | FlowKind::NodeRegisterToken
+                | FlowKind::ApiKeyCreate
+        )
     }
 
     /// String slug embedded in the served HTML's `<meta name="wizard-flow">`
@@ -58,18 +72,23 @@ impl FlowKind {
             FlowKind::AiKey => "ai-key",
             FlowKind::ApiKeyRotate => "api-key-rotate",
             FlowKind::NodeRotateToken => "node-rotate-token",
+            FlowKind::NodeRegisterToken => "node-register-token",
+            FlowKind::ApiKeyCreate => "api-key-create",
         }
     }
 }
 
 /// Prefill data routed into the wizard's URL query string. Per-flow
-/// shapes — `WizardPrefill` for ai-key (slug/label/via_node/endpoint_url),
-/// `RotatePrefill` for the two rotation flows (resource_id/display_name).
-/// Kept as an enum so server::run_flow's signature stays single-typed
-/// while each flow's prefill can grow independently.
+/// shapes — `WizardPrefill` for ai-key, `RotatePrefill` for the two
+/// rotation flows, `NodeRegisterPrefill` for `node register-token`,
+/// `ApiKeyCreatePrefill` for `api-key create`. Kept as an enum so
+/// `server::run_flow`'s signature stays single-typed while each flow's
+/// prefill can grow independently.
 pub enum PrefillData {
     AiKey(WizardPrefill),
     Rotate(RotatePrefill),
+    NodeRegister(NodeRegisterPrefill),
+    ApiKeyCreate(ApiKeyCreatePrefill),
 }
 
 /// Static assets live under `src/wizard/assets/` and are baked into the binary.
@@ -255,6 +274,59 @@ fn allowlist_for(kind: FlowKind) -> Vec<ProxyRoute> {
                 method: Method::POST,
                 path_template: "/api/v1/nodes/:node_id/rotate-token",
                 body_fields: &[],
+            },
+        ],
+        // Node registration-token creation (v3.1). One route: POST with
+        // just the node `name`. Body allowlist is tight — no metadata,
+        // no target_org_id, no TTL override. The response carries the
+        // one-time `token` (nyx_nreg_...) which the wizard renders in
+        // the DisplayOnce panel; the browser then posts back only
+        // `{ acknowledged, token_id }` to `/api/proxy/complete`.
+        FlowKind::NodeRegisterToken => vec![ProxyRoute {
+            method: Method::POST,
+            path_template: "/api/v1/nodes/register-token",
+            body_fields: &["name"],
+        }],
+        // API key creation (v3.1). Fields mirror what the wizard's
+        // scope-picker panel can emit — not the full
+        // `CreateApiKeyRequest` surface. Keeps privileged extras off
+        // the wire even if the wizard page were compromised. Extra
+        // reads: `/orgs` for the owner picker, `/user-services` and
+        // `/nodes` to populate the scope multi-selects lazily (only
+        // fetched when the user picks "Select specific").
+        FlowKind::ApiKeyCreate => vec![
+            ProxyRoute {
+                method: Method::GET,
+                path_template: "/api/v1/orgs",
+                body_fields: &[],
+            },
+            ProxyRoute {
+                method: Method::GET,
+                path_template: "/api/v1/user-services",
+                body_fields: &[],
+            },
+            ProxyRoute {
+                method: Method::GET,
+                path_template: "/api/v1/nodes",
+                body_fields: &[],
+            },
+            ProxyRoute {
+                method: Method::POST,
+                path_template: "/api/v1/api-keys",
+                body_fields: &[
+                    "name",
+                    "scopes",
+                    "expires_at",
+                    "allowed_service_ids",
+                    "allowed_node_ids",
+                    "allow_all_services",
+                    "allow_all_nodes",
+                    "rate_limit_per_second",
+                    "rate_limit_burst",
+                    "platform",
+                    "callback_url",
+                    "target_org_id",
+                ],
             },
         ],
     }
@@ -527,6 +599,58 @@ async fn handle_complete(
                     .into_response();
             }
             WizardOutcome::RotationAcknowledged(payload)
+        }
+        FlowKind::NodeRegisterToken => {
+            let payload: NodeRegisterAckPayload = match serde_json::from_slice(&body) {
+                Ok(p) => p,
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        format!("complete: invalid node-register ack payload: {e}"),
+                    )
+                        .into_response();
+                }
+            };
+            if payload.token_id.is_empty()
+                || payload.token_id.len() > 64
+                || !is_uuid_like(&payload.token_id)
+            {
+                return (StatusCode::BAD_REQUEST, "complete: bad token_id").into_response();
+            }
+            if !payload.acknowledged {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    "complete: acknowledged must be true",
+                )
+                    .into_response();
+            }
+            WizardOutcome::NodeRegisterAcknowledged(payload)
+        }
+        FlowKind::ApiKeyCreate => {
+            let payload: ApiKeyCreateAckPayload = match serde_json::from_slice(&body) {
+                Ok(p) => p,
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        format!("complete: invalid api-key-create ack payload: {e}"),
+                    )
+                        .into_response();
+                }
+            };
+            if payload.api_key_id.is_empty()
+                || payload.api_key_id.len() > 64
+                || !is_uuid_like(&payload.api_key_id)
+            {
+                return (StatusCode::BAD_REQUEST, "complete: bad api_key_id").into_response();
+            }
+            if !payload.acknowledged {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    "complete: acknowledged must be true",
+                )
+                    .into_response();
+            }
+            WizardOutcome::ApiKeyCreateAcknowledged(payload)
         }
     };
     signal_and_shutdown(state, outcome).await;
@@ -996,6 +1120,27 @@ fn prefill_query(prefill: &PrefillData) -> String {
             push(&mut parts, "resource_id", &p.resource_id);
             push(&mut parts, "display_name", &p.display_name);
         }
+        PrefillData::NodeRegister(p) => {
+            push_opt(&mut parts, "name", &p.name);
+        }
+        PrefillData::ApiKeyCreate(p) => {
+            push_opt(&mut parts, "name", &p.name);
+            push_opt(&mut parts, "platform", &p.platform);
+            push_opt(&mut parts, "scopes", &p.scopes);
+            if let Some(d) = p.expires_in_days {
+                parts.push(format!("expires_in_days={d}"));
+            }
+            if p.allow_all_services {
+                parts.push("allow_all_services=1".to_string());
+            }
+            if p.allow_all_nodes {
+                parts.push("allow_all_nodes=1".to_string());
+            }
+            push_opt(&mut parts, "allowed_services", &p.allowed_services_csv);
+            push_opt(&mut parts, "allowed_nodes", &p.allowed_nodes_csv);
+            push_opt(&mut parts, "callback_url", &p.callback_url);
+            push_opt(&mut parts, "org_id", &p.org_id);
+        }
     }
     if parts.is_empty() {
         String::new()
@@ -1107,11 +1252,11 @@ pub async fn run_flow(
     let watchdog_state = state.clone();
     let watchdog_shutdown = shutdown.clone();
     let (watchdog_tx, watchdog_rx) = oneshot::channel::<()>();
-    // Per-flow dead-after window. Rotation flows render a one-time
+    // Per-flow dead-after window. DisplayOnce flows render a one-time
     // secret; users may alt-tab into a password manager mid-save and
     // browsers throttle hidden-tab `setInterval` heartbeats. Cap is
     // still bounded (60s) so a truly-dead tab still gets cleaned up.
-    let dead_after = if kind.is_rotation() {
+    let dead_after = if kind.is_display_once() {
         HEARTBEAT_DEAD_AFTER_ROTATION
     } else {
         HEARTBEAT_DEAD_AFTER

--- a/docs/CLI_WIZARD_V3.md
+++ b/docs/CLI_WIZARD_V3.md
@@ -33,18 +33,28 @@ This document is also honest about what v3 does NOT promise (see §3.5).
 
 ## 2. Commands Affected
 
-| Credential                | Existing command               | Backend API                                    | v3.0  |
-|---------------------------|--------------------------------|------------------------------------------------|:-----:|
-| API key rotation          | `nyxid api-key rotate <id>`    | `POST /api/v1/api-keys/{id}/rotate`            |  ✅   |
-| Node token rotation       | `nyxid node rotate-token <id>` | `POST /api/v1/nodes/{id}/rotate-token`         |  ✅   |
-| NyxID agent API key       | `nyxid api-key create`         | `POST /api/v1/api-keys`                        |       |
-| Node registration         | `nyxid node register-token`    | `POST /api/v1/nodes/register-token`            |       |
-| Channel bot               | `nyxid channel-bot register`   | `POST /api/v1/channel-bots`                    |       |
-| MFA / TOTP                | `nyxid mfa setup` + `verify`   | `POST /api/v1/mfa/setup` + `.../verify-setup`  |       |
+| Credential                | Existing command               | Backend API                                    | v3.0  | v3.1  |
+|---------------------------|--------------------------------|------------------------------------------------|:-----:|:-----:|
+| API key rotation          | `nyxid api-key rotate <id>`    | `POST /api/v1/api-keys/{id}/rotate`            |  ✅   |       |
+| Node token rotation       | `nyxid node rotate-token <id>` | `POST /api/v1/nodes/{id}/rotate-token`         |  ✅   |       |
+| NyxID agent API key       | `nyxid api-key create`         | `POST /api/v1/api-keys`                        |       |  ✅   |
+| Node registration         | `nyxid node register-token`    | `POST /api/v1/nodes/register-token`            |       |  ✅   |
+| Channel bot               | `nyxid channel-bot register`   | `POST /api/v1/channel-bots`                    |       |       |
+| MFA / TOTP                | `nyxid mfa setup` + `verify`   | `POST /api/v1/mfa/setup` + `.../verify-setup`  |       |       |
 
-v3.0 ships the two rotation flows. The other rows are follow-up PRs:
+v3.0 shipped the two rotation flows. v3.1 adds the create-side pair
+(`nyxid api-key create` with scope picker + `nyxid node register-token`).
 
-- **v3.1:** `api-key create` (needs a scope picker — see [v3.0 follow-up notes](#10-known-debt--follow-up-prs)) + `node register-token` + `channel-bot register`.
+- **v3.1:** `api-key create` + `node register-token` — ✅ shipped.
+- **Deferred:** `channel-bot register` does not emit a one-time secret
+  today (`CreateChannelBotResponse` in `backend/src/handlers/channel_bots.rs`
+  returns only `id`/`platform`/`platform_bot_username`/`status`; the
+  webhook secret is generated, used to register with the platform, then
+  discarded from the response). That's a v2-style *input-collection*
+  problem, not a DisplayOnce problem, and it needs its own design
+  conversation — either add a backend change that reveals the webhook
+  secret on creation + a rotate endpoint, or ship a v2-style bot-token
+  input flow. Tracked for a follow-up PR.
 - **v3.2:** `mfa setup` (also needs the §10.3 QR-code work flagged in v2).
 
 ---
@@ -334,19 +344,23 @@ v3.0 deliberately excludes:
 
 ### 10.1 Pty test harness extraction (v2 §10.5)
 
-Still unextracted. v3 ships without expanded automated coverage. Should land before v3.1 to catch regressions in the rotation flows + the ai-key flow simultaneously.
+Still unextracted. v3 and v3.1 both shipped without expanded automated coverage. The cost of skipping has grown: four DisplayOnce flows (api-key rotate, node rotate-token, node register-token, api-key create) + the ai-key flow all share the same machinery now, so a regression in one of them bleeds into all. Should land before v3.2 (MFA setup).
 
 ### 10.2 Browser-level test (Playwright)
 
 Mask-on-blur, visibility-driven remask, and rotation-flow heartbeat behavior need a real browser to test. Standalone PR.
 
-### 10.3 api-key create + scope picker (v3.1)
+### 10.3 api-key create + scope picker (v3.1) — ✅ shipped
 
-The next DisplayOnce flow. Step 2 needs a multi-select against the user's services + nodes with allow-all toggles. Treat the picker as its own design exercise.
+Scope picker lives in `#step-scope-picker` (wizard.html) with `initApiKeyCreateFlow` in wizard.js. Layout: name, owner (personal or org, hidden when no orgs), platform, read/write scopes, expiry in days, service-access radio + multi-select, node-access radio + multi-select, rate-limit pair, callback URL. Multi-select lists fetched lazily on "Select specific". Proxy allowlist at `server.rs::allowlist_for(FlowKind::ApiKeyCreate)` covers `GET /orgs`, `GET /user-services`, `GET /nodes`, `POST /api-keys` (body allowlist: 12 fields including `target_org_id`).
 
-### 10.4 node register-token + channel-bot register (v3.1)
+### 10.4 node register-token (v3.1) — ✅ shipped
 
-Same DisplayOnce panel; per-flow Step 2 forms.
+`FlowKind::NodeRegisterToken` allowlist: just `POST /api/v1/nodes/register-token` with body_fields `["name"]`. Reuses `step-confirm-rotate` (panel copy overridden at init) + `step-display-once` verbatim. Typed ack payload `NodeRegisterAckPayload { acknowledged, token_id }` with the same `deny_unknown_fields` guard as rotation flows. Heartbeat dead-after window widened to 60 s via the generalized `FlowKind::is_display_once()` (previously `is_rotation()`).
+
+### 10.4.1 channel-bot register — deferred
+
+Not a DisplayOnce flow today: `CreateChannelBotResponse` returns only `id`/`platform`/`platform_bot_username`/`status`; the webhook secret is generated server-side, used to register the webhook with the external platform, then discarded. The right shape is either (a) a backend change to reveal the webhook secret + add a rotate-secret endpoint, or (b) a v2-style input flow that hides the platform bot token on entry. Design conversation pending.
 
 ### 10.5 mfa setup (v3.2)
 

--- a/docs/CLI_WIZARD_V3.md
+++ b/docs/CLI_WIZARD_V3.md
@@ -358,6 +358,20 @@ Scope picker lives in `#step-scope-picker` (wizard.html) with `initApiKeyCreateF
 
 `FlowKind::NodeRegisterToken` allowlist: just `POST /api/v1/nodes/register-token` with body_fields `["name"]`. Reuses `step-confirm-rotate` (panel copy overridden at init) + `step-display-once` verbatim. Typed ack payload `NodeRegisterAckPayload { acknowledged, token_id }` with the same `deny_unknown_fields` guard as rotation flows. Heartbeat dead-after window widened to 60 s via the generalized `FlowKind::is_display_once()` (previously `is_rotation()`).
 
+### 10.4.1 UI shell inheritance — v3.1 flows reuse the v2/v3 chrome
+
+Both v3.1 flows sit **inside the existing v2 shell**, not a new one. `wizard.html` puts every per-flow panel inside `<div class="wizard-shell"> … <main class="wizard-main"> … </main> …` — and everything outside `<main>` is shared across all flows:
+
+- **Header** — brand mark + NyxID wordmark (DM Serif Display) on the left; a per-flow step label (`#wizard-step-label`) on the right. v3.1's flows just update the step-label text ("Step 1 of 2 · name this node" for `node register-token`, "Step 1 of 2 · configure scope" for `api-key create`); the brand lockup is untouched.
+- **Footer** — "Served locally from `<origin>`  · Nothing leaves your machine." Rendered once at the bottom of the shell and inherited by every flow. No v3.1 change.
+- **Overlay** — the ✓ success / ✗ cancel / ⚠ disconnect end-state card (`#wizard-overlay`). v3.1 reuses `showOverlay(...)` on ack/cancel paths just like v3 rotation flows do.
+- **Design tokens** — `--bg`, `--fg`, `--muted`, `--panel`, `--border`, `--primary`, `--primary-hover`, `--wordmark`, `--ghost-hover`, `--card-hover`, `--selected-ring`. Defined once in `wizard.css` with a `prefers-color-scheme: light` override. v3.1 styles only use these tokens — no new color literals, no new font stacks.
+- **Button / secret-row tier** — `.wizard-btn`, `.wizard-btn-primary`, `.wizard-btn-ghost`, `.wizard-btn-tiny`, `.wizard-btn-tiny-icon`, `.wizard-secret-row`, `.wizard-status`, `.wizard-error-banner`, `.wizard-detail-list`. All reused as-is.
+
+New CSS in v3.1 is limited to the scope-picker's internal widgets (`.wizard-text-input`, `.wizard-scope-group`, `.wizard-checkbox`, `.wizard-radio`, `.wizard-multi-wrap`, `.wizard-multi-list`, `.wizard-multi-toolbar`, `.wizard-rate-row`, `.wizard-field-inline`). They all key off the existing tokens, so light/dark mode and accent-color rules apply automatically.
+
+Net effect: a user who ran `nyxid api-key rotate` on a v3 CLI and runs `nyxid api-key create` on a v3.1 CLI sees the identical frame — same logo, same step-label position, same footer tagline, same overlay. Only the body of the active panel differs.
+
 ### 10.4.1 channel-bot register — deferred
 
 Not a DisplayOnce flow today: `CreateChannelBotResponse` returns only `id`/`platform`/`platform_bot_username`/`status`; the webhook secret is generated server-side, used to register the webhook with the external platform, then discarded. The right shape is either (a) a backend change to reveal the webhook secret + add a rotate-secret endpoint, or (b) a v2-style input flow that hides the platform bot token on entry. Design conversation pending.

--- a/skills/nyxid/SKILL.md
+++ b/skills/nyxid/SKILL.md
@@ -500,20 +500,25 @@ export NYXID_ACCESS_TOKEN="nyxid_ag_..."
 
 Agent keys need `write` or `admin` scope to call management endpoints via REST (create/update/delete/rotate API keys, services, endpoints, bindings, etc.). `proxy read` is sufficient for proxy traffic only -- paths under `/proxy`, `/llm`, `/ssh`, `/channel-events`, `/channel-relay`, and `/delegation` do not require write scope. The `nyxid` CLI uses session auth (not API keys) and is unaffected.
 
-### Browser wizard for one-time secrets (v3.0 + v3.1)
+### Browser wizard for one-time secrets (v2 + v3.0 + v3.1)
 
-Four commands now open a local browser-based wizard for interactive use, so the new secret lands in the user's browser tab instead of the terminal / agent context:
+Five commands now open a local browser-based wizard for interactive use, so the secret (either collected from the user or minted by the backend) lands in the user's browser tab instead of the terminal / agent context:
 
-- `nyxid api-key rotate` — v3.0
-- `nyxid node rotate-token` — v3.0
-- `nyxid node register-token` — v3.1
-- `nyxid api-key create` — v3.1 (scope picker collects name + owner + platform + scopes + expiry + allowed services/nodes + rate limits; the key is minted on submit and shown once in the same DisplayOnce panel)
+| Command                           | Version | Wizard role                                                                                            |
+|-----------------------------------|:-------:|--------------------------------------------------------------------------------------------------------|
+| `nyxid service add [<slug>]`      |   v2    | Collects a paste-key / OAuth / device-code credential; creates the service + key record.               |
+| `nyxid api-key rotate <id>`       |   v3.0  | DisplayOnce: backend mints a new `nyxid_ag_…`, rendered masked with click-to-reveal + copy.            |
+| `nyxid node rotate-token <id>`    |   v3.0  | DisplayOnce: backend mints a new auth token + signing secret (two rows).                               |
+| `nyxid node register-token`       |   v3.1  | DisplayOnce: backend mints a new `nyx_nreg_…` for bootstrapping a fresh node.                          |
+| `nyxid api-key create`            |   v3.1  | Scope picker (name + owner + platform + scopes + expiry + service/node multi-select + rate limits) → DisplayOnce on the new `nyxid_ag_…`. |
 
-The CLI prints `→ Opening http://127.0.0.1:…/wizard …` and a no-secret success line on exit. Full spec: [`docs/CLI_WIZARD_V3.md`](../../docs/CLI_WIZARD_V3.md).
+The CLI prints `→ Opening http://127.0.0.1:…/wizard …` and a no-secret success line on exit. Full spec: [`docs/CLI_WIZARD_V2.md`](../../docs/CLI_WIZARD_V2.md) (v2) + [`docs/CLI_WIZARD_V3.md`](../../docs/CLI_WIZARD_V3.md) (v3 / v3.1).
+
+**Visual consistency.** Every wizard command — v2 and v3 and v3.1 alike — shares the same shell: same brand lockup (NyxID wordmark in DM Serif Display) in the header, same "Served locally from <origin> · Nothing leaves your machine" footer, same ✓/✗/⚠ overlay system, same purple accent (`#8b5cf6` / `#7c3aed`), same button and field styling. v3.1 adds only the scope-picker's internal widgets (multi-select rows, radio groups, numeric inputs); the frame around them is unchanged from v2. A user who ran `nyxid api-key rotate` on v3.0 sees the identical chrome when running `nyxid api-key create` on v3.1.
 
 For scripted / agent use, the wizard is **bypassed automatically** when ANY of these is true:
 
-- `--terminal` (alias `--no-wizard`) is passed -- per-invocation override, available on all four wizard commands + `nyxid service add`
+- `--terminal` (alias `--no-wizard`) is passed -- per-invocation override, available on all five wizard commands
 - `--output json` is passed (output is machine-readable)
 - stdout is not a TTY (piped, captured, redirected)
 - `NYXID_NO_WIZARD=1` is set in the environment

--- a/skills/nyxid/SKILL.md
+++ b/skills/nyxid/SKILL.md
@@ -451,9 +451,11 @@ Each AI agent or integration should use its own NyxID API key (agent key). This 
 
 ```bash
 # CRUD
+nyxid api-key create                                       # interactive: opens scope-picker wizard (v3.1)
 nyxid api-key create --name "My Key" --scopes "proxy read"
-nyxid api-key create --name "coding-agent" --platform claude-code  # optional platform label
+nyxid api-key create --name "coding-agent" --platform claude-code  # any prefill flag is picked up by the wizard
 nyxid api-key create --name "relay-agent" --callback-url "https://..."  # for channel bot relay
+nyxid api-key create --name "My Key" --output json         # scripted: prints raw key to stdout (legacy shape)
 nyxid api-key list --output json
 nyxid api-key show <ID_OR_NAME> --output json
 nyxid api-key rotate <ID_OR_NAME>                          # interactive: opens browser wizard
@@ -498,20 +500,27 @@ export NYXID_ACCESS_TOKEN="nyxid_ag_..."
 
 Agent keys need `write` or `admin` scope to call management endpoints via REST (create/update/delete/rotate API keys, services, endpoints, bindings, etc.). `proxy read` is sufficient for proxy traffic only -- paths under `/proxy`, `/llm`, `/ssh`, `/channel-events`, `/channel-relay`, and `/delegation` do not require write scope. The `nyxid` CLI uses session auth (not API keys) and is unaffected.
 
-### Browser wizard for one-time secrets (v3.0)
+### Browser wizard for one-time secrets (v3.0 + v3.1)
 
-`nyxid api-key rotate` and `nyxid node rotate-token` open a local browser-based wizard for interactive use, so the new secret value lands in the user's browser tab instead of the terminal / agent context. The CLI prints `→ Opening http://127.0.0.1:…/wizard …` and a no-secret success line on exit. Full spec: [`docs/CLI_WIZARD_V3.md`](../../docs/CLI_WIZARD_V3.md).
+Four commands now open a local browser-based wizard for interactive use, so the new secret lands in the user's browser tab instead of the terminal / agent context:
+
+- `nyxid api-key rotate` — v3.0
+- `nyxid node rotate-token` — v3.0
+- `nyxid node register-token` — v3.1
+- `nyxid api-key create` — v3.1 (scope picker collects name + owner + platform + scopes + expiry + allowed services/nodes + rate limits; the key is minted on submit and shown once in the same DisplayOnce panel)
+
+The CLI prints `→ Opening http://127.0.0.1:…/wizard …` and a no-secret success line on exit. Full spec: [`docs/CLI_WIZARD_V3.md`](../../docs/CLI_WIZARD_V3.md).
 
 For scripted / agent use, the wizard is **bypassed automatically** when ANY of these is true:
 
-- `--terminal` (alias `--no-wizard`) is passed -- per-invocation override, mirrors the same flag on `nyxid service add`
+- `--terminal` (alias `--no-wizard`) is passed -- per-invocation override, available on all four wizard commands + `nyxid service add`
 - `--output json` is passed (output is machine-readable)
 - stdout is not a TTY (piped, captured, redirected)
 - `NYXID_NO_WIZARD=1` is set in the environment
 - `SSH_CONNECTION` or `SSH_TTY` is set (SSH session, no local browser)
 - on Linux: both `DISPLAY` and `WAYLAND_DISPLAY` are unset
 
-In any of these cases, the rotate commands print the raw secret to stdout exactly as before (legacy shape, byte-identical). Agents calling these commands programmatically should always use `--output json` to be explicit and to make the response machine-parseable.
+In any of these cases, the commands print the raw secret to stdout exactly as before (legacy shape, byte-identical). Agents calling these commands programmatically should always use `--output json` to be explicit and to make the response machine-parseable.
 
 Behavior change to be aware of: `nyxid api-key rotate <name>` now **refuses ambiguous names** — if multiple keys share the same name, the command exits with `Name 'X' matches N keys. Pass the ID instead.` Previously it silently rotated the first match (which could rotate the wrong key). Always prefer ID over name for scripted rotation.
 
@@ -799,7 +808,8 @@ nyxid node daemon uninstall                             # remove service (stops 
 # nyxid CLI (manage nodes from user side)
 nyxid node list --output json                          # list nodes (includes IDs)
 nyxid node show <ID_OR_NAME> --output json             # show node details + metrics
-nyxid node register-token                              # generate registration token
+nyxid node register-token                              # interactive: opens browser wizard (v3.1)
+nyxid node register-token --name "edge-tokyo" --output json  # scripted: prints raw nyx_nreg_... (legacy shape)
 nyxid node delete <ID_OR_NAME> --yes                   # delete node
 nyxid node rotate-token <ID_OR_NAME>                   # interactive: opens browser wizard (shows new auth_token + signing_secret)
 nyxid node rotate-token <ID_OR_NAME> --output json     # scripted: prints raw secret to stdout (legacy shape)


### PR DESCRIPTION
## Summary

- Extends the v3 DisplayOnce wizard primitive to two create-side commands: `nyxid node register-token` and `nyxid api-key create`. Both now route their backend-minted one-time secret (`nyx_nreg_…` or `nyxid_ag_…`) through the local browser wizard on interactive TTYs, so it never lands in the terminal / LLM context.
- Adds a scope-picker panel for `api-key create` (name, owner, platform, scopes, expiry, per-service multi-select, per-node multi-select, rate limits, callback URL). Every CLI flag prefills the matching form field.
- Renames `FlowKind::is_rotation` → `is_display_once` and broadens it to cover all four DisplayOnce flows (api-key rotate, node rotate-token, node register-token, api-key create). Same 60 s heartbeat-dead window applies to all.

Deferred to a follow-up PR: `nyxid channel-bot register`. `CreateChannelBotResponse` doesn't return the webhook secret today (generated server-side, used to register the webhook, then discarded), so routing it through DisplayOnce needs either a backend change or a v2-style input-only flow. Design conversation pending.

## Guards (why this is safe)

- **Typed ack payloads** — `NodeRegisterAckPayload { acknowledged, token_id }` and `ApiKeyCreateAckPayload { acknowledged, api_key_id }`, both with `#[serde(deny_unknown_fields)]`. A buggy or compromised wizard page cannot smuggle `token` / `full_key` / `auth_token` / `signing_secret` back through `/api/proxy/complete`.
- **Field-allowlist printers** — the success closures read only `ack.token_id` / `ack.api_key_id` plus CLI-resolved metadata. Never `Debug`-format the payload, never `serde_json::to_string` the outcome.
- **Tight per-flow proxy allowlists** — `NodeRegisterToken` gets one route (`POST /nodes/register-token` with `body_fields: ["name"]`); `ApiKeyCreate` gets four (`GET /orgs`, `GET /user-services`, `GET /nodes`, `POST /api-keys` with a 12-key body allowlist). No DELETE, no PATCH, no admin routes, no `/keys` placeholder machinery.
- **Scripted-path byte-identity** — `--terminal` (alias `--no-wizard`), `--output json`, piped stdout, SSH, and `NYXID_NO_WIZARD=1` all bypass the wizard and fall through to pre-wizard behavior byte-identical. The old `node register-token` stdin-prompted shape still works under SSH / headless.

## Test plan

- [x] `cargo build -p nyxid-cli` — clean, zero warnings
- [x] `cargo test -p nyxid-cli` — 152/152 passing
- [x] `node --check cli/src/wizard/assets/wizard.js` — parses clean
- [x] Codex independent review — implicit pass on secret-leak surface, allowlist tightness, byte-identity, `is_rotation → is_display_once` rename, and the `renderSecretRow` refactor
- [x] Dogfood `nyxid node register-token` against a live backend — confirm (a) browser opens on 127.0.0.1 random port, (b) token appears masked, reveals on click, copies cleanly, (c) terminal summary contains no `nyx_nreg_` bytes, (d) closing the tab triggers cancel within ≤60 s
- [x] Dogfood `nyxid api-key create` — same checks on `nyxid_ag_…`, plus (e) owner selector hidden when user has no orgs, (f) service / node multi-select lists load lazily on "Select specific", (g) prefill via CLI flags (`--name`, `--platform`, `--allowed-services foo,bar`) pre-populates the form
- [x] Scripted regressions: `--output json` and `--terminal` for both new commands — diff against `main` to confirm byte-identity
- [ ] SSH regression: run under `SSH_CONNECTION=1` — wizard must skip, old stdin-prompt shape for `node register-token` intact
- [ ] Linux headless regression: unset `DISPLAY` + `WAYLAND_DISPLAY` — wizard must skip
- [ ] Secret-leak grep: capture stdout/stderr of both wizard commands, confirm zero hits for `nyx_nreg_` and `nyxid_ag_` prefixes
- [ ] Proxy allowlist boundary: `curl` the wizard's local proxy with a non-allowlisted path (e.g. `/api/v1/admin/users`) — must 403

## Docs

- `docs/CLI_WIZARD_V3.md` — v3.1 rows marked shipped in §2; §10.3/10.4 updated with what actually landed; channel-bot deferral rationale captured.
- `skills/nyxid/SKILL.md` — bypass rules and scripted examples updated for all four wizard-driven commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)