### PR TITLE
chore: merge main into feat/cli-remote-pairing — resolve CLAUDE.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,12 @@ RATE_LIMIT_BURST=30
 # index. Per ADR-013, message bodies are never persisted — only routing
 # metadata is stored in channel_messages, so there is no content to retain.
 # CHANNEL_RELAY_MESSAGE_TTL_DAYS=30
+# Per-upstream-message edit rate limit for POST /channel-relay/reply/update
+# (edits per second per platform_message_id). Abuse guard only — legitimate
+# throttling of progressive / streaming edits is the caller's job.
+# CHANNEL_RELAY_EDIT_RATE_LIMIT_PER_SECOND=10
+# Burst capacity for the per-upstream-message edit limiter.
+# CHANNEL_RELAY_EDIT_RATE_LIMIT_BURST=20
 
 # ─── HTTP Event Gateway (NyxID#221, ADR-013) ───
 # Per-conversation rate limit for inbound device events (events per second).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ All API routes under `/api/v1`:
 - `/channel-bots` -- channel bot registration CRUD + PATCH updates for platform verification material
 - `/channel-conversations` -- conversation-to-agent routing (CRUD). Maps platform conversations to agent API keys.
 - `/channel-relay/reply` -- agent async reply to a platform conversation. **Only async replies are supported** — sync 200+body replies from agent callbacks were removed per ADR-013 / NyxID#221. Agents must return 202 to the callback and post replies here. Accepts two auth modes: (a) the agent's API key (`Authorization: Bearer nyxid_ag_…`), scoped by `conversation.agent_api_key_id`; or (b) a per-callback reply token (`Authorization: Bearer <reply_token>`) delivered in the inbound callback payload's `reply_token` field. Reply tokens are RS256 JWTs with `aud="channel-relay/reply"`, bound to one `inbound_message_id` + `conversation_id` + `api_key_id` + `platform`, single-use (enforced via MongoDB `reply_token_uses`), and valid for `JWT_RELAY_REPLY_TTL_SECS` (default 30 min). Intended for downstream runtimes (e.g. Aevatar) that want to reply without persisting agent API keys.
