### PR TITLE
feat: ship telemetry consent withdrawal toggle (web + CLI)

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -43,10 +43,13 @@ pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
                 matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "on")
             });
 
-    // The `profile` parameter is intentionally unused below. See comment
-    // above. Acknowledged to clippy via binding prefix.
-    let _profile_for_future_use = profile;
-    let user_consented = crate::telemetry::consent::resolve_consent(None).enabled;
+    // `resolve_consent_preferring_profile` honors the default profile
+    // (where v1 persists user choice) but also falls back to any
+    // explicit per-profile consent from older releases, so upgrading
+    // doesn't silently override a historical opt-out on a named
+    // profile.
+    let user_consented =
+        crate::telemetry::consent::resolve_consent_preferring_profile(profile).enabled;
 
     let mut builder = Client::builder()
         .user_agent(CLI_USER_AGENT)

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -12,7 +12,7 @@ pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
     //   (a) the operator has configured a telemetry DSN (or opted into
     //       the community share-back), AND
     //   (b) the user on this machine has actually consented (CLI
-    //       config / `NYXID_TELEMETRY=on` / etc — see
+    //       config / `NYXID_TELEMETRY=on` / `DO_NOT_TRACK` — see
     //       `crate::telemetry::consent::resolve_consent`).
     //
     // Historically this function checked only (a), which meant that a
@@ -22,11 +22,18 @@ pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
     // for their traffic anyway. Local opt-out was partial theater.
     // Tracked in `docs/TELEMETRY_CONSENT_FIX.md` §8.3.
     //
-    // Profile-scoped consent: when `profile` is `Some`, the per-profile
-    // config at `~/.nyxid/profiles/{name}/config.toml` is consulted.
-    // `None` means "use the default profile's consent," which is the
-    // right fallback for pre-auth flows (register, forgot-password,
-    // reset-password) where no profile has been selected yet.
+    // The `profile` argument is kept on the signature for future per-
+    // profile features, but consent is read against the DEFAULT profile
+    // regardless. Rationale: the only built-in consent editor today is
+    // `nyxid telemetry enable|disable`, which writes to
+    // `~/.nyxid/config.toml` (default profile). The main.rs first-run
+    // prompt also writes there. Reading profile-specific consent here
+    // would mean `nyxid --profile dev some-command` silently lost its
+    // headers until the user manually edited `~/.nyxid/profiles/dev/
+    // config.toml` — a footgun that treats consent as per-profile when
+    // no editor UI treats it that way. Consent is user-global in v1;
+    // making it per-profile is a separate feature that also needs a
+    // `nyxid telemetry --profile ...` editor path.
     let telemetry_configured = std::env::var("NYXID_TELEMETRY_DSN")
         .ok()
         .is_some_and(|s| !s.is_empty())
@@ -36,7 +43,10 @@ pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
                 matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "on")
             });
 
-    let user_consented = crate::telemetry::consent::resolve_consent(profile).enabled;
+    // The `profile` parameter is intentionally unused below. See comment
+    // above. Acknowledged to clippy via binding prefix.
+    let _profile_for_future_use = profile;
+    let user_consented = crate::telemetry::consent::resolve_consent(None).enabled;
 
     let mut builder = Client::builder()
         .user_agent(CLI_USER_AGENT)

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -6,14 +6,27 @@ use serde::{Deserialize, Serialize};
 /// User-Agent string sent on all CLI HTTP requests.
 pub const CLI_USER_AGENT: &str = concat!("nyxid-cli/", env!("CARGO_PKG_VERSION"));
 
-pub fn build_cli_http_client() -> Result<Client> {
+pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
     // Attach `X-NyxID-Client: cli` + `X-NyxID-Client-Version` ONLY when
-    // a telemetry DSN is configured on this machine (or when share-back
-    // is opted in). Keeps the default-off CLI byte-identical to the
-    // pre-telemetry build — no new headers on the wire, no CORS-style
-    // drift visible to the backend. The backend's telemetry middleware
-    // reads these to tag events with `surface`; see
-    // docs/TELEMETRY.md §3.
+    // BOTH conditions are true:
+    //   (a) the operator has configured a telemetry DSN (or opted into
+    //       the community share-back), AND
+    //   (b) the user on this machine has actually consented (CLI
+    //       config / `NYXID_TELEMETRY=on` / etc — see
+    //       `crate::telemetry::consent::resolve_consent`).
+    //
+    // Historically this function checked only (a), which meant that a
+    // user who had run `nyxid telemetry disable` — or set
+    // `DO_NOT_TRACK=1` — still produced surface-tagged headers on every
+    // request, and the backend emitted `surface="cli"` telemetry events
+    // for their traffic anyway. Local opt-out was partial theater.
+    // Tracked in `docs/TELEMETRY_CONSENT_FIX.md` §8.3.
+    //
+    // Profile-scoped consent: when `profile` is `Some`, the per-profile
+    // config at `~/.nyxid/profiles/{name}/config.toml` is consulted.
+    // `None` means "use the default profile's consent," which is the
+    // right fallback for pre-auth flows (register, forgot-password,
+    // reset-password) where no profile has been selected yet.
     let telemetry_configured = std::env::var("NYXID_TELEMETRY_DSN")
         .ok()
         .is_some_and(|s| !s.is_empty())
@@ -23,11 +36,13 @@ pub fn build_cli_http_client() -> Result<Client> {
                 matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "on")
             });
 
+    let user_consented = crate::telemetry::consent::resolve_consent(profile).enabled;
+
     let mut builder = Client::builder()
         .user_agent(CLI_USER_AGENT)
         .connect_timeout(std::time::Duration::from_secs(10));
 
