### PR TITLE
feat: surface viewer node routing on /services and /keys (#416)

### DIFF
--- a/backend/src/handlers/services.rs
+++ b/backend/src/handlers/services.rs
@@ -25,8 +25,8 @@ use crate::services::{api_docs_service, audit_service, oauth_client_service, ssh
 use crate::telemetry::{TelemetryContext, TelemetryEvent, emit_event};
 
 use super::services_helpers::{
-    DeleteServiceResponse, fetch_service, require_admin_or_creator, service_to_response,
-    validate_developer_app_ids,
+    DeleteServiceResponse, compute_viewer_routing, fetch_service, require_admin_or_creator,
+    service_to_response_with_viewer, validate_developer_app_ids,
 };
 
 // --- Request / Response types ---
@@ -187,6 +187,33 @@ pub struct ServiceResponse {
     pub created_by: String,
     pub created_at: String,
     pub updated_at: String,
+
+    // -- Viewer-scoped routing fields (issue #416) --
+    //
+    // These three fields describe **the current viewer's** personal
+    // `UserService` binding for this catalog row -- not a property of the
+    // catalog itself. They let the admin `/services` UI render the same
+    // routing UX as `/keys` without picking arbitrarily when the viewer
+    // has 0 or many bindings.
+    //
+    // Read-only mirror; mutations go through `PUT /api/v1/keys/{id}`
+    // using `your_user_service_id` as the path parameter.
+    /// Viewer's current `UserService.node_id` for this catalog row, or
+    /// `None` when the viewer has no personal binding (or has multiple
+    /// and no single answer applies; see `your_binding_count`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    /// Viewer's `UserService._id` for this catalog row, used as the
+    /// mutation target by the editable Routing UI. `None` when the
+    /// viewer has zero or multiple personal bindings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub your_user_service_id: Option<String>,
+    /// Number of personal `UserService` rows the viewer owns for this
+    /// catalog row. `0` = no binding (UI offers a "Bind" CTA), `1` =
+    /// editable single binding, `>=2` = multiple bindings (UI offers a
+    /// "manage in AI Services" link instead of picking one silently).
+    #[serde(default)]
+    pub your_binding_count: u32,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -562,7 +589,19 @@ pub async fn list_services(
         .try_collect()
         .await?;
 
-    let items: Vec<ServiceResponse> = services.into_iter().map(service_to_response).collect();
+    // Issue #416: batch-resolve the viewer's personal `UserService`
+    // bindings for these catalog rows so the FE can render an editable
+    // Routing section on the admin /services list/detail surfaces.
+    let catalog_ids: Vec<&str> = services.iter().map(|s| s.id.as_str()).collect();
+    let mut viewer_routing = compute_viewer_routing(&state.db, &user_id_str, &catalog_ids).await?;
+
+    let items: Vec<ServiceResponse> = services
+        .into_iter()
+        .map(|svc| {
+            let routing = viewer_routing.remove(&svc.id);
+            service_to_response_with_viewer(svc, routing.as_ref())
+        })
+        .collect();
 
     Ok(Json(ServiceListResponse { services: items }))
 }
@@ -1004,7 +1043,10 @@ pub async fn create_service(
         },
     );
 
-    Ok(Json(service_to_response(new_service)))
+    // Brand-new catalog row -- no `UserService` can reference it yet,
+    // so the viewer-routing fields default to "no binding" without a
+    // lookup query.
+    Ok(Json(service_to_response_with_viewer(new_service, None)))
 }
 
 /// DELETE /api/v1/services/:service_id
@@ -1130,11 +1172,20 @@ pub async fn delete_service(
 )]
 pub async fn get_service(
     State(state): State<AppState>,
-    _auth_user: AuthUser,
+    auth_user: AuthUser,
     Path(service_id): Path<String>,
 ) -> AppResult<Json<ServiceResponse>> {
     let service = fetch_service(&state, &service_id).await?;
-    Ok(Json(service_to_response(service)))
+    let viewer_id = auth_user.user_id.to_string();
+    // Issue #416: surface the viewer's own routing for this catalog row
+    // so /services/$id can render the editable Routing section.
+    let mut viewer_routing =
+        compute_viewer_routing(&state.db, &viewer_id, &[service.id.as_str()]).await?;
+    let routing = viewer_routing.remove(&service.id);
+    Ok(Json(service_to_response_with_viewer(
+        service,
+        routing.as_ref(),
+    )))
 }
 
 /// PUT /api/v1/services/{service_id}
@@ -1821,7 +1872,17 @@ pub async fn update_service(
         },
     );
 
-    Ok(Json(service_to_response(updated)))
+    // Issue #416: include the actor's own routing for response shape
+    // parity with GET / list (the actor may already have a personal
+    // binding for this catalog row).
+    let actor_id = auth_user.user_id.to_string();
+    let mut viewer_routing =
+        compute_viewer_routing(&state.db, &actor_id, &[updated.id.as_str()]).await?;
+    let routing = viewer_routing.remove(&updated.id);
+    Ok(Json(service_to_response_with_viewer(
+        updated,
+        routing.as_ref(),
+    )))
 }
 
 /// GET /api/v1/services/{service_id}/oidc-credentials

