### PR TITLE
feat(approvals): org-aware presentation in mobile app and notifications

### DIFF
--- a/backend/src/handlers/approvals.rs
+++ b/backend/src/handlers/approvals.rs
@@ -41,6 +41,20 @@ pub struct ApprovalRequestItem {
     pub created_at: String,
     pub decided_at: Option<String>,
     pub decision_channel: Option<String>,
+    /// True when this request was created under an org's per-service
+    /// approval policy. Clients use this to render an "Org" badge and
+    /// the `on behalf of {org_name}` context line.
+    #[serde(default)]
+    pub from_org_policy: bool,
+    /// Owning org id, present only when `from_org_policy` is true.
+    /// For org-policy requests this equals `ApprovalRequest.user_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
+    /// Owning org display name, resolved at list time via `org_service`.
+    /// May be absent even when `from_org_policy` is true if the org row
+    /// is missing a display name or the lookup failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_name: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -61,6 +75,19 @@ pub struct ApprovalGrantItem {
     pub requester_label: Option<String>,
     pub granted_at: String,
     pub expires_at: String,
+    /// True when the grant is owned by an org (reusable by any member of
+    /// that org). Clients render an "Org" chip when set.
+    #[serde(default)]
+    pub org_scoped: bool,
+    /// Owning org id, present only when `org_scoped` is true.
+    /// For org-scoped grants this equals `ApprovalGrant.user_id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
+    /// Owning org display name, resolved at list time via `org_service`.
+    /// May be absent even when `org_scoped` is true if the org row
+    /// is missing a display name or the lookup failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_name: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -110,7 +137,15 @@ pub struct CreateApprovalResponse {
 
 fn to_approval_request_item(
     request: crate::models::approval_request::ApprovalRequest,
+    org_name: Option<String>,
 ) -> ApprovalRequestItem {
+    let from_org_policy = request.from_org_policy;
+    let org_id = if from_org_policy {
+        Some(request.user_id.clone())
+    } else {
+        None
+    };
+    let resolved_org_name = if from_org_policy { org_name } else { None };
     ApprovalRequestItem {
         id: request.id,
         service_name: request.service_name,
@@ -128,7 +163,156 @@ fn to_approval_request_item(
         created_at: request.created_at.to_rfc3339(),
         decided_at: request.decided_at.map(|d| d.to_rfc3339()),
         decision_channel: request.decision_channel,
+        from_org_policy,
+        org_id,
+        org_name: resolved_org_name,
     }
+}
+
+/// Map an `ApprovalGrant` to its API representation, stamping the org
+/// context fields when the grant is org-scoped. `org_name` is passed in
+/// after a batch lookup by the caller so we never issue per-row queries.
+fn to_approval_grant_item(
+    grant: crate::models::approval_grant::ApprovalGrant,
+    org_name: Option<String>,
+) -> ApprovalGrantItem {
+    let org_scoped = grant.org_scoped;
+    let org_id = if org_scoped {
+        Some(grant.user_id.clone())
+    } else {
+        None
+    };
+    let resolved_org_name = if org_scoped { org_name } else { None };
+    ApprovalGrantItem {
+        id: grant.id,
+        service_id: grant.service_id,
+        service_name: grant.service_name,
+        requester_type: grant.requester_type,
+        requester_id: grant.requester_id,
+        requester_label: grant.requester_label,
+        granted_at: grant.granted_at.to_rfc3339(),
+        expires_at: grant.expires_at.to_rfc3339(),
+        org_scoped,
+        org_id,
+        org_name: resolved_org_name,
+    }
+}
+
+/// Translate a scoped admin's `allowed_service_ids` (which live in
+/// `UserService.id` space) into the concrete set of storage-space
+/// `service_id`s that can match an `ApprovalRequest` or
+/// `ApprovalGrant` row under the supplied org. The stored
+/// `service_id` may be either a `UserService.id` (custom services)
+/// or the `catalog_service_id` from the underlying `UserService`
+/// (catalog-backed services), so we union both for every allowed
+/// UserService that still exists.
+///
+/// This is the inverse direction of `scope_user_service_ids_for_config`:
+/// that helper maps a stored row to the UserService.ids the scope is
+/// written against; this one maps the scope forward into the space
+/// the stored rows actually live in, so we can push the whole filter
+/// into Mongo and keep pagination correct.
+///
+/// Returns an empty Vec when no supplied id resolves to a UserService
+/// owned by the org (deleted services, or a mis-scoped membership).
+/// Callers use an empty result to short-circuit the whole org branch.
+async fn resolve_scope_storage_service_ids(
+    db: &mongodb::Database,
+    org_user_id: &str,
+    allowed_user_service_ids: &[String],
+) -> AppResult<Vec<String>> {
+    use futures::TryStreamExt;
+    if allowed_user_service_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut ids_bson = mongodb::bson::Array::new();
+    for id in allowed_user_service_ids {
+        ids_bson.push(mongodb::bson::Bson::String(id.clone()));
+    }
+    let rows: Vec<UserService> = db
+        .collection::<UserService>(USER_SERVICES)
+        .find(mongodb::bson::doc! {
+            "_id": { "$in": ids_bson },
+            "user_id": org_user_id,
+        })
+        .await?
+        .try_collect()
+        .await?;
+
+    let mut out: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for row in rows {
+        out.insert(row.id.clone());
+        if let Some(cat) = row.catalog_service_id {
+            out.insert(cat);
+        }
+    }
+    Ok(out.into_iter().collect())
+}
+
+/// Build the `OrgFilterBranch` list the service layer consumes, given
+/// the caller's current active admin memberships. Scoped admins get
+/// their `allowed_service_ids` pre-resolved into storage-space ids so
+/// the Mongo filter applies scope at query time (rather than post-
+/// fetch, which would break pagination). Unscoped admins get
+/// `service_id_scope: None`.
+///
+/// Returns an empty Vec when the caller has no admin memberships.
+async fn resolve_admin_org_branches(
+    db: &mongodb::Database,
+    actor_user_id: &str,
+) -> AppResult<Vec<approval_service::OrgFilterBranch>> {
+    let memberships = crate::services::org_service::list_memberships_for_member(
+        db,
+        actor_user_id,
+        false, // active only
+    )
+    .await?;
+
+    let mut branches: Vec<approval_service::OrgFilterBranch> =
+        Vec::with_capacity(memberships.len());
+    for m in memberships {
+        if !matches!(m.role, crate::models::org_membership::OrgRole::Admin) {
+            continue;
+        }
+        let service_id_scope: Option<Vec<String>> = match m.allowed_service_ids {
+            None => None,
+            Some(ids) => Some(resolve_scope_storage_service_ids(db, &m.org_user_id, &ids).await?),
+        };
+        branches.push(approval_service::OrgFilterBranch {
+            org_id: m.org_user_id,
+            service_id_scope,
+        });
+    }
+    Ok(branches)
+}
+
+/// Resolve a map of `org_id -> display_name` for the supplied set of
+/// org ids. Looks each id up via `org_service::get_org_user` (reuse;
+/// no new helper) and skips any that fail to resolve — missing org
+/// names on the response are permitted and the client renders a
+/// generic "Org" fallback. De-dupes inputs so each distinct org is
+/// fetched at most once per list call.
+async fn resolve_org_names(
+    db: &mongodb::Database,
+    org_ids: impl IntoIterator<Item = String>,
+) -> std::collections::HashMap<String, String> {
+    let mut unique: Vec<String> = org_ids.into_iter().collect();
+    unique.sort();
+    unique.dedup();
+    let mut out = std::collections::HashMap::with_capacity(unique.len());
+    for id in unique {
+        match crate::services::org_service::get_org_user(db, &id).await {
+            Ok(user) => {
+                if let Some(name) = user.display_name.clone() {
+                    out.insert(id, name);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(org_id = %id, error = %e, "Failed to resolve org display name for approvals listing");
+            }
+        }
+    }
+    out
 }
 
 /// Legacy strict ownership check kept for the existing unit tests. The
@@ -218,6 +402,13 @@ pub struct ApprovalRequestsQuery {
     /// org. Without this filter the endpoint returns the actor's personal
     /// approval history (existing behavior).
     pub org_id: Option<String>,
+    /// Opt-in union: when `true` (and `org_id` is not set), also include
+    /// org-policy requests owned by every org the caller is currently an
+    /// active admin of. Default `false` keeps the existing personal-only
+    /// behavior so web clients that distinguish personal vs org pages are
+    /// unaffected. Mobile sets this so the unified Activity inbox can
+    /// show personal + admin-org items together (see ChronoAIProject/NyxID#376).
+    pub include_admin_orgs: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -229,6 +420,9 @@ pub struct GrantsQuery {
     /// org. Org-policy approvals create grants under the org's user_id,
     /// so this is the only way for org admins to see them.
     pub org_id: Option<String>,
+    /// Opt-in union for active grants. Same semantics as the field on
+    /// `ApprovalRequestsQuery`. Default `false`.
+    pub include_admin_orgs: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -254,12 +448,26 @@ pub async fn list_requests(
 ) -> AppResult<Json<ApprovalRequestsResponse>> {
     let actor = auth_user.user_id.to_string();
 
-    if let Some(ref status) = query.status
-        && !["pending", "approved", "rejected", "expired"].contains(&status.as_str())
-    {
-        return Err(crate::errors::AppError::ValidationError(
-            "status must be one of: pending, approved, rejected, expired".to_string(),
-        ));
+    // `status` accepts one value ("pending") or a comma-separated list
+    // ("approved,rejected,expired") so the history view can ask for
+    // "everything except pending" in one query. Each token is validated
+    // against the canonical set; whitespace around tokens is tolerated.
+    let allowed_statuses = ["pending", "approved", "rejected", "expired"];
+    let parsed_statuses: Vec<String> = match query.status.as_deref() {
+        None => Vec::new(),
+        Some(raw) => raw
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+    };
+    for s in &parsed_statuses {
+        if !allowed_statuses.contains(&s.as_str()) {
+            return Err(crate::errors::AppError::ValidationError(
+                "status must be one of: pending, approved, rejected, expired (comma-separated list allowed)"
+                    .to_string(),
+            ));
+        }
     }
 
     // org_id query param scopes the listing to org-policy approvals.
@@ -276,23 +484,61 @@ pub async fn list_requests(
         }
         target_org_id.to_string()
     } else {
-        actor
+        actor.clone()
     };
 
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
 
+    // Opt-in union: resolve admin-org branches (scope pre-translated
+    // into storage-space service ids) so scope is enforced in the
+    // Mongo filter itself. This keeps pagination correct for scoped
+    // admins — post-fetch filtering could leave a scoped admin's
+    // first page empty while later pages held in-scope rows, which
+    // the mobile Activity inbox would treat as end-of-list. Union
+    // only runs on the default personal listing; when `?org_id=` is
+    // supplied the caller already pinned the scope to one org and the
+    // existing single-owner path stays in charge.
+    let admin_branches = if query.org_id.is_none() && query.include_admin_orgs.unwrap_or(false) {
+        resolve_admin_org_branches(&state.db, &actor).await?
+    } else {
+        Vec::new()
+    };
+
+    let status_refs: Vec<&str> = parsed_statuses.iter().map(|s| s.as_str()).collect();
     let (requests, total) = approval_service::list_requests(
         &state.db,
         &listing_user_id,
-        query.status.as_deref(),
+        &admin_branches,
+        &status_refs,
         page,
         per_page,
     )
     .await?;
 
-    let items: Vec<ApprovalRequestItem> =
-        requests.into_iter().map(to_approval_request_item).collect();
+    // Batch-resolve org display names for rows backed by an org policy.
+    // When `?org_id=` is set every returned row shares the same owning
+    // org, so this collapses to a single fetch; on the personal inbox
+    // this fetches one name per distinct org the caller is an admin
+    // for, bounded by the page size.
+    let org_ids: Vec<String> = requests
+        .iter()
+        .filter(|r| r.from_org_policy)
+        .map(|r| r.user_id.clone())
+        .collect();
+    let org_names = resolve_org_names(&state.db, org_ids).await;
+
+    let items: Vec<ApprovalRequestItem> = requests
+        .into_iter()
+        .map(|r| {
+            let name = if r.from_org_policy {
+                org_names.get(&r.user_id).cloned()
+            } else {
+                None
+            };
+            to_approval_request_item(r, name)
+        })
+        .collect();
 
     Ok(Json(ApprovalRequestsResponse {
         requests: items,
@@ -317,7 +563,17 @@ pub async fn get_request_by_id(
 
     ensure_caller_can_decide(&state.db, &request, &user_id).await?;
 
-    Ok(Json(to_approval_request_item(request)))
+    // Single-row path: look up the owning org name directly when the
+    // request was created under an org policy so the detail response
+    // carries the same org context as the list endpoint.
+    let org_name = if request.from_org_policy {
+        resolve_org_names(&state.db, std::iter::once(request.user_id.clone()))
+            .await
+            .remove(&request.user_id)
+    } else {
+        None
+    };
+    Ok(Json(to_approval_request_item(request, org_name)))
 }
 
 /// GET /api/v1/approvals/requests/{request_id}/status
@@ -546,23 +802,41 @@ pub async fn list_grants(
         }
         target_org_id.to_string()
     } else {
-        actor
+        actor.clone()
+    };
+
+    // Mirror `list_requests`: opt-in union only kicks in on the
+    // personal listing path. Scope + per-owner grant-mode filtering
+    // happens in the Mongo filter via `OrgFilterBranch`.
+    let admin_branches = if query.org_id.is_none() && query.include_admin_orgs.unwrap_or(false) {
+        resolve_admin_org_branches(&state.db, &actor).await?
+    } else {
+        Vec::new()
     };
 
     let (grants, total) =
-        approval_service::list_grants(&state.db, &listing_user_id, page, per_page).await?;
+        approval_service::list_grants(&state.db, &listing_user_id, &admin_branches, page, per_page)
+            .await?;
+
+    // Same batching strategy as `list_requests`: resolve each distinct
+    // owning org id once per call. Personal grants (`org_scoped=false`)
+    // contribute nothing to the lookup.
+    let org_ids: Vec<String> = grants
+        .iter()
+        .filter(|g| g.org_scoped)
+        .map(|g| g.user_id.clone())
+        .collect();
+    let org_names = resolve_org_names(&state.db, org_ids).await;
 
     let items: Vec<ApprovalGrantItem> = grants
         .into_iter()
-        .map(|g| ApprovalGrantItem {
-            id: g.id,
-            service_id: g.service_id,
-            service_name: g.service_name,
-            requester_type: g.requester_type,
-            requester_id: g.requester_id,
-            requester_label: g.requester_label,
-            granted_at: g.granted_at.to_rfc3339(),
-            expires_at: g.expires_at.to_rfc3339(),
+        .map(|g| {
+            let name = if g.org_scoped {
+                org_names.get(&g.user_id).cloned()
+            } else {
+                None
+            };
+            to_approval_grant_item(g, name)
         })
         .collect();
 
@@ -1285,7 +1559,7 @@ mod tests {
         let expected_service = request.service_name.clone();
         let expected_status = request.status.clone();
 
-        let item = to_approval_request_item(request);
+        let item = to_approval_request_item(request, None);
 
         assert_eq!(item.id, expected_id);
         assert_eq!(item.service_name, expected_service);
@@ -1304,12 +1578,87 @@ mod tests {
         request.tool_arguments = Some(r#"{"service_id":"svc_1"}"#.to_string());
         request.is_destructive = Some(true);
 
-        let item = to_approval_request_item(request);
+        let item = to_approval_request_item(request, None);
 
         assert_eq!(item.tool_name.as_deref(), Some("invoke_service"));
         assert_eq!(item.tool_call_id.as_deref(), Some("call_abc"));
         assert!(item.tool_arguments.is_some());
         assert_eq!(item.is_destructive, Some(true));
+    }
+
+    #[test]
+    fn to_approval_request_item_stamps_org_fields_when_from_org_policy() {
+        let mut request = sample_request("org_abc");
+        request.from_org_policy = true;
+
+        let item = to_approval_request_item(request, Some("Acme Inc.".to_string()));
+
+        assert!(item.from_org_policy);
+        assert_eq!(item.org_id.as_deref(), Some("org_abc"));
+        assert_eq!(item.org_name.as_deref(), Some("Acme Inc."));
+    }
+
+    #[test]
+    fn to_approval_request_item_omits_org_fields_for_personal_requests() {
+        let request = sample_request("user_1");
+        // Even if a caller mistakenly passes an org_name for a personal
+        // request, the mapper must not stamp org fields — from_org_policy
+        // is the authoritative signal.
+        let item = to_approval_request_item(request, Some("Irrelevant".to_string()));
+
+        assert!(!item.from_org_policy);
+        assert!(item.org_id.is_none());
+        assert!(item.org_name.is_none());
+    }
+
+    #[test]
+    fn to_approval_grant_item_stamps_org_fields_when_org_scoped() {
+        use crate::models::approval_grant::ApprovalGrant;
+        let grant = ApprovalGrant {
+            id: uuid::Uuid::new_v4().to_string(),
+            user_id: "org_abc".to_string(),
+            service_id: uuid::Uuid::new_v4().to_string(),
+            service_name: "OpenAI".to_string(),
+            requester_type: "service_account".to_string(),
+            requester_id: "sa_123".to_string(),
+            requester_label: Some("CI bot".to_string()),
+            approval_request_id: uuid::Uuid::new_v4().to_string(),
+            granted_at: Utc::now(),
+            expires_at: Utc::now() + chrono::Duration::days(30),
+            revoked: false,
+            org_scoped: true,
+        };
+
+        let item = to_approval_grant_item(grant, Some("Acme Inc.".to_string()));
+
+        assert!(item.org_scoped);
+        assert_eq!(item.org_id.as_deref(), Some("org_abc"));
+        assert_eq!(item.org_name.as_deref(), Some("Acme Inc."));
+    }
+
+    #[test]
+    fn to_approval_grant_item_omits_org_fields_for_personal_grants() {
+        use crate::models::approval_grant::ApprovalGrant;
+        let grant = ApprovalGrant {
+            id: uuid::Uuid::new_v4().to_string(),
+            user_id: "user_1".to_string(),
+            service_id: uuid::Uuid::new_v4().to_string(),
+            service_name: "OpenAI".to_string(),
+            requester_type: "service_account".to_string(),
+            requester_id: "sa_123".to_string(),
+            requester_label: None,
+            approval_request_id: uuid::Uuid::new_v4().to_string(),
+            granted_at: Utc::now(),
+            expires_at: Utc::now() + chrono::Duration::days(30),
+            revoked: false,
+            org_scoped: false,
+        };
+
+        let item = to_approval_grant_item(grant, Some("Leaked name".to_string()));
+
+        assert!(!item.org_scoped);
+        assert!(item.org_id.is_none());
+        assert!(item.org_name.is_none());
     }
 
     #[test]

--- a/backend/src/services/approval_service.rs
+++ b/backend/src/services/approval_service.rs
@@ -348,6 +348,28 @@ pub async fn create_approval_request(
     // their channel/message ids are not stored on the request -- the
     // decision-time edit will only update one of them. Trade-off accepted
     // for now; a fuller fix would store per-recipient delivery state.
+    //
+    // For org-policy requests, resolve the owning org's display name
+    // exactly once and pass it into every fan-out call so Telegram and
+    // push notifications can render org-aware wording. A failed lookup
+    // degrades gracefully to the generic template (`None`) rather than
+    // blocking the request.
+    let org_name: Option<String> = if request.from_org_policy {
+        match crate::services::org_service::get_org_user(db, &request.user_id).await {
+            Ok(org_user) => org_user.display_name.clone(),
+            Err(e) => {
+                tracing::warn!(
+                    org_id = %request.user_id,
+                    error = %e,
+                    "Failed to resolve org display name for approval notification"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let mut all_channels: Vec<String> = Vec::new();
     let mut primary_chat_id: Option<i64> = None;
     let mut primary_message_id: Option<i64> = None;
@@ -363,6 +385,7 @@ pub async fn create_approval_request(
             apns_auth,
             recipient,
             &request,
+            org_name.as_deref(),
         )
         .await
         {
@@ -503,7 +526,9 @@ pub async fn create_tool_approval_request(
         .await
         .map_err(AppError::DatabaseError)?;
 
-    // Send notification through existing pipeline
+    // Send notification through existing pipeline. Tool approvals are
+    // always personal (see `from_org_policy: false` above), so no org
+    // context is ever passed here.
     match notification_service::send_approval_notification(
         db,
         config,
@@ -512,6 +537,7 @@ pub async fn create_tool_approval_request(
         apns_auth,
         user_id,
         &request,
+        None,
     )
     .await
     {
@@ -970,17 +996,119 @@ pub fn map_wait_for_decision_error(
     }
 }
 
+/// Listing-scope descriptor for one admin org branch on the
+/// opt-in `include_admin_orgs=true` listing paths. Handlers pre-resolve
+/// each admin membership's `allowed_service_ids` (which live in
+/// `UserService.id` space) into the set of concrete storage-space
+/// `service_id`s that can match an `ApprovalRequest` / `ApprovalGrant`
+/// row, so the Mongo filter itself enforces scope. This keeps
+/// pagination correct: a scoped admin's empty-page case from the
+/// post-fetch filter is eliminated, because we never fetch rows we
+/// can't return.
+///
+/// `service_id_scope` semantics:
+/// - `None` — unscoped admin. Every org-owned row (subject to the
+///   `from_org_policy` / `org_scoped` flag) passes.
+/// - `Some(vec)` — scoped admin. Only rows whose `service_id` is in
+///   `vec` pass. An empty `vec` means the admin's scope resolved to no
+///   storage-space ids — the caller should drop this branch entirely
+///   so the admin sees nothing from that org.
+#[derive(Debug, Clone)]
+pub struct OrgFilterBranch {
+    pub org_id: String,
+    pub service_id_scope: Option<Vec<String>>,
+}
+
+/// Build the Mongo filter for listing approval requests.
+///
+/// Empty `admin_branches` preserves the legacy per-user shape so
+/// callers that don't opt in to the admin-org union get byte-identical
+/// behavior. When non-empty, branches are emitted as `$or` alternatives
+/// keyed on each org's `user_id` + `from_org_policy: true`, with a
+/// per-branch `service_id: { $in: ... }` when the admin is scoped.
+/// Scoped admins whose resolved storage-space id list is empty are
+/// dropped from the filter (they see no org rows from that
+/// membership).
+fn build_requests_filter(user_id: &str, admin_branches: &[OrgFilterBranch]) -> bson::Document {
+    let mut branches: Vec<bson::Document> = Vec::new();
+    // Personal branch always included so the caller's own rows are
+    // part of the unified result.
+    branches.push(doc! { "user_id": user_id });
+
+    for branch in admin_branches {
+        match &branch.service_id_scope {
+            Some(ids) if ids.is_empty() => {
+                // Scoped admin with no services in scope — emit nothing.
+                continue;
+            }
+            Some(ids) => {
+                let mut ids_bson = bson::Array::new();
+                for id in ids {
+                    ids_bson.push(bson::Bson::String(id.clone()));
+                }
+                branches.push(doc! {
+                    "user_id": &branch.org_id,
+                    "from_org_policy": true,
+                    "service_id": { "$in": ids_bson },
+                });
+            }
+            None => {
+                branches.push(doc! {
+                    "user_id": &branch.org_id,
+                    "from_org_policy": true,
+                });
+            }
+        }
+    }
+
+    if branches.len() == 1 {
+        // Only the personal branch survived. Fall back to the legacy
+        // flat shape so callers see the same Document they always did.
+        return branches.remove(0);
+    }
+    let mut arr = bson::Array::new();
+    for b in branches {
+        arr.push(bson::Bson::Document(b));
+    }
+    doc! { "$or": arr }
+}
+
 /// List approval requests for a user (for history page).
+///
+/// `admin_branches` widens the listing to also include org-policy
+/// requests owned by each supplied admin org, with per-branch scope
+/// applied in the Mongo filter so pagination is correct. Callers
+/// that don't want the union pass `&[]` and get the historic
+/// personal-only result.
+///
+/// `statuses` accepts zero, one, or many status values. Empty slice
+/// means "no status filter" (all statuses returned). Single value
+/// becomes an equality predicate (`status: "pending"`). Multiple
+/// values become `status: { $in: [...] }` so the history view can
+/// ask for "everything except pending" in a single query — the
+/// alternative (filter client-side after pagination) stranded
+/// decided rows behind pages full of admin-org PENDING items.
 pub async fn list_requests(
     db: &Database,
     user_id: &str,
-    status_filter: Option<&str>,
+    admin_branches: &[OrgFilterBranch],
+    statuses: &[&str],
     page: u64,
     per_page: u64,
 ) -> AppResult<(Vec<ApprovalRequest>, u64)> {
-    let mut filter = doc! { "user_id": user_id };
-    if let Some(status) = status_filter {
-        filter.insert("status", status);
+    let mut filter = build_requests_filter(user_id, admin_branches);
+    match statuses {
+        [] => {}
+        [single] => {
+            filter.insert("status", *single);
+        }
+        many => {
+            let mut arr = bson::Array::new();
+            for s in many {
+                arr.push(bson::Bson::String((*s).to_string()));
+            }
+            filter.insert("status", doc! { "$in": arr });
+        }
     }
 
     let total = db
@@ -1014,39 +1142,161 @@ pub async fn get_request(db: &Database, request_id: &str) -> AppResult<ApprovalR
         .ok_or_else(|| AppError::NotFound("Approval request not found".to_string()))
 }
 
+/// Build the Mongo filter for listing approval grants. Empty
+/// `admin_branches` preserves the legacy per-user shape. When
+/// non-empty, branches are emitted as `$or` alternatives. Each
+/// branch carries its OWN grant-mode service-id set so one owner's
+/// `grant_mode` config never leaks another owner's grants (the
+/// cross-owner bug codex flagged in round 2). Per-branch scope is
+/// also intersected with the mode set so a scoped admin never sees
+/// rows outside their `allowed_service_ids`.
+///
+/// `grant_mode_by_owner` maps an owner `user_id` → its grant-mode
+/// service ids. An owner missing from the map has no services in
+/// grant mode and contributes no grants.
+fn build_grants_filter(
+    user_id: &str,
+    admin_branches: &[OrgFilterBranch],
+    grant_mode_by_owner: &std::collections::HashMap<String, Vec<String>>,
+    now: bson::DateTime,
+) -> bson::Document {
+    let mut branches: Vec<bson::Document> = Vec::new();
+
+    // Personal branch: only include if the caller has at least one
+    // service in grant mode. Otherwise we emit no personal branch at
+    // all, matching the legacy "no configs → no grants" behavior.
+    if let Some(actor_mode_ids) = grant_mode_by_owner.get(user_id)
+        && !actor_mode_ids.is_empty()
+    {
+        let mut ids_bson = bson::Array::new();
+        for id in actor_mode_ids {
+            ids_bson.push(bson::Bson::String(id.clone()));
+        }
+        branches.push(doc! {
+            "user_id": user_id,
+            "service_id": { "$in": ids_bson },
+        });
+    }
+
+    // Admin org branches. Each intersects the org's own grant-mode
+    // service ids with the admin's scope (if any). Skip branches that
+    // resolve to an empty set.
+    for branch in admin_branches {
+        let Some(mode_ids) = grant_mode_by_owner.get(&branch.org_id) else {
+            continue;
+        };
+        if mode_ids.is_empty() {
+            continue;
+        }
+        let effective: Vec<String> = match &branch.service_id_scope {
+            None => mode_ids.clone(),
+            Some(scope_ids) => mode_ids
+                .iter()
+                .filter(|sid| scope_ids.iter().any(|s| s == *sid))
+                .cloned()
+                .collect(),
+        };
+        if effective.is_empty() {
+            continue;
+        }
+        let mut ids_bson = bson::Array::new();
+        for id in &effective {
+            ids_bson.push(bson::Bson::String(id.clone()));
+        }
+        branches.push(doc! {
+            "user_id": &branch.org_id,
+            "org_scoped": true,
+            "service_id": { "$in": ids_bson },
+        });
+    }
+
+    let mut filter = doc! {
+        "revoked": false,
+        "expires_at": { "$gt": now },
+    };
+
+    if branches.is_empty() {
+        // Nothing matches. Use a predicate that's cheap for Mongo to
+        // evaluate as false (synthetic sentinel on the `_id` field).
+        filter.insert("_id", doc! { "$in": bson::Array::new() });
+    } else if branches.len() == 1 {
+        // Inline single branch so the filter stays flat and indexed.
+        let only = branches.remove(0);
+        for (k, v) in only {
+            filter.insert(k, v);
+        }
+    } else {
+        let mut arr = bson::Array::new();
+        for b in branches {
+            arr.push(bson::Bson::Document(b));
+        }
+        filter.insert("$or", bson::Bson::Array(arr));
+    }
+
+    filter
+}
+
 /// List active approval grants for a user.
 ///
-/// Only returns grants for services currently in `Grant` mode. Grants for
-/// services in `PerRequest` mode (or with no config, which defaults to
-/// `PerRequest`) are excluded even if they haven't been revoked yet. This
-/// read-time filter acts as a safety net for any write-time race conditions
-/// or partial failures during mode switches (see #146).
+/// Only returns grants for services currently in `Grant` mode.
+/// Grants for services in `PerRequest` mode (or with no config,
+/// which defaults to `PerRequest`) are excluded even if they
+/// haven't been revoked yet. This read-time filter acts as a
+/// safety net for any write-time race conditions or partial
+/// failures during mode switches (see #146).
+///
+/// `admin_branches` widens the listing to also include org-scoped
+/// grants owned by each supplied admin org, with per-branch scope
+/// (`service_id_scope`) intersected against that org's own grant-mode
+/// configs in the Mongo filter. Callers that don't opt in pass
+/// `&[]`.
 pub async fn list_grants(
     db: &Database,
     user_id: &str,
+    admin_branches: &[OrgFilterBranch],
     page: u64,
     per_page: u64,
 ) -> AppResult<(Vec<ApprovalGrant>, u64)> {
     let now = bson::DateTime::from_chrono(Utc::now());
 
-    // Collect service IDs that are explicitly in grant mode for this user.
-    // Services with no config default to per_request, so their grants are excluded.
-    let grant_mode_service_ids: Vec<String> = db
+    // Collect grant-mode configs for the actor AND each admin org,
+    // but keep them grouped BY owner. The per-owner grouping is the
+    // fix for the round-2 cross-owner leak: owner A's "grant" config
+    // must not allow owner B's grants through.
+    let mut config_owner_ids: Vec<String> = vec![user_id.to_string()];
+    for b in admin_branches {
+        if !config_owner_ids.iter().any(|id| id == &b.org_id) {
+            config_owner_ids.push(b.org_id.clone());
+        }
+    }
+    let mut ids_bson = bson::Array::new();
+    for id in &config_owner_ids {
+        ids_bson.push(bson::Bson::String(id.clone()));
+    }
+    let configs: Vec<ServiceApprovalConfig> = db
         .collection::<ServiceApprovalConfig>(SERVICE_APPROVAL_CONFIGS)
-        .find(doc! { "user_id": user_id, "approval_mode": "grant" })
+        .find(doc! {
+            "user_id": { "$in": ids_bson },
+            "approval_mode": "grant",
+        })
         .await?
-        .try_collect::<Vec<ServiceApprovalConfig>>()
-        .await?
-        .into_iter()
-        .map(|c| c.service_id)
-        .collect();
+        .try_collect()
+        .await?;
+    let mut grant_mode_by_owner: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for c in configs {
+        grant_mode_by_owner
+            .entry(c.user_id)
+            .or_default()
+            .push(c.service_id);
+    }
+    // De-dupe per owner.
+    for v in grant_mode_by_owner.values_mut() {
+        let set: HashSet<String> = v.drain(..).collect();
+        v.extend(set);
+    }
 
-    let filter = doc! {
-        "user_id": user_id,
-        "revoked": false,
-        "expires_at": { "$gt": now },
-        "service_id": { "$in": &grant_mode_service_ids },
-    };
+    let filter = build_grants_filter(user_id, admin_branches, &grant_mode_by_owner, now);
 
     let total = db
         .collection::<ApprovalGrant>(GRANTS)
@@ -1739,5 +1989,157 @@ mod tests {
         );
 
         assert!(matches!(error, AppError::DatabaseError(_)));
+    }
+
+    fn unscoped_branch(org_id: &str) -> OrgFilterBranch {
+        OrgFilterBranch {
+            org_id: org_id.to_string(),
+            service_id_scope: None,
+        }
+    }
+
+    fn scoped_branch(org_id: &str, ids: &[&str]) -> OrgFilterBranch {
+        OrgFilterBranch {
+            org_id: org_id.to_string(),
+            service_id_scope: Some(ids.iter().map(|s| s.to_string()).collect()),
+        }
+    }
+
+    #[test]
+    fn build_requests_filter_without_admin_branches_keeps_legacy_shape() {
+        // Empty admin_branches must produce the historic single-owner
+        // filter so callers that don't opt in see byte-identical
+        // behavior.
+        let filter = build_requests_filter("user-1", &[]);
+        assert_eq!(filter.get_str("user_id").unwrap(), "user-1");
+        assert!(filter.get("$or").is_none());
+    }
+
+    #[test]
+    fn build_requests_filter_with_unscoped_admin_unions_every_org_row() {
+        let filter = build_requests_filter(
+            "user-1",
+            &[unscoped_branch("org-a"), unscoped_branch("org-b")],
+        );
+        let branches = filter.get_array("$or").expect("$or present");
+        assert_eq!(branches.len(), 3);
+
+        assert_eq!(
+            branches[0]
+                .as_document()
+                .unwrap()
+                .get_str("user_id")
+                .unwrap(),
+            "user-1"
+        );
+        // Each org branch keys on its own org_id and requires
+        // from_org_policy = true. No service_id restriction.
+        for (i, org) in ["org-a", "org-b"].iter().enumerate() {
+            let b = branches[i + 1].as_document().unwrap();
+            assert_eq!(b.get_str("user_id").unwrap(), *org);
+            assert!(b.get_bool("from_org_policy").unwrap());
+            assert!(b.get("service_id").is_none());
+        }
+    }
+
+    #[test]
+    fn build_requests_filter_scoped_admin_applies_service_id_in() {
+        let filter =
+            build_requests_filter("user-1", &[scoped_branch("org-a", &["svc-1", "svc-2"])]);
+        let branches = filter.get_array("$or").expect("$or present");
+        assert_eq!(branches.len(), 2);
+        let org = branches[1].as_document().unwrap();
+        let ids = org
+            .get_document("service_id")
+            .unwrap()
+            .get_array("$in")
+            .unwrap();
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids[0].as_str().unwrap(), "svc-1");
+        assert_eq!(ids[1].as_str().unwrap(), "svc-2");
+    }
+
+    #[test]
+    fn build_requests_filter_scoped_admin_with_empty_scope_drops_branch() {
+        // An admin whose scope resolves to no storage-space ids (e.g.
+        // every allowed UserService was deleted) must not widen the
+        // caller's view at all. The filter should collapse back to
+        // the legacy personal-only shape.
+        let filter = build_requests_filter("user-1", &[scoped_branch("org-a", &[])]);
+        assert_eq!(filter.get_str("user_id").unwrap(), "user-1");
+        assert!(filter.get("$or").is_none());
+    }
+
+    #[test]
+    fn build_grants_filter_without_admin_branches_keeps_legacy_shape() {
+        let now = bson::DateTime::from_chrono(chrono::Utc::now());
+        let mut mode = std::collections::HashMap::new();
+        mode.insert("user-1".to_string(), vec!["svc-1".to_string()]);
+        let filter = build_grants_filter("user-1", &[], &mode, now);
+        assert_eq!(filter.get_str("user_id").unwrap(), "user-1");
+        assert!(filter.get("$or").is_none());
+        // Grant-mode restriction is inlined on the same document.
+        assert!(filter.get("service_id").is_some());
+    }
+
+    #[test]
+    fn build_grants_filter_keeps_grant_mode_per_owner() {
+        // The round-2 cross-owner leak: actor has svc-1 in grant mode
+        // but org-a has svc-1 in per_request mode. Org-a must not
+        // contribute any branch, so actor's grants for svc-1 show up
+        // while org-a's grants for svc-1 do not.
+        let now = bson::DateTime::from_chrono(chrono::Utc::now());
+        let mut mode = std::collections::HashMap::new();
+        mode.insert("user-1".to_string(), vec!["svc-1".to_string()]);
+        // org-a has NO entry in the map → no grants from org-a.
+
+        let filter = build_grants_filter("user-1", &[unscoped_branch("org-a")], &mode, now);
+        // Only the actor branch survives. Should be inlined, not an $or.
+        assert_eq!(filter.get_str("user_id").unwrap(), "user-1");
+        assert!(filter.get("$or").is_none());
+    }
+
+    #[test]
+    fn build_grants_filter_scoped_admin_intersects_scope_with_mode() {
+        // Admin is scoped to [svc-1, svc-2], org has svc-2 and svc-3
+        // in grant mode. Effective set = {svc-2}.
+        let now = bson::DateTime::from_chrono(chrono::Utc::now());
+        let mut mode = std::collections::HashMap::new();
+        mode.insert(
+            "org-a".to_string(),
+            vec!["svc-2".to_string(), "svc-3".to_string()],
+        );
+        let filter = build_grants_filter(
+            "user-1",
+            &[scoped_branch("org-a", &["svc-1", "svc-2"])],
+            &mode,
+            now,
+        );
+        // No actor grant-mode entries, so only the org branch is
+        // present — gets inlined since it's the sole branch.
+        assert_eq!(filter.get_str("user_id").unwrap(), "org-a");
+        assert!(filter.get_bool("org_scoped").unwrap());
+        let ids = filter
+            .get_document("service_id")
+            .unwrap()
+            .get_array("$in")
+            .unwrap();
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].as_str().unwrap(), "svc-2");
+    }
+
+    #[test]
+    fn build_grants_filter_no_owners_in_grant_mode_returns_empty_match() {
+        // Neither the actor nor the admin org has any service in
+        // grant mode → the filter must match nothing, not leak
+        // unrelated grants via a degenerate $or.
+        let now = bson::DateTime::from_chrono(chrono::Utc::now());
+        let mode: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+        let filter = build_grants_filter("user-1", &[unscoped_branch("org-a")], &mode, now);
+        // Empty-match sentinel on _id keeps the query valid and
+        // indexed while matching zero rows.
+        let id_clause = filter.get_document("_id").unwrap();
+        let in_arr = id_clause.get_array("$in").unwrap();
+        assert_eq!(in_arr.len(), 0);
     }
 }

--- a/backend/src/services/notification_service.rs
+++ b/backend/src/services/notification_service.rs
@@ -28,6 +28,13 @@ enum PushResult {
 
 /// Send an approval notification to the user via all enabled channels.
 /// Returns which channels succeeded and Telegram metadata.
+///
+/// `org_name` is the display name of the owning org when
+/// `request.from_org_policy` is true. Pass `None` for personal requests
+/// (or when the lookup failed); the resulting Telegram / push wording is
+/// then byte-identical to the pre-org behavior so non-org callers are
+/// unaffected.
+#[allow(clippy::too_many_arguments)]
 pub async fn send_approval_notification(
     db: &Database,
     config: &AppConfig,
@@ -36,15 +43,25 @@ pub async fn send_approval_notification(
     apns_auth: Option<&ApnsAuth>,
     user_id: &str,
     request: &ApprovalRequest,
+    org_name: Option<&str>,
 ) -> AppResult<NotificationResult> {
     let channel = get_or_create_channel(db, user_id).await?;
+
+    // Only treat `org_name` as meaningful when the request itself carries
+    // the org-policy flag. This keeps the "from_org_policy is the
+    // authoritative signal" invariant shared by the DTO mapper.
+    let effective_org_name = if request.from_org_policy {
+        org_name
+    } else {
+        None
+    };
 
     let mut channels_used: Vec<String> = Vec::new();
     let mut telegram_chat_id = None;
     let mut telegram_message_id = None;
     let mut tokens_to_remove: Vec<String> = Vec::new();
 
-    // 1. Telegram (existing behavior)
+    // 1. Telegram (existing behavior; wording switches when org-scoped)
     if channel.telegram_enabled
         && let Some(chat_id) = channel.telegram_chat_id
     {
@@ -69,6 +86,7 @@ pub async fn send_approval_notification(
                     .as_deref()
                     .unwrap_or(&request.operation_summary),
                 channel.approval_timeout_secs,
+                effective_org_name,
             )
             .await
             {
@@ -93,6 +111,32 @@ pub async fn send_approval_notification(
             "deeplink".to_string(),
             format!("nyxid://challenge/{}", request.id),
         );
+        // When the request is created under an org policy, inject the
+        // org context so the mobile app can render the org badge on
+        // the detail screen opened via the deeplink before the list
+        // endpoint is re-fetched. Keys are only added when defined —
+        // missing keys are tolerated by the client.
+        if request.from_org_policy {
+            data.insert("from_org_policy".to_string(), "true".to_string());
+            data.insert("org_id".to_string(), request.user_id.clone());
+            if let Some(name) = effective_org_name {
+                data.insert("org_name".to_string(), name.to_string());
+            }
+        }
+
+        // Push title/body switch when the request is org-scoped so admins
+        // can distinguish an org decision from a personal one from the
+        // lock-screen preview alone.
+        let (push_title, push_body_owned): (&str, Option<String>) = match effective_org_name {
+            Some(name) => (
+                "Org Approval Required",
+                Some(format!("{name} admins: a service is requesting access")),
+            ),
+            None => ("Approval Required", None),
+        };
+        let push_body: &str = push_body_owned
+            .as_deref()
+            .unwrap_or("A service is requesting access");
 
         let push_futures: Vec<_> = unique_devices
             .iter()
@@ -103,8 +147,8 @@ pub async fn send_approval_notification(
                     apns_auth,
                     config,
                     device,
-                    "Approval Required",
-                    "A service is requesting access",
+                    push_title,
+                    push_body,
                     &data,
                 )
             })

--- a/backend/src/services/telegram_service.rs
+++ b/backend/src/services/telegram_service.rs
@@ -128,8 +128,54 @@ struct GetUpdatesResponse {
     result: Vec<TelegramUpdate>,
 }
 
+/// Build the HTML body of an approval notification. Extracted from
+/// `send_approval_message` so the template logic can be unit-tested
+/// without a Telegram client.
+fn format_approval_message(
+    service_name: &str,
+    service_slug: &str,
+    requester_label: &str,
+    operation_summary: &str,
+    expires_in_secs: u32,
+    org_name: Option<&str>,
+) -> String {
+    let svc_name = html_escape(service_name);
+    let svc_slug = html_escape(service_slug);
+    let req_label = html_escape(requester_label);
+    let op_summary = html_escape(operation_summary);
+
+    match org_name {
+        Some(org) => {
+            let org_escaped = html_escape(org);
+            format!(
+                "<b>Org Access Request — {org_escaped}</b>\n\n\
+                 <b>Org:</b> {org_escaped}\n\
+                 <b>Service:</b> {svc_name} (<code>{svc_slug}</code>)\n\
+                 <b>Requester:</b> {req_label}\n\
+                 <b>Action:</b> <code>{op_summary}</code>\n\
+                 <b>Expires:</b> {expires_in_secs}s"
+            )
+        }
+        None => format!(
+            "<b>Access Request</b>\n\n\
+             <b>Service:</b> {svc_name} (<code>{svc_slug}</code>)\n\
+             <b>Requester:</b> {req_label}\n\
+             <b>Action:</b> <code>{op_summary}</code>\n\
+             <b>Expires:</b> {expires_in_secs}s"
+        ),
+    }
+}
+
 /// Send an approval request message with Approve/Reject inline keyboard.
 /// Returns the Telegram message_id.
+///
+/// `org_name` is `Some(name)` when the request was created under an org's
+/// approval policy. In that case the header switches to `Org Access
+/// Request — {org_name}` and an extra `<b>Org:</b> {org_name}` line is
+/// prepended so admins can tell at a glance that they are deciding on
+/// behalf of the org rather than for themselves. Passing `None` keeps
+/// the message byte-identical to the pre-org wording so non-org
+/// requests are unaffected.
 #[allow(clippy::too_many_arguments)]
 pub async fn send_approval_message(
     http_client: &Client,
@@ -141,17 +187,15 @@ pub async fn send_approval_message(
     requester_label: &str,
     operation_summary: &str,
     expires_in_secs: u32,
+    org_name: Option<&str>,
 ) -> AppResult<i64> {
-    let svc_name = html_escape(service_name);
-    let svc_slug = html_escape(service_slug);
-    let req_label = html_escape(requester_label);
-    let op_summary = html_escape(operation_summary);
-    let text = format!(
-        "<b>Access Request</b>\n\n\
-         <b>Service:</b> {svc_name} (<code>{svc_slug}</code>)\n\
-         <b>Requester:</b> {req_label}\n\
-         <b>Action:</b> <code>{op_summary}</code>\n\
-         <b>Expires:</b> {expires_in_secs}s"
+    let text = format_approval_message(
+        service_name,
+        service_slug,
+        requester_label,
+        operation_summary,
+        expires_in_secs,
+        org_name,
     );
 
     // Use UUID without hyphens for callback data (32 chars + 2 prefix = 34 chars)
@@ -517,5 +561,50 @@ mod tests {
     #[test]
     fn parse_no_separator() {
         assert!(parse_callback_data("noseparator").is_none());
+    }
+
+    #[test]
+    fn format_personal_approval_message_keeps_existing_wording() {
+        let text = format_approval_message(
+            "OpenAI",
+            "openai",
+            "CI bot",
+            "POST /v1/chat/completions",
+            30,
+            None,
+        );
+        assert!(text.starts_with("<b>Access Request</b>"));
+        assert!(!text.contains("Org Access Request"));
+        assert!(!text.contains("<b>Org:</b>"));
+        assert!(text.contains("<b>Service:</b> OpenAI"));
+    }
+
+    #[test]
+    fn format_org_approval_message_uses_org_header_and_line() {
+        let text = format_approval_message(
+            "OpenAI",
+            "openai",
+            "CI bot",
+            "POST /v1/chat/completions",
+            30,
+            Some("Acme Inc."),
+        );
+        assert!(text.starts_with("<b>Org Access Request — Acme Inc.</b>"));
+        assert!(text.contains("<b>Org:</b> Acme Inc."));
+        assert!(text.contains("<b>Service:</b> OpenAI"));
+    }
+
+    #[test]
+    fn format_org_approval_message_escapes_html_in_org_name() {
+        let text = format_approval_message(
+            "OpenAI",
+            "openai",
+            "CI bot",
+            "POST /v1/chat/completions",
+            30,
+            Some("<script>&"),
+        );
+        assert!(text.contains("&lt;script&gt;&amp;"));
+        assert!(!text.contains("<script>"));
     }
 }

--- a/mobile/src/components/ChallengeCard.tsx
+++ b/mobile/src/components/ChallengeCard.tsx
@@ -41,10 +41,21 @@ export function ChallengeCard({
   const modeLabel = challenge.approval_mode === "grant" ? "Grant mode" : "Per-request";
   const durationLabel = challenge.approval_mode === "grant" ? ` · ${grantDurationLabel}` : "";
   const timeAgo = formatTimeAgo(challenge.created_at);
+  // Render an org chip when the backend marks the request as
+  // created under an org approval policy. The label falls back to
+  // a generic "Org" when the server omitted the name, so old
+  // backends still render something meaningful.
+  const showOrgChip = challenge.from_org_policy === true;
+  const orgChipLabel = challenge.org_name
+    ? `Org · ${challenge.org_name}`
+    : "Org";
 
   return (
     <Pressable style={styles.card} onPress={onPress} disabled={isMutating}>
       <View style={styles.chipRow}>
+        {showOrgChip ? (
+          <StatusBadge variant="orgChip" label={orgChipLabel} />
+        ) : null}
         <StatusBadge variant={riskVariant} label={challenge.risk_level.toUpperCase()} />
         <StatusBadge variant="modeChip" label={modeLabel} />
       </View>

--- a/mobile/src/components/GrantCard.tsx
+++ b/mobile/src/components/GrantCard.tsx
@@ -39,6 +39,8 @@ export function GrantCard({ grant, onRevoke, isMutating = false }: GrantCardProp
   const grantedLabel = `Approved ${formatDate(grant.granted_at)}`;
   const expiresLabel = `Expires ${formatDate(grant.expires_at)}`;
   const requesterLabel = grant.requester_label ?? grant.requester_type;
+  const showOrgChip = grant.org_scoped === true;
+  const orgChipLabel = grant.org_name ? `Org · ${grant.org_name}` : "Org";
 
   return (
     <View style={styles.card}>
@@ -54,6 +56,11 @@ export function GrantCard({ grant, onRevoke, isMutating = false }: GrantCardProp
           <Text style={styles.revokeBtnText}>Revoke</Text>
         </Pressable>
       </View>
+      {showOrgChip ? (
+        <View style={styles.chipRow}>
+          <StatusBadge variant="orgChip" label={orgChipLabel} />
+        </View>
+      ) : null}
       <Text style={styles.secondary} numberOfLines={1}>
         {grant.requester_type} · {requesterLabel}
       </Text>
@@ -80,6 +87,10 @@ const createStyles = (c: ThemeColors) =>
       justifyContent: "space-between",
       alignItems: "center",
       gap: spacing.sm,
+    },
+    chipRow: {
+      flexDirection: "row",
+      gap: 6,
     },
     title: {
       flex: 1,

--- a/mobile/src/components/StatusBadge.tsx
+++ b/mobile/src/components/StatusBadge.tsx
@@ -13,7 +13,8 @@ type BadgeVariant =
   | "decisionApproved"
   | "decisionDenied"
   | "decisionExpired"
-  | "modeChip";
+  | "modeChip"
+  | "orgChip";
 
 type StatusBadgeProps = {
   variant: BadgeVariant;
@@ -31,6 +32,10 @@ function getVariantStyles(c: ThemeColors): Record<BadgeVariant, { bg: string; te
     decisionDenied: { bg: c.dangerSoftBg, text: c.danger, border: c.riskHigh.border },
     decisionExpired: { bg: c.ghostBg, text: c.textMuted, border: c.borderSoft },
     modeChip: { bg: c.primaryGlow, text: c.primary, border: c.primaryGlow },
+    // Org chip reuses the muted ghost palette so it reads as
+    // structural context (whose decision is this?) rather than risk
+    // or status. Keeps DESIGN.md tokens; no new colors introduced.
+    orgChip: { bg: c.ghostBg, text: c.textSecondary, border: c.borderSoft },
   };
 }
 

--- a/mobile/src/features/activity/ActivityDetailScreen.tsx
+++ b/mobile/src/features/activity/ActivityDetailScreen.tsx
@@ -125,6 +125,11 @@ export function ActivityDetailScreen({ navigation, route }: Props) {
             Review this request before creating reusable access for {grantDurationLabel}.
           </Text>
         )}
+        {data.from_org_policy ? (
+          <Text style={styles.orgContext}>
+            On behalf of {data.org_name ?? "your org"}
+          </Text>
+        ) : null}
 
         <View style={styles.detailCard}>
           <Text style={flowStyles.cardTitle}>Request Context</Text>
@@ -134,6 +139,13 @@ export function ActivityDetailScreen({ navigation, route }: Props) {
           <DetailRow label="Risk Level" value={data.risk_level.toUpperCase()} valueColor={riskColor} flowStyles={flowStyles} />
           <DetailRow label="Status" value={actionState.statusLabel} valueColor={colors.warning} flowStyles={flowStyles} />
           {isGrantMode && <DetailRow label="Grant Duration" value={grantDurationLabel} flowStyles={flowStyles} />}
+          {data.from_org_policy ? (
+            <DetailRow
+              label="Org"
+              value={data.org_name ?? "Unnamed org"}
+              flowStyles={flowStyles}
+            />
+          ) : null}
           <DetailRow label="Location" value={data.request_context.location} isLast flowStyles={flowStyles} />
         </View>
 
@@ -182,6 +194,12 @@ const createStyles = (c: ThemeColors) => StyleSheet.create({
     fontSize: 13,
     color: c.textSecondary,
     lineHeight: 20,
+  },
+  orgContext: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: c.textSecondary,
+    letterSpacing: 0.3,
   },
   stateNotice: {
     borderRadius: radius.sm,

--- a/mobile/src/features/activity/ActivityScreen.tsx
+++ b/mobile/src/features/activity/ActivityScreen.tsx
@@ -226,6 +226,11 @@ function ChallengeDetailSheet({
           </View>
 
           <ScrollView style={sheetStyles.sheetBody} contentContainerStyle={sheetStyles.sheetBodyContent}>
+            {shown.from_org_policy ? (
+              <Text style={sheetStyles.orgContext}>
+                On behalf of {shown.org_name ?? "your org"}
+              </Text>
+            ) : null}
             <View style={sheetStyles.detailCard}>
               <Text style={flowStyles.cardTitle}>Request Context</Text>
               <DetailRow label="Action" value={shown.action} flowStyles={flowStyles} />
@@ -235,6 +240,13 @@ function ChallengeDetailSheet({
               <DetailRow label="Risk Level" value={shown.risk_level.toUpperCase()} valueColor={riskColor} flowStyles={flowStyles} />
               <DetailRow label="Status" value={actionState.statusLabel} flowStyles={flowStyles} />
               {isGrantMode && <DetailRow label="Grant Duration" value={grantDurationLabel} flowStyles={flowStyles} />}
+              {shown.from_org_policy ? (
+                <DetailRow
+                  label="Org"
+                  value={shown.org_name ?? "Unnamed org"}
+                  flowStyles={flowStyles}
+                />
+              ) : null}
               <DetailRow label="Location" value={shown.request_context.location} isLast flowStyles={flowStyles} />
             </View>
 
@@ -391,8 +403,9 @@ export function ActivityScreen() {
   });
 
   const revokeMutation = useMutation({
-    mutationFn: (approvalId: string) => mobileApi.revoke(approvalId),
-    onMutate: (id) => {
+    mutationFn: ({ id, orgId }: { id: string; orgId?: string | null }) =>
+      mobileApi.revoke(id, orgId),
+    onMutate: ({ id }) => {
       setMutatingIds((prev) => new Set(prev).add(id));
     },
     onSuccess: () => {
@@ -402,7 +415,7 @@ export function ActivityScreen() {
     onError: () => {
       setToast({ message: "Failed to revoke. Try again.", kind: "error" });
     },
-    onSettled: (_, __, id) => {
+    onSettled: (_, __, { id }) => {
       setMutatingIds((prev) => {
         const next = new Set(prev);
         next.delete(id);
@@ -414,7 +427,15 @@ export function ActivityScreen() {
   const handleRevoke = useCallback((grant: ApprovalItem) => {
     Alert.alert("Revoke Access", `Revoke access for ${grant.service_name}?`, [
       { text: "Cancel", style: "cancel" },
-      { text: "Revoke", style: "destructive", onPress: () => revokeMutation.mutate(grant.id) },
+      {
+        text: "Revoke",
+        style: "destructive",
+        // Forward org_id when the grant is org-scoped so the backend
+        // pivots ownership to the owning org (otherwise DELETE 404s
+        // because the default path searches by user_id = actor).
+        onPress: () =>
+          revokeMutation.mutate({ id: grant.id, orgId: grant.org_id ?? null }),
+      },
     ]);
   }, [revokeMutation]);
 
@@ -708,6 +729,12 @@ const createSheetStyles = (c: ThemeColors) => StyleSheet.create({
   sheetBodyContent: {
     paddingBottom: spacing.huge,
     gap: spacing.lg,
+  },
+  orgContext: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: c.textSecondary,
+    letterSpacing: 0.3,
   },
   stateNotice: {
     borderRadius: radius.sm,

--- a/mobile/src/lib/api/http.ts
+++ b/mobile/src/lib/api/http.ts
@@ -96,6 +96,12 @@ type BackendApprovalRequestItem = {
   approval_mode: ApprovalMode;
   status: string;
   created_at: string;
+  // Org context — optional so responses from older backends still
+  // parse. `from_org_policy` is the authoritative flag; `org_id` and
+  // `org_name` are only set when the flag is true.
+  from_org_policy?: boolean;
+  org_id?: string | null;
+  org_name?: string | null;
 };
 
 type BackendApprovalRequestsResponse = {
@@ -114,6 +120,10 @@ type BackendApprovalGrantItem = {
   requester_label?: string | null;
   granted_at: string;
   expires_at: string;
+  // Org context for grants — optional for the same reason as above.
+  org_scoped?: boolean;
+  org_id?: string | null;
+  org_name?: string | null;
 };
 
 type BackendApprovalGrantsResponse = {
@@ -304,6 +314,13 @@ function mapBackendRequestToChallenge(item: BackendApprovalRequestItem): Challen
   const summary = item.action_description ?? item.operation_summary;
   const parsed = parseOperationSummary(summary);
 
+  // Only surface org fields when the backend flags the request as
+  // created under an org policy. Falsy / missing `from_org_policy`
+  // yields the pre-existing personal-approval shape.
+  const fromOrgPolicy = item.from_org_policy === true;
+  const orgId = fromOrgPolicy ? item.org_id ?? null : undefined;
+  const orgName = fromOrgPolicy ? item.org_name ?? null : undefined;
+
   return {
     id: item.id,
     title: sanitizeDisplayValue(item.service_name, "Unknown Service"),
@@ -322,6 +339,9 @@ function mapBackendRequestToChallenge(item: BackendApprovalRequestItem): Challen
         "Unknown"
       ),
     },
+    from_org_policy: fromOrgPolicy,
+    org_id: orgId,
+    org_name: orgName,
   };
 }
 
@@ -530,8 +550,13 @@ async function listPendingApprovalRequests(
   page = 1,
   perPage = ACTIVITY_PAGE_SIZE
 ): Promise<BackendApprovalRequestsResponse> {
+  // `include_admin_orgs=true` asks the backend to union in org-policy
+  // requests for every org the caller is an active admin of. Backends
+  // that don't yet recognize the param ignore it and return the legacy
+  // personal-only list, so the mobile build remains compatible with
+  // older deployments (see ChronoAIProject/NyxID#376).
   return requestJson<BackendApprovalRequestsResponse>(
-    `/approvals/requests?status=pending&page=${page}&per_page=${perPage}`
+    `/approvals/requests?status=pending&page=${page}&per_page=${perPage}&include_admin_orgs=true`
   );
 }
 
@@ -601,6 +626,10 @@ export async function listApprovalRequestsRequest(params?: {
   if (params?.status) qs.set("status", params.status);
   qs.set("page", String(params?.page ?? 1));
   qs.set("per_page", String(params?.per_page ?? 20));
+  // See listPendingApprovalRequests for rationale. History queries use
+  // the same opt-in so admins see their org's approved/rejected items
+  // alongside their personal history.
+  qs.set("include_admin_orgs", "true");
 
   const response = await requestJson<BackendApprovalRequestsResponse>(
     `/approvals/requests?${qs.toString()}`
@@ -658,31 +687,51 @@ export async function listApprovalsRequest(
   page = 1,
   perPage = ACTIVITY_PAGE_SIZE
 ): Promise<PageResponse<ApprovalItem>> {
+  // Same admin-org opt-in as requests: mobile's Active tab shows
+  // personal grants plus any org-scoped grants the caller admins.
   const response = await requestJson<BackendApprovalGrantsResponse>(
-    `/approvals/grants?page=${page}&per_page=${perPage}`
+    `/approvals/grants?page=${page}&per_page=${perPage}&include_admin_orgs=true`
   );
 
   return {
-    items: response.grants.map((item) => ({
-      id: item.id,
-      service_id: item.service_id,
-      service_name: sanitizeDisplayValue(item.service_name, "Unknown Service"),
-      requester_type: sanitizeDisplayValue(item.requester_type, "Unknown"),
-      requester_id: sanitizeDisplayValue(item.requester_id, "unknown"),
-      requester_label: sanitizeOptionalDisplayValue(item.requester_label),
-      granted_at: item.granted_at,
-      expires_at: item.expires_at,
-    })),
+    items: response.grants.map((item) => {
+      const orgScoped = item.org_scoped === true;
+      return {
+        id: item.id,
+        service_id: item.service_id,
+        service_name: sanitizeDisplayValue(item.service_name, "Unknown Service"),
+        requester_type: sanitizeDisplayValue(item.requester_type, "Unknown"),
+        requester_id: sanitizeDisplayValue(item.requester_id, "unknown"),
+        requester_label: sanitizeOptionalDisplayValue(item.requester_label),
+        granted_at: item.granted_at,
+        expires_at: item.expires_at,
+        org_scoped: orgScoped,
+        org_id: orgScoped ? item.org_id ?? null : undefined,
+        org_name: orgScoped ? item.org_name ?? null : undefined,
+      };
+    }),
     total: response.total,
     page: response.page,
     per_page: response.per_page,
   };
 }
 
-export async function revokeApprovalRequest(approvalId: string): Promise<RevokeApprovalResponse> {
-  return requestJson<MessageResponse>(`/approvals/grants/${encodeURIComponent(approvalId)}`, {
-    method: "DELETE",
-  });
+export async function revokeApprovalRequest(
+  approvalId: string,
+  orgId?: string | null
+): Promise<RevokeApprovalResponse> {
+  // Org-scoped grants live under the owning org's user_id, not the
+  // caller's. The backend's revoke handler uses `?org_id=` to pivot
+  // ownership to the target org and then checks the caller is an
+  // active admin of it. Without this param, DELETE on an org grant
+  // 404s because the default path still searches by user_id = actor.
+  const qs = orgId ? `?org_id=${encodeURIComponent(orgId)}` : "";
+  return requestJson<MessageResponse>(
+    `/approvals/grants/${encodeURIComponent(approvalId)}${qs}`,
+    {
+      method: "DELETE",
+    }
+  );
 }
 
 export async function registerPushTokenRequest(

--- a/mobile/src/lib/api/mobileApi.ts
+++ b/mobile/src/lib/api/mobileApi.ts
@@ -1,3 +1,4 @@
+import { ApiError } from "./ApiError";
 import { createIdempotencyKey } from "./idempotency";
 import {
   deleteCurrentUserAccountRequest,
@@ -134,14 +135,43 @@ export const mobileApi = {
     return listApprovalsRequest(page, perPage);
   },
   async getHistory(page = 1, perPage = 20): Promise<PageResponse<ChallengeDetail>> {
-    const response = await listApprovalRequestsRequest({ page, per_page: perPage });
-    return {
-      ...response,
-      items: response.items.filter((item) => item.status !== "PENDING"),
-    };
+    // Preferred path: filter out PENDING server-side via the multi-
+    // status list form. Client-side filtering would silently strand
+    // decided items when an admin's org has enough pending items to
+    // fill page 1 under include_admin_orgs — the first page comes
+    // back empty of history and the screen renders the empty state
+    // instead of paging further.
+    //
+    // Fallback: pre-376 backends only accept a single status value
+    // and reject "approved,rejected,expired" with a 400. When the
+    // mobile app ships before the backend is upgraded, the History
+    // tab would otherwise break entirely. Fall back to fetching
+    // without a status filter and dropping PENDING client-side.
+    // That fallback is only safe because older backends also ignore
+    // include_admin_orgs, so the response never contains admin-org
+    // PENDING items that would fill a page — the original
+    // personal-only behavior is preserved byte-for-byte.
+    try {
+      return await listApprovalRequestsRequest({
+        page,
+        per_page: perPage,
+        status: "approved,rejected,expired",
+      });
+    } catch (error) {
+      const isOldBackendValidationError =
+        error instanceof ApiError &&
+        error.statusCode === 400 &&
+        error.errorKey === "validation_error";
+      if (!isOldBackendValidationError) throw error;
+      const response = await listApprovalRequestsRequest({ page, per_page: perPage });
+      return {
+        ...response,
+        items: response.items.filter((item) => item.status !== "PENDING"),
+      };
+    }
   },
-  async revoke(approvalId: string): Promise<{ message: string }> {
-    return revokeApprovalRequest(approvalId);
+  async revoke(approvalId: string, orgId?: string | null): Promise<{ message: string }> {
+    return revokeApprovalRequest(approvalId, orgId);
   },
   async registerPushToken(
     payload: PushTokenRegisterRequest

--- a/mobile/src/lib/api/types.ts
+++ b/mobile/src/lib/api/types.ts
@@ -11,6 +11,13 @@ export type ChallengeItem = {
   status: ChallengeStatus;
   created_at: string;
   expires_at: string;
+  // Org context: populated when the backend reports the request was
+  // created under an org's per-service approval policy. Optional so
+  // the mobile build keeps working against backends that pre-date
+  // the org-aware response fields.
+  from_org_policy?: boolean;
+  org_id?: string | null;
+  org_name?: string | null;
 };
 
 export type ChallengeDetail = ChallengeItem & {
@@ -30,6 +37,12 @@ export type ApprovalItem = {
   requester_label?: string | null;
   granted_at: string;
   expires_at: string;
+  // Org context for grants. Mirrors the request fields above: both the
+  // flag and the org id/name are optional so the app continues to
+  // render personal-approval UI when the backend omits them.
+  org_scoped?: boolean;
+  org_id?: string | null;
+  org_name?: string | null;
 };
 
 export type PageResponse<T> = {


### PR DESCRIPTION
## Summary

Closes #376.

Org admins can now see and act on org-policy approvals from the NyxID mobile app and distinguish them from personal decisions in Telegram and push notifications. Before this PR, the app only rendered personal approvals; org-policy items were siloed behind the web admin panel and notifications used the same generic "Access Request" wording for both.

## Changes

### Backend
- `ApprovalRequestItem` / `ApprovalGrantItem` DTOs gain `from_org_policy` / `org_scoped` / `org_id` / `org_name`. All additive; org fields only populate when the authoritative flag is true.
- Opt-in `?include_admin_orgs=true` on `GET /approvals/requests` and `GET /approvals/grants` unions in admin-org rows. Scope is pre-translated to storage-space `service_id`s and per-owner grant-mode is applied in the Mongo filter, so pagination stays correct and one owner's grant-mode config can't leak another owner's grants.
- `status` param accepts a comma-separated list (`status=approved,rejected,expired`) so history can exclude PENDING server-side.
- `notification_service::send_approval_notification` accepts an `org_name: Option<&str>`. Telegram header swaps to `Org Access Request — {org_name}` and push title to `Org Approval Required` when set; generic wording preserved otherwise. Push `data` payload gains `from_org_policy` / `org_id` / `org_name` keys.
- 8 new filter-builder unit tests (scope, per-owner grant-mode, empty-scope degeneration, empty-match sentinel).

### Mobile
- `ChallengeCard`, `GrantCard`, `ChallengeDetailSheet`, and `ActivityDetailScreen` render an "Org · {name}" chip and an "On behalf of {org}" context line when the row is org-scoped.
- `StatusBadge` gains an `orgChip` variant reusing existing `ghostBg` / `textSecondary` tokens — no new design tokens.
- Activity tabs send `include_admin_orgs=true`. Revoke forwards `?org_id=` for org-scoped grants so `DELETE /approvals/grants/{id}` hits the org owner path.
- `getHistory` asks for `status=approved,rejected,expired` server-side. Falls back to the single-status path + client-side filter on 400 `validation_error` so the app keeps working against pre-376 backends.

## Non-breaking / no-new-deps guarantees

- **Additive only.** No response field removed or renamed. New fields marked `skip_serializing_if = "Option::is_none"` / `#[serde(default)]`.
- **Default list behavior unchanged.** Without `?include_admin_orgs` the filter is still `user_id = actor` (byte-identical to before).
- **Rollout-safe.** Old mobile + new BE: BE returns legacy shape (mobile never opts in). New mobile + old BE: BE ignores unknown param, history fallback catches multi-status 400. New ↔ new: full org-aware path.
- **No DB migration.** `from_org_policy` and `org_scoped` already exist on stored models.
- **No dependencies changed.** `Cargo.toml`, `Cargo.lock`, `mobile/package.json`, and `mobile/pnpm-lock.yaml` are untouched.

## Verification

- [x] `cargo test --bin nyxid` — **1401 passed** (4 new DTO mapper tests, 3 new Telegram template tests, 8 new filter-builder tests).
- [x] `cargo test -p nyxid-cli` — **152 passed**.
- [x] `cargo clippy --all-targets` — clean.
- [x] `tsc --noEmit` on `mobile/` — clean.
- [x] 4 rounds of `/codex review` ending at 0 findings (earlier rounds surfaced and closed a paging bug, a cross-owner grant-mode leak, a missed detail screen, and a mixed-version compatibility regression).

## Test plan

- [ ] As org admin with Telegram linked, trigger an org-policy approval from a shared service → Telegram message starts with `Org Access Request — {org}`, iOS/Android push title shows `Org Approval Required`.
- [ ] Mobile inbox (Pending tab) shows the request with an "Org · {name}" chip; personal items have no chip.
- [ ] Detail sheet opened from the card and from `nyxid://challenge/{id}` push deeplink both show "On behalf of {org}".
- [ ] Approve the request → grant appears in the Active tab with the Org chip; Revoke works.
- [ ] History tab shows approved/rejected/expired items (no PENDING leakage) even when many org approvals are pending.
- [ ] Scoped admin (`allowed_service_ids` set) sees only in-scope org rows; page 1 is never empty while later pages have rows.
- [ ] Web frontend approval views unchanged (web doesn't send `include_admin_orgs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)