-    if telemetry_configured {
+    if telemetry_configured && user_consented {
         let mut default_headers = reqwest::header::HeaderMap::new();
         default_headers.insert(
             reqwest::header::HeaderName::from_static("x-nyxid-client"),
@@ -71,7 +86,7 @@ impl ApiClient {
         access_token: String,
         profile: Option<String>,
     ) -> Result<Self> {
-        let client = build_cli_http_client()?;
+        let client = build_cli_http_client(profile.as_deref())?;
 
         Ok(Self {
             client,
@@ -472,10 +487,11 @@ pub async fn anonymous_post(
     base_url: &str,
     path: &str,
     body: &impl Serialize,
+    profile: Option<&str>,
 ) -> Result<serde_json::Value> {
     let base = format!("{}/api/v1", base_url.trim_end_matches('/'));
     let url = format!("{base}{path}");
-    let client = build_cli_http_client()?;
+    let client = build_cli_http_client(profile)?;
 
     let resp = client
         .post(&url)
@@ -496,10 +512,15 @@ pub async fn anonymous_post(
 }
 
 /// Make an unauthenticated POST request that returns no body.
-pub async fn anonymous_post_empty(base_url: &str, path: &str, body: &impl Serialize) -> Result<()> {
+pub async fn anonymous_post_empty(
+    base_url: &str,
+    path: &str,
+    body: &impl Serialize,
+    profile: Option<&str>,
+) -> Result<()> {
     let base = format!("{}/api/v1", base_url.trim_end_matches('/'));
     let url = format!("{base}{path}");
-    let client = build_cli_http_client()?;
+    let client = build_cli_http_client(profile)?;
 
     let resp = client
         .post(&url)

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -257,7 +257,7 @@ pub async fn run_logout(base_url: &str, profile: Option<&str>) -> Result<()> {
 
     // Best-effort server-side logout
     if let Some(token) = read_saved_token_for(profile) {
-        let client = build_cli_http_client()?;
+        let client = build_cli_http_client(profile)?;
 
         let _ = client
             .post(format!("{base_url}/api/v1/auth/logout"))
@@ -284,7 +284,7 @@ pub async fn run_logout(base_url: &str, profile: Option<&str>) -> Result<()> {
 async fn run_browser_login(base_url: &str, profile: Option<&str>) -> Result<()> {
     let base_url = base_url.trim_end_matches('/');
 
-    let frontend_url = fetch_frontend_url(base_url).await?;
+    let frontend_url = fetch_frontend_url(base_url, profile).await?;
 
     let listener =
         TcpListener::bind("127.0.0.1:0").context("Failed to bind local callback server")?;
@@ -447,9 +447,9 @@ struct PublicConfig {
     frontend_url: String,
 }
 
-pub async fn fetch_frontend_url(base_url: &str) -> Result<String> {
+pub async fn fetch_frontend_url(base_url: &str, profile: Option<&str>) -> Result<String> {
     let config_url = format!("{base_url}/api/v1/public/config");
-    let client = build_cli_http_client()?;
+    let client = build_cli_http_client(profile)?;
 
     let config: PublicConfig = client
         .get(&config_url)
@@ -501,7 +501,7 @@ async fn run_password_login(
     let base_url = base_url.trim_end_matches('/');
     let login_url = format!("{base_url}/api/v1/auth/login");
 
-    let client = build_cli_http_client()?;
+    let client = build_cli_http_client(profile)?;
 
     let response = client
         .post(&login_url)

--- a/cli/src/commands/ai_setup.rs
+++ b/cli/src/commands/ai_setup.rs
@@ -105,7 +105,10 @@ fn substitute_urls(content: &str, base_url: &str, dashboard_url: &str) -> String
 }
 
 async fn resolve_dashboard_url(base_url: &str) -> String {
-    crate::auth::fetch_frontend_url(base_url)
+    // ai-setup is a pre-flight informational command — no profile is
+    // in scope here. Using `None` falls back to the default profile's
+    // consent, which is the right behavior for a non-profile command.
+    crate::auth::fetch_frontend_url(base_url, None)
         .await
         .unwrap_or_else(|_| base_url.to_string())
 }

--- a/cli/src/commands/auth_flows.rs
+++ b/cli/src/commands/auth_flows.rs
@@ -32,8 +32,10 @@ pub async fn run_register(args: RegisterArgs) -> Result<()> {
         body["display_name"] = serde_json::Value::String(name.clone());
     }
 
+    // Pre-auth flow: no profile has been selected yet, so consent is
+    // resolved against the default profile's config.
     let result: serde_json::Value =
-        api::anonymous_post(&args.base_url, "/auth/register", &body).await?;
+        api::anonymous_post(&args.base_url, "/auth/register", &body, None).await?;
 
     let msg = result["message"]
         .as_str()
@@ -44,14 +46,14 @@ pub async fn run_register(args: RegisterArgs) -> Result<()> {
 
 pub async fn run_verify_email(args: VerifyEmailArgs) -> Result<()> {
     let body = serde_json::json!({ "token": args.token });
-    api::anonymous_post_empty(&args.base_url, "/auth/verify-email", &body).await?;
+    api::anonymous_post_empty(&args.base_url, "/auth/verify-email", &body, None).await?;
     eprintln!("Email verified successfully.");
     Ok(())
 }
 
 pub async fn run_forgot_password(args: ForgotPasswordArgs) -> Result<()> {
     let body = serde_json::json!({ "email": args.email });
-    api::anonymous_post_empty(&args.base_url, "/auth/forgot-password", &body).await?;
+    api::anonymous_post_empty(&args.base_url, "/auth/forgot-password", &body, None).await?;
     eprintln!(
         "If an account exists for {}, a password reset email has been sent.",
         args.email
@@ -81,7 +83,7 @@ pub async fn run_reset_password(args: ResetPasswordArgs) -> Result<()> {
         "token": args.token,
         "password": password,
     });
-    api::anonymous_post_empty(&args.base_url, "/auth/reset-password", &body).await?;
+    api::anonymous_post_empty(&args.base_url, "/auth/reset-password", &body, None).await?;
     eprintln!("Password reset successfully. You can now log in with your new password.");
     Ok(())
 }

--- a/cli/src/commands/ssh.rs
+++ b/cli/src/commands/ssh.rs
@@ -68,6 +68,7 @@ pub async fn run(cli: SshCli) -> Result<()> {
                 &principal,
                 &certificate_file,
                 ca_public_key_file.as_deref(),
+                auth.profile.as_deref(),
             )
             .await
         }
@@ -99,6 +100,7 @@ pub async fn run(cli: SshCli) -> Result<()> {
                     &princ,
                     &cert,
                     ca_public_key_file.as_deref(),
+                    auth.profile.as_deref(),
                 )
                 .await?;
             }
@@ -325,6 +327,10 @@ struct IssueCertificateResponse {
     ca_public_key: String,
 }
 
+// Adding `profile` to honor the user's telemetry consent when building
+// the HTTP client. Refactoring these args into a struct is out of scope
+// for the consent fix; the arg count warning is acknowledged here.
+#[allow(clippy::too_many_arguments)]
 async fn issue_certificate(
     base_url: &str,
     service_id: &str,
@@ -333,6 +339,7 @@ async fn issue_certificate(
     principal: &str,
     certificate_file: &Path,
     ca_public_key_file: Option<&Path>,
+    profile: Option<&str>,
 ) -> Result<()> {
     let public_key = tokio::fs::read_to_string(public_key_file)
         .await
@@ -349,7 +356,8 @@ async fn issue_certificate(
     };
 
     let endpoint = build_issue_cert_url(base_url, service_id)?;
-    let client = build_cli_http_client().context("Failed to build SSH certificate HTTP client")?;
+    let client =
+        build_cli_http_client(profile).context("Failed to build SSH certificate HTTP client")?;
 
     let response = client
         .post(endpoint)

--- a/cli/src/commands/telemetry.rs
+++ b/cli/src/commands/telemetry.rs
@@ -30,6 +30,9 @@ pub async fn run(command: TelemetryCommands, profile: Option<&str>) -> Result<()
         TelemetryCommands::Status => {
             let state = telemetry::consent::resolve_consent(profile);
             let source = match state.source {
+                telemetry::consent::ConsentSource::DoNotTrack => {
+                    "env: DO_NOT_TRACK is set (forced disable, not persisted)"
+                }
                 telemetry::consent::ConsentSource::EnvVarOff => {
                     "env: NYXID_TELEMETRY=off (forced disable)"
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,23 +38,19 @@ async fn main() {
         // DSN is present. Resolve consent, prompt if first-run TTY,
         // then init. Prompt refusal never bails the command.
         //
-        // Consent is deliberately read + persisted against the default
-        // profile (`None`), not the current CLI profile. This matches
-        // `api::build_cli_http_client` (which also reads `None`) and
-        // `commands::telemetry` (enable/disable/status, all None).
-        // Treating consent as user-global keeps the three paths
-        // consistent. If the first-run prompt persisted to a profile
-        // config instead, later invocations of the same profile would
-        // look up default-profile consent and find nothing → silent
-        // loss of `X-NyxID-Client` headers for that profile. Tracked
-        // as a future enhancement in docs/TELEMETRY_CONSENT_FIX.md;
-        // a proper per-profile mode also needs a `nyxid telemetry
-        // --profile` editor path, which v1 does not ship.
+        // Consent resolution honors any explicit per-profile choice
+        // persisted by older releases (via `_preferring_profile`) but
+        // otherwise defaults to the user-global (default profile)
+        // config. That keeps migration safe: upgrading will not
+        // silently override a historical opt-out on a named profile.
+        // Going forward, only the default profile is written to — the
+        // prompt and the `nyxid telemetry` editor both use `None`.
         //
-        // `TelemetryClient::init` still gets the profile so the anon
-        // distinct_id is isolated per profile (that's identity, not
+        // `TelemetryClient::init` receives `profile` so the anon
+        // distinct_id file is isolated per profile (identity, not
         // consent — different concern).
-        let mut consent = telemetry::consent::resolve_consent(None);
+        let mut consent =
+            telemetry::consent::resolve_consent_preferring_profile(profile.as_deref());
         let _ = telemetry::consent::prompt_if_needed_interactive(None, &mut consent);
         if consent.enabled {
             telemetry::TelemetryClient::init(profile.as_deref())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,8 +37,25 @@ async fn main() {
     let mut tele_client: Option<telemetry::TelemetryClient> = if telemetry_dsn_configured {
         // DSN is present. Resolve consent, prompt if first-run TTY,
         // then init. Prompt refusal never bails the command.
-        let mut consent = telemetry::consent::resolve_consent(profile.as_deref());
-        let _ = telemetry::consent::prompt_if_needed_interactive(profile.as_deref(), &mut consent);
+        //
+        // Consent is deliberately read + persisted against the default
+        // profile (`None`), not the current CLI profile. This matches
+        // `api::build_cli_http_client` (which also reads `None`) and
+        // `commands::telemetry` (enable/disable/status, all None).
+        // Treating consent as user-global keeps the three paths
+        // consistent. If the first-run prompt persisted to a profile
+        // config instead, later invocations of the same profile would
+        // look up default-profile consent and find nothing → silent
+        // loss of `X-NyxID-Client` headers for that profile. Tracked
+        // as a future enhancement in docs/TELEMETRY_CONSENT_FIX.md;
+        // a proper per-profile mode also needs a `nyxid telemetry
+        // --profile` editor path, which v1 does not ship.
+        //
+        // `TelemetryClient::init` still gets the profile so the anon
+        // distinct_id is isolated per profile (that's identity, not
+        // consent — different concern).
+        let mut consent = telemetry::consent::resolve_consent(None);
+        let _ = telemetry::consent::prompt_if_needed_interactive(None, &mut consent);
         if consent.enabled {
             telemetry::TelemetryClient::init(profile.as_deref())
         } else {

--- a/cli/src/telemetry/consent.rs
+++ b/cli/src/telemetry/consent.rs
@@ -1,12 +1,15 @@
 //! First-run consent resolver for the CLI.
 //!
-//! Implements the precedence ladder from `docs/TELEMETRY.md` §3.
+//! Implements the precedence ladder from `docs/TELEMETRY.md` §3, plus
+//! the industry-standard `DO_NOT_TRACK=1` signal honored by Homebrew,
+//! Netlify, GitHub CLI, and Meteor (see consoledonottrack.com).
 //! `resolve_consent` is pure — it only reads env vars + the config
 //! file, never prompts. `prompt_if_needed_interactive` handles the
 //! one-time interactive prompt on a real TTY and persists the answer.
 //!
 //! Resolution order (first match wins):
-//!   1. `NYXID_TELEMETRY=off` env var → off (always wins).
+//!   0. `DO_NOT_TRACK=1` (non-empty, non-zero) → off, never persisted.
+//!   1. `NYXID_TELEMETRY=off` env var → off (always wins over config).
 //!   2. `NYXID_TELEMETRY=on` env var → on (only if a DSN resolves).
 //!   3. `[telemetry] enabled=true` in `~/.nyxid/config.toml` → on.
 //!   4. `[telemetry] enabled=false AND asked=true` → off.
@@ -15,6 +18,10 @@
 //! `FirstRunPending` + TTY → prompt. `FirstRunPending` + non-TTY →
 //! treated as "No" for this invocation but NOT persisted, so the next
 //! interactive run re-prompts.
+//!
+//! `DO_NOT_TRACK` is checked before `NYXID_TELEMETRY` so a user who has
+//! opted out globally across all their dev tools is never overridden by
+//! a stale `NYXID_TELEMETRY=on` in the same environment.
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -31,6 +38,10 @@ const CONFIG_FILE_NAME: &str = "config.toml";
 /// print an honest explanation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ConsentSource {
+    /// `DO_NOT_TRACK=1` (industry-standard global opt-out). Beats every
+    /// other source. Never persisted to config — honoring the convention
+    /// that `DO_NOT_TRACK` is a per-invocation global signal.
+    DoNotTrack,
     /// `NYXID_TELEMETRY=off` (forced disable)
     EnvVarOff,
     /// `NYXID_TELEMETRY=on` (forced enable)
@@ -76,6 +87,23 @@ struct NyxidConfig {
 /// Pure function: resolve the current effective consent state. Reads
 /// env vars + config file; does not prompt, does not write.
 pub fn resolve_consent(profile: Option<&str>) -> ConsentState {
+    // Step 0: `DO_NOT_TRACK` (consoledonottrack.com). Values that count
+    // as "please do not track me" are any non-empty string other than
+    // literal "0" — mirrors the convention in Homebrew, Netlify, and
+    // GitHub CLI. Not persisted: `DO_NOT_TRACK` is a per-invocation
+    // signal, not a durable preference.
+    if let Ok(raw) = std::env::var("DO_NOT_TRACK") {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() && trimmed != "0" {
+            return ConsentState {
+                enabled: false,
+                source: ConsentSource::DoNotTrack,
+                persisted: false,
+                needs_prompt: false,
+            };
+        }
+    }
+
     // Steps 1 and 2: env var override.
     if let Ok(raw) = std::env::var("NYXID_TELEMETRY") {
         match raw.trim().to_ascii_lowercase().as_str() {
@@ -144,6 +172,8 @@ pub fn prompt_if_needed_interactive(profile: Option<&str>, state: &mut ConsentSt
     eprintln!();
     eprintln!("NyxID collects anonymous usage telemetry to help us improve the CLI.");
     eprintln!("We never capture credentials, command arguments, or file contents.");
+    eprintln!("This choice applies to this machine only — the web dashboard and");
+    eprintln!("mobile app manage their own telemetry settings.");
     eprintln!("You can change this later with `nyxid telemetry enable|disable`.");
     eprint!("Enable telemetry for this machine? [y/N] ");
     std::io::stderr().flush().ok();
@@ -225,8 +255,10 @@ mod tests {
             std::env::set_var("HOME", tmp.path());
         }
         let prev_telemetry = std::env::var_os("NYXID_TELEMETRY");
+        let prev_dnt = std::env::var_os("DO_NOT_TRACK");
         unsafe {
             std::env::remove_var("NYXID_TELEMETRY");
+            std::env::remove_var("DO_NOT_TRACK");
         }
         f();
         unsafe {
@@ -237,6 +269,10 @@ mod tests {
             match prev_telemetry {
                 Some(v) => std::env::set_var("NYXID_TELEMETRY", v),
                 None => std::env::remove_var("NYXID_TELEMETRY"),
+            }
+            match prev_dnt {
+                Some(v) => std::env::set_var("DO_NOT_TRACK", v),
+                None => std::env::remove_var("DO_NOT_TRACK"),
             }
         }
     }
@@ -281,6 +317,67 @@ mod tests {
         with_temp_home(|| {
             persist_choice(None, true).unwrap();
             let s = resolve_consent(None);
+            assert_eq!(s.source, ConsentSource::ConfigEnabled);
+            assert!(s.enabled);
+        });
+    }
+
+    #[test]
+    fn do_not_track_beats_config_enabled() {
+        with_temp_home(|| {
+            persist_choice(None, true).unwrap();
+            // SAFETY: serialized via test_lock; only one test at a time.
+            unsafe {
+                std::env::set_var("DO_NOT_TRACK", "1");
+            }
+            let s = resolve_consent(None);
+            assert_eq!(s.source, ConsentSource::DoNotTrack);
+            assert!(!s.enabled);
+            // DO_NOT_TRACK is a per-invocation signal — never persisted.
+            assert!(!s.persisted);
+        });
+    }
+
+    #[test]
+    fn do_not_track_beats_env_var_on() {
+        with_temp_home(|| {
+            // SAFETY: serialized via test_lock; only one test at a time.
+            unsafe {
+                std::env::set_var("NYXID_TELEMETRY", "on");
+                std::env::set_var("DO_NOT_TRACK", "1");
+            }
+            let s = resolve_consent(None);
+            assert_eq!(s.source, ConsentSource::DoNotTrack);
+            assert!(!s.enabled);
+        });
+    }
+
+    #[test]
+    fn do_not_track_zero_is_not_active() {
+        with_temp_home(|| {
+            persist_choice(None, true).unwrap();
+            // SAFETY: serialized via test_lock; only one test at a time.
+            unsafe {
+                std::env::set_var("DO_NOT_TRACK", "0");
+            }
+            let s = resolve_consent(None);
+            // "0" means "do track me" per the consoledonottrack.com spec.
+            // Precedence falls through to the config.
+            assert_eq!(s.source, ConsentSource::ConfigEnabled);
+            assert!(s.enabled);
+        });
+    }
+
+    #[test]
+    fn empty_do_not_track_is_not_active() {
+        with_temp_home(|| {
+            persist_choice(None, true).unwrap();
+            // SAFETY: serialized via test_lock; only one test at a time.
+            unsafe {
+                std::env::set_var("DO_NOT_TRACK", "");
+            }
+            let s = resolve_consent(None);
+            // Empty = unset = fall through to normal resolution.
             assert_eq!(s.source, ConsentSource::ConfigEnabled);
             assert!(s.enabled);
         });

--- a/cli/src/telemetry/consent.rs
+++ b/cli/src/telemetry/consent.rs
@@ -113,8 +113,20 @@ pub fn resolve_consent_preferring_profile(profile: Option<&str>) -> ConsentState
             return resolve_consent(None);
         }
     }
-    if std::env::var("NYXID_TELEMETRY").is_ok() {
-        return resolve_consent(None);
+    // Only treat RECOGNIZED NYXID_TELEMETRY values as a global override.
+    // A garbage value (`NYXID_TELEMETRY=maybe`) must not bypass the
+    // per-profile historical-consent check below — that would let a
+    // stray env export silently re-enable telemetry for a user who
+    // had opted out on a named profile in a prior release. Matches
+    // the set of values parsed by `resolve_consent` itself.
+    if let Ok(raw) = std::env::var("NYXID_TELEMETRY") {
+        let norm = raw.trim().to_ascii_lowercase();
+        if matches!(
+            norm.as_str(),
+            "off" | "false" | "0" | "no" | "on" | "true" | "1" | "yes"
+        ) {
+            return resolve_consent(None);
+        }
     }
 
     // No env override. If the user has an explicit per-profile
@@ -498,6 +510,26 @@ mod tests {
             }
             let s = resolve_consent_preferring_profile(Some("dev"));
             assert_eq!(s.source, ConsentSource::DoNotTrack);
+            assert!(!s.enabled);
+        });
+    }
+
+    #[test]
+    fn preferring_profile_ignores_garbage_telemetry_env_and_honors_profile_optout() {
+        // A stray `NYXID_TELEMETRY=maybe` in the environment must not
+        // bypass the per-profile consent check. Otherwise a user who
+        // opted OUT on `--profile dev` in a prior release could have
+        // their explicit choice silently overridden by an unrelated
+        // env export.
+        with_temp_home(|| {
+            persist_choice(Some("dev"), false).unwrap();
+            persist_choice(None, true).unwrap();
+            // SAFETY: serialized via test_lock.
+            unsafe {
+                std::env::set_var("NYXID_TELEMETRY", "maybe");
+            }
+            let s = resolve_consent_preferring_profile(Some("dev"));
+            assert_eq!(s.source, ConsentSource::ConfigDeclined);
             assert!(!s.enabled);
         });
     }

--- a/cli/src/telemetry/consent.rs
+++ b/cli/src/telemetry/consent.rs
@@ -84,6 +84,69 @@ struct NyxidConfig {
     telemetry: TelemetrySection,
 }
 
+/// Migration-aware consent lookup. v1 consent is user-global (read +
+/// edited against the default profile), but older releases persisted
+/// explicit per-profile consent via the login prompt. Silently
+/// erasing those choices on upgrade is a privacy regression — a user
+/// who opted OUT on `--profile dev` would find their default
+/// profile's "Yes" override that explicit opt-out.
+///
+/// Resolution order:
+///   1. Env overrides (DO_NOT_TRACK / NYXID_TELEMETRY) — same as
+///      `resolve_consent`, global regardless of profile.
+///   2. If `profile` is Some AND that profile's config has
+///      `asked=true`, honor that explicit historical choice.
+///   3. Fall back to the default profile's config.
+///
+/// Going forward, only the default profile is written to (by
+/// `nyxid telemetry enable|disable` and the first-run prompt), so
+/// step 2 only matches persisted choices from pre-v1 releases.
+pub fn resolve_consent_preferring_profile(profile: Option<&str>) -> ConsentState {
+    // Env overrides win regardless of profile — these are global
+    // signals by design. `resolve_consent(None)` handles them at the
+    // top of its ladder, so if any env override is active we'll pick
+    // it up via the default-profile path without consulting the
+    // named profile's config at all.
+    if let Ok(raw) = std::env::var("DO_NOT_TRACK") {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() && trimmed != "0" {
+            return resolve_consent(None);
+        }
+    }
+    if std::env::var("NYXID_TELEMETRY").is_ok() {
+        return resolve_consent(None);
+    }
+
+    // No env override. If the user has an explicit per-profile
+    // choice from a prior release, honor it so we don't silently
+    // override an opt-out (or an opt-in the user remembers making
+    // on that profile).
+    if let Some(name) = profile
+        && let Some(cfg) = load_config(Some(name))
+        && cfg.telemetry.asked
+    {
+        return if cfg.telemetry.enabled {
+            ConsentState {
+                enabled: true,
+                source: ConsentSource::ConfigEnabled,
+                persisted: true,
+                needs_prompt: false,
+            }
+        } else {
+            ConsentState {
+                enabled: false,
+                source: ConsentSource::ConfigDeclined,
+                persisted: true,
+                needs_prompt: false,
+            }
+        };
+    }
+
+    // No env override, no per-profile historical choice. Fall back
+    // to the default profile's config / first-run state.
+    resolve_consent(None)
+}
+
 /// Pure function: resolve the current effective consent state. Reads
 /// env vars + config file; does not prompt, does not write.
 pub fn resolve_consent(profile: Option<&str>) -> ConsentState {
@@ -380,6 +443,62 @@ mod tests {
             // Empty = unset = fall through to normal resolution.
             assert_eq!(s.source, ConsentSource::ConfigEnabled);
             assert!(s.enabled);
+        });
+    }
+
+    #[test]
+    fn preferring_profile_honors_prior_release_profile_optout() {
+        // Simulates the migration scenario: a user of an older release
+        // opted OUT via the login prompt on `--profile dev`, which
+        // persisted `{enabled:false, asked:true}` to the profile
+        // config. They later opt IN on the default profile (v1
+        // behavior). The profile opt-out must still be honored — a
+        // silent override would be a privacy regression.
+        with_temp_home(|| {
+            persist_choice(None, true).unwrap();
+            persist_choice(Some("dev"), false).unwrap();
+            let s = resolve_consent_preferring_profile(Some("dev"));
+            assert_eq!(s.source, ConsentSource::ConfigDeclined);
+            assert!(!s.enabled);
+        });
+    }
+
+    #[test]
+    fn preferring_profile_falls_back_to_default_when_profile_unset() {
+        with_temp_home(|| {
+            persist_choice(None, true).unwrap();
+            let s = resolve_consent_preferring_profile(Some("dev"));
+            // dev profile has no config, fall through to default.
+            assert_eq!(s.source, ConsentSource::ConfigEnabled);
+            assert!(s.enabled);
+        });
+    }
+
+    #[test]
+    fn preferring_profile_env_var_beats_profile_config() {
+        with_temp_home(|| {
+            persist_choice(Some("dev"), true).unwrap();
+            // SAFETY: serialized via test_lock.
+            unsafe {
+                std::env::set_var("NYXID_TELEMETRY", "off");
+            }
+            let s = resolve_consent_preferring_profile(Some("dev"));
+            assert_eq!(s.source, ConsentSource::EnvVarOff);
+            assert!(!s.enabled);
+        });
+    }
+
+    #[test]
+    fn preferring_profile_do_not_track_beats_profile_config() {
+        with_temp_home(|| {
+            persist_choice(Some("dev"), true).unwrap();
+            // SAFETY: serialized via test_lock.
+            unsafe {
+                std::env::set_var("DO_NOT_TRACK", "1");
+            }
+            let s = resolve_consent_preferring_profile(Some("dev"));
+            assert_eq!(s.source, ConsentSource::DoNotTrack);
+            assert!(!s.enabled);
         });
     }
 }

--- a/cli/src/telemetry/mod.rs
+++ b/cli/src/telemetry/mod.rs
@@ -107,16 +107,16 @@ impl TelemetryClient {
     /// Does NOT prompt — see [`consent::prompt_if_needed_interactive`]
     /// which must run before this on an interactive TTY.
     ///
-    /// Consent is read against the default profile (`None`) regardless
-    /// of the current `profile` argument, matching
-    /// `api::build_cli_http_client` and the `main.rs` first-run prompt.
-    /// Making consent per-profile would require a matching
-    /// `nyxid telemetry --profile ...` editor path, which v1 does not
-    /// ship. The `profile` argument is still used below for the anon
-    /// distinct_id file path — that's identity isolation (a per-profile
-    /// concern), not consent (a user-global concern).
+    /// Consent is resolved via
+    /// [`consent::resolve_consent_preferring_profile`]: default profile
+    /// wins, but any explicit per-profile choice persisted by older
+    /// releases is honored so upgrades don't silently override historical
+    /// opt-outs. Matches `api::build_cli_http_client` and the `main.rs`
+    /// first-run prompt. The `profile` argument is still used below for
+    /// the anon distinct_id file path — that's identity isolation (a
+    /// per-profile concern), not consent (a user-global concern).
     pub fn init(profile: Option<&str>) -> Option<Self> {
-        let state = consent::resolve_consent(None);
+        let state = consent::resolve_consent_preferring_profile(profile);
         if !state.enabled {
             return None;
         }

--- a/cli/src/telemetry/mod.rs
+++ b/cli/src/telemetry/mod.rs
@@ -106,8 +106,17 @@ impl TelemetryClient {
     ///
     /// Does NOT prompt — see [`consent::prompt_if_needed_interactive`]
     /// which must run before this on an interactive TTY.
+    ///
+    /// Consent is read against the default profile (`None`) regardless
+    /// of the current `profile` argument, matching
+    /// `api::build_cli_http_client` and the `main.rs` first-run prompt.
+    /// Making consent per-profile would require a matching
+    /// `nyxid telemetry --profile ...` editor path, which v1 does not
+    /// ship. The `profile` argument is still used below for the anon
+    /// distinct_id file path — that's identity isolation (a per-profile
+    /// concern), not consent (a user-global concern).
     pub fn init(profile: Option<&str>) -> Option<Self> {
-        let state = consent::resolve_consent(profile);
+        let state = consent::resolve_consent(None);
         if !state.enabled {
             return None;
         }

--- a/docs/TELEMETRY_CONSENT_FIX.md
+++ b/docs/TELEMETRY_CONSENT_FIX.md
@@ -99,6 +99,31 @@ SERVICE_APPROVAL_CONFIGS, NOTIFICATION_CHANNELS
 
 Grouped by whether the item is load-bearing for Article 7(3) / Article 17 compliance (P0) versus customary best-practice (P1) versus nice-to-have (P2). Done criterion is verifiable from code, not from docs.
 
+### 8.0 Progress — what's landed per PR
+
+| Item | Status | Landed in |
+|---|---|---|
+| §8.1 Web consent withdrawal | ✅ Done | PR #485 |
+| §8.2 Mobile consent withdrawal | ⬜ Pending | Next: mobile PR |
+| §8.3 CLI portion (header gating) | ✅ Done | PR #485 |
+| §8.3 Mobile portion (header gating) | ⬜ Pending | Next: mobile PR |
+| §8.3 Backend integration test | ⬜ Pending | Backend PR |
+| §8.4 `AUDIT_LOG` cascade + TTL | ⬜ Pending | Backend PR |
+| §8.5 Web + CLI copy fixes | ✅ Done | PR #485 |
+| §8.5 EU/US host decision (kept US + TODO for SCCs) | ✅ Done | PR #485 |
+| §8.6 Age gate | ⬜ Pending | Age gate PR (FE + backend) |
+| §8.7 Operator guidance | ⬜ Pending | Backend PR |
+| §8.8 Mobile P1 contradictions | ⬜ Pending | Mobile PR |
+| §8.9 `DO_NOT_TRACK` (CLI) | ✅ Done | PR #485 |
+| §8.9 GPC (web) | ⬜ Pending | P1 hygiene follow-up |
+| §8.9 ToS checkbox (web) | ⬜ Pending | P1 hygiene follow-up |
+| §8.9 DSAR export endpoint | ⬜ Pending | P1 hygiene follow-up |
+| §8.9 Node `last_error` sanitization | ⬜ Pending | Backend PR |
+| §8.9 Browser DNT honoring (bonus — §10) | ✅ Done | PR #485 |
+| §9.3 follow-ups (surfaced during PR #485) | ⬜ Pending | Various |
+
+Update this table as each PR lands.
+
 ### P0 — Blocking for EU launch
 
 #### 8.1 Wire consent withdrawal on web
@@ -215,6 +240,14 @@ These surfaced during the audit but don't belong in a "telemetry consent fix" ch
 - **Breach notification procedure (Art. 33/34).** 72-hour notification playbook, contact list, template. *Why parked:* pure ops/legal process, no code.
 
 The two items that *did* move from "nice to have later" into the active checklist (age gate §8.6, operator guidance §8.7) are the ones that are either already-lied-about in policy (age gate) or unique to NyxID's self-hosted positioning (operator guidance) — neither fits in a generic compliance-readiness doc.
+
+### 9.3 Follow-ups surfaced during implementation (PR #485 — web + CLI consent withdrawal)
+
+These didn't exist as checklist items before PR #485 started; codex review of the actual diff identified them and we chose to defer rather than expand scope. All three are narrow enough to belong in a follow-up; all three are documented here so they don't fall off the floor.
+
+- **`nyxid telemetry disable` anon_id scope mismatch.** v1 treats consent as user-global (read + edited against default profile), but `TelemetryClient::init(profile)` still pulls the anon distinct_id from `~/.nyxid/profiles/<name>/anon_id`. `nyxid telemetry disable` only deletes the default-profile anon_id file, so a user who disables telemetry, later re-enables, and then runs `--profile <name>` resumes the old anonymous identity instead of getting the documented "fresh trail." *Severity:* narrow (only matters for named-profile users who toggle telemetry), documentation/contract mismatch rather than consent violation. *Fix:* either globalize anon_id too, or have `nyxid telemetry disable` delete anon_id files across all profiles.
+- **Privacy policy region hardcoded vs operator-overridable `telemetry_host`.** `frontend/src/pages/privacy.tsx:187` states "PostHog, US region," which is correct for NyxID Inc's deploy but factually wrong for any self-hosted or EU-hosted operator who sets `telemetry_host` to `eu.i.posthog.com` or their own instance. *Severity:* tied into §8.7 operator guidance; operators are expected to publish their own privacy notice once §8.7 ships, which makes NyxID Inc's `privacy.tsx` copy irrelevant for them. *Fix path:* land §8.7 (operator-identity fields in `/public/config` + degraded banner when operator policy missing), then either (a) soften the region claim in NyxID Inc's copy to reference operator setting, or (b) accept that operators own their own policy once §8.7 exists.
+- **CI snapshot regression guard for false-claim strings.** §10 specifies a snapshot-on-commit check that fails if any of the known false-claim strings ("change in Settings" pointing to nowhere, "PostHog EU region" when code uses US, "no analytics SDKs" when SDK is bundled) reappear in `privacy.tsx` / `consent-banner.tsx` / `PrivacyPolicyScreen.tsx` / `TELEMETRY.md`. Unit tests in PR #485 cover code-level correctness but don't guard against future copy drift. *Severity:* prevention-only; there's no active regression today. *Fix:* a single vitest file reading the target paths and asserting literals are absent — ~15 min. Recommended to land alongside the mobile PR so both surfaces' copy are guarded at once.
 
 ## 10. Verification plan post-fix
 

--- a/docs/TELEMETRY_CONSENT_FIX.md
+++ b/docs/TELEMETRY_CONSENT_FIX.md
@@ -1,0 +1,241 @@
+# Telemetry Consent — Failings & Fix Checklist
+
+Status: Pre-fix audit. Use this document as the checklist for closing the consent-withdrawal gaps before NyxID telemetry v1 is considered shippable to EU users.
+
+Pair document: `docs/TELEMETRY.md` (the spec this fix brings the implementation into line with).
+
+---
+
+## 1. Context — what shipped vs what's actually wired
+
+NyxID shipped the **banner** side of telemetry consent across web, mobile, and CLI. It did not ship the **withdrawal** side end-to-end:
+
+| Surface | Banner / first-run prompt | Withdrawal UI | Withdrawal actually works |
+|---------|---------------------------|---------------|---------------------------|
+| Web     | Yes — `consent-banner.tsx`  | **Missing** — Settings page has no telemetry tab | Only by deleting `nyxid.telemetry_consent` in browser localStorage |
+| Mobile  | **Never prompted** — `MobileConsentProvider` exists but no UI triggers it | **Missing** — `AccountSettingsScreen.tsx` has no toggle | Only by reinstalling the app |
+| CLI     | Yes — first-run TTY prompt (`consent.rs:132-170`) | Yes — `nyxid telemetry {enable\|disable\|status}` | **Local PostHog client only** — backend still emits telemetry events because `X-NyxID-Client` header is gated on DSN presence, not consent (see §6) |
+
+Worse than "missing UI": the stores on both web and mobile **have no persisted opt-out state at all**. `clearConsent()` exists in both (`frontend/src/stores/consent-store.ts:34`, `mobile/src/lib/consent.tsx:91`) but it resets the store to `asked=false, enabled=false`, which re-triggers the first-time banner on next page load. It does not represent a persisted "this user opted out" state, and it does not call PostHog's `opt_out_capturing()` / `reset()`. Building the Settings toggle therefore requires *implementing* a disable path first, not wiring up existing code.
+
+## 2. Why this is a legal issue, not a UX polish issue
+
+NyxID processes telemetry on the basis of **explicit user consent** (Article 6(1)(a) GDPR) — that's the contract the banner creates. Article 6(1)(a) is chained to **Article 7(3)**:
+
+> *"It shall be as easy to withdraw consent as to give it."*
+
+Current reality:
+- **Web:** give = one click on the banner. Withdraw = open DevTools, delete the `nyxid.telemetry_consent` localStorage key. **Not "as easy."**
+- **Mobile:** give = never prompted. Withdraw = uninstall the app. **Not "as easy."**
+
+This isn't defensible under legitimate-interest either, because the banner language explicitly frames processing as consent-based.
+
+Further, the existence of the banner + privacy policy language + internal spec claiming a toggle that *doesn't* exist compounds the issue — it's not only a missing feature but **user-facing false statements**.
+
+## 3. Evidence trail — every layer promises a feature that doesn't exist
+
+| Layer | Claim | File | Reality |
+|-------|-------|------|---------|
+| Banner user-facing copy | *"You can change this later in Settings."* | `frontend/src/components/consent-banner.tsx:47` | False |
+| Banner source-code comment | *"Users can reverse their choice later from Settings."* | `frontend/src/components/consent-banner.tsx:7` | False |
+| Privacy policy page | *"You can change your telemetry choice at any time from the Settings page"* | `frontend/src/pages/privacy.tsx:203` | False |
+| Privacy policy page | *"Revoke consent for third-party service connections"* (telemetry implied elsewhere) | `frontend/src/pages/privacy.tsx:168` | Telemetry withdrawal: false |
+| Internal spec | *"Settings screen — telemetry toggle flip-off: reset() + anon-ID clear + setConsent(false)"* | `docs/TELEMETRY.md:662` | Never built |
+| Internal spec | *"Mobile in-app Settings toggle flipping off calls reset()..."* | `docs/TELEMETRY.md:71` | Never built |
+| Mobile privacy policy | *"No analytics SDKs are used"* | `mobile/src/features/legal/PrivacyPolicyScreen.tsx:105-108` | False — `posthog-react-native` is a direct dependency (`mobile/package.json:51`) |
+| Mobile iOS privacy manifest | `NSPrivacyCollectedDataTypes` = empty array | `mobile/ios/NyxIDMobile/PrivacyInfo.xcprivacy:43-46` | Inconsistent with the app's own privacy screen (`PrivacyPolicyScreen.tsx:35-39`) which documents collection of account identity, push tokens, usage data |
+| Web privacy policy | Region: EU | `frontend/src/pages/privacy.tsx:183-188` | Code default is US host `https://us.i.posthog.com` (`frontend/src/lib/telemetry.ts:37-38, 137-140`) |
+
+## 4. Store shape — there is no persisted opt-out, only an "un-answer" reset
+
+Both stores were designed as one-way doors for the banner, not as consent lifecycles:
+
+```
+frontend/src/stores/consent-store.ts
+  setConsent(enabled)    → { enabled, asked: true }     // persists a choice
+  clearConsent()         → { enabled: false, asked: false }  // resets, re-triggers banner
+
+mobile/src/lib/consent.tsx
+  setConsent(enabled)    → { enabled, asked: true }
+  clearConsent()         → { enabled: false, asked: false }  // same shape
+```
+
+Neither `setConsent(false)` nor `clearConsent()` calls PostHog's `opt_out_capturing()` or `reset()`, and `initTelemetry()` in `frontend/src/lib/telemetry.ts:122-124, 190-219` is guarded by a one-way `inited` flag — once initialized, there is no code path that disables the client at runtime. Mobile has the same shape (`mobile/src/lib/telemetry.ts`).
+
+**Implication for the fix:** building the Settings toggle requires first adding a `disableTelemetry()` / `shutdownTelemetry()` function that calls `posthog.opt_out_capturing()` + `posthog.reset()` and is safe to call from a running app. Until that function exists, any Settings toggle wired directly to `setConsent(false)` would silently fail to stop event capture.
+
+## 5. Proof the team knows how to ship consent withdrawal
+
+`frontend/src/pages/consents.tsx` is a **fully functional OAuth-consent revocation UI**: list all consents, per-row revoke button, confirmation modal, `useRevokeConsent` mutation hook, backend endpoint `DELETE /api/v1/users/me/consents/{client_id}`.
+
+The telemetry equivalent was simply never finished. This is not a capability gap — it's an incomplete feature.
+
+## 6. The second structural issue — backend bypasses local consent
+
+Even if the web/mobile Settings toggles existed tomorrow, **backend telemetry would continue firing** for CLI and mobile users:
+
+- `cli/src/api.rs:9-41` — attaches `X-NyxID-Client: cli` + version header whenever `NYXID_TELEMETRY_DSN` or `NYXID_SHARE_ANALYTICS` is set in the environment. **Never checks the user's `nyxid telemetry disable` state.**
+- `mobile/src/lib/api/http.ts:500-522` — same pattern; headers driven by build config, not consent.
+- `backend/src/handlers/auth.rs:399-416` and `486-535` — backend emits telemetry events (signup, login, logout) tagged with `surface="cli"` / `"mobile"` based purely on those headers.
+
+A user who runs `nyxid telemetry disable` silences the *local* PostHog client but the backend continues to receive surface-tagged attribution and emits its own events. That makes local consent partial theater.
+
+## 7. The third structural issue — audit log survives account deletion
+
+`backend/src/services/admin_user_service.rs:420-444` lists the collections cascaded on account deletion:
+
+```
+SESSIONS, REFRESH_TOKENS, API_KEYS, USER_SERVICE_CONNECTIONS,
+USER_PROVIDER_TOKENS, MFA_FACTORS, AUTHORIZATION_CODES, OAUTH_STATES,
+CONSENTS, MCP_SESSIONS, APPROVAL_REQUESTS, APPROVAL_GRANTS,
+SERVICE_APPROVAL_CONFIGS, NOTIFICATION_CHANNELS
+```
+
+`AUDIT_LOG` is not in the list. `backend/src/db.rs:266-288` shows no TTL index on audit_log either. Deleted users' IP, user-agent, and event-data rows persist indefinitely. This is an Article 17 (right to erasure) issue, distinct from the Article 7(3) consent issue above.
+
+---
+
+## 8. Fix checklist
+
+Grouped by whether the item is load-bearing for Article 7(3) / Article 17 compliance (P0) versus customary best-practice (P1) versus nice-to-have (P2). Done criterion is verifiable from code, not from docs.
+
+### P0 — Blocking for EU launch
+
+#### 8.1 Wire consent withdrawal on web
+- [ ] **Prereq** — add a `disableTelemetry()` function to `frontend/src/lib/telemetry.ts` that calls `posthog.opt_out_capturing()` + `posthog.reset()` and resets the module-level `inited` flag so a later re-enable can call `init()` again. (Today `initTelemetry()` is one-way; there is no runtime disable path.)
+- [ ] Add a matching `enableTelemetry()` entry point if current `initTelemetry()` isn't reusable, so a user turning the toggle back on gets a fresh PostHog session
+- [ ] Add a **Privacy & Telemetry** section to `frontend/src/pages/settings.tsx` (could be a 5th tab, or inside Security — team call)
+- [ ] Section reads current state from `useConsentStore` (`enabled` + `asked`)
+- [ ] Toggle ON → `setConsent(true)` + `enableTelemetry()` → user sees events begin to fire on navigation
+- [ ] Toggle OFF → `setConsent(false)` + `disableTelemetry()` → no further events captured even while the tab stays open; verify `isTelemetryActive()` returns false
+- [ ] **Copy — per-device clarity.** Update banner copy in `consent-banner.tsx:47` and Settings toggle helper text to state explicitly that the choice applies to **this browser only**. Proposed banner replacement: *"We collect anonymous usage telemetry to help us improve NyxID. We never capture credentials, form content, or the contents of your requests. This choice applies to this browser only — other devices and the CLI manage their own telemetry settings. You can change this later in Settings."* Settings helper text should repeat the per-browser scope.
+- [ ] Done criterion: a user who accepts the banner can fully withdraw without opening DevTools AND without a page reload, AND banner/settings copy makes the per-browser scope explicit
+
+#### 8.2 Wire consent withdrawal on mobile
+- [ ] **Prereq** — add `disableTelemetry()` / `enableTelemetry()` in `mobile/src/lib/telemetry.ts` that call PostHog RN's `optOut()` / `optIn()` + `reset()`. PostHog RN's `reset()` handles its own internal distinct-ID cleanup, so NyxID code does not need to manipulate AsyncStorage keys it does not own. Today `setConsent(false)` only mutates our own consent AsyncStorage record; no lifecycle hook in `AuthSessionContext.tsx:99-113` calls `reset()` on a running app.
+- [ ] Add a **Privacy & Telemetry** row to `mobile/src/features/account/AccountSettingsScreen.tsx`
+- [ ] Row reads from `useMobileConsent()` — the hook returns flat fields (`enabled`, `asked`, `isHydrated`, `setConsent`, `clearConsent`), not a nested `.state` object. See `mobile/src/lib/consent.tsx:35-40, 109-117`
+- [ ] Toggle ON/OFF calls `useMobileConsent().setConsent(bool)` **and** the new `enableTelemetry()` / `disableTelemetry()`
+- [ ] Decision: whether to also add a first-run prompt on mobile (recommended: yes — matches CLI pattern, avoids silent default), or keep default-off and require user to find the toggle
+- [ ] **Copy — per-install clarity.** First-run prompt copy (if added) and Settings row helper text must state that the choice applies to **this install only** — signing in on another device or reinstalling the app does not inherit the choice. Mirrors web §8.1 language but uses "install" rather than "device" because mobile reinstall resets AsyncStorage. Example: *"This choice applies to this install only — reinstalling, or using NyxID on another device, starts fresh. The web dashboard and CLI manage their own telemetry settings."*
+- [ ] Done criterion: a mobile user can read their current telemetry state and flip it from Settings; after flipping off, no PostHog network calls fire even while the app stays in the foreground; copy explicitly scopes the choice to "this install"
+
+#### 8.3 Gate CLI/mobile `X-NyxID-Client` headers on consent
+- [ ] `cli/src/api.rs:build_cli_http_client` — replace the `telemetry_configured` DSN-presence check with a check against `telemetry::consent::resolve_consent()` (or equivalent); headers attach only when the *user* has opted in, not just when the *operator* has set a DSN
+- [ ] `mobile/src/lib/api/http.ts:500-522` — `http.ts` is not a React component and cannot call `useMobileConsent()`. Expose a non-hook read path: either a module-level `getConsentSnapshot()` that reads AsyncStorage on init + subscribes to changes, or a small Zustand/event-bus mirror. Header attaches only when that snapshot says `enabled === true`
+- [ ] Backend: add a lightweight integration test that hits `/api/v1/auth/register` and `/api/v1/auth/login` **without** the header and asserts `TelemetryEvent::UserSignedUp` / `AuthLoggedIn` are **not** emitted (backend attribution today fires on `surface` tags from these headers at `backend/src/handlers/auth.rs:399-416`, `:486-535` — these are pre-auth flows, so the scope is broader than "authenticated requests")
+- [ ] Done criterion: a user who has declined telemetry produces zero `X-NyxID-Client` / `X-NyxID-Client-Version` headers on any request (authenticated **or** pre-auth signup/login), verified by inspecting network traffic AND by the backend integration test above
+
+#### 8.4 Add AUDIT_LOG to account-deletion cascade
+- [ ] Add `AUDIT_LOG` to the `user_scoped_collections` array in `backend/src/services/admin_user_service.rs:423-438`
+- [ ] Decide retention policy for non-deleted users: TTL index on `audit_log.created_at` (e.g. 180 or 365 days) in `backend/src/db.rs:ensure_indexes`
+- [ ] Align retention language in `frontend/src/pages/privacy.tsx` with the actual TTL chosen
+- [ ] Decide whether to wrap the cascade in a Mongo transaction. Current code is a sequential loop of `delete_many` calls with no transactional guarantee — a crash mid-cascade leaves partial data. If a transaction is out of scope, document the cascade-order invariant (e.g. delete `audit_log` first so the user row is the last thing removed).
+- [ ] Done criterion: after `delete_current_user_cascade` returns successfully, zero `audit_log` rows remain for that `user_id`, verified by integration test
+
+#### 8.5 Resolve P0 user-facing contradictions tied to consent validity
+- [ ] Banner copy line 47 + doc comment line 7 (`consent-banner.tsx`): remove "change in Settings" phrasing OR (preferred) leave it and complete 8.1
+- [ ] Privacy policy line 203 (`privacy.tsx`): same — leave the sentence if 8.1 completes; otherwise rewrite
+- [ ] Privacy policy line 183-188 PostHog EU claim: either change `lib/telemetry.ts` default host to `eu.i.posthog.com` (also applies to `mobile/src/lib/telemetry.ts:69-70, 86-89`), or rewrite the policy sentence to reflect the US default. (If the policy is rewritten to US, the "International transfer mechanism" item in §9.2 becomes **in-scope / not deferrable** — a lawful basis for EU→US transfer must be documented.)
+- [ ] **Privacy policy — per-device scope of consent.** Add a sentence to both `frontend/src/pages/privacy.tsx` §8 (Cookies, Local Storage, and Analytics) and `mobile/src/features/legal/PrivacyPolicyScreen.tsx` stating explicitly: *"Your telemetry choice is stored per device / per install and does not sync across the web dashboard, mobile app, and CLI. Each surface manages its own telemetry setting."* This avoids the UX footgun where a user opts out in one place and assumes it applies everywhere.
+- [ ] **CLI first-run prompt — match language.** Update `cli/src/telemetry/consent.rs:139-170` disclosure to include the same per-device framing for consistency: *"This choice applies to this machine only — the web dashboard and mobile app manage their own telemetry settings."* The existing line *"You can change this later with `nyxid telemetry enable|disable`"* stays.
+- [ ] Done criterion: no policy/banner copy makes a withdrawal claim or regional claim that the code contradicts, AND every surface's consent-setting UI (web banner, web Settings, mobile prompt/Settings, CLI first-run) clearly states the choice is per-device. Verified by reading the relevant screens, not just grep (grep catches literals, not paraphrases or future locales).
+
+#### 8.6 Enforce age gate at registration
+
+Policies already restrict signup to users 13+ (web) and 16+ (mobile). Code has no enforcement — a 10-year-old can register today, which makes the policy a false statement and invites COPPA exposure in the US plus GDPR-K exposure in the EU.
+
+**Scope decision upfront** — *checkbox affirmation, not birthdate.* Birthdate is a data-minimization step backwards (collects DOB we don't otherwise need); checkbox is the lighter-weight default chosen by most auth/SSO peers (Clerk, Auth0, Supabase). If legal later requires jurisdiction-specific logic (e.g. parental consent <16 in EU), that's a follow-up, not v1.
+
+**Age bar decision upfront** — *16+ single global bar.* This is the highest age claimed by any current policy (mobile under-16). Applying it to both surfaces is simpler than per-surface logic, conservatively covers GDPR-K (which varies between 13 and 16 by EU member state), and requires updating web policy wording (`privacy.tsx:208-214`) from "13+" to "16+" to stay internally consistent.
+
+- [ ] Add `accepts_age_requirement: z.literal(true)` (or similar) to `frontend/src/schemas/auth.ts` registration schema (`frontend/src/schemas/auth.ts:10-38`)
+- [ ] Add matching checkbox input in `frontend/src/components/auth/auth-flow.tsx:255-262` with copy: *"I confirm I am at least 16 years old"*
+- [ ] Match on mobile: add the same checkbox to the signup screen (`mobile/src/features/auth/AuthHomeScreen.tsx:428-439` currently has only passive browsewrap text; the schema that feeds its submit call needs the same `accepts_age_requirement` field)
+- [ ] Backend: add a `accepts_age_requirement: bool` field to the register handler input (`backend/src/handlers/auth.rs` register path), reject registration with 400 if missing or false. Do not trust client-only validation.
+- [ ] Update web privacy policy (`frontend/src/pages/privacy.tsx:208-214`) to say "16+" to match mobile and the new checkbox
+- [ ] Done criterion: attempting to register without `accepts_age_requirement=true` returns 400 from the backend, verified by integration test
+
+#### 8.7 Ship self-hosted operator guidance
+
+NyxID is self-hostable. Any operator flipping telemetry on via `backend/src/config.rs:81-89` or via the `/public/config` endpoint (handler at `backend/src/handlers/health.rs:67, 118`, route registered at `backend/src/routes.rs:774`) inherits every obligation below, on behalf of *their* users. Without a guidance doc, operators ship a telemetry pipeline into production without the compliance paperwork that pipeline assumes. The fix here is documentation + a runtime check, not a feature.
+
+- [ ] Add a new section to `docs/TELEMETRY.md` (or a sibling `docs/TELEMETRY_OPERATORS.md`) titled "Operator obligations when enabling telemetry." Must cover: publishing their own privacy notice, disclosing PostHog as a processor, documenting EU→US transfer basis if using US host, setting a retention window in their PostHog project, honoring DSAR/delete requests routed through their deployment.
+- [ ] Add a startup-time warning in `backend/src/main.rs` (or `telemetry/mod.rs`) whenever **either** `NYXID_TELEMETRY_DSN` is set **or** `NYXID_SHARE_ANALYTICS=true`: log a single WARN-level line pointing to the operator doc, e.g. *"Telemetry enabled. If you are operating NyxID on behalf of third-party users, review docs/TELEMETRY_OPERATORS.md for your disclosure and processor obligations."*
+- [ ] Add operator-identity env vars + `AppConfig` fields (`backend/src/config.rs`): `NYXID_OPERATOR_NAME` (string), `NYXID_OPERATOR_PRIVACY_URL` (string, URL), `NYXID_OPERATOR_CONTACT` (string, email or URL for DSAR/privacy inquiries). All three optional at parse time; see next bullet for runtime gating.
+- [ ] Extend `PublicConfigResponse` in `backend/src/handlers/health.rs:38-58` with `operator_name: Option<String>`, `operator_privacy_url: Option<String>`, `operator_contact: Option<String>`. `public_config` handler (`backend/src/handlers/health.rs:67-128`) copies them from `AppConfig`
+- [ ] Extend frontend `PublicConfigResponse` type + `usePublicConfig` hook to consume those fields
+- [ ] **Runtime policy** — pick one of two stances (team decision, document which):
+  - *Strict (recommended):* when `telemetry_dsn` is set but operator-identity fields are not, **do not enable telemetry** — the banner does not render, `initTelemetry()` does not run, and the server logs a hard ERROR line. Forces operator compliance before any data is captured.
+  - *Soft:* telemetry enables, but the banner shows a placeholder saying "This instance has telemetry enabled but its operator has not published a privacy policy." Allows development and preview deployments to keep working without operator setup.
+- [ ] Done criterion: an operator who sets `NYXID_TELEMETRY_DSN=xxx` **without** configuring operator-identity fields sees the server log line AND the chosen runtime behavior (hard-block or placeholder) verified manually
+
+### P1 — Customary / peer-standard, not legally blocking
+
+#### 8.8 P1 user-facing contradictions (previously bundled into 8.5)
+
+- [ ] Mobile privacy policy line 105-108 ("no analytics SDKs are used"): either delete the sentence OR remove `posthog-react-native` from `mobile/package.json` and `mobile/src/lib/telemetry.ts`. Less urgent than §8.5 because it doesn't touch consent validity, but it's a factual lie in a legal document — fix before any broader launch.
+- [ ] iOS `PrivacyInfo.xcprivacy` lines 43-46: either declare the actual `NSPrivacyCollectedDataTypes` that match the app's privacy screen, or tighten the privacy screen to match the manifest. Apple App Review flags this class of inconsistency on submission.
+
+#### 8.9 Customary developer-tool telemetry hygiene
+
+- [ ] Honor `DO_NOT_TRACK=1` env var in `cli/src/telemetry/consent.rs:78-99` alongside `NYXID_TELEMETRY` (convention used by Homebrew, Netlify, GitHub CLI)
+- [ ] Honor `navigator.globalPrivacyControl` in `frontend/src/lib/telemetry.ts:154-160` alongside the existing `respect_dnt: true` (CPRA requirement)
+- [ ] Add ToS + Privacy acknowledgement checkbox at web registration (`frontend/src/components/auth/auth-flow.tsx:255-262`, schema in `frontend/src/schemas/auth.ts:10-38`). Today the registration form links Privacy only, no ToS page exists
+- [ ] Ship a DSAR / data-export endpoint under `/api/v1/users/me/export` returning a ZIP or JSON of user_id-keyed rows from `audit_log`, `sessions`, `api_keys`, etc. OR remove the access-rights language from both web `privacy.tsx:162-174` and mobile `PrivacyPolicyScreen.tsx:94-102`
+- [ ] Sanitize node `last_error` strings before storage in `backend/src/services/node_metrics_service.rs:43-68` — currently stores raw (truncated) upstream error text, which can contain downstream secrets if upstream includes them
+
+### P2 — Nice to have
+
+- [ ] User-visible audit log for the user's own rows (not admin-only at `/api/v1/admin/audit-log`)
+- [ ] Node-registration-time opt-in for node metrics (today metrics collect silently; matches Homebrew's "show notice before first send" pattern)
+- [ ] Granular telemetry tiers à la VS Code's `telemetry.telemetryLevel` — all / errors / off — instead of binary
+
+---
+
+## 9. Implementation docs — leftover / deferred
+
+Two buckets here. Already-working systems that don't need changes, and known compliance gaps that are real but belong in a separate workstream (tracked for visibility so they don't fall off the floor).
+
+### 9.1 Working systems, left as-is
+
+- PostHog egress scrubber (`backend/src/telemetry/scrub.rs`) is good — keep
+- Durable erasure queue (`backend/src/services/telemetry_erasure_service.rs`) works — keep
+- Backend PostHog hard-off default (`backend/src/config.rs:81-89`) — keep
+- OAuth consent revocation (`frontend/src/pages/consents.tsx`, `/api/v1/users/me/consents/{client_id}`) — separate system, works correctly
+
+### 9.2 Deferred to a separate compliance/operations doc
+
+These surfaced during the audit but don't belong in a "telemetry consent fix" checklist. Suggested home: a future `docs/PRIVACY_OPERATIONS.md` that sits alongside `docs/TELEMETRY.md` and `docs/TELEMETRY_CONSENT_FIX.md` (this doc). None are trivial. All are real. Each one has a reason it's parked, not skipped.
+
+- **Consent receipts / Art. 7(1) accountability.** No server-side record of who consented, when, to which policy version, on which surface. Today consent is localStorage/AsyncStorage only — if a regulator asks "prove user A opted in on date B," we can't produce evidence. *Parked, not skipped:* not in the same PR as the toggle work above, but **actively tracked as a blocker before any enterprise contract or public EU launch** — not a "we'll get to it." Requires new backend schema + migration + policy-versioning infra, which is why it doesn't fit in this checklist. Someone should open a follow-up ticket before this doc is closed.
+- **International transfer mechanism (SCCs / adequacy disclosure).** EU→US data transfer to US-hosted PostHog requires a documented legal basis (SCCs 2021/914 or adequacy). *Conditional on §8.5:* if §8.5 chooses "move to EU host," this item stays deferred. If §8.5 chooses "keep US host, rewrite policy," this item **becomes in-scope** and must be closed before the checklist is done — the pointer from §8.5 already states this. In that case, the work is legal paperwork (not engineering), but it's not skippable.
+- **Sub-processor / processor list.** Both privacy policies list data *categories* but not the actual *processors* (PostHog, SMTP vendor, APNs/FCM, Telegram). GDPR Art. 28 and customer DPAs expect a named, versioned sub-processor list. *Why parked:* docs/legal work.
+- **Retention TTLs for non-audit-log collections.** §8.4 sets retention for `audit_log`. Sessions already expire via token TTLs; refresh tokens decay. Node metrics live inside the `Node` document and soft-delete is handled at `backend/src/services/node_service.rs:262-287`. PostHog retention is an operator setting on the PostHog project, not a NyxID code change. *Why parked:* most of this is either already handled or operator-owned — no clean engineering unit-of-work.
+- **Breach notification procedure (Art. 33/34).** 72-hour notification playbook, contact list, template. *Why parked:* pure ops/legal process, no code.
+
+The two items that *did* move from "nice to have later" into the active checklist (age gate §8.6, operator guidance §8.7) are the ones that are either already-lied-about in policy (age gate) or unique to NyxID's self-hosted positioning (operator guidance) — neither fits in a generic compliance-readiness doc.
+
+## 10. Verification plan post-fix
+
+Before closing this document:
+
+- [ ] Manual test, web (§8.1): fresh browser → click banner Allow → navigate to Settings → flip toggle off → **do not reload** → assert `isTelemetryActive()` returns false AND no PostHog network traffic fires on subsequent navigation. Reload test is a separate pass for persistence.
+- [ ] Manual test, mobile (§8.2): fresh install → first-run prompt (if included) → accept → Settings → flip off → assert `posthog-react-native` stops capturing while app stays in foreground
+- [ ] Manual test, CLI (§8.3): `nyxid telemetry disable` → run any command, authenticated OR unauthenticated → inspect request headers → assert no `X-NyxID-Client` / `X-NyxID-Client-Version`
+- [ ] Automated test (§8.3): backend integration test hits `/api/v1/auth/register` and `/api/v1/auth/login` without telemetry headers; asserts no `UserSignedUp` / `AuthLoggedIn` telemetry event is emitted
+- [ ] Automated test (§8.4): integration test in `backend/src/services/admin_user_service.rs` asserts zero `audit_log` rows remain for a user_id after `delete_current_user_cascade`
+- [ ] Copy audit (§8.5, §8.8): manual review of `frontend/src/pages/privacy.tsx`, `frontend/src/components/consent-banner.tsx`, `mobile/src/features/legal/PrivacyPolicyScreen.tsx`, `docs/TELEMETRY.md` — read each claim, verify against current code. Grep pass is a first filter, not proof. Snapshot-on-commit check added to CI for the specific literal strings as a regression guard.
+- [ ] Per-device scope copy check (§8.1, §8.2, §8.5): verify every consent-setting surface explicitly scopes the choice to *this browser / this install / this machine*. Surfaces to check: web banner, web Settings toggle helper text, mobile first-run prompt (if added), mobile Settings row helper text, CLI first-run prompt, web privacy policy §8, mobile privacy policy. Any surface missing the per-device scoping fails this check.
+- [ ] Automated test (§8.6): backend integration test asserts registration without age-affirmation returns 400
+- [ ] Manual test (§8.7): test both activation paths — set `NYXID_TELEMETRY_DSN=xxx` (run once), then set `NYXID_SHARE_ANALYTICS=true` with DSN unset (run again). For each, omit operator-identity fields and assert the WARN log line fires on startup.
+- [ ] Manual test (§8.7 outcome): verification depends on whether team chose the strict or soft runtime stance in §8.7:
+  - *If strict:* assert the banner does **not** render, `initTelemetry()` does **not** run, no PostHog traffic fires, and startup emits a hard ERROR log line
+  - *If soft:* assert the banner renders with the placeholder "operator has not published a privacy policy" copy, and telemetry otherwise functions
+- [ ] Legal review sign-off on updated privacy policy language (whichever direction §8.5 chose — code change or copy change)
+
+---
+
+## 11. One-sentence summary
+
+NyxID shipped a consent banner whose own copy, privacy policy, and internal spec all promise a Settings-page withdrawal mechanism that the code does not contain and was never designed to support — leaving EU users unable to withdraw consent as easily as they gave it, which is the test Article 7(3) imposes on Article 6(1)(a)-based processing.

--- a/frontend/src/components/consent-banner.tsx
+++ b/frontend/src/components/consent-banner.tsx
@@ -3,8 +3,10 @@
  *
  * Rendered by the Root component when the user has never answered the
  * consent prompt (`useConsentStore.asked === false`). Offers a binary
- * opt-in / opt-out; either choice dismisses the banner permanently for
- * this browser. Users can reverse their choice later from Settings.
+ * opt-in / opt-out; either choice dismisses the banner for this browser.
+ * Consent is scoped to the current browser — other devices, the mobile
+ * app, and the CLI manage their own telemetry state. Users can reverse
+ * their choice at any time from Settings → Privacy.
  *
  * See `docs/TELEMETRY.md` §7 + §D for privacy gate + consent model.
  */
@@ -44,7 +46,9 @@ export function ConsentBanner() {
         <div className="text-sm text-muted-foreground">
           We collect anonymous usage telemetry to help us improve NyxID.
           We never capture credentials, form content, or the contents of
-          your requests. You can change this later in Settings.
+          your requests. This choice applies to this browser only — other
+          devices and the CLI manage their own telemetry settings. You
+          can change this later in Settings.
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Button

--- a/frontend/src/lib/telemetry.test.ts
+++ b/frontend/src/lib/telemetry.test.ts
@@ -61,6 +61,36 @@ describe("isTelemetryActive", () => {
     disableTelemetry();
     expect(isTelemetryActive()).toBe(false);
   });
+
+  it("returns false when navigator.doNotTrack is '1', even after successful init", () => {
+    // The privacy policy promises we honor DNT. This must be true
+    // across the whole surface, not just inside the PostHog SDK —
+    // api-client.ts reads this flag to decide whether to send
+    // `X-NyxID-Client: ui` headers, which drive backend-side
+    // surface-tagged telemetry.
+    const original = Object.getOwnPropertyDescriptor(
+      Navigator.prototype,
+      "doNotTrack",
+    );
+    Object.defineProperty(navigator, "doNotTrack", {
+      value: "1",
+      configurable: true,
+    });
+    try {
+      initTelemetry(validArgs);
+      expect(isTelemetryActive()).toBe(false);
+    } finally {
+      if (original) {
+        Object.defineProperty(navigator, "doNotTrack", original);
+      } else {
+        // happy-dom may not have set a descriptor; best-effort reset.
+        Object.defineProperty(navigator, "doNotTrack", {
+          value: "unspecified",
+          configurable: true,
+        });
+      }
+    }
+  });
 });
 
 describe("initTelemetry", () => {

--- a/frontend/src/lib/telemetry.test.ts
+++ b/frontend/src/lib/telemetry.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// PostHog mock. `vi.mock` is hoisted above imports, so the factory can't
+// reference a top-level `const`. `vi.hoisted` lets us declare the spy
+// object in the same hoisted scope so `./telemetry`'s `import posthog
+// from 'posthog-js'` resolves to these stubs from the first call.
+const mockPosthog = vi.hoisted(() => ({
+  init: vi.fn(),
+  capture: vi.fn(),
+  captureException: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+  opt_out_capturing: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: mockPosthog,
+}));
+
+import {
+  initTelemetry,
+  isTelemetryActive,
+  disableTelemetry,
+  identify,
+  reset as telemetryReset,
+} from "./telemetry";
+
+const validArgs = {
+  dsn: "phc_test_dsn",
+  host: "https://us.i.posthog.com",
+  shareBack: false,
+  consent: true,
+};
+
+beforeEach(() => {
+  // Clear spy history. Module-level `inited` state is reset via the
+  // `disableTelemetry()` call in afterEach of the prior test.
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  // Return `telemetry.ts` module state to pre-init. Safe to call
+  // unconditionally — it's a no-op when `inited === false`.
+  disableTelemetry();
+});
+
+describe("isTelemetryActive", () => {
+  it("returns false before any init", () => {
+    expect(isTelemetryActive()).toBe(false);
+  });
+
+  it("returns true after successful init", () => {
+    initTelemetry(validArgs);
+    expect(isTelemetryActive()).toBe(true);
+  });
+
+  it("returns false after disableTelemetry", () => {
+    initTelemetry(validArgs);
+    disableTelemetry();
+    expect(isTelemetryActive()).toBe(false);
+  });
+});
+
+describe("initTelemetry", () => {
+  it("no-ops when consent is false", () => {
+    initTelemetry({ ...validArgs, consent: false });
+    expect(mockPosthog.init).not.toHaveBeenCalled();
+    expect(isTelemetryActive()).toBe(false);
+  });
+
+  it("no-ops when dsn is empty", () => {
+    initTelemetry({ ...validArgs, dsn: "" });
+    expect(mockPosthog.init).not.toHaveBeenCalled();
+    expect(isTelemetryActive()).toBe(false);
+  });
+
+  it("calls posthog.init exactly once when consent + dsn are present", () => {
+    initTelemetry(validArgs);
+    expect(mockPosthog.init).toHaveBeenCalledTimes(1);
+    expect(mockPosthog.init).toHaveBeenCalledWith(
+      "phc_test_dsn",
+      expect.objectContaining({
+        api_host: "https://us.i.posthog.com",
+        mask_all_text: true,
+        respect_dnt: true,
+        ip: false,
+      }),
+    );
+  });
+
+  it("is idempotent — second call with same args is a no-op", () => {
+    initTelemetry(validArgs);
+    initTelemetry(validArgs);
+    expect(mockPosthog.init).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults host to PostHog US when host is empty", () => {
+    initTelemetry({ ...validArgs, host: "" });
+    expect(mockPosthog.init).toHaveBeenCalledWith(
+      "phc_test_dsn",
+      expect.objectContaining({ api_host: "https://us.i.posthog.com" }),
+    );
+  });
+});
+
+describe("disableTelemetry", () => {
+  it("no-ops when not inited", () => {
+    disableTelemetry();
+    expect(mockPosthog.opt_out_capturing).not.toHaveBeenCalled();
+    expect(mockPosthog.reset).not.toHaveBeenCalled();
+  });
+
+  it("calls opt_out_capturing and reset when inited", () => {
+    initTelemetry(validArgs);
+    disableTelemetry();
+    expect(mockPosthog.opt_out_capturing).toHaveBeenCalledTimes(1);
+    expect(mockPosthog.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("flips isTelemetryActive to false", () => {
+    initTelemetry(validArgs);
+    expect(isTelemetryActive()).toBe(true);
+    disableTelemetry();
+    expect(isTelemetryActive()).toBe(false);
+  });
+
+  it("swallows vendor errors during teardown", () => {
+    initTelemetry(validArgs);
+    mockPosthog.opt_out_capturing.mockImplementationOnce(() => {
+      throw new Error("SDK teardown failed");
+    });
+    // Must not throw — state reset is the source of truth for the app.
+    expect(() => disableTelemetry()).not.toThrow();
+    expect(isTelemetryActive()).toBe(false);
+  });
+});
+
+describe("re-init after disable (consent withdrawal + re-opt-in flow)", () => {
+  it("runs initTelemetry cleanly after disableTelemetry", () => {
+    initTelemetry(validArgs);
+    expect(mockPosthog.init).toHaveBeenCalledTimes(1);
+
+    disableTelemetry();
+    expect(isTelemetryActive()).toBe(false);
+
+    initTelemetry(validArgs);
+    expect(mockPosthog.init).toHaveBeenCalledTimes(2);
+    expect(isTelemetryActive()).toBe(true);
+  });
+});
+
+describe("emit helpers (identify / reset / capture) are gated on init", () => {
+  it("identify is a no-op before init", () => {
+    identify("user-123");
+    expect(mockPosthog.identify).not.toHaveBeenCalled();
+  });
+
+  it("identify calls posthog.identify after init", () => {
+    initTelemetry(validArgs);
+    identify("user-123");
+    expect(mockPosthog.identify).toHaveBeenCalledWith("user-123");
+  });
+
+  it("identify is a no-op with empty user id", () => {
+    initTelemetry(validArgs);
+    identify("");
+    expect(mockPosthog.identify).not.toHaveBeenCalled();
+  });
+
+  it("reset is a no-op before init", () => {
+    telemetryReset();
+    expect(mockPosthog.reset).not.toHaveBeenCalled();
+  });
+
+  it("reset calls posthog.reset after init", () => {
+    initTelemetry(validArgs);
+    telemetryReset();
+    expect(mockPosthog.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/telemetry.test.ts
+++ b/frontend/src/lib/telemetry.test.ts
@@ -11,6 +11,8 @@ const mockPosthog = vi.hoisted(() => ({
   identify: vi.fn(),
   reset: vi.fn(),
   opt_out_capturing: vi.fn(),
+  opt_in_capturing: vi.fn(),
+  has_opted_out_capturing: vi.fn(() => false),
 }));
 
 vi.mock("posthog-js", () => ({
@@ -146,6 +148,23 @@ describe("re-init after disable (consent withdrawal + re-opt-in flow)", () => {
     initTelemetry(validArgs);
     expect(mockPosthog.init).toHaveBeenCalledTimes(2);
     expect(isTelemetryActive()).toBe(true);
+  });
+
+  it("clears the persistent PostHog opt-out flag on re-enable so events flow again", () => {
+    // PostHog's `opt_out_capturing` writes a flag to localStorage that
+    // survives `init()`. Without this explicit `opt_in_capturing`, a
+    // user who toggles OFF in Settings and later toggles back ON would
+    // silently get no events — `telemetryActive` says yes but PostHog's
+    // own flag says no.
+    mockPosthog.has_opted_out_capturing.mockReturnValue(true);
+    initTelemetry(validArgs);
+    expect(mockPosthog.opt_in_capturing).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire opt_in_capturing on a fresh init (avoids noisy $opt_in events)", () => {
+    mockPosthog.has_opted_out_capturing.mockReturnValue(false);
+    initTelemetry(validArgs);
+    expect(mockPosthog.opt_in_capturing).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -136,6 +136,17 @@ export function initTelemetry(args: InitTelemetryArgs): void {
   if (!dsn) return;
   if (!host) host = 'https://us.i.posthog.com';
 
+  // Clear any persistent PostHog opt-out flag. `opt_out_capturing()`
+  // (called from `disableTelemetry()`) writes a flag to localStorage
+  // that survives re-init — so a user who toggles OFF in Settings and
+  // later toggles back ON would otherwise re-enter with the SDK still
+  // refusing to capture events, even though our own `telemetryActive`
+  // flag says yes. Guarded so we only call it when actually coming out
+  // of a prior opt-out (avoids firing an `$opt_in` event every boot).
+  if (posthog.has_opted_out_capturing?.()) {
+    posthog.opt_in_capturing();
+  }
+
   posthog.init(dsn, {
     api_host: host,
 

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -49,8 +49,44 @@ let inited = false;
  */
 let telemetryActive = false;
 
-/** Synchronous read of the runtime telemetry state. */
+/**
+ * Best-effort Do-Not-Track detection. We honor the browser's DNT
+ * signal across the whole surface — not just inside PostHog — because
+ * `lib/api-client.ts` also attaches `X-NyxID-Client: ui` headers based
+ * on `isTelemetryActive()`, and the backend tags its own telemetry
+ * events off those headers. Without this check, a user with DNT set
+ * who clicked Allow on the banner would still generate backend-side
+ * telemetry even though our privacy policy claims we honor DNT.
+ *
+ * Values that count as "please do not track me": navigator.doNotTrack
+ * === "1", window.doNotTrack === "1", or legacy `navigator.msDoNotTrack
+ * === "1"` on older IE/Edge. All other values (including "0" and
+ * "unspecified") fall through to normal consent resolution.
+ */
+function isDntActive(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // Modern browsers: navigator.doNotTrack
+  const nav = (navigator as Navigator & { msDoNotTrack?: string }).doNotTrack;
+  if (nav === "1" || nav === "yes") return true;
+  // Legacy IE/old Edge: navigator.msDoNotTrack
+  const ms = (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack;
+  if (ms === "1") return true;
+  // Non-standard Firefox-era fallback
+  const win = (
+    typeof window !== "undefined" ? (window as Window & { doNotTrack?: string }) : null
+  )?.doNotTrack;
+  if (win === "1" || win === "yes") return true;
+  return false;
+}
+
+/**
+ * Synchronous read of the runtime telemetry state. Returns false if
+ * the browser has DNT set, regardless of the module-level
+ * `telemetryActive` flag, so callers like `api-client.ts` suppress
+ * surface-identification headers on DNT browsers.
+ */
 export function isTelemetryActive(): boolean {
+  if (isDntActive()) return false;
   return telemetryActive;
 }
 

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -241,3 +241,34 @@ export function captureException(err: unknown): void {
   posthog.captureException?.(err as Error);
 }
 
+/**
+ * Runtime teardown. Call when the user opts out of telemetry from the
+ * Settings page after a prior opt-in, to stop further event capture
+ * without requiring a page reload.
+ *
+ * Resets the PostHog client's anon distinct_id and flips the vendor
+ * into opt-out mode (double-safety: `before_send` already short-circuits
+ * via the `inited` guard on each emit helper, and PostHog's
+ * `opt_out_capturing` prevents any network call even for code that
+ * reaches past us into the vendor SDK directly).
+ *
+ * After this call, the module is back to its pre-init state — another
+ * call to `initTelemetry` (e.g. user toggles back on) will run cleanly.
+ *
+ * No-op when telemetry was never inited.
+ */
+export function disableTelemetry(): void {
+  if (!inited) return;
+  try {
+    posthog.opt_out_capturing();
+    posthog.reset();
+  } catch {
+    // Tolerate vendor errors during teardown. The state resets below
+    // are the source of truth for the rest of the app (api-client.ts
+    // etc. read `isTelemetryActive()`), so even a partial vendor
+    // failure leaves the app in the correct "off" posture.
+  }
+  inited = false;
+  telemetryActive = false;
+}
+

--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -184,11 +184,14 @@ export function PrivacyPage() {
               via the consent banner on your first visit (or the toggle in
               Settings), NyxID collects anonymous usage events (pageviews,
               clicks, uncaught errors) through a third-party analytics
-              provider (PostHog, EU region). No credentials, form content,
+              provider (PostHog, US region). No credentials, form content,
               tokens, or the body of any request you make are ever captured.
               Sensitive URL segments (reset tokens, OAuth callback codes,
               approval IDs) are dropped at the egress layer before any event
               leaves your browser.
+              {/* TODO(legal): document EU→US transfer basis (SCCs / adequacy)
+                  here before broader EU launch. Tracked in
+                  docs/TELEMETRY_CONSENT_FIX.md §9.2. */}
             </p>
             <p>
               Events are keyed to your NyxID account UUID after you sign in,
@@ -202,6 +205,16 @@ export function PrivacyPage() {
             <p>
               You can change your telemetry choice at any time from the
               Settings page. We honor the browser Do-Not-Track signal.
+            </p>
+            <p>
+              <strong>Per-device scope.</strong> Your telemetry choice is
+              stored on this browser and does not sync across the web
+              dashboard, mobile app, and CLI. Each surface manages its own
+              telemetry setting — the CLI uses{" "}
+              <code>nyxid telemetry enable|disable</code> or the{" "}
+              <code>DO_NOT_TRACK=1</code> environment variable, and the
+              mobile app exposes a matching toggle in its own Settings
+              screen.
             </p>
           </Section>
 

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -4,8 +4,10 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/stores/auth-store";
+import { useConsentStore } from "@/stores/consent-store";
 import { useUser, useMfaDisable } from "@/hooks/use-auth";
 import { api, ApiError } from "@/lib/api-client";
+import { disableTelemetry, isTelemetryActive } from "@/lib/telemetry";
 import type { User, Session } from "@/types/api";
 import {
   changePasswordSchema,
@@ -91,6 +93,7 @@ export function SettingsPage() {
           <TabsTrigger value="security">Security</TabsTrigger>
           <TabsTrigger value="sessions">Sessions</TabsTrigger>
           <TabsTrigger value="mcp">MCP</TabsTrigger>
+          <TabsTrigger value="privacy">Privacy</TabsTrigger>
         </TabsList>
 
         <TabsContent value="profile">
@@ -104,6 +107,9 @@ export function SettingsPage() {
         </TabsContent>
         <TabsContent value="mcp">
           <McpTab />
+        </TabsContent>
+        <TabsContent value="privacy">
+          <PrivacyTab />
         </TabsContent>
       </Tabs>
     </div>
@@ -861,6 +867,74 @@ function SessionsTab() {
             </TableBody>
           </Table>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PrivacyTab() {
+  const consentEnabled = useConsentStore((s) => s.enabled);
+  const consentAsked = useConsentStore((s) => s.asked);
+  const setConsent = useConsentStore((s) => s.setConsent);
+
+  // When the user flips OFF here after a prior opt-in, tear down the
+  // running PostHog client immediately so no further events fire even
+  // while the tab stays open. The `useEffect` in main.tsx that drives
+  // `initTelemetry` already re-runs whenever `enabled` changes, so the
+  // ON path only needs to flip the store — main.tsx picks it up and
+  // re-initializes cleanly against the `inited` guard.
+  function handleToggle(next: boolean) {
+    setConsent(next);
+    if (!next) {
+      disableTelemetry();
+    }
+  }
+
+  const statusLabel = !consentAsked
+    ? "Not yet answered"
+    : consentEnabled
+      ? "Enabled"
+      : "Disabled";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Anonymous Usage Telemetry</CardTitle>
+        <CardDescription>
+          Help us improve NyxID by sharing anonymous usage events. We never
+          capture credentials, form content, or the contents of your
+          requests. This choice applies to this browser only — other
+          devices and the CLI manage their own telemetry settings.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Switch
+              checked={consentEnabled}
+              onCheckedChange={handleToggle}
+              aria-label="Toggle anonymous usage telemetry"
+            />
+            <span className="text-sm">{statusLabel}</span>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {isTelemetryActive() ? "Active" : "Inactive"}
+          </span>
+        </div>
+        <Separator />
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            For the full disclosure of what we collect, how it's stored, and
+            retention windows, see the{" "}
+            <a
+              href="/privacy"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              privacy policy
+            </a>
+            .
+          </p>
+        </div>
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useConsentStore } from "@/stores/consent-store";
 import { useUser, useMfaDisable } from "@/hooks/use-auth";
 import { api, ApiError } from "@/lib/api-client";
-import { disableTelemetry, isTelemetryActive } from "@/lib/telemetry";
+import { disableTelemetry } from "@/lib/telemetry";
 import type { User, Session } from "@/types/api";
 import {
   changePasswordSchema,
@@ -908,18 +908,13 @@ function PrivacyTab() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Switch
-              checked={consentEnabled}
-              onCheckedChange={handleToggle}
-              aria-label="Toggle anonymous usage telemetry"
-            />
-            <span className="text-sm">{statusLabel}</span>
-          </div>
-          <span className="text-xs text-muted-foreground">
-            {isTelemetryActive() ? "Active" : "Inactive"}
-          </span>
+        <div className="flex items-center gap-3">
+          <Switch
+            checked={consentEnabled}
+            onCheckedChange={handleToggle}
+            aria-label="Toggle anonymous usage telemetry"
+          />
+          <span className="text-sm">{statusLabel}</span>
         </div>
         <Separator />
         <div className="space-y-2 text-sm text-muted-foreground">

--- a/frontend/src/stores/consent-store.test.ts
+++ b/frontend/src/stores/consent-store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const STORAGE_KEY = "nyxid.telemetry_consent";
+
+/**
+ * These tests verify that the Settings → Privacy toggle actually
+ * persists to localStorage — i.e. that flipping it is NOT cosmetic.
+ * Without this, a toggle OFF would "work" inside a single page load
+ * and then silently revert on reload, because `main.tsx` reads
+ * `consentEnabled` from the same store at boot.
+ *
+ * happy-dom 20.x ships a stub `localStorage` without the Storage API
+ * methods (it expects a `--localstorage-file` path to enable full
+ * persistence). We back it with a plain in-memory map so the zustand
+ * `persist` middleware has something real to read and write. This is
+ * the same behavior as a browser's volatile localStorage within one
+ * session, which is exactly what we need to verify.
+ */
+
+function installInMemoryLocalStorage() {
+  const store = new Map<string, string>();
+  const impl: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: impl,
+    configurable: true,
+    writable: true,
+  });
+}
+
+async function loadFreshStore() {
+  // Reset the module graph so the `persist` middleware re-runs its
+  // hydration from whatever is currently in localStorage. Simulates a
+  // full page reload for the purpose of this test.
+  const { useConsentStore } = await import("./consent-store");
+  return useConsentStore;
+}
+
+beforeEach(() => {
+  // Start each test from a known-clean slate: fresh in-memory storage
+  // AND a reset module graph so the store's `persist` middleware
+  // re-initializes from the empty storage.
+  installInMemoryLocalStorage();
+  vi.resetModules();
+});
+
+describe("consent-store persistence", () => {
+  it("starts with enabled=false, asked=false when localStorage is empty", async () => {
+    const useConsentStore = await loadFreshStore();
+    const state = useConsentStore.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.asked).toBe(false);
+  });
+
+  it("writes {enabled:true, asked:true} to localStorage when setConsent(true)", async () => {
+    const useConsentStore = await loadFreshStore();
+    useConsentStore.getState().setConsent(true);
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    // zustand `persist` wraps state in `{ state: {...}, version }`
+    expect(parsed.state.enabled).toBe(true);
+    expect(parsed.state.asked).toBe(true);
+  });
+
+  it("writes {enabled:false, asked:true} to localStorage when setConsent(false)", async () => {
+    const useConsentStore = await loadFreshStore();
+    useConsentStore.getState().setConsent(false);
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw!);
+    expect(parsed.state.enabled).toBe(false);
+    expect(parsed.state.asked).toBe(true);
+  });
+
+  it("rehydrates enabled=true from localStorage after a simulated reload", async () => {
+    // Round 1: opt in.
+    const store1 = await loadFreshStore();
+    store1.getState().setConsent(true);
+
+    // Round 2: simulate page reload — module graph reset, fresh import
+    // should read back what Round 1 wrote to localStorage. The storage
+    // itself is preserved because `installInMemoryLocalStorage` ran
+    // only once in beforeEach, and module reset doesn't touch it.
+    vi.resetModules();
+    const store2 = await loadFreshStore();
+    const state = store2.getState();
+    expect(state.enabled).toBe(true);
+    expect(state.asked).toBe(true);
+  });
+
+  it("rehydrates enabled=false from localStorage after a simulated reload (the critical withdrawal path)", async () => {
+    // This is the test that matters: user toggles OFF in Settings,
+    // closes the tab, reopens later. Their choice MUST survive.
+    const store1 = await loadFreshStore();
+    store1.getState().setConsent(true);
+    store1.getState().setConsent(false);
+
+    vi.resetModules();
+    const store2 = await loadFreshStore();
+    const state = store2.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.asked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the frontend + CLI portions of the telemetry consent-withdrawal gap catalogued in [`docs/TELEMETRY_CONSENT_FIX.md`](docs/TELEMETRY_CONSENT_FIX.md). Before this PR: banner + privacy policy both promised a Settings toggle that did not exist, PostHog SDK had no runtime disable path, CLI attached `X-NyxID-Client` headers regardless of local opt-out. Users on both surfaces could not withdraw consent through product UI.

## What this PR lands (referenced to doc sections)

- **§8.1** Web consent withdrawal — Privacy tab in Settings wired to `useConsentStore` + `disableTelemetry()`. PostHog `opt_in_capturing()` on re-enable so toggle ON works after a prior toggle OFF
- **§8.3 (CLI portion)** — `build_cli_http_client` + `TelemetryClient::init` gate `X-NyxID-Client` on consent, not just DSN presence. Profile-preferring consent helper honors explicit per-profile choices from pre-v1 releases (migration safety)
- **§8.5** Web + CLI copy fixes — banner copy scoped to "this browser only," CLI prompt scoped to "this machine only," privacy policy region rewritten to US (with `TODO(legal)` for SCCs), per-device scope paragraph added to privacy policy §8
- **§8.9 (partial)** — `DO_NOT_TRACK=1` honored in CLI (step-0 precedence, beats env var + config). Browser DNT honored across the surface (previously only honored inside PostHog SDK, not for our own backend attribution)
- **§10 verification (partial)** — 13 Rust + 26 vitest unit tests cover correctness, persistence across simulated reload, DNT, migration, garbage env values

## What's not in this PR — see [doc §8.0 progress table](docs/TELEMETRY_CONSENT_FIX.md) for full list

### Next PR candidates (tracked in §8 + §9)

| Item | Owner | Doc section |
|---|---|---|
| Mobile toggle + mobile header gating | Mobile PR | §8.2 + §8.3 mobile |
| Mobile policy contradictions ("no analytics SDKs" + `PrivacyInfo.xcprivacy`) | Mobile PR | §8.8 |
| `AUDIT_LOG` cascade + TTL index | Backend PR | §8.4 |
| Operator guidance + `/public/config` extensions | Backend PR | §8.7 |
| Backend integration tests (pre-auth header + cascade) | Backend PR | §10 |
| Age gate at registration | Age gate PR (FE + backend) | §8.6 |
| GPC signal | P1 hygiene follow-up | §8.9 |
| ToS checkbox at registration | P1 hygiene follow-up | §8.9 |
| DSAR export endpoint | P1 hygiene follow-up | §8.9 |
| Node `last_error` sanitization | P1 hygiene follow-up | §8.9 |

### Follow-ups surfaced during this PR's review (new — [doc §9.3](docs/TELEMETRY_CONSENT_FIX.md))

- `nyxid telemetry disable` only clears the default-profile anon_id file; named-profile users who toggle off + on keep their old trail
- `privacy.tsx` hardcodes "US region" while `telemetry_host` is operator-overridable (resolves once §8.7 ships)
- CI snapshot regression guard for false-claim copy strings — specified in §10 but not shipped in this PR; recommended to bundle with the mobile PR so both surfaces' copy get guarded at once

### Legal / ops not code

- EU→US transfer basis (SCCs 2021/914) — `TODO(legal)` marker in `privacy.tsx` right now. Blocking for EU launch, not blocking for PR merge
- Consent receipts (Art. 7(1) accountability) — doc §9.2
- Sub-processor disclosure — doc §9.2
- Breach notification procedure — doc §9.2

## Review trail

4 Codex review passes. Each round surfaced increasingly narrower issues; stopped when findings became "narrow edge case" or "belongs to deferred scope" rather than correctness bugs.

| Commit | What it does |
|---|---|
| `feat(frontend)` | Toggle + `disableTelemetry` + copy |
| `feat(cli)` | Header gating + `DO_NOT_TRACK` |
| `test(frontend)` | Persistence regression guard (5 cases) |
| `fix(telemetry)` | PostHog `opt_in_capturing` on re-enable; consent from default profile |
| `fix(cli)` first-run | Prompt consistency |
| `fix(telemetry)` align | `TelemetryClient` consent + drop non-reactive Settings badge |
| `fix(frontend)` DNT | Actually honor browser DNT across the surface |
| `fix(cli)` migration | Honor prior-release per-profile consent |
| `fix(cli)` garbage env | Reject unknown `NYXID_TELEMETRY` values |
| `docs` progress table | Adds §8.0 progress tracker + §9.3 follow-ups to the design doc |

## Test plan

- [x] `cd frontend && npm run test` — 26 vitest cases (21 telemetry + 5 persistence) all pass. Pre-existing `React.act is not a function` failures in unrelated files are React 19 RTL compat, not caused by this PR
- [x] `cd frontend && npm run build` — clean
- [x] `cargo test -p nyxid-cli` — 178 tests pass (was 166 pre-PR, +12 from DO_NOT_TRACK + migration cases)
- [x] `cargo clippy -p nyxid-cli --tests -- -D warnings` — clean
- [ ] Manual web smoke: flip toggle OFF → verify no PostHog traffic → reload → confirm `{enabled:false}` in localStorage survives → flip back ON → verify traffic resumes
- [ ] Manual CLI smoke: `nyxid telemetry disable` + run command → inspect request headers absent. `DO_NOT_TRACK=1 nyxid telemetry status` → reports `DoNotTrack` source
- [ ] Legal review of updated privacy.tsx copy (US region, per-device scope, DNT honoring, SCCs TODO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)