--- a/backend/src/handlers/services_helpers.rs
+++ b/backend/src/handlers/services_helpers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use mongodb::bson::doc;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -12,11 +14,107 @@ use crate::models::downstream_service::{
 use crate::models::oauth_client::{COLLECTION_NAME as OAUTH_CLIENTS, OauthClient};
 use crate::models::user::{COLLECTION_NAME as USERS, User};
 use crate::models::user_endpoint::{COLLECTION_NAME as USER_ENDPOINTS, UserEndpoint};
-use crate::models::user_service::UserService;
+use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
 use crate::mw::auth::AuthUser;
 use crate::services::{org_service, user_service_service};
 
 use super::services::{ServiceResponse, SshServiceConfigResponse};
+
+/// Per-viewer routing summary for a single catalog `DownstreamService`.
+///
+/// Resolved from the viewer's personal `UserService` rows (rows where
+/// `user_id == viewer_user_id`). Org-shared bindings are intentionally
+/// excluded -- editing those silently from a catalog page would leak
+/// across org boundaries.
+#[derive(Clone, Debug, Default)]
+pub struct ViewerRouting {
+    pub node_id: Option<String>,
+    pub user_service_id: Option<String>,
+    pub binding_count: u32,
+}
+
+impl ViewerRouting {
+    /// `binding_count == 1` -- safe to populate `node_id` /
+    /// `your_user_service_id` on the response. Zero or many bindings
+    /// leave both flat fields unset; the FE renders the corresponding
+    /// empty / disambiguation state from `binding_count` alone.
+    fn single(node_id: Option<String>, user_service_id: String) -> Self {
+        Self {
+            node_id,
+            user_service_id: Some(user_service_id),
+            binding_count: 1,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            node_id: None,
+            user_service_id: None,
+            binding_count: 0,
+        }
+    }
+
+    fn ambiguous(count: u32) -> Self {
+        Self {
+            node_id: None,
+            user_service_id: None,
+            binding_count: count,
+        }
+    }
+}
+
+/// Batch-resolve the viewer's personal routing for a set of catalog
+/// `DownstreamService` ids in a single MongoDB query.
+///
+/// Returns a `HashMap<catalog_service_id, ViewerRouting>` for every
+/// catalog id passed in (missing entries are treated as
+/// `ViewerRouting::empty()` by the caller via `.unwrap_or_default()`).
+pub async fn compute_viewer_routing(
+    db: &mongodb::Database,
+    viewer_user_id: &str,
+    catalog_service_ids: &[&str],
+) -> AppResult<HashMap<String, ViewerRouting>> {
+    if catalog_service_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let id_strings: Vec<String> = catalog_service_ids.iter().map(|s| s.to_string()).collect();
+    let user_services: Vec<UserService> = db
+        .collection::<UserService>(USER_SERVICES)
+        .find(doc! {
+            "user_id": viewer_user_id,
+            "catalog_service_id": { "$in": &id_strings },
+        })
+        .await?
+        .try_collect()
+        .await?;
+
+    // Group by catalog_service_id so we can detect "multiple bindings".
+    let mut grouped: HashMap<String, Vec<UserService>> = HashMap::new();
+    for us in user_services {
+        let Some(catalog_id) = us.catalog_service_id.clone() else {
+            continue;
+        };
+        grouped.entry(catalog_id).or_default().push(us);
+    }
+
+    let mut out = HashMap::with_capacity(grouped.len());
+    for (catalog_id, mut bindings) in grouped {
+        let entry = match bindings.len() {
+            0 => ViewerRouting::empty(),
+            1 => {
+                let us = bindings.pop().unwrap();
+                ViewerRouting::single(us.node_id.clone(), us.id)
+            }
+            // Don't pick arbitrarily when the viewer has multiple
+            // personal bindings -- the FE shows a disambiguation hint.
+            n => ViewerRouting::ambiguous(u32::try_from(n).unwrap_or(u32::MAX)),
+        };
+        out.insert(catalog_id, entry);
+    }
+
+    Ok(out)
+}
 
 /// Verify that the authenticated user has admin privileges.
 pub async fn require_admin(state: &AppState, auth_user: &AuthUser) -> AppResult<()> {
@@ -126,7 +224,17 @@ pub async fn resolve_service_or_user_service(
 }
 
 /// Build a `ServiceResponse` from a `DownstreamService` model.
-pub fn service_to_response(s: DownstreamService) -> ServiceResponse {
+///
+/// `viewer` carries the viewer's personal routing for this catalog row
+/// (issue #416). Pass `None` for handlers that don't have viewer
+/// context or know the result will always be "no binding" (e.g.
+/// the create handler, where the catalog row didn't exist a moment
+/// ago). See [`compute_viewer_routing`] for batched resolution and
+/// [`ViewerRouting`] for the multi-binding semantics.
+pub fn service_to_response_with_viewer(
+    s: DownstreamService,
+    viewer: Option<&ViewerRouting>,
+) -> ServiceResponse {
     ServiceResponse {
         id: s.id,
         name: s.name,
@@ -180,6 +288,9 @@ pub fn service_to_response(s: DownstreamService) -> ServiceResponse {
         created_by: s.created_by,
         created_at: s.created_at.to_rfc3339(),
         updated_at: s.updated_at.to_rfc3339(),
+        node_id: viewer.and_then(|v| v.node_id.clone()),
+        your_user_service_id: viewer.and_then(|v| v.user_service_id.clone()),
+        your_binding_count: viewer.map_or(0, |v| v.binding_count),
     }
 }
 
@@ -432,5 +543,249 @@ mod tests {
             .expect_err("missing service should 404");
 
         assert!(matches!(err, AppError::NotFound(message) if message == "Service not found"));
+    }
+
+    // ----------------------------------------------------------------
+    // Issue #416: viewer-scoped routing lookup for /services responses
+    // ----------------------------------------------------------------
+
+    use super::compute_viewer_routing;
+
+    /// Empty input -> empty result; no DB hit needed.
+    #[tokio::test]
+    async fn viewer_routing_short_circuits_on_empty_input() {
+        let Some(db) = connect_test_database("viewer_routing_empty").await else {
+            eprintln!("skipping services_helpers integration test: no local MongoDB available");
+            return;
+        };
+        let viewer_id = Uuid::new_v4().to_string();
+        let routing = compute_viewer_routing(&db, &viewer_id, &[]).await.unwrap();
+        assert!(routing.is_empty());
+    }
+
+    /// No personal binding for the viewer -> map omits the catalog id
+    /// (the caller's `.unwrap_or_default()` then renders count=0).
+    #[tokio::test]
+    async fn viewer_routing_no_binding() {
+        let Some(db) = connect_test_database("viewer_routing_zero").await else {
+            eprintln!("skipping services_helpers integration test: no local MongoDB available");
+            return;
+        };
+        let viewer_id = Uuid::new_v4().to_string();
+        let catalog_id = Uuid::new_v4().to_string();
+
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&viewer_id, UserType::Person))
+            .await
+            .unwrap();
+
+        let routing = compute_viewer_routing(&db, &viewer_id, &[catalog_id.as_str()])
+            .await
+            .unwrap();
+        assert!(!routing.contains_key(&catalog_id));
+    }
+
+    /// Single personal binding routed via a node -> all three fields
+    /// populated (`node_id`, `your_user_service_id`, count=1).
+    #[tokio::test]
+    async fn viewer_routing_single_binding_via_node() {
+        let Some(db) = connect_test_database("viewer_routing_single_via").await else {
+            eprintln!("skipping services_helpers integration test: no local MongoDB available");
+            return;
+        };
+        let viewer_id = Uuid::new_v4().to_string();
+        let catalog_id = Uuid::new_v4().to_string();
+        let node_id = Uuid::new_v4().to_string();
+        let endpoint = test_user_endpoint(
+            &Uuid::new_v4().to_string(),
+            &viewer_id,
+            "Bound",
+            "https://bound.example.com",
+            None,
+            None,
+        );
+        let us = test_user_service(
+            &Uuid::new_v4().to_string(),
+            &viewer_id,
+            "bound",
+            &endpoint.id,
+            Some(&catalog_id),
+            Some(&node_id),
+        );
+
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&viewer_id, UserType::Person))
+            .await
+            .unwrap();
+        db.collection::<UserEndpoint>(USER_ENDPOINTS)
+            .insert_one(endpoint)
+            .await
+            .unwrap();
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(us.clone())
+            .await
+            .unwrap();
+
+        let routing = compute_viewer_routing(&db, &viewer_id, &[catalog_id.as_str()])
+            .await
+            .unwrap();
+        let entry = routing.get(&catalog_id).expect("entry present");
+        assert_eq!(entry.node_id.as_deref(), Some(node_id.as_str()));
+        assert_eq!(entry.user_service_id.as_deref(), Some(us.id.as_str()));
+        assert_eq!(entry.binding_count, 1);
+    }
+
+    /// Single personal binding with direct routing -> `node_id` is
+    /// `None` but `your_user_service_id` is populated (admin can still
+    /// edit via the RoutingSection).
+    #[tokio::test]
+    async fn viewer_routing_single_binding_direct() {
+        let Some(db) = connect_test_database("viewer_routing_single_direct").await else {
+            eprintln!("skipping services_helpers integration test: no local MongoDB available");
+            return;
+        };
+        let viewer_id = Uuid::new_v4().to_string();
+        let catalog_id = Uuid::new_v4().to_string();
+        let endpoint = test_user_endpoint(
+            &Uuid::new_v4().to_string(),
+            &viewer_id,
+            "Direct",
+            "https://direct.example.com",
+            None,
+            None,
+        );
+        let us = test_user_service(
+            &Uuid::new_v4().to_string(),
+            &viewer_id,
+            "direct",
+            &endpoint.id,
+            Some(&catalog_id),
+            None,
+        );
+
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&viewer_id, UserType::Person))
+            .await
+            .unwrap();
+        db.collection::<UserEndpoint>(USER_ENDPOINTS)
+            .insert_one(endpoint)
+            .await
+            .unwrap();
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(us.clone())
+            .await
+            .unwrap();
+
+        let routing = compute_viewer_routing(&db, &viewer_id, &[catalog_id.as_str()])
+            .await
+            .unwrap();
+        let entry = routing.get(&catalog_id).expect("entry present");
+        assert!(entry.node_id.is_none());
+        assert_eq!(entry.user_service_id.as_deref(), Some(us.id.as_str()));
+        assert_eq!(entry.binding_count, 1);
+    }
+
+    /// Multiple personal bindings -> count >= 2, neither flat field
+    /// populated (FE shows a "manage in AI Services" link instead of
+    /// silently picking one).
+    #[tokio::test]
+    async fn viewer_routing_multiple_bindings_dont_pick() {
+        let Some(db) = connect_test_database("viewer_routing_multi").await else {
+            eprintln!("skipping services_helpers integration test: no local MongoDB available");
+            return;
+        };
+        let viewer_id = Uuid::new_v4().to_string();
+        let catalog_id = Uuid::new_v4().to_string();
+
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&viewer_id, UserType::Person))
+            .await
+            .unwrap();
+
+        for slug in ["binding-a", "binding-b"] {
+            let endpoint = test_user_endpoint(
+                &Uuid::new_v4().to_string(),
+                &viewer_id,
+                slug,
+                "https://multi.example.com",
+                None,
+                None,
+            );
+            let us = test_user_service(
+                &Uuid::new_v4().to_string(),
+                &viewer_id,
+                slug,
+                &endpoint.id,
+                Some(&catalog_id),
+                None,
+            );
+            db.collection::<UserEndpoint>(USER_ENDPOINTS)
+                .insert_one(endpoint)
+                .await
+                .unwrap();
+            db.collection::<UserService>(USER_SERVICES)
+                .insert_one(us)
+                .await
+                .unwrap();
+        }
+
+        let routing = compute_viewer_routing(&db, &viewer_id, &[catalog_id.as_str()])
+            .await
+            .unwrap();
+        let entry = routing.get(&catalog_id).expect("entry present");
+        assert!(entry.node_id.is_none());
+        assert!(entry.user_service_id.is_none());
+        assert_eq!(entry.binding_count, 2);
+    }
+
+    /// Org-shared binding (different `user_id`) doesn't surface for the
+    /// admin viewing the catalog -- editing org state from the catalog
+    /// page would leak across org boundaries.
+    #[tokio::test]
+    async fn viewer_routing_excludes_org_shared_bindings() {
+        let Some(db) = connect_test_database("viewer_routing_org_only").await else {
+            eprintln!("skipping services_helpers integration test: no local MongoDB available");
+            return;
+        };
+        let viewer_id = Uuid::new_v4().to_string();
+        let org_id = Uuid::new_v4().to_string();
+        let catalog_id = Uuid::new_v4().to_string();
+        let endpoint = test_user_endpoint(
+            &Uuid::new_v4().to_string(),
+            &org_id,
+            "Org",
+            "https://org.example.com",
+            None,
+            None,
+        );
+        let us = test_user_service(
+            &Uuid::new_v4().to_string(),
+            &org_id,
+            "org",
+            &endpoint.id,
+            Some(&catalog_id),
+            Some(&Uuid::new_v4().to_string()),
+        );
+
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_many([
+                test_user(&viewer_id, UserType::Person),
+                test_user(&org_id, UserType::Person),
+            ])
+            .await
+            .unwrap();
+        db.collection::<UserEndpoint>(USER_ENDPOINTS)
+            .insert_one(endpoint)
+            .await
+            .unwrap();
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(us)
+            .await
+            .unwrap();
+
+        let routing = compute_viewer_routing(&db, &viewer_id, &[catalog_id.as_str()])
+            .await
+            .unwrap();
+        assert!(!routing.contains_key(&catalog_id));
     }
 }

