### PR TITLE
chore(frontend): update landing footer Discord invite link

### DIFF
--- a/frontend/src/features/landing/components/landing-footer.tsx
+++ b/frontend/src/features/landing/components/landing-footer.tsx
@@ -7,7 +7,7 @@ export function LandingFooter() {
         </p>
         <div className="flex items-center gap-4">
           <a
-            href="https://discord.gg/MB5bRa4arr"
+            href="https://discord.gg/QMvcs8UQBW"
             target="_blank"
             rel="noopener noreferrer"
             className="text-gray-500 transition-colors hover:text-white"


### PR DESCRIPTION
## Summary
- Update the Discord icon link in the landing footer (`frontend/src/features/landing/components/landing-footer.tsx`) to the new invite URL `https://discord.gg/QMvcs8UQBW`.
- Companion to #526, which updates the README badge to the same invite.

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [ ] Visit the landing page and click the Discord icon — confirm it opens the new invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)