### PR TITLE
fix(channels/lark): verify webhooks with the right security material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,6 +3326,7 @@ dependencies = [
 name = "nyxid"
 version = "0.2.0"
 dependencies = [
+ "aes",
  "aes-gcm",
  "anyhow",
  "argon2",
@@ -3337,6 +3338,7 @@ dependencies = [
  "base64 0.22.1",
  "bson",
  "bytes",
+ "cbc",
  "chrono",
  "clap",
  "dashmap",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,7 +22,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 jsonwebtoken = { version = "10.3", default-features = false, features = ["use_pem", "aws_lc_rs"] }
 argon2 = "0.5.3"
+aes = "0.8.4"
 aes-gcm = "0.10.3"
+cbc = { version = "0.1.2", features = ["std"] }
 sha2 = "0.10.9"
 rand = "0.8.5"
 hex = "0.4.3"

--- a/backend/src/handlers/channel_bots.rs
+++ b/backend/src/handlers/channel_bots.rs
@@ -30,6 +30,18 @@ pub struct CreateChannelBotRequest {
     pub app_id: Option<String>,
     #[serde(default)]
     pub app_secret: Option<String>,
+    /// Lark/Feishu only: Event Subscription Verification Token (plaintext).
+    /// Required for Lark/Feishu bots. Lark copies this value into every
+    /// inbound webhook body so the server can confirm the request came from
+    /// Lark. Not the same as `app_secret`.
+    #[serde(default)]
+    pub verification_token: Option<String>,
+    /// Lark/Feishu only: Event Subscription Encrypt Key (plaintext). Optional.
+    /// When set, Lark AES-256-CBC-encrypts the webhook body and signs it with
+    /// `X-Lark-Signature`; the server decrypts the body and verifies the
+    /// signature before processing.
+    #[serde(default)]
+    pub encrypt_key: Option<String>,
     #[serde(default)]
     pub public_key: Option<String>,
     /// When set, create this channel bot under the given org. The
@@ -299,6 +311,8 @@ pub async fn create_bot(
         &body.label,
         body.app_id.as_deref(),
         body.app_secret.as_deref(),
+        body.verification_token.as_deref(),
+        body.encrypt_key.as_deref(),
         body.public_key.as_deref(),
     )
     .await?;

--- a/backend/src/handlers/channel_webhooks.rs
+++ b/backend/src/handlers/channel_webhooks.rs
@@ -274,34 +274,46 @@ async fn handle_webhook_inner(
         },
     )?;
 
-    // For Lark/Feishu/Slack, the adapter needs the raw signing material, not
-    // its hash. We store the encrypted secret in `app_secret_encrypted` and
-    // decrypt + inject it into `webhook_secret_hash` on a cloned bot here so
-    // the adapter's verify_webhook can use it as the HMAC key.
-    let bot_for_verify = if matches!(bot.platform.as_str(), "lark" | "feishu" | "slack") {
-        if let Some(ref encrypted) = bot.app_secret_encrypted {
-            match state.encryption_keys.decrypt(encrypted).await {
-                Ok(decrypted) => {
-                    let mut cloned = bot.clone();
-                    cloned.webhook_secret_hash = String::from_utf8_lossy(&decrypted).to_string();
-                    cloned
-                }
-                Err(_) => bot.clone(),
-            }
-        } else {
-            bot.clone()
-        }
-    } else {
-        bot.clone()
-    };
+    // Build the plaintext secrets bag the adapter needs. The handler owns
+    // the encryption keys and decrypts here so each adapter sees only the
+    // bytes it actually needs to verify the request (and so we do not have
+    // to overload unrelated fields on the `ChannelBot` struct).
+    let mut secrets = crate::services::channel_platform::WebhookSecrets::default();
 
-    // Verify webhook signature
-    adapter
-        .verify_webhook(&bot_for_verify, headers, body)
+    if matches!(bot.platform.as_str(), "slack") {
+        if let Some(ref encrypted) = bot.app_secret_encrypted
+            && let Ok(decrypted) = state.encryption_keys.decrypt(encrypted).await
+        {
+            secrets.slack_signing_secret =
+                Some(String::from_utf8_lossy(&decrypted).to_string());
+        }
+    }
+
+    if matches!(bot.platform.as_str(), "lark" | "feishu") {
+        if let Some(ref encrypted) = bot.lark_verification_token_encrypted
+            && let Ok(decrypted) = state.encryption_keys.decrypt(encrypted).await
+        {
+            secrets.lark_verification_token =
+                Some(String::from_utf8_lossy(&decrypted).to_string());
+        }
+        if let Some(ref encrypted) = bot.lark_encrypt_key_encrypted
+            && let Ok(decrypted) = state.encryption_keys.decrypt(encrypted).await
+        {
+            secrets.lark_encrypt_key = Some(String::from_utf8_lossy(&decrypted).to_string());
+        }
+    }
+
+    // Verify webhook signature. The adapter may return a decrypted plaintext
+    // body (Lark with Encrypt Key enabled); in that case `parse_inbound` must
+    // see the plaintext, not the ciphertext we received.
+    let decoded_body = adapter
+        .verify_webhook(&bot, &secrets, headers, body)
         .await
         .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
             format!("webhook verification failed: {e}").into()
         })?;
+
+    let body_for_parse: &[u8] = decoded_body.as_deref().unwrap_or(body);
 
     // Auto-promote pending_webhook bots AFTER successful signature verification.
     // This proves the user correctly configured the webhook URL on the platform.
@@ -324,8 +336,8 @@ async fn handle_webhook_inner(
         tracing::info!(bot_id = %bot_id, "auto-promoted pending_webhook bot to active");
     }
 
-    // Parse inbound messages
-    let messages = adapter.parse_inbound(body).await.map_err(
+    // Parse inbound messages from the (possibly decrypted) body.
+    let messages = adapter.parse_inbound(body_for_parse).await.map_err(
         |e| -> Box<dyn std::error::Error + Send + Sync> {
             format!("failed to parse inbound messages: {e}").into()
         },

--- a/backend/src/models/channel_bot.rs
+++ b/backend/src/models/channel_bot.rs
@@ -29,10 +29,22 @@ pub struct ChannelBot {
     #[serde(default)]
     pub app_id: Option<String>,
     /// Encrypted app/signing secret (AES-256 envelope encryption).
-    /// Lark/Feishu use it for HMAC + tenant-token exchange; Slack stores its
-    /// app signing secret here for Events API signature verification.
+    /// Lark/Feishu use it for tenant-token exchange; Slack stores its app
+    /// signing secret here for Events API signature verification.
     #[serde(default, with = "crate::models::bson_bytes::optional")]
     pub app_secret_encrypted: Option<Vec<u8>>,
+    /// Lark/Feishu only: encrypted Event Subscription "Verification Token".
+    /// Lark copies this value into every event callback body (`header.token`
+    /// in v2 schema, top-level `token` in v1) so the server can prove the
+    /// request originated from Lark. Distinct from `app_secret_encrypted`.
+    #[serde(default, with = "crate::models::bson_bytes::optional")]
+    pub lark_verification_token_encrypted: Option<Vec<u8>>,
+    /// Lark/Feishu only: encrypted Event Subscription "Encrypt Key".
+    /// When present, Lark AES-256-CBC-encrypts the webhook body and signs it
+    /// via the `X-Lark-Signature` header. Absent means plaintext bodies with
+    /// token-only verification.
+    #[serde(default, with = "crate::models::bson_bytes::optional")]
+    pub lark_encrypt_key_encrypted: Option<Vec<u8>>,
     /// Discord only: application public key for Ed25519 signature verification
     #[serde(default)]
     pub public_key: Option<String>,
@@ -67,6 +79,8 @@ mod tests {
             webhook_secret_hash: "abc123".to_string(),
             app_id: None,
             app_secret_encrypted: None,
+            lark_verification_token_encrypted: None,
+            lark_encrypt_key_encrypted: None,
             public_key: None,
             status: "pending".to_string(),
             is_active: true,
@@ -93,11 +107,18 @@ mod tests {
         bot.platform = "lark".to_string();
         bot.app_id = Some("cli_abc123".to_string());
         bot.app_secret_encrypted = Some(vec![10, 20, 30]);
+        bot.lark_verification_token_encrypted = Some(vec![40, 50, 60]);
+        bot.lark_encrypt_key_encrypted = Some(vec![70, 80, 90]);
         bot.public_key = Some("ed25519pubkey".to_string());
         let doc = bson::to_document(&bot).expect("serialize");
         let restored: ChannelBot = bson::from_document(doc).expect("deserialize");
         assert_eq!(restored.app_id.as_deref(), Some("cli_abc123"));
         assert_eq!(restored.app_secret_encrypted, Some(vec![10, 20, 30]));
+        assert_eq!(
+            restored.lark_verification_token_encrypted,
+            Some(vec![40, 50, 60])
+        );
+        assert_eq!(restored.lark_encrypt_key_encrypted, Some(vec![70, 80, 90]));
         assert_eq!(restored.public_key.as_deref(), Some("ed25519pubkey"));
     }
 
@@ -126,10 +147,14 @@ mod tests {
         let mut doc = bson::to_document(&bot).expect("serialize");
         doc.remove("app_id");
         doc.remove("app_secret_encrypted");
+        doc.remove("lark_verification_token_encrypted");
+        doc.remove("lark_encrypt_key_encrypted");
         doc.remove("public_key");
         let restored: ChannelBot = bson::from_document(doc).expect("deserialize");
         assert_eq!(restored.app_id, None);
         assert_eq!(restored.app_secret_encrypted, None);
+        assert_eq!(restored.lark_verification_token_encrypted, None);
+        assert_eq!(restored.lark_encrypt_key_encrypted, None);
         assert_eq!(restored.public_key, None);
     }
 }

--- a/backend/src/services/channel_adapters/discord.rs
+++ b/backend/src/services/channel_adapters/discord.rs
@@ -13,7 +13,7 @@ use ed25519_dalek::{Signature, VerifyingKey};
 use crate::errors::{AppError, AppResult};
 use crate::models::channel_bot::ChannelBot;
 use crate::services::channel_platform::{
-    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter,
+    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter, WebhookSecrets,
 };
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
@@ -226,9 +226,10 @@ impl PlatformAdapter for DiscordAdapter {
     async fn verify_webhook(
         &self,
         bot: &ChannelBot,
+        _secrets: &WebhookSecrets,
         headers: &axum::http::HeaderMap,
         body: &[u8],
-    ) -> AppResult<()> {
+    ) -> AppResult<Option<Vec<u8>>> {
         let public_key_hex = bot.public_key.as_deref().ok_or_else(|| {
             AppError::ChannelWebhookVerificationFailed(
                 "Discord bot missing public_key configuration".to_string(),
@@ -293,7 +294,7 @@ impl PlatformAdapter for DiscordAdapter {
             )
         })?;
 
-        Ok(())
+        Ok(None)
     }
 
     async fn parse_inbound(&self, body: &[u8]) -> AppResult<Vec<InboundMessage>> {
@@ -647,11 +648,14 @@ mod tests {
         let signature_hex = hex::encode(signature.to_bytes());
 
         let bot = make_test_bot(Some(&public_key_hex));
+        let secrets = WebhookSecrets::default();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert("x-signature-ed25519", signature_hex.parse().unwrap());
         headers.insert("x-signature-timestamp", timestamp.parse().unwrap());
 
-        let result = adapter.verify_webhook(&bot, &headers, body_content).await;
+        let result = adapter
+            .verify_webhook(&bot, &secrets, &headers, body_content)
+            .await;
         assert!(result.is_ok());
     }
 
@@ -661,6 +665,7 @@ mod tests {
 
         // Use a known public key but wrong signature
         let bot = make_test_bot(Some(&hex::encode([1u8; 32])));
+        let secrets = WebhookSecrets::default();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(
             "x-signature-ed25519",
@@ -668,7 +673,9 @@ mod tests {
         );
         headers.insert("x-signature-timestamp", "12345".parse().unwrap());
 
-        let result = adapter.verify_webhook(&bot, &headers, b"{}").await;
+        let result = adapter
+            .verify_webhook(&bot, &secrets, &headers, b"{}")
+            .await;
         assert!(result.is_err());
     }
 
@@ -676,9 +683,12 @@ mod tests {
     async fn verify_webhook_missing_public_key() {
         let adapter = DiscordAdapter;
         let bot = make_test_bot(None);
+        let secrets = WebhookSecrets::default();
         let headers = axum::http::HeaderMap::new();
 
-        let result = adapter.verify_webhook(&bot, &headers, b"{}").await;
+        let result = adapter
+            .verify_webhook(&bot, &secrets, &headers, b"{}")
+            .await;
         assert!(result.is_err());
     }
 
@@ -686,9 +696,12 @@ mod tests {
     async fn verify_webhook_missing_headers() {
         let adapter = DiscordAdapter;
         let bot = make_test_bot(Some(&hex::encode([1u8; 32])));
+        let secrets = WebhookSecrets::default();
         let headers = axum::http::HeaderMap::new();
 
-        let result = adapter.verify_webhook(&bot, &headers, b"{}").await;
+        let result = adapter
+            .verify_webhook(&bot, &secrets, &headers, b"{}")
+            .await;
         assert!(result.is_err());
     }
 
@@ -707,6 +720,8 @@ mod tests {
             webhook_secret_hash: "unused_for_discord".to_string(),
             app_id: None,
             app_secret_encrypted: None,
+            lark_verification_token_encrypted: None,
+            lark_encrypt_key_encrypted: None,
             public_key: public_key.map(String::from),
             status: "active".to_string(),
             is_active: true,

--- a/backend/src/services/channel_adapters/lark.rs
+++ b/backend/src/services/channel_adapters/lark.rs
@@ -5,8 +5,17 @@
 //! identifier. The two platforms share the same webhook format, event schema,
 //! and REST API shape -- only the hostname differs.
 //!
-//! Webhook verification uses HMAC-SHA256 over the request body, with the
-//! verification token stored on the [`ChannelBot`] document.
+//! Webhook verification follows the Event Subscriptions security model
+//! documented by Lark / Feishu:
+//! - **Verification Token** (required): Lark copies this token into every
+//!   event body (`header.token` in v2 schema, top-level `token` in v1). The
+//!   adapter compares it against the decrypted token stored on the bot in
+//!   constant time.
+//! - **Encrypt Key** (optional): when set on the platform side, Lark
+//!   encrypts the body with AES-256-CBC, wraps it in `{"encrypt": "..."}`,
+//!   and signs it with `X-Lark-Signature = hex(SHA-256(timestamp + nonce +
+//!   encrypt_key + raw_encrypted_body))`. The adapter verifies the signature
+//!   and returns the decrypted plaintext body for downstream parsing.
 //!
 //! Message parsing handles the standard `im.message.receive_v1` event schema,
 //! interactive card callbacks via `card.action.trigger`, and the
@@ -19,19 +28,21 @@
 
 use std::sync::Arc;
 
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
+use aes::Aes256;
+use aes::cipher::{BlockDecryptMut, KeyIvInit, block_padding::Pkcs7};
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 use crate::errors::{AppError, AppResult};
 use crate::models::channel_bot::ChannelBot;
 use crate::models::downstream_service::{CredentialFieldSpec, TokenExchangeConfig};
 use crate::services::channel_platform::{
-    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter,
+    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter, WebhookSecrets,
 };
 use crate::services::provider_token_exchange_service::{self, TokenExchangeCache};
 
-type HmacSha256 = Hmac<Sha256>;
+type Aes256CbcDec = cbc::Decryptor<Aes256>;
 
 /// Build the `TokenExchangeConfig` that matches Lark / Feishu's tenant
 /// token endpoint. Shared with the proxy catalog seeds so there is exactly
@@ -307,69 +318,68 @@ impl PlatformAdapter for LarkFamilyAdapter {
 
     async fn verify_webhook(
         &self,
-        bot: &ChannelBot,
+        _bot: &ChannelBot,
+        secrets: &WebhookSecrets,
         headers: &axum::http::HeaderMap,
         body: &[u8],
-    ) -> AppResult<()> {
-        // Lark sends signature in X-Lark-Signature header
-        let header_signature = headers
-            .get("x-lark-signature")
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| {
-                AppError::ChannelWebhookVerificationFailed(
-                    "missing X-Lark-Signature header".to_string(),
-                )
+    ) -> AppResult<Option<Vec<u8>>> {
+        let verification_token =
+            secrets
+                .lark_verification_token
+                .as_deref()
+                .ok_or_else(|| {
+                    AppError::ChannelWebhookVerificationFailed(
+                        "Lark/Feishu verification token not configured on the bot. \
+                         Re-register the bot with its Event Subscription Verification Token."
+                            .to_string(),
+                    )
+                })?;
+
+        // When Encrypt Key is configured on the Lark side, the body arrives
+        // as `{"encrypt": "<base64>"}` accompanied by `X-Lark-Signature`. Verify
+        // the signature and decrypt the envelope before any token check.
+        let (plaintext_bytes, rewrote_body) = match secrets.lark_encrypt_key.as_deref() {
+            Some(key) if !key.is_empty() => {
+                verify_lark_signature(key, headers, body)?;
+                (decrypt_lark_envelope(key, body)?, true)
+            }
+            _ => (body.to_vec(), false),
+        };
+
+        let payload: serde_json::Value =
+            serde_json::from_slice(&plaintext_bytes).map_err(|e| {
+                AppError::ChannelWebhookVerificationFailed(format!(
+                    "Lark webhook body is not valid JSON: {e}"
+                ))
             })?;
 
-        // Parse the body to extract timestamp and nonce for verification
-        let payload: serde_json::Value = serde_json::from_slice(body).map_err(|_| {
+        // url_verification requests are sent BEFORE the inbound-event flow
+        // and carry the token at the top level; handle_challenge upstream
+        // should already have short-circuited them, but if one ever lands
+        // here (e.g. replay) we still accept it as long as the token matches.
+        let payload_token = extract_lark_token(&payload);
+
+        let payload_token = payload_token.ok_or_else(|| {
             AppError::ChannelWebhookVerificationFailed(
-                "invalid JSON body for signature verification".to_string(),
+                "Lark webhook body missing `token` field; cannot verify origin".to_string(),
             )
         })?;
 
-        let timestamp = payload
-            .get("header")
-            .and_then(|h| h.get("create_time"))
-            .and_then(|v| v.as_str())
-            .or_else(|| payload.get("ts").and_then(|v| v.as_str()))
-            .unwrap_or("");
-
-        let nonce = payload
-            .get("header")
-            .and_then(|h| h.get("nonce"))
-            .and_then(|v| v.as_str())
-            .or_else(|| payload.get("nonce").and_then(|v| v.as_str()))
-            .unwrap_or("");
-
-        // The webhook_secret_hash stores the SHA-256 hash of the verification
-        // token. For HMAC verification we compute:
-        // HMAC-SHA256(verification_token, timestamp + nonce + body)
-        // However, since we only store the hash, we use the hash itself as the
-        // HMAC key (consistent with how the token was registered).
-        let stored_hash = &bot.webhook_secret_hash;
-
-        // Build the HMAC message: timestamp + nonce + encrypt_key + body_string
-        let body_str = std::str::from_utf8(body).unwrap_or("");
-        let hmac_message = format!("{timestamp}{nonce}{stored_hash}{body_str}");
-
-        let mut mac = HmacSha256::new_from_slice(stored_hash.as_bytes()).map_err(|_| {
-            AppError::ChannelWebhookVerificationFailed("failed to create HMAC verifier".to_string())
-        })?;
-        mac.update(hmac_message.as_bytes());
-        let computed = hex::encode(mac.finalize().into_bytes());
-
-        if computed
+        let matches: bool = payload_token
             .as_bytes()
-            .ct_eq(header_signature.as_bytes())
-            .into()
-        {
-            Ok(())
-        } else {
-            Err(AppError::ChannelWebhookVerificationFailed(
-                "Lark signature verification failed".to_string(),
-            ))
+            .ct_eq(verification_token.as_bytes())
+            .into();
+        if !matches {
+            return Err(AppError::ChannelWebhookVerificationFailed(
+                "Lark verification token mismatch".to_string(),
+            ));
         }
+
+        Ok(if rewrote_body {
+            Some(plaintext_bytes)
+        } else {
+            None
+        })
     }
 
     async fn parse_inbound(&self, body: &[u8]) -> AppResult<Vec<InboundMessage>> {
@@ -541,6 +551,128 @@ impl PlatformAdapter for LarkFamilyAdapter {
 }
 
 // ---------------------------------------------------------------------------
+// Lark Event Subscription security helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the Lark Event Subscription "Verification Token" from a decoded
+/// webhook payload.
+///
+/// Lark delivers the token in different places depending on the schema:
+/// v2 events put it at `header.token`, older v1 events and `url_verification`
+/// challenges put it at the top level (`token`). We accept both.
+fn extract_lark_token(payload: &serde_json::Value) -> Option<&str> {
+    payload
+        .get("header")
+        .and_then(|h| h.get("token"))
+        .and_then(|v| v.as_str())
+        .or_else(|| payload.get("token").and_then(|v| v.as_str()))
+}
+
+/// Verify the `X-Lark-Signature` header that Lark sends when Event
+/// Subscription encryption is enabled.
+///
+/// Per Lark's docs the signature is
+/// `hex(SHA256(timestamp + nonce + encrypt_key + raw_body))` -- a plain
+/// SHA-256 digest, NOT HMAC. The comparison is constant-time to avoid
+/// timing oracles.
+fn verify_lark_signature(
+    encrypt_key: &str,
+    headers: &axum::http::HeaderMap,
+    body: &[u8],
+) -> AppResult<()> {
+    let expected_sig = headers
+        .get("x-lark-signature")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| {
+            AppError::ChannelWebhookVerificationFailed(
+                "missing X-Lark-Signature header (Encrypt Key is configured on this bot, \
+                 so Lark must sign every request)"
+                    .to_string(),
+            )
+        })?;
+
+    let timestamp = headers
+        .get("x-lark-request-timestamp")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| {
+            AppError::ChannelWebhookVerificationFailed(
+                "missing X-Lark-Request-Timestamp header".to_string(),
+            )
+        })?;
+
+    let nonce = headers
+        .get("x-lark-request-nonce")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| {
+            AppError::ChannelWebhookVerificationFailed(
+                "missing X-Lark-Request-Nonce header".to_string(),
+            )
+        })?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(timestamp.as_bytes());
+    hasher.update(nonce.as_bytes());
+    hasher.update(encrypt_key.as_bytes());
+    hasher.update(body);
+    let computed = hex::encode(hasher.finalize());
+
+    if computed.as_bytes().ct_eq(expected_sig.as_bytes()).into() {
+        Ok(())
+    } else {
+        Err(AppError::ChannelWebhookVerificationFailed(
+            "Lark signature verification failed".to_string(),
+        ))
+    }
+}
+
+/// Decrypt Lark's `{"encrypt": "<base64>"}` envelope into the plaintext JSON
+/// event body.
+///
+/// Lark uses AES-256-CBC with PKCS#7 padding. The encryption key is
+/// `SHA-256(encrypt_key)` and the IV is the first 16 bytes of the ciphertext;
+/// the remainder is the actual encrypted payload.
+fn decrypt_lark_envelope(encrypt_key: &str, body: &[u8]) -> AppResult<Vec<u8>> {
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        encrypt: String,
+    }
+
+    let env: Envelope = serde_json::from_slice(body).map_err(|e| {
+        AppError::ChannelWebhookVerificationFailed(format!(
+            "Lark encrypted body must be JSON with an `encrypt` field: {e}"
+        ))
+    })?;
+
+    let ciphertext = base64::engine::general_purpose::STANDARD
+        .decode(env.encrypt.as_bytes())
+        .map_err(|e| {
+            AppError::ChannelWebhookVerificationFailed(format!(
+                "Lark `encrypt` value is not valid base64: {e}"
+            ))
+        })?;
+
+    if ciphertext.len() < 16 {
+        return Err(AppError::ChannelWebhookVerificationFailed(
+            "Lark encrypted payload shorter than AES block size".to_string(),
+        ));
+    }
+
+    let (iv, payload) = ciphertext.split_at(16);
+    let key = Sha256::digest(encrypt_key.as_bytes());
+
+    let mut buffer = payload.to_vec();
+    let plaintext = Aes256CbcDec::new(key.as_slice().into(), iv.into())
+        .decrypt_padded_mut::<Pkcs7>(&mut buffer)
+        .map_err(|_| {
+            AppError::ChannelWebhookVerificationFailed(
+                "Lark AES-256-CBC decryption failed (wrong Encrypt Key?)".to_string(),
+            )
+        })?;
+
+    Ok(plaintext.to_vec())
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -601,6 +733,240 @@ mod tests {
     fn handle_challenge_invalid_json_returns_none() {
         let adapter = LarkFamilyAdapter::lark(test_cache());
         assert!(adapter.handle_challenge(b"not json").is_none());
+    }
+
+    // -- verify_webhook ------------------------------------------------------
+
+    fn make_test_bot() -> ChannelBot {
+        ChannelBot {
+            id: uuid::Uuid::new_v4().to_string(),
+            user_id: uuid::Uuid::new_v4().to_string(),
+            platform: "lark".to_string(),
+            label: "Test Lark Bot".to_string(),
+            bot_token_encrypted: vec![0; 16],
+            platform_bot_id: "cli_test".to_string(),
+            platform_bot_username: "lark_bot".to_string(),
+            webhook_registered: true,
+            webhook_secret_hash: String::new(),
+            app_id: Some("cli_test".to_string()),
+            app_secret_encrypted: None,
+            lark_verification_token_encrypted: None,
+            lark_encrypt_key_encrypted: None,
+            public_key: None,
+            status: "active".to_string(),
+            is_active: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn secrets_with(verification_token: &str, encrypt_key: Option<&str>) -> WebhookSecrets {
+        WebhookSecrets {
+            lark_verification_token: Some(verification_token.to_string()),
+            lark_encrypt_key: encrypt_key.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_plaintext_matching_token_v2_header() {
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        let secrets = secrets_with("vt_abc123", None);
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "schema": "2.0",
+            "header": {
+                "event_type": "im.message.receive_v1",
+                "token": "vt_abc123"
+            },
+            "event": {}
+        }))
+        .unwrap();
+
+        let headers = axum::http::HeaderMap::new();
+        let result = adapter
+            .verify_webhook(&bot, &secrets, &headers, &body)
+            .await
+            .expect("matching token should pass without signature");
+        assert!(result.is_none(), "plaintext body should not be rewritten");
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_plaintext_matching_token_v1_top_level() {
+        let adapter = LarkFamilyAdapter::feishu(test_cache());
+        let bot = make_test_bot();
+        let secrets = secrets_with("vt_xyz", None);
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "type": "event_callback",
+            "token": "vt_xyz",
+            "event": {}
+        }))
+        .unwrap();
+
+        let headers = axum::http::HeaderMap::new();
+        adapter
+            .verify_webhook(&bot, &secrets, &headers, &body)
+            .await
+            .expect("v1 top-level token should match");
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_plaintext_mismatched_token_is_rejected() {
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        let secrets = secrets_with("expected_token", None);
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "header": { "token": "wrong_token" },
+            "event": {}
+        }))
+        .unwrap();
+
+        let err = adapter
+            .verify_webhook(&bot, &secrets, &axum::http::HeaderMap::new(), &body)
+            .await
+            .expect_err("mismatched token must fail");
+        assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_missing_verification_token_on_bot() {
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        // No verification token configured on the bot.
+        let secrets = WebhookSecrets::default();
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "header": { "token": "anything" },
+            "event": {}
+        }))
+        .unwrap();
+
+        let err = adapter
+            .verify_webhook(&bot, &secrets, &axum::http::HeaderMap::new(), &body)
+            .await
+            .expect_err("bot without verification token must not pass");
+        assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_body_missing_token_field() {
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        let secrets = secrets_with("some_token", None);
+
+        let body = serde_json::to_vec(&serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1" },
+            "event": {}
+        }))
+        .unwrap();
+
+        let err = adapter
+            .verify_webhook(&bot, &secrets, &axum::http::HeaderMap::new(), &body)
+            .await
+            .expect_err("body without token must fail");
+        assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_encrypted_body_valid_roundtrip() {
+        use aes::Aes256;
+        use aes::cipher::{BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
+        type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        let encrypt_key = "bZBy7jqmK8Uy8d3C";
+        let verification_token = "vt_encrypted";
+        let secrets = secrets_with(verification_token, Some(encrypt_key));
+
+        // Build a plaintext event body that carries the verification token.
+        let plaintext = serde_json::to_vec(&serde_json::json!({
+            "header": { "token": verification_token },
+            "event": { "hello": "world" }
+        }))
+        .unwrap();
+
+        // Encrypt it the way Lark does: AES-256-CBC / PKCS7 / key =
+        // SHA256(encrypt_key), IV = 16 random bytes prepended to the
+        // ciphertext.
+        let key = Sha256::digest(encrypt_key.as_bytes());
+        let iv = [0x11u8; 16];
+        let block_size = 16;
+        let mut buf = vec![0u8; plaintext.len() + block_size];
+        buf[..plaintext.len()].copy_from_slice(&plaintext);
+        let ct_len = Aes256CbcEnc::new(key.as_slice().into(), (&iv).into())
+            .encrypt_padded_mut::<Pkcs7>(&mut buf, plaintext.len())
+            .expect("encrypt")
+            .len();
+        let mut full_ct = iv.to_vec();
+        full_ct.extend_from_slice(&buf[..ct_len]);
+        let envelope = serde_json::to_vec(&serde_json::json!({
+            "encrypt": base64::engine::general_purpose::STANDARD.encode(&full_ct)
+        }))
+        .unwrap();
+
+        // Build the matching X-Lark-Signature: SHA256(ts + nonce + key + body)
+        let ts = "1700000000";
+        let nonce = "nonce123";
+        let mut hasher = Sha256::new();
+        hasher.update(ts.as_bytes());
+        hasher.update(nonce.as_bytes());
+        hasher.update(encrypt_key.as_bytes());
+        hasher.update(&envelope);
+        let sig = hex::encode(hasher.finalize());
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-lark-signature", sig.parse().unwrap());
+        headers.insert("x-lark-request-timestamp", ts.parse().unwrap());
+        headers.insert("x-lark-request-nonce", nonce.parse().unwrap());
+
+        let decoded = adapter
+            .verify_webhook(&bot, &secrets, &headers, &envelope)
+            .await
+            .expect("valid encrypted body should pass");
+        let decoded = decoded.expect("encrypted path must return plaintext body");
+        assert_eq!(decoded, plaintext);
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_encrypted_body_bad_signature() {
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        let encrypt_key = "k";
+        let secrets = secrets_with("vt", Some(encrypt_key));
+
+        let envelope = serde_json::to_vec(&serde_json::json!({
+            "encrypt": "aaaa"
+        }))
+        .unwrap();
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-lark-signature", "deadbeef".parse().unwrap());
+        headers.insert("x-lark-request-timestamp", "1".parse().unwrap());
+        headers.insert("x-lark-request-nonce", "n".parse().unwrap());
+
+        let err = adapter
+            .verify_webhook(&bot, &secrets, &headers, &envelope)
+            .await
+            .expect_err("bad signature must fail");
+        assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_encrypted_body_missing_signature_header() {
+        let adapter = LarkFamilyAdapter::lark(test_cache());
+        let bot = make_test_bot();
+        let secrets = secrets_with("vt", Some("key"));
+        let envelope = serde_json::to_vec(&serde_json::json!({ "encrypt": "x" })).unwrap();
+
+        let err = adapter
+            .verify_webhook(&bot, &secrets, &axum::http::HeaderMap::new(), &envelope)
+            .await
+            .expect_err("missing signature must fail when encrypt_key is configured");
+        assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
     }
 
     // -- parse_inbound -------------------------------------------------------

--- a/backend/src/services/channel_adapters/openclaw.rs
+++ b/backend/src/services/channel_adapters/openclaw.rs
@@ -12,7 +12,7 @@
 use crate::errors::AppResult;
 use crate::models::channel_bot::ChannelBot;
 use crate::services::channel_platform::{
-    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter,
+    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter, WebhookSecrets,
 };
 use crate::services::openclaw_channel_service::OpenClawChannelMessage;
 
@@ -43,10 +43,11 @@ impl PlatformAdapter for OpenClawAdapter {
     async fn verify_webhook(
         &self,
         _bot: &ChannelBot,
+        _secrets: &WebhookSecrets,
         _headers: &axum::http::HeaderMap,
         _body: &[u8],
-    ) -> AppResult<()> {
-        Ok(())
+    ) -> AppResult<Option<Vec<u8>>> {
+        Ok(None)
     }
 
     /// Parse an OpenClaw channel webhook payload into the normalized
@@ -155,8 +156,9 @@ mod tests {
     async fn verify_webhook_always_succeeds() {
         let adapter = OpenClawAdapter;
         let bot = make_test_bot();
+        let secrets = WebhookSecrets::default();
         let headers = axum::http::HeaderMap::new();
-        let result = adapter.verify_webhook(&bot, &headers, b"").await;
+        let result = adapter.verify_webhook(&bot, &secrets, &headers, b"").await;
         assert!(result.is_ok());
     }
 
@@ -285,6 +287,8 @@ mod tests {
             webhook_secret_hash: "placeholder".to_string(),
             app_id: None,
             app_secret_encrypted: None,
+            lark_verification_token_encrypted: None,
+            lark_encrypt_key_encrypted: None,
             public_key: None,
             status: "active".to_string(),
             is_active: true,

--- a/backend/src/services/channel_adapters/slack.rs
+++ b/backend/src/services/channel_adapters/slack.rs
@@ -36,7 +36,7 @@ use subtle::ConstantTimeEq;
 use crate::errors::{AppError, AppResult};
 use crate::models::channel_bot::ChannelBot;
 use crate::services::channel_platform::{
-    BotIdentity, InboundAttachment, InboundMessage, OutboundReply, PlatformAdapter,
+    BotIdentity, InboundAttachment, InboundMessage, OutboundReply, PlatformAdapter, WebhookSecrets,
 };
 
 type HmacSha256 = Hmac<Sha256>;
@@ -261,10 +261,11 @@ impl PlatformAdapter for SlackAdapter {
 
     async fn verify_webhook(
         &self,
-        bot: &ChannelBot,
+        _bot: &ChannelBot,
+        secrets: &WebhookSecrets,
         headers: &axum::http::HeaderMap,
         body: &[u8],
-    ) -> AppResult<()> {
+    ) -> AppResult<Option<Vec<u8>>> {
         let signature = headers
             .get(SIGNATURE_HEADER)
             .and_then(|v| v.to_str().ok())
@@ -297,15 +298,15 @@ impl PlatformAdapter for SlackAdapter {
             ));
         }
 
-        // The webhook handler decrypts `app_secret_encrypted` (the signing
-        // secret) and injects the raw value into `webhook_secret_hash` for
-        // this verification step, mirroring the Lark/Feishu pattern.
-        let signing_secret = &bot.webhook_secret_hash;
-        if signing_secret.is_empty() {
-            return Err(AppError::ChannelWebhookVerificationFailed(
-                "Slack signing secret not configured".to_string(),
-            ));
-        }
+        let signing_secret = secrets
+            .slack_signing_secret
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                AppError::ChannelWebhookVerificationFailed(
+                    "Slack signing secret not configured".to_string(),
+                )
+            })?;
 
         let body_str = std::str::from_utf8(body).map_err(|_| {
             AppError::ChannelWebhookVerificationFailed(
@@ -323,7 +324,7 @@ impl PlatformAdapter for SlackAdapter {
         let expected = format!("v0={}", hex::encode(mac.finalize().into_bytes()));
 
         if expected.as_bytes().ct_eq(signature.as_bytes()).into() {
-            Ok(())
+            Ok(None)
         } else {
             Err(AppError::ChannelWebhookVerificationFailed(
                 "Slack signature verification failed".to_string(),
@@ -530,7 +531,7 @@ impl PlatformAdapter for SlackAdapter {
 mod tests {
     use super::*;
 
-    fn make_test_bot(signing_secret: &str) -> ChannelBot {
+    fn make_test_bot() -> ChannelBot {
         ChannelBot {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: uuid::Uuid::new_v4().to_string(),
@@ -540,17 +541,23 @@ mod tests {
             platform_bot_id: "B12345".to_string(),
             platform_bot_username: "testbot".to_string(),
             webhook_registered: true,
-            // The webhook handler decrypts app_secret_encrypted into this
-            // field at verify time. Tests skip the decryption and inject the
-            // raw signing secret directly.
-            webhook_secret_hash: signing_secret.to_string(),
+            webhook_secret_hash: String::new(),
             app_id: None,
             app_secret_encrypted: None,
+            lark_verification_token_encrypted: None,
+            lark_encrypt_key_encrypted: None,
             public_key: None,
             status: "active".to_string(),
             is_active: true,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn secrets_with_signing_secret(signing_secret: &str) -> WebhookSecrets {
+        WebhookSecrets {
+            slack_signing_secret: Some(signing_secret.to_string()),
+            ..Default::default()
         }
     }
 
@@ -610,16 +617,18 @@ mod tests {
         let secret = "8f742231b10e8888abcd99yyyzzz85a5";
         let body = br#"{"type":"event_callback"}"#;
         let ts = chrono::Utc::now().timestamp();
-        let bot = make_test_bot(secret);
+        let bot = make_test_bot();
+        let secrets = secrets_with_signing_secret(secret);
 
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(SIGNATURE_HEADER, sign(secret, ts, body).parse().unwrap());
         headers.insert(TIMESTAMP_HEADER, ts.to_string().parse().unwrap());
 
-        adapter
-            .verify_webhook(&bot, &headers, body)
+        let decoded = adapter
+            .verify_webhook(&bot, &secrets, &headers, body)
             .await
             .expect("valid signature should pass");
+        assert!(decoded.is_none(), "Slack does not rewrite the body");
     }
 
     #[tokio::test]
@@ -627,7 +636,8 @@ mod tests {
         let adapter = SlackAdapter::new();
         let body = br#"{"type":"event_callback"}"#;
         let ts = chrono::Utc::now().timestamp();
-        let bot = make_test_bot("real_secret");
+        let bot = make_test_bot();
+        let secrets = secrets_with_signing_secret("real_secret");
 
         let mut headers = axum::http::HeaderMap::new();
         // Sign with a different secret -> mismatch.
@@ -638,7 +648,7 @@ mod tests {
         headers.insert(TIMESTAMP_HEADER, ts.to_string().parse().unwrap());
 
         let err = adapter
-            .verify_webhook(&bot, &headers, body)
+            .verify_webhook(&bot, &secrets, &headers, body)
             .await
             .expect_err("mismatched signature should fail");
         assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
@@ -647,11 +657,12 @@ mod tests {
     #[tokio::test]
     async fn verify_webhook_missing_signature_header() {
         let adapter = SlackAdapter::new();
-        let bot = make_test_bot("secret");
+        let bot = make_test_bot();
+        let secrets = secrets_with_signing_secret("secret");
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(TIMESTAMP_HEADER, "1700000000".parse().unwrap());
         let err = adapter
-            .verify_webhook(&bot, &headers, b"{}")
+            .verify_webhook(&bot, &secrets, &headers, b"{}")
             .await
             .expect_err("missing signature should fail");
         assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
@@ -660,11 +671,12 @@ mod tests {
     #[tokio::test]
     async fn verify_webhook_missing_timestamp_header() {
         let adapter = SlackAdapter::new();
-        let bot = make_test_bot("secret");
+        let bot = make_test_bot();
+        let secrets = secrets_with_signing_secret("secret");
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(SIGNATURE_HEADER, "v0=abc".parse().unwrap());
         let err = adapter
-            .verify_webhook(&bot, &headers, b"{}")
+            .verify_webhook(&bot, &secrets, &headers, b"{}")
             .await
             .expect_err("missing timestamp should fail");
         assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
@@ -677,14 +689,15 @@ mod tests {
         let body = br#"{"type":"event_callback"}"#;
         // 10 minutes in the past, beyond the 5-minute replay window.
         let ts = chrono::Utc::now().timestamp() - 600;
-        let bot = make_test_bot(secret);
+        let bot = make_test_bot();
+        let secrets = secrets_with_signing_secret(secret);
 
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(SIGNATURE_HEADER, sign(secret, ts, body).parse().unwrap());
         headers.insert(TIMESTAMP_HEADER, ts.to_string().parse().unwrap());
 
         let err = adapter
-            .verify_webhook(&bot, &headers, body)
+            .verify_webhook(&bot, &secrets, &headers, body)
             .await
             .expect_err("stale timestamp should fail");
         assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));
@@ -695,15 +708,16 @@ mod tests {
         let adapter = SlackAdapter::new();
         let body = b"{}";
         let ts = chrono::Utc::now().timestamp();
-        // Bot without a configured signing secret (empty string).
-        let bot = make_test_bot("");
+        let bot = make_test_bot();
+        // Secrets bag without a signing secret (the handler decrypted nothing).
+        let secrets = WebhookSecrets::default();
 
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(SIGNATURE_HEADER, "v0=00".parse().unwrap());
         headers.insert(TIMESTAMP_HEADER, ts.to_string().parse().unwrap());
 
         let err = adapter
-            .verify_webhook(&bot, &headers, body)
+            .verify_webhook(&bot, &secrets, &headers, body)
             .await
             .expect_err("missing signing secret should fail");
         assert!(matches!(err, AppError::ChannelWebhookVerificationFailed(_)));

--- a/backend/src/services/channel_adapters/telegram.rs
+++ b/backend/src/services/channel_adapters/telegram.rs
@@ -10,7 +10,7 @@ use subtle::ConstantTimeEq;
 use crate::errors::{AppError, AppResult};
 use crate::models::channel_bot::ChannelBot;
 use crate::services::channel_platform::{
-    BotIdentity, InboundAttachment, InboundMessage, OutboundReply, PlatformAdapter,
+    BotIdentity, InboundAttachment, InboundMessage, OutboundReply, PlatformAdapter, WebhookSecrets,
 };
 
 const TELEGRAM_API_BASE: &str = "https://api.telegram.org/bot";
@@ -264,9 +264,10 @@ impl PlatformAdapter for TelegramAdapter {
     async fn verify_webhook(
         &self,
         bot: &ChannelBot,
+        _secrets: &WebhookSecrets,
         headers: &axum::http::HeaderMap,
         _body: &[u8],
-    ) -> AppResult<()> {
+    ) -> AppResult<Option<Vec<u8>>> {
         let header_value = headers
             .get(SECRET_HEADER)
             .and_then(|v| v.to_str().ok())
@@ -286,7 +287,7 @@ impl PlatformAdapter for TelegramAdapter {
             .ct_eq(stored_hash.as_bytes())
             .into()
         {
-            Ok(())
+            Ok(None)
         } else {
             Err(AppError::ChannelWebhookVerificationFailed(
                 "secret token mismatch".to_string(),
@@ -755,10 +756,11 @@ mod tests {
         let stored_hash = hex::encode(Sha256::digest(secret.as_bytes()));
 
         let bot = make_test_bot(&stored_hash);
+        let secrets = WebhookSecrets::default();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(SECRET_HEADER, secret.parse().unwrap());
 
-        let result = adapter.verify_webhook(&bot, &headers, b"").await;
+        let result = adapter.verify_webhook(&bot, &secrets, &headers, b"").await;
         assert!(result.is_ok());
     }
 
@@ -768,10 +770,11 @@ mod tests {
         let stored_hash = hex::encode(Sha256::digest(b"correct_secret"));
 
         let bot = make_test_bot(&stored_hash);
+        let secrets = WebhookSecrets::default();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(SECRET_HEADER, "wrong_secret".parse().unwrap());
 
-        let result = adapter.verify_webhook(&bot, &headers, b"").await;
+        let result = adapter.verify_webhook(&bot, &secrets, &headers, b"").await;
         assert!(result.is_err());
     }
 
@@ -779,9 +782,10 @@ mod tests {
     async fn verify_webhook_missing_header() {
         let adapter = TelegramAdapter::new();
         let bot = make_test_bot("somehash");
+        let secrets = WebhookSecrets::default();
         let headers = axum::http::HeaderMap::new();
 
-        let result = adapter.verify_webhook(&bot, &headers, b"").await;
+        let result = adapter.verify_webhook(&bot, &secrets, &headers, b"").await;
         assert!(result.is_err());
     }
 
@@ -800,6 +804,8 @@ mod tests {
             webhook_secret_hash: webhook_secret_hash.to_string(),
             app_id: None,
             app_secret_encrypted: None,
+            lark_verification_token_encrypted: None,
+            lark_encrypt_key_encrypted: None,
             public_key: None,
             status: "active".to_string(),
             is_active: true,

--- a/backend/src/services/channel_bot_service.rs
+++ b/backend/src/services/channel_bot_service.rs
@@ -39,6 +39,8 @@ pub async fn create_bot(
     label: &str,
     app_id: Option<&str>,
     app_secret: Option<&str>,
+    lark_verification_token: Option<&str>,
+    lark_encrypt_key: Option<&str>,
     public_key: Option<&str>,
 ) -> AppResult<CreateBotResult> {
     // Validate label
@@ -71,6 +73,23 @@ pub async fn create_bot(
     if adapter.platform_id() == "slack" && app_secret.map(|s| s.trim().is_empty()).unwrap_or(true) {
         return Err(AppError::ValidationError(
             "Slack signing secret is required (pass via app_secret)".to_string(),
+        ));
+    }
+
+    // Lark/Feishu require the Event Subscription Verification Token. Without
+    // it, there is no way to authenticate inbound webhook deliveries when
+    // Encrypt Key is disabled (the only other proof-of-origin path), and the
+    // bot would stay stuck in pending_webhook forever. Failing fast at
+    // registration time surfaces the misconfiguration to the caller.
+    if matches!(adapter.platform_id(), "lark" | "feishu")
+        && lark_verification_token
+            .map(|s| s.trim().is_empty())
+            .unwrap_or(true)
+    {
+        return Err(AppError::ValidationError(
+            "Lark/Feishu Verification Token is required (pass via verification_token). \
+             Copy it from the Lark Developer Console -> Event Subscriptions."
+                .to_string(),
         ));
     }
 
@@ -127,10 +146,23 @@ pub async fn create_bot(
     // Encrypt the bot token
     let bot_token_encrypted = encryption_keys.encrypt(effective_token.as_bytes()).await?;
 
-    // Encrypt app secret if provided (Lark/Feishu)
+    // Encrypt app secret if provided (Lark/Feishu, Slack)
     let app_secret_encrypted = match app_secret {
         Some(secret) => Some(encryption_keys.encrypt(secret.as_bytes()).await?),
         None => None,
+    };
+
+    // Encrypt Lark/Feishu Event Subscription secrets separately from the
+    // app secret. The verification token and encrypt key are rotated and
+    // configured independently of the app secret in the Lark Developer
+    // Console, so they need their own storage.
+    let lark_verification_token_encrypted = match lark_verification_token {
+        Some(v) if !v.trim().is_empty() => Some(encryption_keys.encrypt(v.as_bytes()).await?),
+        _ => None,
+    };
+    let lark_encrypt_key_encrypted = match lark_encrypt_key {
+        Some(v) if !v.trim().is_empty() => Some(encryption_keys.encrypt(v.as_bytes()).await?),
+        _ => None,
     };
 
     let now = Utc::now();
@@ -146,6 +178,8 @@ pub async fn create_bot(
         webhook_secret_hash: secret_hash,
         app_id: app_id.map(String::from),
         app_secret_encrypted,
+        lark_verification_token_encrypted,
+        lark_encrypt_key_encrypted,
         public_key: public_key.map(String::from),
         status: "pending".to_string(),
         is_active: true,

--- a/backend/src/services/channel_platform.rs
+++ b/backend/src/services/channel_platform.rs
@@ -53,6 +53,28 @@ pub struct OutboundReply {
     pub metadata: Option<serde_json::Value>,
 }
 
+/// Plaintext secrets that the handler has already decrypted from the
+/// [`ChannelBot`](crate::models::channel_bot::ChannelBot) record and is
+/// passing to the adapter for webhook verification.
+///
+/// Kept separate from `ChannelBot` so verification material never has to be
+/// written back into the model struct in memory, and so each adapter only
+/// sees the fields it actually needs.
+#[derive(Default, Debug)]
+pub struct WebhookSecrets {
+    /// Slack: plaintext app signing secret used as the HMAC-SHA256 key for
+    /// `X-Slack-Signature` verification.
+    pub slack_signing_secret: Option<String>,
+    /// Lark/Feishu: plaintext Event Subscription Verification Token. Lark
+    /// places this value in every inbound body so the server can confirm
+    /// the request came from Lark.
+    pub lark_verification_token: Option<String>,
+    /// Lark/Feishu: plaintext Event Subscription Encrypt Key. When set, Lark
+    /// AES-256-CBC-encrypts the request body and signs it via
+    /// `X-Lark-Signature`.
+    pub lark_encrypt_key: Option<String>,
+}
+
 /// Trait that each chat platform (Telegram, Discord, Lark, Feishu) implements
 /// to normalize webhook verification, message parsing, and reply sending.
 #[async_trait::async_trait]
@@ -61,12 +83,18 @@ pub trait PlatformAdapter: Send + Sync {
     fn platform_id(&self) -> &str;
 
     /// Verify the incoming webhook signature or secret headers.
+    ///
+    /// Returns `Some(plaintext_body)` if the adapter decrypted the body on
+    /// the way through (e.g. Lark with Encrypt Key enabled) and the handler
+    /// should feed that plaintext to [`parse_inbound`] instead of the raw
+    /// body. Returns `None` when the input body should be used as-is.
     async fn verify_webhook(
         &self,
         bot: &crate::models::channel_bot::ChannelBot,
+        secrets: &WebhookSecrets,
         headers: &axum::http::HeaderMap,
         body: &[u8],
-    ) -> AppResult<()>;
+    ) -> AppResult<Option<Vec<u8>>>;
 
     /// Parse the raw webhook body into zero or more normalized inbound messages.
     async fn parse_inbound(&self, body: &[u8]) -> AppResult<Vec<InboundMessage>>;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2028,6 +2028,24 @@ pub enum ChannelBotCommands {
         /// Read app secret from this environment variable
         #[arg(long)]
         app_secret_env: Option<String>,
+        /// Lark/Feishu Event Subscription Verification Token
+        /// (hidden from help -- use --verification-token-env instead).
+        /// REQUIRED for Lark/Feishu. Copy it from the Lark Developer Console
+        /// -> Event Subscriptions. Not the same as the app secret.
+        #[arg(long, hide = true)]
+        verification_token: Option<String>,
+        /// Read Lark/Feishu verification token from this environment variable
+        #[arg(long)]
+        verification_token_env: Option<String>,
+        /// Lark/Feishu Event Subscription Encrypt Key, when enabled on the
+        /// platform side (hidden from help -- use --encrypt-key-env instead).
+        /// Optional: leave blank if Lark Event Subscriptions are not
+        /// configured with an Encrypt Key.
+        #[arg(long, hide = true)]
+        encrypt_key: Option<String>,
+        /// Read Lark/Feishu encrypt key from this environment variable
+        #[arg(long)]
+        encrypt_key_env: Option<String>,
         /// Platform public key (required for Discord)
         #[arg(long)]
         public_key: Option<String>,

--- a/cli/src/commands/channel_bot.rs
+++ b/cli/src/commands/channel_bot.rs
@@ -17,6 +17,10 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
             app_id,
             app_secret,
             app_secret_env,
+            verification_token,
+            verification_token_env,
+            encrypt_key,
+            encrypt_key_env,
             public_key,
             org,
             auth,
@@ -24,6 +28,12 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
             let token = resolve_secret(bot_token.as_deref(), token_env.as_deref(), "bot token")?;
             let resolved_app_secret =
                 resolve_optional_secret(app_secret.as_deref(), app_secret_env.as_deref())?;
+            let resolved_verification_token = resolve_optional_secret(
+                verification_token.as_deref(),
+                verification_token_env.as_deref(),
+            )?;
+            let resolved_encrypt_key =
+                resolve_optional_secret(encrypt_key.as_deref(), encrypt_key_env.as_deref())?;
 
             let mut api = ApiClient::from_auth(&auth)?;
 
@@ -38,6 +48,12 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
             }
             if let Some(secret) = resolved_app_secret {
                 body["app_secret"] = Value::String(secret);
+            }
+            if let Some(token) = resolved_verification_token {
+                body["verification_token"] = Value::String(token);
+            }
+            if let Some(key) = resolved_encrypt_key {
+                body["encrypt_key"] = Value::String(key);
             }
             if let Some(key) = public_key {
                 body["public_key"] = Value::String(key);

--- a/frontend/src/pages/channel-bots.tsx
+++ b/frontend/src/pages/channel-bots.tsx
@@ -385,6 +385,48 @@ function CreateBotDialog({
                   </p>
                 )}
               </div>
+              <div className="space-y-2">
+                <Label htmlFor="verification_token">Verification Token</Label>
+                <Input
+                  id="verification_token"
+                  type="password"
+                  placeholder="Event Subscription Verification Token"
+                  {...register("verification_token")}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Required. Copy it from Lark Developer Console &rarr;
+                  Event Subscriptions. Distinct from the App Secret.
+                </p>
+                {errors.verification_token && (
+                  <p className="text-xs text-destructive">
+                    {errors.verification_token.message}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="encrypt_key">
+                  Encrypt Key{" "}
+                  <span className="text-xs text-muted-foreground">
+                    (optional)
+                  </span>
+                </Label>
+                <Input
+                  id="encrypt_key"
+                  type="password"
+                  placeholder="Leave blank if Encrypt Key is disabled"
+                  {...register("encrypt_key")}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Only set this if Event Subscriptions has an Encrypt Key.
+                  NyxID will AES-decrypt inbound bodies and verify the
+                  <code className="mx-1">X-Lark-Signature</code> header.
+                </p>
+                {errors.encrypt_key && (
+                  <p className="text-xs text-destructive">
+                    {errors.encrypt_key.message}
+                  </p>
+                )}
+              </div>
             </>
           )}
 

--- a/frontend/src/schemas/channels.ts
+++ b/frontend/src/schemas/channels.ts
@@ -43,6 +43,19 @@ export const createChannelBotSchema = z
       .max(128, "Label must be at most 128 characters"),
     app_id: z.string().max(256).optional(),
     app_secret: z.string().max(512).optional(),
+    /**
+     * Lark/Feishu Event Subscription Verification Token. Required for
+     * Lark/Feishu bots; copied from the Lark Developer Console under
+     * Event Subscriptions. Distinct from `app_secret`.
+     */
+    verification_token: z.string().max(512).optional(),
+    /**
+     * Lark/Feishu Event Subscription Encrypt Key. Optional — only set if
+     * the Lark app is configured with an Encrypt Key. When present, Lark
+     * AES-256-CBC-encrypts every webhook body and signs it with
+     * `X-Lark-Signature`, which the server verifies.
+     */
+    encrypt_key: z.string().max(512).optional(),
     public_key: z.string().max(256).optional(),
     /** When set, create this bot under the given org (caller must be admin). */
     target_org_id: z.string().optional(),
@@ -66,6 +79,17 @@ export const createChannelBotSchema = z
         code: z.ZodIssueCode.custom,
         message: "App Secret is required for Lark/Feishu",
         path: ["app_secret"],
+      });
+    }
+    if (
+      (data.platform === "lark" || data.platform === "feishu") &&
+      !data.verification_token
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Verification Token is required for Lark/Feishu. Copy it from the Lark Developer Console -> Event Subscriptions.",
+        path: ["verification_token"],
       });
     }
     if (data.platform === "discord" && !data.public_key) {

--- a/frontend/src/types/channels.ts
+++ b/frontend/src/types/channels.ts
@@ -64,6 +64,16 @@ export interface CreateChannelBotRequest {
   readonly app_id?: string;
   /** Lark/Feishu: app secret. Slack: app signing secret. */
   readonly app_secret?: string;
+  /**
+   * Lark/Feishu only: Event Subscription Verification Token (plaintext).
+   * Required for Lark/Feishu bots.
+   */
+  readonly verification_token?: string;
+  /**
+   * Lark/Feishu only: Event Subscription Encrypt Key (plaintext). Optional —
+   * set only if the Lark Developer Console has Encrypt Key enabled.
+   */
+  readonly encrypt_key?: string;
   /** Discord only */
   readonly public_key?: string;
   /** Create this bot under the given org (caller must be admin). */


### PR DESCRIPTION
Closes #455.

## Summary

- Separates Lark / Feishu Event Subscription security material from the bot's `app_secret`: `ChannelBot` gains `lark_verification_token_encrypted` and `lark_encrypt_key_encrypted`, persisted encrypted via the existing envelope encryption. API / CLI / UI now accept `verification_token` (required for Lark/Feishu) and `encrypt_key` (optional) at bot registration.
- Rewrites the Lark adapter's `verify_webhook` to match Lark's documented security contract. Plaintext deliveries are accepted when the `token` in the body matches (v1 top-level or v2 `header.token`), constant-time compared. When `Encrypt Key` is configured, the adapter verifies `X-Lark-Signature = hex(SHA-256(ts + nonce + encrypt_key + body))`, AES-256-CBC-decrypts the `{"encrypt":"..."}` envelope (key = SHA-256(encrypt_key), IV = first 16 bytes of ciphertext), and still requires the verification token to match.
- Evolves `PlatformAdapter::verify_webhook` to take an explicit `WebhookSecrets` bag and return an optional decrypted body, so the handler stops mutating `ChannelBot` in memory and the Lark adapter can surface the decrypted plaintext to `parse_inbound`.
- Slack's verification piggy-backed on the same bot-clone hack; it now takes its signing secret through the same `WebhookSecrets` bag instead.

## Why this matters

The previous code:

- always required `X-Lark-Signature`, so any bot created with `Encrypt Key` disabled (Lark's default) stayed stuck in `pending_webhook`;
- overloaded the decrypted `app_secret` as both the HMAC key and the `encrypt_key` segment of the signed message, and used HMAC-SHA256 instead of the plain SHA-256 Lark specifies;
- had no field for Lark's Verification Token or Encrypt Key at all.

Issue #455 reproduces exactly this failure mode. After this PR, bots registered with a correct Verification Token pass verification on the first inbound message and auto-promote from `pending_webhook` to `active`.

## Test plan

- [x] `cargo build -p nyxid` and `cargo build -p nyxid-cli`
- [x] `cargo test -p nyxid --bin nyxid` — 1404/1404 pass, including new Lark verify_webhook tests covering plaintext + encrypted paths, mismatch, missing signature, missing verification token
- [x] `cargo test -p nyxid-cli` — 156/156 pass
- [x] `frontend: npm run lint` — 0 errors
- [x] `frontend: npx vitest run` — 425/425 pass
- [ ] End-to-end smoke: register a Lark bot with Encrypt Key disabled, send a DM, confirm webhook verification passes and bot flips to `active`
- [ ] End-to-end smoke: register a Lark bot with Encrypt Key enabled, send a DM, confirm signature verifies and decrypted event is relayed