+- `/channel-relay/reply/update` -- agent edit of a previously-sent platform reply, addressed by the upstream `platform_message_id` returned from `/channel-relay/reply`. Accepts the same dual auth as `/channel-relay/reply`: agent API key or the original per-callback reply token. Reply tokens remain `aud="channel-relay/reply"` and single-use for the initial send; edit requests revalidate the same token and require its JTI to already exist in `reply_token_uses`, which proves the token was previously used to send before it can edit. V1 platform support: Lark / Feishu only; other bot platforms return `edit_unsupported`.
 - `/channel-relay/messages/{conversation_id}` -- message history for agents
 - `/channel-relay/resolve-sender` -- resolve platform sender to NyxID user
 - `/channel-events/{conversation_id}` -- HTTP Event Gateway ingress (NyxID#221, ADR-013). Accepts device event envelopes `{event_id, source, type, timestamp, payload, metadata}`, converts to `CallbackPayload` with `platform="device"`, and forwards through the channel relay pipeline. Per-channel rate limited (default 100/s), idempotent via in-memory LRU dedup (5min TTL), metadata-only logging to `channel_event_logs` (no payload persistence).
@@ -320,6 +321,11 @@ SA_TOKEN_TTL_SECS=3600              # 1 hour (service account tokens)
 ENVIRONMENT=development
 RATE_LIMIT_PER_SECOND=10
 RATE_LIMIT_BURST=30
+CHANNEL_RELAY_CALLBACK_TIMEOUT_SECS=30          # Callback timeout for inbound agent delivery (default: 30)
+CHANNEL_RELAY_MAX_BOTS_PER_USER=5               # Maximum bots a user can register (default: 5)
+CHANNEL_RELAY_MESSAGE_TTL_DAYS=30               # Channel message TTL in MongoDB (default: 30 days)
+CHANNEL_RELAY_EDIT_RATE_LIMIT_PER_SECOND=10     # Per-platform-message edit rate limit (default: 10)
+CHANNEL_RELAY_EDIT_RATE_LIMIT_BURST=20          # Per-platform-message edit burst capacity (default: 20)
 
 # Telegram / Approval System (optional)
 TELEGRAM_BOT_TOKEN=                     # From @BotFather

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -188,6 +188,10 @@ pub struct AppConfig {
     pub channel_relay_max_bots_per_user: u32,
     /// TTL in days for channel messages before automatic expiry (default: 30)
     pub channel_relay_message_ttl_days: u32,
+    /// Per-message edit rate limit for channel relay replies (default: 10/s).
+    pub channel_relay_edit_rate_limit_per_second: u32,
+    /// Burst capacity for per-message edit rate limiting (default: 20).
+    pub channel_relay_edit_rate_limit_burst: u32,
 
     // HTTP Event Gateway (NyxID#221 / ADR-013)
     /// Per-channel event rate limit (events per second, default 100).
@@ -364,6 +368,14 @@ impl std::fmt::Debug for AppConfig {
             .field(
                 "channel_relay_message_ttl_days",
                 &self.channel_relay_message_ttl_days,
+            )
+            .field(
+                "channel_relay_edit_rate_limit_per_second",
+                &self.channel_relay_edit_rate_limit_per_second,
+            )
+            .field(
+                "channel_relay_edit_rate_limit_burst",
+                &self.channel_relay_edit_rate_limit_burst,
             )
             .field(
                 "channel_event_rate_limit_per_second",
@@ -627,6 +639,16 @@ impl AppConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(30),
+            channel_relay_edit_rate_limit_per_second: env::var(
+                "CHANNEL_RELAY_EDIT_RATE_LIMIT_PER_SECOND",
+            )
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(10),
+            channel_relay_edit_rate_limit_burst: env::var("CHANNEL_RELAY_EDIT_RATE_LIMIT_BURST")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(20),
             channel_event_rate_limit_per_second: env::var("CHANNEL_EVENT_RATE_LIMIT_PER_SECOND")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -950,6 +972,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -759,6 +759,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -193,6 +193,8 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -860,6 +860,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -338,6 +338,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -948,6 +948,19 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
                 .build(),
         )
         .await?;
+    channel_msgs
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "platform": 1, "platform_message_id": 1, "direction": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("channel_messages_platform_msg_idx".to_string())
+                        .sparse(true)
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
 
     // ── reply_token_uses ──
     let reply_token_uses = db.collection::<mongodb::bson::Document>("reply_token_uses");

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -187,6 +187,9 @@ pub enum AppError {
     #[error("Channel platform error: {0}")]
     ChannelPlatformError(String),
 
+    #[error("Channel platform does not support message edits")]
+    ChannelPlatformEditUnsupported,
+
     #[error("Device channel conversations do not support replies")]
     DeviceChannelReplyNotAllowed,
 
@@ -274,6 +277,7 @@ impl AppError {
             Self::ChannelWebhookVerificationFailed(_) => StatusCode::UNAUTHORIZED,
             Self::ChannelRelayFailed(_) => StatusCode::BAD_GATEWAY,
             Self::ChannelPlatformError(_) => StatusCode::BAD_GATEWAY,
+            Self::ChannelPlatformEditUnsupported => StatusCode::NOT_IMPLEMENTED,
             Self::DeviceChannelReplyNotAllowed => StatusCode::BAD_REQUEST,
             Self::OrgCannotAuthenticate => StatusCode::FORBIDDEN,
             Self::OrgQueryTimeout => StatusCode::SERVICE_UNAVAILABLE,
@@ -343,6 +347,7 @@ impl AppError {
             Self::ChannelWebhookVerificationFailed(_) => 10003,
             Self::ChannelRelayFailed(_) => 10004,
             Self::ChannelPlatformError(_) => 10005,
+            Self::ChannelPlatformEditUnsupported => 10007,
             Self::DeviceChannelReplyNotAllowed => 10006,
             Self::OrgCannotAuthenticate => 1403,
             Self::OrgQueryTimeout => 8100,
@@ -442,6 +447,7 @@ impl AppError {
             Self::ChannelWebhookVerificationFailed(_) => "channel_webhook_verification_failed",
             Self::ChannelRelayFailed(_) => "channel_relay_failed",
             Self::ChannelPlatformError(_) => "channel_platform_error",
+            Self::ChannelPlatformEditUnsupported => "edit_unsupported",
             Self::DeviceChannelReplyNotAllowed => "device_channel_reply_not_allowed",
             Self::OrgCannotAuthenticate => "org_cannot_authenticate",
             Self::OrgQueryTimeout => "org_query_timeout",

--- a/backend/src/handlers/channel_relay.rs
+++ b/backend/src/handlers/channel_relay.rs
@@ -1,8 +1,14 @@
 //! Agent-facing channel relay endpoints (API-key or reply-token authenticated).
 //!
 //! These endpoints allow agents to send asynchronous replies to platform
-//! conversations, list conversation message history, and resolve platform
-//! senders to NyxID users.
+//! conversations, edit previously-sent platform replies, list conversation
+//! message history, and resolve platform senders to NyxID users.
+//!
+//! Reply tokens are single-use for the initial `POST /reply` send: their JTI is
+//! consumed on first successful use. `POST /reply/update` reuses the same token
+//! by validating signature + bindings and requiring that the JTI was already
+//! consumed by the original send, which ties edits to a prior reply without
+//! minting a separate edit-only token.
 
 use axum::{
     Json,
@@ -11,7 +17,7 @@ use axum::{
 };
 use base64::Engine as _;
 use chrono::{Duration, Utc};
-use mongodb::bson::doc;
+use mongodb::bson::{Bson, doc};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -28,7 +34,9 @@ use crate::models::notification_channel::{
 use crate::models::reply_token_use::{COLLECTION_NAME as REPLY_TOKEN_USES, ReplyTokenUse};
 use crate::mw::auth::{AuthUser, OptionalAuthUser};
 use crate::services::{
-    channel_bot_service, channel_platform::OutboundReply, channel_relay_service,
+    audit_service, channel_bot_service,
+    channel_platform::{OutboundEdit, OutboundReply},
+    channel_relay_service,
 };
 
 // ---------------------------------------------------------------------------
@@ -37,6 +45,12 @@ use crate::services::{
 
 #[derive(Debug, Deserialize)]
 pub struct AsyncReplyRequest {
+    pub message_id: String,
+    pub reply: AsyncReplyBody,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateReplyRequest {
     pub message_id: String,
     pub reply: AsyncReplyBody,
 }
@@ -79,6 +93,12 @@ pub struct AsyncReplyResponse {
     pub message_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform_message_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdateReplyResponse {
+    pub upstream_message_id: String,
+    pub edited_at: String,
 }
 
 /// Metadata-only message summary returned from
@@ -217,6 +237,14 @@ struct ReplyRequestContext {
     validated_bot: Option<ChannelBot>,
 }
 
+#[derive(Debug)]
+struct EditRequestContext {
+    outbound: ChannelMessage,
+    conversation: ChannelConversation,
+    bot: ChannelBot,
+    attributed_api_key_id: String,
+}
+
 fn extract_bearer_token(headers: &HeaderMap) -> AppResult<Option<String>> {
     let Some(raw) = headers.get("authorization") else {
         return Ok(None);
@@ -259,6 +287,13 @@ fn token_targets_reply_audience(token: &str) -> bool {
             .any(|aud| aud.as_str() == Some(jwt::RELAY_REPLY_AUDIENCE)),
         _ => false,
     }
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
 }
 
 async fn load_active_conversation(
@@ -351,6 +386,27 @@ async fn consume_reply_token_use(
     }
 }
 
+async fn reply_token_has_been_consumed(state: &AppState, jti: &str) -> AppResult<bool> {
+    Ok(state
+        .db
+        .collection::<ReplyTokenUse>(REPLY_TOKEN_USES)
+        .find_one(doc! { "_id": jti })
+        .await?
+        .is_some())
+}
+
+fn check_message_edit_rate_limit(state: &AppState, platform_message_id: &str) -> AppResult<()> {
+    if !state.per_message_edit_limiter.check(platform_message_id) {
+        tracing::warn!(
+            platform_message_id = %platform_message_id,
+            "Per-message edit rate limit exceeded"
+        );
+        return Err(AppError::RateLimited);
+    }
+
+    Ok(())
+}
+
 async fn resolve_reply_token_context(
     state: &AppState,
     token: &str,
@@ -432,6 +488,136 @@ async fn resolve_api_key_reply_context(
     })
 }
 
+async fn find_outbound_message_for_api_key(
+    state: &AppState,
+    api_key_id: &str,
+    platform_message_id: &str,
+) -> AppResult<ChannelMessage> {
+    let platforms = state
+        .db
+        .collection::<ChannelConversation>(CONVERSATIONS)
+        .distinct("platform", doc! { "agent_api_key_id": api_key_id })
+        .await?;
+
+    let mut found: Option<ChannelMessage> = None;
+
+    for platform in platforms {
+        let Bson::String(platform) = platform else {
+            continue;
+        };
+
+        match channel_relay_service::get_outbound_message_by_platform_id(
+            &state.db,
+            &platform,
+            platform_message_id,
+        )
+        .await
+        {
+            Ok(message) => {
+                if found.is_some() {
+                    return Err(AppError::Conflict(format!(
+                        "Multiple outbound messages found for platform message ID: {platform_message_id}"
+                    )));
+                }
+                found = Some(message);
+            }
+            Err(AppError::NotFound(_)) => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    found.ok_or_else(|| {
+        AppError::NotFound(format!("Outbound message not found: {platform_message_id}"))
+    })
+}
+
+async fn resolve_reply_token_edit_context(
+    state: &AppState,
+    token: &str,
+    body: &UpdateReplyRequest,
+) -> AppResult<EditRequestContext> {
+    let claims = jwt::validate_relay_reply_token(&state.jwt_keys, &state.config, token)?;
+
+    if !reply_token_has_been_consumed(state, &claims.jti).await? {
+        return Err(AppError::Unauthorized(
+            "reply token must be used to send before it can edit".to_string(),
+        ));
+    }
+
+    let outbound = channel_relay_service::get_outbound_message_by_platform_id(
+        &state.db,
+        &claims.platform,
+        &body.message_id,
+    )
+    .await?;
+
+    if outbound.reply_to_message_id.as_deref() != Some(claims.inbound_message_id.as_str()) {
+        return Err(AppError::Unauthorized(
+            "Reply token inbound_message_id mismatch".to_string(),
+        ));
+    }
+
+    let conversation = load_active_conversation(state, &outbound.conversation_id).await?;
+    if claims.conversation_id != conversation.id || outbound.conversation_id != conversation.id {
+        return Err(AppError::Unauthorized(
+            "Reply token conversation mismatch".to_string(),
+        ));
+    }
+
+    if claims.platform != outbound.platform || claims.platform != conversation.platform {
+        return Err(AppError::Unauthorized(
+            "Reply token platform mismatch".to_string(),
+        ));
+    }
+
+    if is_device_reply_forbidden(&outbound.platform, &conversation.platform) {
+        return Err(AppError::DeviceChannelReplyNotAllowed);
+    }
+
+    let api_key = load_active_api_key(state, &claims.api_key_id).await?;
+    let bot = load_active_bot(state, &outbound).await?;
+
+    Ok(EditRequestContext {
+        outbound,
+        conversation,
+        bot,
+        attributed_api_key_id: api_key.id,
+    })
+}
+
+async fn resolve_api_key_edit_context(
+    state: &AppState,
+    auth_user: &AuthUser,
+    body: &UpdateReplyRequest,
+) -> AppResult<EditRequestContext> {
+    let caller_api_key_id = auth_user.api_key_id.as_deref().ok_or_else(|| {
+        AppError::Forbidden("This endpoint requires API key authentication".to_string())
+    })?;
+
+    let outbound =
+        find_outbound_message_for_api_key(state, caller_api_key_id, &body.message_id).await?;
+    let conversation = load_active_conversation(state, &outbound.conversation_id).await?;
+
+    if conversation.agent_api_key_id != caller_api_key_id {
+        return Err(AppError::Forbidden(
+            "API key is not the assigned agent for this conversation".to_string(),
+        ));
+    }
+
+    if is_device_reply_forbidden(&outbound.platform, &conversation.platform) {
+        return Err(AppError::DeviceChannelReplyNotAllowed);
+    }
+
+    let bot = load_active_bot(state, &outbound).await?;
+
+    Ok(EditRequestContext {
+        outbound,
+        conversation,
+        bot,
+        attributed_api_key_id: caller_api_key_id.to_string(),
+    })
+}
+
 async fn resolve_reply_request_context(
     state: &AppState,
     headers: &HeaderMap,
@@ -448,6 +634,24 @@ async fn resolve_reply_request_context(
         AppError::Unauthorized("API key or relay reply token required".to_string())
     })?;
     resolve_api_key_reply_context(state, auth_user, body).await
+}
+
+async fn resolve_edit_request_context(
+    state: &AppState,
+    headers: &HeaderMap,
+    auth_user: Option<&AuthUser>,
+    body: &UpdateReplyRequest,
+) -> AppResult<EditRequestContext> {
+    if let Some(token) = extract_bearer_token(headers)?
+        && token_targets_reply_audience(&token)
+    {
+        return resolve_reply_token_edit_context(state, &token, body).await;
+    }
+
+    let auth_user = auth_user.ok_or_else(|| {
+        AppError::Unauthorized("API key or relay reply token required".to_string())
+    })?;
+    resolve_api_key_edit_context(state, auth_user, body).await
 }
 
 // ---------------------------------------------------------------------------
@@ -598,6 +802,76 @@ pub async fn async_reply(
     }))
 }
 
+/// POST /api/v1/channel-relay/reply/update
+///
+/// Edit a previously-sent asynchronous reply by its upstream platform message
+/// ID. The platform edit surface is adapter-specific; unsupported platforms
+/// return `edit_unsupported`.
+pub async fn update_reply(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    OptionalAuthUser(auth_user): OptionalAuthUser,
+    Json(body): Json<UpdateReplyRequest>,
+) -> AppResult<Json<UpdateReplyResponse>> {
+    check_message_edit_rate_limit(&state, &body.message_id)?;
+
+    let EditRequestContext {
+        outbound,
+        conversation,
+        bot,
+        attributed_api_key_id,
+    } = resolve_edit_request_context(&state, &headers, auth_user.as_ref(), &body).await?;
+
+    if is_device_reply_forbidden(&outbound.platform, &conversation.platform) {
+        return Err(AppError::DeviceChannelReplyNotAllowed);
+    }
+
+    validate_reply_for_platform(&body.reply, &bot.platform)?;
+
+    let adapter = resolve_adapter(&bot.platform, &state.token_exchange_cache)?;
+    let bot_token = channel_bot_service::decrypt_bot_token(&state.encryption_keys, &bot).await?;
+    let edit = OutboundEdit {
+        text: body.reply.text,
+        metadata: body.reply.metadata,
+    };
+
+    adapter
+        .edit_reply(&state.http_client, &bot_token, &body.message_id, &edit)
+        .await?;
+
+    let inbound_message_id = outbound.reply_to_message_id.clone().ok_or_else(|| {
+        AppError::Internal("outbound channel relay row is missing reply_to_message_id".to_string())
+    })?;
+    let edited_at = Utc::now();
+
+    channel_relay_service::update_outbound_message_timestamp(&state.db, &outbound.id, edited_at)
+        .await?;
+
+    audit_service::log_async(
+        state.db.clone(),
+        Some(bot.user_id.clone()),
+        "channel_relay.reply.edit".to_string(),
+        Some(serde_json::json!({
+            "outbound_message_id": outbound.id,
+            "inbound_message_id": inbound_message_id,
+            "conversation_id": conversation.id,
+            "api_key_id": attributed_api_key_id.clone(),
+            "bot_id": bot.id,
+            "platform": outbound.platform,
+            "platform_message_id": body.message_id,
+        })),
+        None,
+        header_value(&headers, "user-agent"),
+        Some(attributed_api_key_id),
+        None,
+    );
+
+    Ok(Json(UpdateReplyResponse {
+        upstream_message_id: body.message_id,
+        edited_at: edited_at.to_rfc3339(),
+    }))
+}
+
 /// GET /api/v1/channel-relay/messages/{conversation_id}
 ///
 /// List messages for a conversation. The calling agent must be the assigned
@@ -718,6 +992,7 @@ mod tests {
         bot: ChannelBot,
         conversation: ChannelConversation,
         message: ChannelMessage,
+        outbound_message: ChannelMessage,
     }
 
     fn body(text: Option<&str>, metadata: Option<serde_json::Value>) -> AsyncReplyBody {
@@ -732,6 +1007,75 @@ mod tests {
             message_id: message_id.to_string(),
             reply: body(Some("hello"), None),
         }
+    }
+
+    fn update_reply_request(platform_message_id: &str) -> UpdateReplyRequest {
+        UpdateReplyRequest {
+            message_id: platform_message_id.to_string(),
+            reply: body(Some("hello"), None),
+        }
+    }
+
+    fn bearer_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}")
+                .parse()
+                .expect("authorization header"),
+        );
+        headers
+    }
+
+    fn api_key_auth_user(api_key: &ApiKey) -> AuthUser {
+        AuthUser {
+            user_id: Uuid::parse_str(&api_key.user_id).expect("valid api key user id"),
+            session_id: None,
+            scope: api_key.scopes.clone(),
+            acting_client_id: None,
+            approval_owner_user_id: None,
+            auth_method: crate::mw::auth::AuthMethod::ApiKey,
+            allow_all_services: api_key.allow_all_services,
+            allow_all_nodes: api_key.allow_all_nodes,
+            allowed_service_ids: api_key.allowed_service_ids.clone(),
+            allowed_node_ids: api_key.allowed_node_ids.clone(),
+            api_key_id: Some(api_key.id.clone()),
+            api_key_name: Some(api_key.name.clone()),
+            rate_limit_per_second: api_key.rate_limit_per_second,
+            rate_limit_burst: api_key.rate_limit_burst,
+        }
+    }
+
+    async fn insert_reply_token_use(
+        fixture: &ReplyTokenFixture,
+        claims: &jwt::RelayReplyClaims,
+    ) -> usize {
+        let count_before = fixture
+            .state
+            .db
+            .collection::<ReplyTokenUse>(REPLY_TOKEN_USES)
+            .count_documents(doc! {})
+            .await
+            .expect("count reply token uses before");
+
+        let exp_at =
+            chrono::DateTime::from_timestamp(claims.exp + REPLY_TOKEN_USE_TTL_BUFFER_SECS, 0)
+                .expect("valid exp_at");
+        fixture
+            .state
+            .db
+            .collection::<ReplyTokenUse>(REPLY_TOKEN_USES)
+            .insert_one(&ReplyTokenUse {
+                id: claims.jti.clone(),
+                exp_at,
+                api_key_id: claims.api_key_id.clone(),
+                conversation_id: claims.conversation_id.clone(),
+                consumed_at: Utc::now(),
+            })
+            .await
+            .expect("insert reply token use");
+
+        count_before as usize
     }
 
     fn encode_reply_claims(state: &AppState, claims: &jwt::RelayReplyClaims) -> String {
@@ -851,6 +1195,28 @@ mod tests {
             reply_to_message_id: None,
             platform_reply_message_id: None,
             created_at: now,
+            updated_at: None,
+        };
+
+        let outbound_message = ChannelMessage {
+            id: Uuid::new_v4().to_string(),
+            channel_bot_id: Some(bot.id.clone()),
+            conversation_id: conversation.id.clone(),
+            platform_conversation_id: Some(conversation.platform_conversation_id.clone()),
+            user_id: api_key.user_id.clone(),
+            direction: "outbound".to_string(),
+            platform: conversation.platform.clone(),
+            platform_message_id: Some("platform_reply_123".to_string()),
+            sender_platform_id: None,
+            sender_display_name: None,
+            content_type: "text".to_string(),
+            thread_id: None,
+            agent_api_key_id: Some(api_key.id.clone()),
+            callback_status: None,
+            reply_to_message_id: Some(message.id.clone()),
+            platform_reply_message_id: None,
+            created_at: now,
+            updated_at: Some(now),
         };
 
         db.collection::<ApiKey>(API_KEYS)
@@ -869,6 +1235,10 @@ mod tests {
             .insert_one(&message)
             .await
             .expect("insert message");
+        db.collection::<ChannelMessage>(crate::models::channel_message::COLLECTION_NAME)
+            .insert_one(&outbound_message)
+            .await
+            .expect("insert outbound message");
 
         Some(ReplyTokenFixture {
             state,
@@ -876,6 +1246,7 @@ mod tests {
             bot,
             conversation,
             message,
+            outbound_message,
         })
     }
 
@@ -1272,6 +1643,240 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(consumed, 1);
+
+        db.drop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_reply_token_context_happy_path_no_jti_consumption() {
+        let Some(fixture) = setup_reply_token_fixture("update_reply_token_happy_path").await else {
+            eprintln!("skipping channel_relay reply-token test: no local MongoDB available");
+            return;
+        };
+        let db = fixture.state.db.clone();
+
+        let claims = valid_reply_claims(&fixture);
+        let token = encode_reply_claims(&fixture.state, &claims);
+        let count_before = insert_reply_token_use(&fixture, &claims).await;
+
+        let ctx = resolve_edit_request_context(
+            &fixture.state,
+            &bearer_headers(&token),
+            None,
+            &update_reply_request(
+                fixture
+                    .outbound_message
+                    .platform_message_id
+                    .as_deref()
+                    .expect("outbound platform message id"),
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(ctx.outbound.id, fixture.outbound_message.id);
+        assert_eq!(ctx.conversation.id, fixture.conversation.id);
+        assert_eq!(ctx.bot.id, fixture.bot.id);
+        assert_eq!(ctx.attributed_api_key_id, fixture.api_key.id);
+
+        let count_after = db
+            .collection::<ReplyTokenUse>(REPLY_TOKEN_USES)
+            .count_documents(doc! {})
+            .await
+            .unwrap();
+        assert_eq!(count_after as usize, count_before + 1);
+
+        db.drop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_reply_token_context_rejects_unused_jti() {
+        let Some(fixture) = setup_reply_token_fixture("update_reply_token_unused_jti").await else {
+            eprintln!("skipping channel_relay reply-token test: no local MongoDB available");
+            return;
+        };
+        let db = fixture.state.db.clone();
+
+        let claims = valid_reply_claims(&fixture);
+        let token = encode_reply_claims(&fixture.state, &claims);
+        let err = resolve_edit_request_context(
+            &fixture.state,
+            &bearer_headers(&token),
+            None,
+            &update_reply_request(
+                fixture
+                    .outbound_message
+                    .platform_message_id
+                    .as_deref()
+                    .expect("outbound platform message id"),
+            ),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AppError::Unauthorized(msg) if msg.contains("must be used to send before it can edit"))
+        );
+        db.drop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_reply_rejects_mismatched_inbound_id() {
+        let Some(fixture) = setup_reply_token_fixture("update_reply_inbound_mismatch").await else {
+            eprintln!("skipping channel_relay reply-token test: no local MongoDB available");
+            return;
+        };
+        let db = fixture.state.db.clone();
+
+        let claims = jwt::RelayReplyClaims {
+            inbound_message_id: Uuid::new_v4().to_string(),
+            ..valid_reply_claims(&fixture)
+        };
+        let token = encode_reply_claims(&fixture.state, &claims);
+        insert_reply_token_use(&fixture, &claims).await;
+
+        let err = resolve_edit_request_context(
+            &fixture.state,
+            &bearer_headers(&token),
+            None,
+            &update_reply_request(
+                fixture
+                    .outbound_message
+                    .platform_message_id
+                    .as_deref()
+                    .expect("outbound platform message id"),
+            ),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AppError::Unauthorized(msg) if msg.contains("inbound_message_id mismatch"))
+        );
+        db.drop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_reply_rejects_device_conversation() {
+        let Some(fixture) = setup_reply_token_fixture("update_reply_device_guard").await else {
+            eprintln!("skipping channel_relay reply-token test: no local MongoDB available");
+            return;
+        };
+        let db = fixture.state.db.clone();
+
+        db.collection::<ChannelConversation>(CONVERSATIONS)
+            .update_one(
+                doc! { "_id": &fixture.conversation.id },
+                doc! { "$set": { "platform": "device" } },
+            )
+            .await
+            .unwrap();
+
+        let err = update_reply(
+            State(fixture.state.clone()),
+            HeaderMap::new(),
+            OptionalAuthUser(Some(api_key_auth_user(&fixture.api_key))),
+            Json(update_reply_request(
+                fixture
+                    .outbound_message
+                    .platform_message_id
+                    .as_deref()
+                    .expect("outbound platform message id"),
+            )),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, AppError::DeviceChannelReplyNotAllowed));
+        db.drop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_reply_returns_501_on_telegram() {
+        let cache = std::sync::Arc::new(
+            crate::services::provider_token_exchange_service::TokenExchangeCache::new(),
+        );
+        let adapter = resolve_adapter("telegram", &cache).expect("telegram adapter");
+
+        let err = adapter
+            .edit_reply(
+                &reqwest::Client::new(),
+                "bot-token",
+                "platform-msg-id",
+                &OutboundEdit {
+                    text: Some("hello".to_string()),
+                    metadata: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AppError::ChannelPlatformEditUnsupported));
+    }
+
+    #[tokio::test]
+    async fn update_reply_returns_404_on_unknown_platform_message_id() {
+        let Some(fixture) = setup_reply_token_fixture("update_reply_unknown_msg").await else {
+            eprintln!("skipping channel_relay reply-token test: no local MongoDB available");
+            return;
+        };
+        let db = fixture.state.db.clone();
+        let auth_user = api_key_auth_user(&fixture.api_key);
+
+        let err = resolve_edit_request_context(
+            &fixture.state,
+            &HeaderMap::new(),
+            Some(&auth_user),
+            &update_reply_request("missing_platform_message"),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AppError::NotFound(msg) if msg.contains("Outbound message not found"))
+        );
+        db.drop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_reply_rate_limits_per_platform_message_id() {
+        let Some(fixture) = setup_reply_token_fixture("update_reply_rate_limit").await else {
+            eprintln!("skipping channel_relay reply-token test: no local MongoDB available");
+            return;
+        };
+        let db = fixture.state.db.clone();
+
+        let mut state = fixture.state.clone();
+        state.per_message_edit_limiter =
+            std::sync::Arc::new(crate::mw::rate_limit::PerMessageEditRateLimiter::new(1, 1));
+
+        let platform_message_id = fixture
+            .outbound_message
+            .platform_message_id
+            .as_deref()
+            .expect("outbound platform message id")
+            .to_string();
+
+        let first = update_reply(
+            State(state.clone()),
+            HeaderMap::new(),
+            OptionalAuthUser(Some(api_key_auth_user(&fixture.api_key))),
+            Json(update_reply_request(&platform_message_id)),
+        )
+        .await;
+        assert!(matches!(
+            first,
+            Err(AppError::ChannelPlatformEditUnsupported)
+        ));
+
+        let second = update_reply(
+            State(state),
+            HeaderMap::new(),
+            OptionalAuthUser(Some(api_key_auth_user(&fixture.api_key))),
+            Json(update_reply_request(&platform_message_id)),
+        )
+        .await;
+        assert!(matches!(second, Err(AppError::RateLimited)));
 
         db.drop().await.unwrap();
     }

--- a/backend/src/handlers/channel_relay.rs
+++ b/backend/src/handlers/channel_relay.rs
@@ -813,6 +813,7 @@ pub async fn update_reply(
     OptionalAuthUser(auth_user): OptionalAuthUser,
     Json(body): Json<UpdateReplyRequest>,
 ) -> AppResult<Json<UpdateReplyResponse>> {
+    // Deliberately rate-limit before auth/DB work so unauth floods fail on one cheap hashmap check.
     check_message_edit_rate_limit(&state, &body.message_id)?;
 
     let EditRequestContext {

--- a/backend/src/handlers/channel_webhooks.rs
+++ b/backend/src/handlers/channel_webhooks.rs
@@ -689,6 +689,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -69,6 +69,8 @@ pub struct AppState {
     /// Per-channel rate limiter keyed by conversation_id, for the HTTP Event
     /// Gateway (NyxID#221). Distinct from `per_agent_limiter`.
     pub per_channel_event_limiter: mw::rate_limit::SharedPerChannelEventLimiter,
+    /// Per-upstream-message edit limiter for progressive channel relay edits.
+    pub per_message_edit_limiter: mw::rate_limit::SharedPerMessageEditRateLimiter,
     /// Best-effort idempotency cache for inbound channel events.
     pub event_dedup_cache: Arc<EventDedupCache>,
     /// Active WebSocket passthrough connection count (for resource limiting)
@@ -356,6 +358,10 @@ async fn main() {
         config.channel_event_dedup_capacity,
         std::time::Duration::from_secs(config.channel_event_dedup_ttl_secs),
     ));
+    let per_message_edit_limiter = Arc::new(mw::rate_limit::PerMessageEditRateLimiter::new(
+        config.channel_relay_edit_rate_limit_per_second,
+        config.channel_relay_edit_rate_limit_burst,
+    ));
 
     // Create shared state
     let state = AppState {
@@ -373,6 +379,7 @@ async fn main() {
         ssh_session_manager,
         per_agent_limiter: Arc::new(mw::rate_limit::PerAgentRateLimiter::new()),
         per_channel_event_limiter,
+        per_message_edit_limiter,
         event_dedup_cache,
         ws_passthrough_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         token_exchange_cache: Arc::new(TokenExchangeCache::new()),
@@ -422,6 +429,14 @@ async fn main() {
         loop {
             interval.tick().await;
             cleanup_event_limiter.cleanup();
+        }
+    });
+    let cleanup_edit_limiter = state.per_message_edit_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            cleanup_edit_limiter.cleanup();
         }
     });
     let cleanup_event_dedup = state.event_dedup_cache.clone();

--- a/backend/src/models/channel_message.rs
+++ b/backend/src/models/channel_message.rs
@@ -68,6 +68,8 @@ pub struct ChannelMessage {
     pub platform_reply_message_id: Option<String>,
     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
     pub created_at: DateTime<Utc>,
+    #[serde(default, with = "crate::models::bson_datetime::optional")]
+    pub updated_at: Option<DateTime<Utc>>,
 }
 
 #[cfg(test)]
@@ -98,6 +100,7 @@ mod tests {
             reply_to_message_id: None,
             platform_reply_message_id: None,
             created_at: Utc::now(),
+            updated_at: None,
         }
     }
 
@@ -140,6 +143,7 @@ mod tests {
             restored.platform_reply_message_id.as_deref(),
             Some("platform_msg_789")
         );
+        assert!(restored.updated_at.is_none());
     }
 
     #[test]
@@ -167,9 +171,23 @@ mod tests {
         doc.remove("callback_status");
         doc.remove("reply_to_message_id");
         doc.remove("platform_reply_message_id");
+        doc.remove("updated_at");
         let restored: ChannelMessage = bson::from_document(doc).expect("deserialize");
         assert_eq!(restored.platform_message_id, None);
         assert_eq!(restored.callback_status, None);
+        assert_eq!(restored.updated_at, None);
+    }
+
+    #[test]
+    fn bson_roundtrip_with_updated_at() {
+        let mut msg = make_message();
+        msg.updated_at = Some(Utc::now());
+        let doc = bson::to_document(&msg).expect("serialize");
+        let restored: ChannelMessage = bson::from_document(doc).expect("deserialize");
+        assert_eq!(
+            restored.updated_at.map(|ts| ts.timestamp_millis()),
+            msg.updated_at.map(|ts| ts.timestamp_millis())
+        );
     }
 
     #[test]

--- a/backend/src/mw/rate_limit.rs
+++ b/backend/src/mw/rate_limit.rs
@@ -123,6 +123,58 @@ impl PerAgentRateLimiter {
 
 pub type SharedPerAgentRateLimiter = Arc<PerAgentRateLimiter>;
 
+/// Per-message edit limiter keyed by upstream platform message ID.
+/// Used by the channel relay edit endpoint so progressive updates on one
+/// message cannot starve the rest of the relay.
+#[derive(Clone)]
+pub struct PerMessageEditRateLimiter {
+    state: Arc<Mutex<HashMap<String, AgentBucket>>>,
+    rate_per_second: u32,
+    burst: u32,
+}
+
+impl PerMessageEditRateLimiter {
+    pub fn new(rate_per_second: u32, burst: u32) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            rate_per_second,
+            burst,
+        }
+    }
+
+    /// Check if an edit for the given upstream message should be allowed.
+    pub fn check(&self, platform_message_id: &str) -> bool {
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = state
+            .entry(platform_message_id.to_string())
+            .or_insert(AgentBucket {
+                tokens: self.burst as f64,
+                last_refill: now,
+            });
+
+        let elapsed_secs = now.duration_since(entry.last_refill).as_secs_f64();
+        entry.tokens =
+            (entry.tokens + elapsed_secs * self.rate_per_second as f64).min(self.burst as f64);
+        entry.last_refill = now;
+
+        if entry.tokens < 1.0 {
+            return false;
+        }
+        entry.tokens -= 1.0;
+        true
+    }
+
+    /// Remove stale entries to prevent unbounded memory growth.
+    pub fn cleanup(&self) {
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.retain(|_, bucket| now.duration_since(bucket.last_refill).as_secs() < 120);
+    }
+}
+
+pub type SharedPerMessageEditRateLimiter = Arc<PerMessageEditRateLimiter>;
+
 /// Per-channel rate limiter keyed by conversation_id for the HTTP Event
 /// Gateway. Distinct from `PerAgentRateLimiter` because event-channel
 /// throttling is per-conversation, not per-API-key.

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -628,6 +628,7 @@ pub fn build_router(proxy_max_body_size: usize) -> (Router<AppState>, Router<App
 
     let channel_relay_routes = Router::new()
         .route("/reply", post(handlers::channel_relay::async_reply))
+        .route("/reply/update", post(handlers::channel_relay::update_reply))
         .route(
             "/messages/{conversation_id}",
             get(handlers::channel_relay::list_messages),

--- a/backend/src/services/channel_adapters/lark.rs
+++ b/backend/src/services/channel_adapters/lark.rs
@@ -33,8 +33,8 @@ use crate::errors::{AppError, AppResult};
 use crate::models::channel_bot::ChannelBot;
 use crate::models::downstream_service::{CredentialFieldSpec, TokenExchangeConfig};
 use crate::services::channel_platform::{
-    BotIdentity, InboundMessage, OutboundReply, PlatformAdapter, PlatformVerifySecrets,
-    PreparedWebhook,
+    BotIdentity, InboundMessage, OutboundEdit, OutboundReply, PlatformAdapter,
+    PlatformVerifySecrets, PreparedWebhook,
 };
 use crate::services::provider_token_exchange_service::{self, TokenExchangeCache};
 
@@ -381,15 +381,44 @@ fn extract_text_content(content_str: &str) -> Option<String> {
 /// JSON is passed through as-is; Feishu validates it server-side.
 ///
 /// Otherwise falls back to a plain text message wrapping `reply.text`.
-fn build_message_body(reply: &OutboundReply) -> (&'static str, String) {
-    if let Some(metadata) = reply.metadata.as_ref()
+fn build_message_body(
+    text: Option<&str>,
+    metadata: Option<&serde_json::Value>,
+) -> (&'static str, String) {
+    if let Some(metadata) = metadata
         && let Some(card) = metadata.get("card")
     {
         return ("interactive", card.to_string());
     }
 
-    let text = reply.text.as_deref().unwrap_or("");
+    let text = text.unwrap_or("");
     ("text", serde_json::json!({ "text": text }).to_string())
+}
+
+fn build_send_body(reply: &OutboundReply) -> (&'static str, String) {
+    build_message_body(reply.text.as_deref(), reply.metadata.as_ref())
+}
+
+fn build_edit_request(edit: &OutboundEdit) -> (reqwest::Method, serde_json::Value) {
+    if let Some(metadata) = edit.metadata.as_ref()
+        && let Some(card) = metadata.get("card")
+    {
+        return (
+            reqwest::Method::PATCH,
+            serde_json::json!({
+                "content": card.to_string(),
+            }),
+        );
+    }
+
+    let (_msg_type, content) = build_message_body(edit.text.as_deref(), edit.metadata.as_ref());
+    (
+        reqwest::Method::PUT,
+        serde_json::json!({
+            "msg_type": "text",
+            "content": content,
+        }),
+    )
 }
 
 /// Detect the content type from the Lark `message_type` field.
@@ -607,7 +636,7 @@ impl PlatformAdapter for LarkFamilyAdapter {
             .get_tenant_access_token(http, app_id, app_secret)
             .await?;
 
-        let (msg_type, content) = build_message_body(reply);
+        let (msg_type, content) = build_send_body(reply);
 
         let body = serde_json::json!({
             "receive_id": conversation_id,
@@ -661,6 +690,83 @@ impl PlatformAdapter for LarkFamilyAdapter {
             .map(String::from);
 
         Ok(message_id)
+    }
+
+    async fn edit_reply(
+        &self,
+        http: &reqwest::Client,
+        bot_token: &str,
+        platform_message_id: &str,
+        edit: &OutboundEdit,
+    ) -> AppResult<()> {
+        let (app_id, app_secret) = bot_token.split_once(':').ok_or_else(|| {
+            AppError::ChannelPlatformError(format!(
+                "{} bot_token must be in app_id:app_secret format",
+                self.platform
+            ))
+        })?;
+
+        let tenant_token = self
+            .get_tenant_access_token(http, app_id, app_secret)
+            .await?;
+
+        let (method, body) = build_edit_request(edit);
+        let url = format!(
+            "{}/open-apis/im/v1/messages/{}",
+            self.base_url, platform_message_id
+        );
+
+        let request = match method {
+            reqwest::Method::PATCH => http.patch(&url),
+            _ => http.put(&url),
+        };
+
+        let resp: serde_json::Value = request
+            .header("Authorization", format!("Bearer {tenant_token}"))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                AppError::ChannelPlatformError(format!(
+                    "{} edit message request failed: {e}",
+                    self.platform
+                ))
+            })?
+            .json()
+            .await
+            .map_err(|e| {
+                AppError::ChannelPlatformError(format!(
+                    "{} edit message response parse failed: {e}",
+                    self.platform
+                ))
+            })?;
+
+        let code = resp.get("code").and_then(|v| v.as_i64()).unwrap_or(-1);
+        if code == 0 {
+            return Ok(());
+        }
+
+        let msg = resp
+            .get("msg")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+
+        match code {
+            230020 => Err(AppError::RateLimited),
+            230011 | 230031 | 230050 | 230071 | 230072 | 230073 | 230074 | 230075 | 230110 => {
+                Err(AppError::Conflict(format!(
+                    "{} refused edit (code {code}): {msg}",
+                    self.platform
+                )))
+            }
+            230001 | 230022 | 230025 | 230028 | 230054 | 230099 => Err(AppError::ValidationError(
+                format!("{} refused edit (code {code}): {msg}", self.platform),
+            )),
+            _ => Err(AppError::ChannelPlatformError(format!(
+                "{} edit message failed (code {code}): {msg}",
+                self.platform
+            ))),
+        }
     }
 
     async fn register_webhook(
@@ -717,6 +823,40 @@ mod tests {
     /// pass to the adapter constructors.
     fn test_cache() -> Arc<TokenExchangeCache> {
         Arc::new(TokenExchangeCache::new())
+    }
+
+    #[test]
+    fn build_edit_request_uses_patch_for_cards() {
+        let edit = OutboundEdit {
+            text: None,
+            metadata: Some(serde_json::json!({
+                "card": {
+                    "config": { "update_multi": true },
+                    "header": { "title": { "tag": "plain_text", "content": "Streaming" } }
+                }
+            })),
+        };
+
+        let (method, body) = build_edit_request(&edit);
+        assert_eq!(method, reqwest::Method::PATCH);
+        assert!(body.get("content").and_then(|v| v.as_str()).is_some());
+        assert!(body.get("msg_type").is_none());
+    }
+
+    #[test]
+    fn build_edit_request_uses_put_for_text() {
+        let edit = OutboundEdit {
+            text: Some("hello".to_string()),
+            metadata: None,
+        };
+
+        let (method, body) = build_edit_request(&edit);
+        assert_eq!(method, reqwest::Method::PUT);
+        assert_eq!(body.get("msg_type").and_then(|v| v.as_str()), Some("text"));
+        assert_eq!(
+            body.get("content").and_then(|v| v.as_str()),
+            Some("{\"text\":\"hello\"}")
+        );
     }
 
     fn make_test_bot(platform: &str) -> ChannelBot {
@@ -1345,7 +1485,7 @@ mod tests {
             reply_to_platform_message_id: None,
             metadata: None,
         };
-        let (msg_type, content) = build_message_body(&reply);
+        let (msg_type, content) = build_send_body(&reply);
         assert_eq!(msg_type, "text");
         assert_eq!(content, r#"{"text":"hello"}"#);
     }
@@ -1357,7 +1497,7 @@ mod tests {
             reply_to_platform_message_id: None,
             metadata: None,
         };
-        let (msg_type, content) = build_message_body(&reply);
+        let (msg_type, content) = build_send_body(&reply);
         assert_eq!(msg_type, "text");
         assert_eq!(content, r#"{"text":""}"#);
     }
@@ -1379,7 +1519,7 @@ mod tests {
             reply_to_platform_message_id: None,
             metadata: Some(serde_json::json!({ "card": card.clone() })),
         };
-        let (msg_type, content) = build_message_body(&reply);
+        let (msg_type, content) = build_send_body(&reply);
         assert_eq!(msg_type, "interactive");
         // Content is the card JSON serialized as a string
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1393,7 +1533,7 @@ mod tests {
             reply_to_platform_message_id: None,
             metadata: Some(serde_json::json!({ "card": { "elements": [] } })),
         };
-        let (msg_type, _) = build_message_body(&reply);
+        let (msg_type, _) = build_send_body(&reply);
         assert_eq!(msg_type, "interactive");
     }
 
@@ -1404,7 +1544,7 @@ mod tests {
             reply_to_platform_message_id: None,
             metadata: Some(serde_json::json!({ "other": "value" })),
         };
-        let (msg_type, content) = build_message_body(&reply);
+        let (msg_type, content) = build_send_body(&reply);
         assert_eq!(msg_type, "text");
         assert_eq!(content, r#"{"text":"plain"}"#);
     }

--- a/backend/src/services/channel_adapters/lark.rs
+++ b/backend/src/services/channel_adapters/lark.rs
@@ -421,6 +421,41 @@ fn build_edit_request(edit: &OutboundEdit) -> (reqwest::Method, serde_json::Valu
     )
 }
 
+/// Classify documented Feishu/Lark edit errors into NyxID error buckets.
+///
+/// Verified against the current official Feishu markdown docs:
+/// - Text/post edit (`PUT /im/v1/messages/{message_id}`):
+///   https://open.feishu.cn/document/server-docs/im-v1/message/update.md
+/// - Card edit (`PATCH /im/v1/messages/{message_id}`):
+///   https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/patch.md
+///
+/// Specifically mapped codes:
+/// - `230020`: frequency limit -> `RateLimited`
+/// - `230011`, `230031`, `230050`, `230071`, `230072`, `230073`, `230074`,
+///   `230075`, `230110`: message state / editability conflicts -> `Conflict`
+/// - `230001`, `230022`, `230025`, `230028`, `230054`, `230099`: invalid
+///   request or invalid content -> `ValidationError`
+///
+/// Intentionally not specialized:
+/// - `230002` appears only in the text/post edit doc and is documented as
+///   "The bot can not be outside the group", not message-not-found.
+/// - Any code not listed above falls back to `ChannelPlatformError` so we do
+///   not invent classifications beyond what the official docs support.
+fn classify_edit_error(platform: &str, code: i64, msg: &str) -> AppError {
+    match code {
+        230020 => AppError::RateLimited,
+        230011 | 230031 | 230050 | 230071 | 230072 | 230073 | 230074 | 230075 | 230110 => {
+            AppError::Conflict(format!("{platform} refused edit (code {code}): {msg}"))
+        }
+        230001 | 230022 | 230025 | 230028 | 230054 | 230099 => {
+            AppError::ValidationError(format!("{platform} refused edit (code {code}): {msg}"))
+        }
+        _ => AppError::ChannelPlatformError(format!(
+            "{platform} edit message failed (code {code}): {msg}"
+        )),
+    }
+}
+
 /// Detect the content type from the Lark `message_type` field.
 fn detect_content_type(message_type: &str) -> &'static str {
     match message_type {
@@ -751,22 +786,7 @@ impl PlatformAdapter for LarkFamilyAdapter {
             .and_then(|v| v.as_str())
             .unwrap_or("unknown error");
 
-        match code {
-            230020 => Err(AppError::RateLimited),
-            230011 | 230031 | 230050 | 230071 | 230072 | 230073 | 230074 | 230075 | 230110 => {
-                Err(AppError::Conflict(format!(
-                    "{} refused edit (code {code}): {msg}",
-                    self.platform
-                )))
-            }
-            230001 | 230022 | 230025 | 230028 | 230054 | 230099 => Err(AppError::ValidationError(
-                format!("{} refused edit (code {code}): {msg}", self.platform),
-            )),
-            _ => Err(AppError::ChannelPlatformError(format!(
-                "{} edit message failed (code {code}): {msg}",
-                self.platform
-            ))),
-        }
+        Err(classify_edit_error(&self.platform, code, msg))
     }
 
     async fn register_webhook(

--- a/backend/src/services/channel_platform.rs
+++ b/backend/src/services/channel_platform.rs
@@ -53,6 +53,14 @@ pub struct OutboundReply {
     pub metadata: Option<serde_json::Value>,
 }
 
+/// A previously-sent outbound message edit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundEdit {
+    pub text: Option<String>,
+    /// Platform-specific metadata for edit operations (e.g. Lark cards).
+    pub metadata: Option<serde_json::Value>,
+}
+
 /// Decrypted, platform-specific webhook verification material prepared by the
 /// handler. Secrets never live on persisted model structs.
 #[derive(Clone, Default)]
@@ -133,6 +141,17 @@ pub trait PlatformAdapter: Send + Sync {
         conversation_id: &str,
         reply: &OutboundReply,
     ) -> AppResult<Option<String>>;
+
+    /// Edit a previously-sent platform message.
+    async fn edit_reply(
+        &self,
+        _http: &reqwest::Client,
+        _bot_token: &str,
+        _platform_message_id: &str,
+        _edit: &OutboundEdit,
+    ) -> AppResult<()> {
+        Err(crate::errors::AppError::ChannelPlatformEditUnsupported)
+    }
 
     /// Register a webhook URL with the platform API.
     async fn register_webhook(

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -131,6 +131,7 @@ pub async fn store_inbound_message(
         reply_to_message_id: None,
         platform_reply_message_id: None,
         created_at: Utc::now(),
+        updated_at: None,
     };
 
     db.collection::<ChannelMessage>(COLLECTION_NAME)
@@ -156,6 +157,7 @@ pub async fn store_outbound_message(
     reply_to_message_id: Option<&str>,
     platform_message_id: Option<&str>,
 ) -> AppResult<ChannelMessage> {
+    let now = Utc::now();
     let message = ChannelMessage {
         id: uuid::Uuid::new_v4().to_string(),
         channel_bot_id: Some(channel_bot_id.to_string()),
@@ -173,7 +175,8 @@ pub async fn store_outbound_message(
         callback_status: None,
         reply_to_message_id: reply_to_message_id.map(String::from),
         platform_reply_message_id: None,
-        created_at: Utc::now(),
+        created_at: now,
+        updated_at: Some(now),
     };
 
     db.collection::<ChannelMessage>(COLLECTION_NAME)
@@ -237,6 +240,7 @@ pub async fn store_device_event_message(
         reply_to_message_id: None,
         platform_reply_message_id: None,
         created_at: Utc::now(),
+        updated_at: None,
     };
 
     db.collection::<ChannelMessage>(COLLECTION_NAME)
@@ -388,6 +392,47 @@ pub async fn get_message(db: &mongodb::Database, message_id: &str) -> AppResult<
         .find_one(doc! { "_id": message_id })
         .await?
         .ok_or_else(|| AppError::NotFound(format!("Message not found: {message_id}")))
+}
+
+/// Get a single outbound message by its upstream platform message ID.
+pub async fn get_outbound_message_by_platform_id(
+    db: &mongodb::Database,
+    platform: &str,
+    platform_message_id: &str,
+) -> AppResult<ChannelMessage> {
+    db.collection::<ChannelMessage>(COLLECTION_NAME)
+        .find_one(doc! {
+            "platform": platform,
+            "platform_message_id": platform_message_id,
+            "direction": "outbound",
+        })
+        .await?
+        .ok_or_else(|| {
+            AppError::NotFound(format!("Outbound message not found: {platform_message_id}"))
+        })
+}
+
+/// Update the outbound row's `updated_at` timestamp after a successful edit.
+pub async fn update_outbound_message_timestamp(
+    db: &mongodb::Database,
+    message_id: &str,
+    updated_at: chrono::DateTime<Utc>,
+) -> AppResult<()> {
+    let result = db
+        .collection::<ChannelMessage>(COLLECTION_NAME)
+        .update_one(
+            doc! { "_id": message_id, "direction": "outbound" },
+            doc! { "$set": { "updated_at": mongodb::bson::DateTime::from_chrono(updated_at) } },
+        )
+        .await?;
+
+    if result.matched_count == 0 {
+        return Err(AppError::NotFound(format!(
+            "Outbound message not found: {message_id}"
+        )));
+    }
+
+    Ok(())
 }
 
 /// List messages for a conversation with pagination (newest first).
@@ -738,6 +783,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 5,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -807,6 +807,8 @@ mod tests {
             channel_relay_callback_timeout_secs: 30,
             channel_relay_max_bots_per_user: 5,
             channel_relay_message_ttl_days: 30,
+            channel_relay_edit_rate_limit_per_second: 10,
+            channel_relay_edit_rate_limit_burst: 20,
             channel_event_rate_limit_per_second: 100,
             channel_event_rate_limit_burst: 200,
             channel_event_dedup_capacity: 32_768,

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -115,6 +115,8 @@ pub(crate) fn test_app_config() -> AppConfig {
         channel_relay_callback_timeout_secs: 30,
         channel_relay_max_bots_per_user: 5,
         channel_relay_message_ttl_days: 30,
+        channel_relay_edit_rate_limit_per_second: 10,
+        channel_relay_edit_rate_limit_burst: 20,
         channel_event_rate_limit_per_second: 100,
         channel_event_rate_limit_burst: 200,
         channel_event_dedup_capacity: 32_768,
@@ -162,6 +164,10 @@ pub(crate) fn test_app_state(db: mongodb::Database) -> AppState {
         per_channel_event_limiter: Arc::new(crate::mw::rate_limit::PerChannelEventLimiter::new(
             config.channel_event_rate_limit_per_second,
             config.channel_event_rate_limit_burst,
+        )),
+        per_message_edit_limiter: Arc::new(crate::mw::rate_limit::PerMessageEditRateLimiter::new(
+            config.channel_relay_edit_rate_limit_per_second,
+            config.channel_relay_edit_rate_limit_burst,
         )),
         event_dedup_cache: Arc::new(EventDedupCache::new(
             config.channel_event_dedup_capacity,

--- a/skills/nyxid/SKILL.md
+++ b/skills/nyxid/SKILL.md
@@ -1155,6 +1155,12 @@ The callback payload includes normalized fields (`content.text`, `sender`, etc.)
 POST /api/v1/channel-relay/reply
 { "message_id": "<inbound-msg-id>", "reply": { "text": "..." } }
 
+# Edit a previously-sent reply (Lark/Feishu only in v1).
+# Addresses the upstream platform message returned by a prior /reply call
+# (e.g. Lark `om_xxx`). Same dual auth as /reply.
+POST /api/v1/channel-relay/reply/update
+{ "message_id": "<upstream_platform_message_id>", "reply": { "text": "..." } }
+
 # Message history (metadata only — `text` and `attachments` are NOT returned per ADR-013)
 GET /api/v1/channel-relay/messages/<conversation_id>?page=1&per_page=50
 
@@ -1162,17 +1168,30 @@ GET /api/v1/channel-relay/messages/<conversation_id>?page=1&per_page=50
 GET /api/v1/channel-relay/resolve-sender?platform=telegram&platform_id=12345
 ```
 
+#### Editing a sent reply (progressive / streaming renders)
+
+`POST /channel-relay/reply/update` lets an agent PATCH the text of a reply it already sent, which is how you implement progressive / streaming reply rendering on Lark/Feishu without flooding the chat with one message per token chunk.
+
+- **Body:** `{ "message_id": "<upstream_platform_message_id>", "reply": { "text": "...", "metadata": {...} } }`. `message_id` is the platform message id (e.g. Lark `om_xxx`) returned by the prior `/reply` call — **not** the inbound message id.
+- **Auth:** Same as `/reply`: agent API key OR the original per-callback reply token. The reply token is reusable for edits — see the reply-token section below for the JTI semantics.
+- **Platform support in v1:**
+  - Lark / Feishu: text edits via `PUT /im/v1/messages/{id}`, card edits via `PATCH /im/v1/messages/{id}` (pass the new card in `reply.metadata.card`).
+  - Telegram / Discord / Slack / OpenClaw: `501` with `code="edit_unsupported"`. Degrade to a final `/reply` at turn end.
+  - Device channels: `400 device_channel_reply_not_allowed` (device conversations have no reply surface).
+- **Throttling is the caller's job.** NyxID only protects against abuse — per-upstream-message rate limit (default `10/s` burst `20`, configurable via `CHANNEL_RELAY_EDIT_RATE_LIMIT_PER_SECOND` / `..._BURST`). `429 rate_limited` on exceed.
+- **Error classification:** Lark frequency-limit errors surface as `429`; "message not editable / wrong state" errors as `409`; malformed content as `400`. Anything else falls through to `502`.
+
 > **ADR-013 note:** `GET /channel-relay/messages/...` returns only routing metadata (direction, platform, sender ids, delivery status, timestamps). Agents that need conversation bodies must retain their own history.
 
-#### Reply token (dual-auth on `/channel-relay/reply`)
+#### Reply token (dual-auth on `/channel-relay/reply` and `/channel-relay/reply/update`)
 
 The callback payload includes a short-lived `reply_token` (RS256 JWT) the agent can present as `Authorization: Bearer <reply_token>` instead of the agent API key. Intended for runtimes that don't want to persist agent credentials (e.g. Aevatar).
 
 - **Shape:** RS256 JWT. `aud = "channel-relay/reply"` (rejected everywhere else). `token_type = "relay_reply"`.
-- **Claim bindings:** `api_key_id`, `conversation_id`, `inbound_message_id`, `platform` — all four must match the reply request, and the request body's `message_id` must equal `inbound_message_id`.
+- **Claim bindings:** `api_key_id`, `conversation_id`, `inbound_message_id`, `platform` — all four must match the reply request. For `/reply`, the body's `message_id` must equal `inbound_message_id`. For `/reply/update`, NyxID looks up the outbound row by the body's `message_id` (platform id) and verifies its stored `reply_to_message_id` equals the token's `inbound_message_id`.
 - **TTL:** `JWT_RELAY_REPLY_TTL_SECS` (default `1800` = 30 min). 60s clock-skew tolerance on both `iat` and `exp`.
-- **Single-use:** `jti` is consumed on first successful reply; reuse returns `401 "Reply token already used"`.
-- **Revocation coupling:** On every reply NyxID re-checks that the bound `api_key_id` (and the channel bot) is still active — revoking the key invalidates all outstanding tokens immediately.
+- **JTI semantics:** `jti` is consumed on the first successful `/reply`. Reuse on `/reply` returns `401 "Reply token already used"`. `/reply/update` uses the same token without consuming a new JTI — it requires the JTI to already exist in `reply_token_uses` (i.e. proof the token was used to send), so bare-minted tokens cannot edit-flood. The same token can therefore drive one send + many edits within the TTL.
+- **Revocation coupling:** On every call NyxID re-checks that the bound `api_key_id` (and the channel bot) is still active — revoking the key invalidates all outstanding tokens immediately.
 - **Null tokens:** If NyxID failed to mint a token, `reply_token` is `null` in the callback; fall back to the agent API key on the reply call.
 
 Agents that already hold the API key can ignore `reply_token` entirely and keep using `Authorization: Bearer nyxid_ag_...`.


### PR DESCRIPTION
## Summary

Brings `feat/cli-remote-pairing` up to date with current `main`. Resolves the one conflict (`CLAUDE.md`); all other files auto-merged cleanly. After this lands, PR #438 becomes mergeable again.

## Why the conflict

PR #438's base is `main`. Main moved forward with commit `7d3ea8c` ("feat(channel-relay): add edit-message endpoint for progressive replies") which added 5 `CHANNEL_RELAY_*` env-var docs. Meanwhile the PR branch previously added `TRUSTED_PROXY_IPS` + `CLI_PAIRING_HMAC_KEY` docs at the same insertion point (right after `RATE_LIMIT_BURST=30`).

Both sides are purely additive — neither deletes or overrides anything from the other. Git couldn't auto-merge because both inserted at the same line with no pre-existing lines to anchor ordering.

## What each side added

**From `main` (`7d3ea8c`):**
```
CHANNEL_RELAY_CALLBACK_TIMEOUT_SECS=30
CHANNEL_RELAY_MAX_BOTS_PER_USER=5
CHANNEL_RELAY_MESSAGE_TTL_DAYS=30
CHANNEL_RELAY_EDIT_RATE_LIMIT_PER_SECOND=10     # new
CHANNEL_RELAY_EDIT_RATE_LIMIT_BURST=20          # new
```

**From `feat/cli-remote-pairing` (`f36d314` + `1c929a9`):**
```
TRUSTED_PROXY_IPS=  (with full doc block on per-IP rate-limit keying)
# CLI remote pairing (optional)
CLI_PAIRING_HMAC_KEY=  (with full doc block on key derivation)
```

## Resolution

Concatenate both blocks:
1. PR branch's `TRUSTED_PROXY_IPS` first — it sits directly after `RATE_LIMIT_BURST=30` as a rate-limit extension.
2. `# CLI remote pairing (optional)` subsection with `CLI_PAIRING_HMAC_KEY` (preserved exactly as PR branch authored).
3. New section header `# Channel Relay (optional, all have defaults)` — documentation-only aid consistent with the file's existing convention (`# Credential Nodes (optional, all have defaults)`, `# Mobile Push Notifications (optional)`, etc.). Without it, the 5 `CHANNEL_RELAY_*` vars would be an unlabeled block between two labeled sections.
4. Main's 5 `CHANNEL_RELAY_*` vars preserved verbatim under the new header.

All env-var additions preserved verbatim from both sides. The new section header is the only non-verbatim addition.

## Rejected alternatives

- **Main's block first** — would put `CHANNEL_RELAY_*` between `RATE_LIMIT_BURST` and `TRUSTED_PROXY_IPS`, breaking the rate-limit adjacency.
- **Move `CHANNEL_RELAY_*` down next to `CHANNEL_EVENT_*` (~30 lines later)** — thematic grouping win, but rearranges main's work. Outside merge-resolution scope; can happen in a follow-up if anyone cares.

## Cross-check

Both myself and Codex (consult mode, adversarial review) reviewed the resolution and agree on all five pressure-test questions:
- Verbatim preservation ✅
- Section header justified ✅
- Ordering sound ✅
- No scope creep beyond the header ✅
- No structural regression elsewhere ✅

Codex quote: *"agree with your approach. I would commit this resolution as-is."*

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets` ✅ (no errors, no warnings)
- All local pre-commit hooks green

## Test plan

- [ ] After merge, PR #438's `mergeStateStatus` flips from `DIRTY` → `CLEAN`
- [ ] All CI checks on PR #438 remain green (this PR touches only `CLAUDE.md` + whatever main auto-merged)
- [ ] Reviewer sanity-check the `CLAUDE.md` resolved block at lines ~322-362