--- a/frontend/src/components/dashboard/routing-section.tsx
+++ b/frontend/src/components/dashboard/routing-section.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { Router } from "lucide-react";
+import { toast } from "sonner";
+
+import { useNodes } from "@/hooks/use-nodes";
+import { useUpdateUserService } from "@/hooks/use-keys";
+import { ApiError } from "@/lib/api-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface RoutingSectionProps {
+  /** The viewer's `UserService.node_id` for this binding (or `null` for direct routing). */
+  readonly nodeId: string | null;
+  /** The `UserService._id` to mutate via `PUT /api/v1/keys/{id}`. */
+  readonly serviceId: string;
+  readonly readOnly?: boolean;
+  /**
+   * Card title. Defaults to `"Routing"` (the original key-detail
+   * wording). The admin services surface uses `"Your Routing"` to
+   * signal viewer-scoped semantics — same data, different label.
+   */
+  readonly title?: string;
+  /** Card description. Defaults match the original key-detail copy. */
+  readonly description?: string;
+}
+
+/**
+ * Editable routing section for a single `UserService` (issue #416).
+ *
+ * Reused by `/keys/$id` (the original surface) and `/services/$id`
+ * (the admin surface). The mutation always targets the underlying
+ * `UserService` regardless of which page hosts the component, so
+ * routing changes stay consistent across surfaces.
+ */
+export function RoutingSection({
+  nodeId,
+  serviceId,
+  readOnly = false,
+  title = "Routing",
+  description = "How requests reach the endpoint",
+}: RoutingSectionProps) {
+  const [picking, setPicking] = useState(false);
+  const { data: nodes } = useNodes();
+  const updateService = useUpdateUserService();
+
+  function handleSelectNode(selectedNodeId: string) {
+    const id = selectedNodeId === "direct" ? "" : selectedNodeId;
+    updateService.mutate(
+      { serviceId, node_id: id },
+      {
+        onSuccess: () => {
+          toast.success(id ? "Route updated" : "Switched to direct routing");
+          setPicking(false);
+        },
+        onError: (err) => {
+          const message =
+            err instanceof ApiError ? err.message : "Failed to update routing";
+          toast.error(message);
+        },
+      },
+    );
+  }
+
+  const allNodes = nodes ?? [];
+  const currentNodeName = nodeId
+    ? (nodes?.find((n) => n.id === nodeId)?.name ?? nodeId)
+    : null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Router className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm">{title}</CardTitle>
+        </div>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Badge variant={nodeId ? "default" : "outline"}>
+            {nodeId ? `Via node: ${currentNodeName}` : "Direct"}
+          </Badge>
+        </div>
+
+        {!readOnly && picking ? (
+          <div className="space-y-2">
+            <Label className="text-xs">Select routing</Label>
+            <Select
+              onValueChange={handleSelectNode}
+              defaultValue={nodeId ?? "direct"}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select routing" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="direct">Direct (no node)</SelectItem>
+                {allNodes.map((n) => (
+                  <SelectItem
+                    key={n.id}
+                    value={n.id}
+                    disabled={n.status !== "online"}
+                  >
+                    {n.name} ({n.status})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {allNodes.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                No nodes registered. Register a node first.
+              </p>
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setPicking(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : !readOnly ? (
+          <Button size="sm" variant="outline" onClick={() => setPicking(true)}>
+            {nodeId ? "Change Route" : "Route via Node"}
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/service-card.tsx
+++ b/frontend/src/components/dashboard/service-card.tsx
@@ -5,9 +5,15 @@ import {
   isOidcService,
   SERVICE_TYPE_LABELS,
 } from "@/lib/constants";
+import { useNodes } from "@/hooks/use-nodes";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Lock, Trash2 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Lock, Router, Trash2 } from "lucide-react";
 
 interface ServiceCardProps {
   readonly service: DownstreamService;
@@ -22,6 +28,18 @@ export function ServiceCard({
   isDeleting,
 }: ServiceCardProps) {
   const navigate = useNavigate();
+  // Issue #416: surface the viewer's node binding for this catalog row
+  // so admins can see at a glance which service routes through which
+  // node without opening each detail page. Multiple cards on one page
+  // share a single `useNodes()` query via TanStack Query's dedupe.
+  const { data: nodes } = useNodes();
+  const node = service.node_id
+    ? nodes?.find((n) => n.id === service.node_id)
+    : undefined;
+  const nodeLabel = service.node_id
+    ? (node?.name ?? service.node_id.slice(0, 8))
+    : null;
+
   const secondaryLabel =
     service.service_type === "ssh"
       ? `${service.ssh_config?.host ?? "ssh"}:${String(service.ssh_config?.port ?? 22)}`
@@ -81,8 +99,32 @@ export function ServiceCard({
         </p>
       )}
 
-      {/* Target */}
-      <span className="text-xs text-text-tertiary">{secondaryLabel}</span>
+      {/* Target + Routing */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-text-tertiary">{secondaryLabel}</span>
+        {nodeLabel && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* asChild + span keeps Radix happy without nesting buttons. */}
+              <span className="inline-flex">
+                <Badge
+                  variant={node?.status === "online" ? "default" : "outline"}
+                  className="gap-1"
+                >
+                  <Router className="h-2.5 w-2.5" />
+                  <span>&rarr; {nodeLabel}</span>
+                </Badge>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="text-xs">
+                Your routing: {node?.name ?? service.node_id}
+                {node?.status ? ` (${node.status})` : ""}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/key-detail.tsx
+++ b/frontend/src/pages/key-detail.tsx
@@ -24,6 +24,7 @@ import { copyToClipboard } from "@/lib/utils";
 import { PageHeader } from "@/components/shared/page-header";
 import { Breadcrumb } from "@/components/shared/breadcrumb";
 import { SshServiceInstructions } from "@/components/dashboard/ssh-service-instructions";
+import { RoutingSection } from "@/components/dashboard/routing-section";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -37,13 +38,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -55,7 +49,6 @@ import {
   Globe,
   KeyRound,
   Server,
-  Router,
   Pencil,
   Trash2,
   RefreshCw,
@@ -672,103 +665,9 @@ function ServiceSection({
   );
 }
 
-function RoutingSection({
-  nodeId,
-  serviceId,
-  readOnly = false,
-}: {
-  readonly nodeId: string | null;
-  readonly serviceId: string;
-  readonly readOnly?: boolean;
-}) {
-  const [picking, setPicking] = useState(false);
-  const { data: nodes } = useNodes();
-  const updateService = useUpdateUserService();
-
-  function handleSelectNode(selectedNodeId: string) {
-    const id = selectedNodeId === "direct" ? "" : selectedNodeId;
-    updateService.mutate(
-      { serviceId, node_id: id },
-      {
-        onSuccess: () => {
-          toast.success(id ? "Route updated" : "Switched to direct routing");
-          setPicking(false);
-        },
-        onError: (err) => {
-          const message =
-            err instanceof ApiError ? err.message : "Failed to update routing";
-          toast.error(message);
-        },
-      },
-    );
-  }
-
-  const allNodes = nodes ?? [];
-  const currentNodeName = nodeId
-    ? (nodes?.find((n) => n.id === nodeId)?.name ?? nodeId)
-    : null;
-
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center gap-2">
-          <Router className="h-4 w-4 text-primary" />
-          <CardTitle className="text-sm">Routing</CardTitle>
-        </div>
-        <CardDescription>How requests reach the endpoint</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Badge variant={nodeId ? "default" : "outline"}>
-            {nodeId ? `Via node: ${currentNodeName}` : "Direct"}
-          </Badge>
-        </div>
-
-        {!readOnly && picking ? (
-          <div className="space-y-2">
-            <Label className="text-xs">Select routing</Label>
-            <Select
-              onValueChange={handleSelectNode}
-              defaultValue={nodeId ?? "direct"}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select routing" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="direct">Direct (no node)</SelectItem>
-                {allNodes.map((n) => (
-                  <SelectItem
-                    key={n.id}
-                    value={n.id}
-                    disabled={n.status !== "online"}
-                  >
-                    {n.name} ({n.status})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {allNodes.length === 0 && (
-              <p className="text-xs text-muted-foreground">
-                No nodes registered. Register a node first.
-              </p>
-            )}
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setPicking(false)}
-            >
-              Cancel
-            </Button>
-          </div>
-        ) : !readOnly ? (
-          <Button size="sm" variant="outline" onClick={() => setPicking(true)}>
-            {nodeId ? "Change Route" : "Route via Node"}
-          </Button>
-        ) : null}
-      </CardContent>
-    </Card>
-  );
-}
+// `RoutingSection` lives in `components/dashboard/routing-section.tsx`
+// so the admin `/services/$id` page can reuse the same editable widget
+// (issue #416). Imported at the top of this file.
 
 function NodeSetupHelper({
   slug,
@@ -1545,6 +1444,15 @@ export function KeyDetailPage() {
     readonly message?: string;
   };
   const { data: keyInfo, isLoading, error } = useKey(keyId);
+  // Issue #416: resolve the bound node's name so the auto-connected
+  // detail branch can show real routing instead of a hardcoded
+  // "Direct" label. Auto-connected services don't expose a routing
+  // editor (they're platform-managed), so this stays read-only here.
+  const { data: nodes } = useNodes();
+  const nodeName = keyInfo?.node_id
+    ? (nodes?.find((n) => n.id === keyInfo.node_id)?.name ??
+      keyInfo.node_id.slice(0, 8))
+    : null;
   // Fetch the catalog entry by slug directly instead of scanning the
   // filtered `/catalog` listing. The list endpoint hides no-auth /
   // internal services that don't need credential setup, but a key can
@@ -1762,7 +1670,16 @@ export function KeyDetailPage() {
                   <span className="text-xs font-medium text-muted-foreground">
                     Routing
                   </span>
-                  <p className="text-xs">Direct</p>
+                  {/*
+                    Issue #416: read the actual routing rather than
+                    hardcoding "Direct". Auto-connected keys are
+                    platform-managed so the editor stays absent here,
+                    but the display now reflects reality if the key
+                    happens to be node-routed.
+                  */}
+                  <p className="text-xs">
+                    {nodeName ? `Via ${nodeName}` : "Direct"}
+                  </p>
                 </div>
               </div>
             </CardContent>

--- a/frontend/src/pages/keys.tsx
+++ b/frontend/src/pages/keys.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import { useNodes } from "@/hooks/use-nodes";
 import { AddKeyDialog } from "@/components/dashboard/add-key-dialog";
 import { ApiKeyTable } from "@/components/dashboard/api-key-table";
 import { ApiKeyCreateDialog } from "@/components/dashboard/api-key-create-dialog";
@@ -57,6 +58,14 @@ interface KeyCardProps {
 function KeyCardContent({ keyInfo, source }: KeyCardProps) {
   const isSsh = keyInfo.service_type === "ssh";
   const hasSshCertificateAuth = isSsh && keyInfo.ssh_ca_public_key !== null;
+  // Issue #416: resolve the bound node's name so the list card shows
+  // "Via my-node" instead of bare "Via node". TanStack Query dedupes
+  // the request across all rendered cards.
+  const { data: nodes } = useNodes();
+  const nodeName = keyInfo.node_id
+    ? (nodes?.find((n) => n.id === keyInfo.node_id)?.name ??
+      keyInfo.node_id.slice(0, 8))
+    : null;
   const displayUrl = isSsh
     ? `${keyInfo.ssh_host ?? "unknown"}:${keyInfo.ssh_port ?? 22}`
     : keyInfo.endpoint_url.length > 50
@@ -160,7 +169,9 @@ function KeyCardContent({ keyInfo, source }: KeyCardProps) {
           </div>
           <div className="flex items-center gap-1.5">
             <Router className="h-3 w-3 shrink-0" />
-            <span>{keyInfo.node_id ? "Via node" : "Direct"}</span>
+            <span className="truncate">
+              {nodeName ? `→ ${nodeName}` : "Direct"}
+            </span>
           </div>
         </div>
       </CardContent>

--- a/frontend/src/pages/service-detail.tsx
+++ b/frontend/src/pages/service-detail.tsx
@@ -18,13 +18,28 @@ import { EndpointList } from "@/components/dashboard/endpoint-list";
 import { McpConnectionInfo } from "@/components/dashboard/mcp-connection-info";
 import { SshServiceInstructions } from "@/components/dashboard/ssh-service-instructions";
 import { ServiceRequirementsView } from "@/components/dashboard/service-requirements-editor";
+import { RoutingSection } from "@/components/dashboard/routing-section";
 import { useMyProviderTokens } from "@/hooks/use-providers";
 import { useDeveloperApps } from "@/hooks/use-developer-apps";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Pencil, Trash2, AlertCircle, Terminal } from "lucide-react";
+import {
+  Pencil,
+  Trash2,
+  AlertCircle,
+  Terminal,
+  Router,
+  ExternalLink,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { toast } from "sonner";
 
 const PROPAGATION_MODE_LABELS: Readonly<Record<string, string>> = {
@@ -211,6 +226,23 @@ export function ServiceDetailPage() {
         <DetailRow label="Created" value={formatDate(service.created_at)} />
         <DetailRow label="Updated" value={formatDate(service.updated_at)} />
       </DetailSection>
+
+      {/*
+        Issue #416: Your Routing — viewer-scoped node binding for this
+        catalog row. Mirrors the section on /keys/$id so admins can
+        manage routing on whichever surface they happen to be on,
+        rather than tunneling through "go look in AI Services".
+      */}
+      <Separator />
+      <YourRoutingSection
+        service={service}
+        onBindClick={() =>
+          void navigate({
+            to: "/keys",
+            search: { tab: "services", slug: service.slug },
+          })
+        }
+      />
 
       {isSshService ? (
         <>
@@ -525,5 +557,85 @@ export function ServiceDetailPage() {
         </>
       )}
     </div>
+  );
+}
+
+/**
+ * Issue #416: viewer-scoped routing for an admin-catalog row.
+ *
+ * Three states driven by `service.your_binding_count`:
+ *
+ *   - `0`: viewer has no personal `UserService` for this catalog row.
+ *     Show a "Bind in AI Services" CTA that hands off to `/keys` with
+ *     the catalog slug pre-selected (the existing AddKeyDialog
+ *     auto-open flow handles credential / endpoint / node selection).
+ *   - `1`: exactly one personal binding -> render the editable
+ *     `RoutingSection` so the admin can change routing in place. Same
+ *     widget as `/keys/$id`; mutates the underlying `UserService`.
+ *   - `>= 2`: multiple personal bindings -> show a disambiguation hint
+ *     with a link to `/keys`. Picking arbitrarily would silently
+ *     mutate one of the user's other bindings.
+ */
+function YourRoutingSection({
+  service,
+  onBindClick,
+}: {
+  readonly service: { readonly slug: string } & Pick<
+    import("@/types/api").DownstreamService,
+    "node_id" | "your_user_service_id" | "your_binding_count"
+  >;
+  readonly onBindClick: () => void;
+}) {
+  const count = service.your_binding_count ?? 0;
+  const userServiceId = service.your_user_service_id ?? null;
+
+  if (count === 1 && userServiceId) {
+    return (
+      <RoutingSection
+        nodeId={service.node_id ?? null}
+        serviceId={userServiceId}
+        title="Your Routing"
+        description="Your personal routing for this service. Other users have their own."
+      />
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Router className="h-4 w-4 text-primary" />
+          <CardTitle className="text-sm">Your Routing</CardTitle>
+        </div>
+        <CardDescription>
+          Your personal routing for this service. Other users have their own.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {count === 0 ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              You haven't bound this service to your account yet, so there's
+              no routing to configure here.
+            </p>
+            <Button size="sm" variant="outline" onClick={onBindClick}>
+              Bind in AI Services
+              <ExternalLink className="ml-1 h-3 w-3" />
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">
+              You have {String(count)} personal bindings for this service.
+              Manage each one's routing in AI Services.
+            </p>
+            <Button size="sm" variant="outline" onClick={onBindClick}>
+              Manage in AI Services
+              <ExternalLink className="ml-1 h-3 w-3" />
+            </Button>
+          </>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -160,6 +160,25 @@ export interface DownstreamService {
    */
   readonly default_request_headers?: readonly DefaultRequestHeader[] | null;
   readonly ws_frame_injections?: readonly WsFrameInjection[] | null;
+  /**
+   * Viewer-scoped (issue #416): the current viewer's
+   * `UserService.node_id` for this catalog row. Read-only mirror —
+   * change via `PUT /api/v1/keys/{your_user_service_id}`.
+   */
+  readonly node_id?: string | null;
+  /**
+   * Viewer-scoped: `UserService._id` to use as the mutation target for
+   * the editable Routing section. `null` when the viewer has zero or
+   * multiple personal bindings (see `your_binding_count`).
+   */
+  readonly your_user_service_id?: string | null;
+  /**
+   * Viewer-scoped: number of personal `UserService` rows the viewer
+   * owns for this catalog row. `0` = no binding (UI offers "Bind"
+   * CTA), `1` = editable single binding, `>=2` = multiple bindings
+   * (UI offers a "manage in AI Services" link).
+   */
+  readonly your_binding_count?: number;
 }
 
 export interface DefaultRequestHeader {


### PR DESCRIPTION
## Summary

Completes the streamline-services UX migration on the admin services surface so node routing is **visible AND editable** on every surface that displays a service. Closes #416.

The Mar 25 streamline refactor (`36652be`) put `node_id` on `UserService` and built `RoutingSection` on `/keys/$id`, but left `/services` unchanged. After PR #414's `--custom --via-node` wizard landed, admins could create node-routed services that appeared in `/services` with zero indication of which node they routed through. This PR closes that gap.

## What changed

### Backend (`ServiceResponse`)
Three viewer-scoped fields, populated via one batched MongoDB query:
- `node_id` — the viewer's `UserService.node_id` for this catalog row
- `your_user_service_id` — mutation target for the editable `RoutingSection`
- `your_binding_count` — disambiguates 0 / 1 / ≥2 bindings

Org-shared bindings are intentionally excluded (editing them silently from a catalog page would leak across org boundaries). Multi-binding case doesn't pick; FE renders a "manage in AI Services" link instead.

### Frontend (4 surfaces fixed)
- `components/dashboard/routing-section.tsx` — extracted from `key-detail.tsx` with optional `title` / `description` props so both `/keys/$id` and `/services/$id` reuse the same editable widget
- `service-detail.tsx` — new "Your Routing" section, three states (0 / 1 / ≥2 bindings)
- `service-card.tsx` — `→ <node-name>` badge with status tooltip
- `keys.tsx` list cards — `→ <node-name>` instead of bare `"Via node"`
- `key-detail.tsx` auto-connected branch — reads `keyInfo.node_id` instead of hardcoded `"Direct"` (the *"won't find it there either"* case from the issue)

## Spec compliance (issue #416)

| Spec | Where | Status |
|---|---|---|
| List view: `→ <node-name>` badge with status | `service-card.tsx`, `keys.tsx` | ✅ |
| Visible AND editable, reusing `RoutingSection`, on both surfaces | `service-detail.tsx`, `key-detail.tsx` | ✅ |
| `node_id?` on `DownstreamService` from backend | `ServiceResponse` | ✅ |

## Non-breaking

- All new fields optional with \`skip_serializing_if = "Option::is_none"\` → old clients see no JSON delta when no binding
- No DB migration (computed at response time)
- No env / CLI / SDK / mobile changes
- Existing endpoints / fields untouched
- Old FE + new BE: ignores new keys
- New FE + old BE: empty-state branch fires gracefully (degraded, never broken)

## Test plan

- [x] \`cargo test -p nyxid\` — 1644 passed (1 unrelated flake passes in isolation)
- [x] 6 new \`services_helpers\` integration tests covering 0 / 1 / ≥2 personal bindings, org-only, empty input
- [x] \`cargo clippy --all-targets -p nyxid\` — clean
- [x] \`npm run lint\` — 0 errors (15 pre-existing warnings)
- [x] \`npm run test\` — 513/513 passed
- [x] \`npm run build\` — clean
- [x] Manual smoke: dev environment with seeded user / node / catalog binding — verified all four surfaces render correctly (badge on `/keys` cards, badge on `/services` cards, editable Routing section on `/services/\$id`, empty-state CTA on un-bound catalog rows)
- [ ] Verify in staging once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)