### PR TITLE
docs(readme): update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ChronoAIProject/NyxID)](https://github.com/ChronoAIProject/NyxID)
-[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/fQw5Nep9)
+[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/QMvcs8UQBW)
 
 <p align="center">
   <img src="assets/banner.png" alt="NyxID — Connect AI agents to any API, anywhere. Securely." width="100%">


### PR DESCRIPTION
## Summary
- Update the Discord badge link in `README.md` to the new invite URL `https://discord.gg/QMvcs8UQBW`.

## Test plan
- [x] Verified diff is limited to the Discord invite URL on README.md:3
- [ ] Confirm the new invite resolves to the intended NyxID Discord server

🤖 Generated with [Claude Code](https://claude.com/claude-code)