### PR TITLE
fix(cli): widen wizard heartbeat first-ping window for NYXID_WIZARD_NO_OPEN

### DIFF
--- a/cli/src/wizard/server.rs
+++ b/cli/src/wizard/server.rs
@@ -116,6 +116,16 @@ const HEARTBEAT_DEAD_AFTER_ROTATION: Duration = Duration::from_secs(30);
 /// Grace period at startup before we start enforcing the heartbeat dead
 /// line. Lets the browser actually load the page.
 const HEARTBEAT_STARTUP_GRACE: Duration = Duration::from_secs(5);
+/// First-heartbeat deadline when `NYXID_WIZARD_NO_OPEN` is set. With
+/// auto-open the browser is loading by the time the watchdog starts,
+/// so the default `HEARTBEAT_STARTUP_GRACE + HEARTBEAT_DEAD_AFTER`
+/// (~9 s) is enough. Without auto-open the user pastes the URL by
+/// hand, so the first ping arrives on human time — 9 s reliably kills
+/// the wizard mid copy-paste. 20 s gives a comfortable manual window
+/// without giving up the eventual cleanup of a wizard nobody loaded.
+/// Once the first ping lands, `HEARTBEAT_DEAD_AFTER` takes over so a
+/// truly-dead tab is still detected at the normal cadence.
+const HEARTBEAT_FIRST_PING_DEADLINE_NO_OPEN: Duration = Duration::from_secs(20);
 /// How often the CLI checks the last-heartbeat timestamp. 500 ms is
 /// tight enough that a watchdog-triggered exit fires within ~4.5 s of
 /// the last successful beat.
@@ -1490,6 +1500,15 @@ pub async fn run_flow(
     } else {
         HEARTBEAT_DEAD_AFTER
     };
+    // `NYXID_WIZARD_NO_OPEN` makes the user paste the URL by hand, so
+    // the first heartbeat arrives on human time. Widen the no-first-
+    // ping deadline without changing post-ping silence detection — once
+    // a real browser pings, `dead_after` takes over as before.
+    let first_ping_deadline = if std::env::var_os("NYXID_WIZARD_NO_OPEN").is_some() {
+        HEARTBEAT_FIRST_PING_DEADLINE_NO_OPEN
+    } else {
+        HEARTBEAT_STARTUP_GRACE + dead_after
+    };
     let watchdog_handle = tokio::spawn(async move {
         let tx = watchdog_tx;
         loop {
@@ -1503,7 +1522,7 @@ pub async fn run_flow(
             let last = *watchdog_state.last_heartbeat.lock().await;
             let dead = match last {
                 Some(t) => t.elapsed() > dead_after,
-                None => watchdog_state.started_at.elapsed() > HEARTBEAT_STARTUP_GRACE + dead_after,
+                None => watchdog_state.started_at.elapsed() > first_ping_deadline,
             };
             if dead {
                 let _ = tx.send(());


### PR DESCRIPTION
## Summary

`NYXID_WIZARD_NO_OPEN=1` prints the wizard URL but skips `open::that(url)` — the user pastes the URL into a browser by hand, so the first heartbeat ping arrives on human time. The watchdog's no-first-ping deadline was hardcoded to `HEARTBEAT_STARTUP_GRACE + HEARTBEAT_DEAD_AFTER = 5 s + 4 s = 9 s`, which races with manual copy-paste and kills the wizard before the user can load the URL.

Practical impact: the env var documented in `server.rs:1465` as "used by automated validation and CI smoke tests" is unusable for the manual-paste scenarios it implies. Reproduced today during prod testing — the wizard prints `Browser stopped responding (tab closed?) — cancelling.` ~9 s after `service add` even when the user is actively trying to copy the URL.

## Fix

Widen the no-first-ping deadline to **20 s** specifically when `NYXID_WIZARD_NO_OPEN` is set. Once the browser pings even once, `HEARTBEAT_DEAD_AFTER` (4 s) takes over as before — a tab that opens then dies is still cleaned up at the normal cadence. Default behavior is unchanged when the env var is unset.

### Diff shape

- **New constant** `HEARTBEAT_FIRST_PING_DEADLINE_NO_OPEN = 20 s` next to the other heartbeat constants in `cli/src/wizard/server.rs`.
- **Watchdog** reads `NYXID_WIZARD_NO_OPEN` once at startup and binds `first_ping_deadline` to either the new 20 s value or the existing `HEARTBEAT_STARTUP_GRACE + dead_after` sum.
- **Match arm** for `last == None` now compares against `first_ping_deadline`. The `Some(t)` arm is untouched — once a real browser is live, `dead_after` semantics are unchanged.

Single-file, ~20 lines added.

## Why no issue

Surfaced inline during issue #430 verification. Tiny scoped fix, single regression, no design debate — opening directly per Calvin's call.

## Test plan

- [x] `cargo build -p nyxid-cli` — clean
- [x] `cargo test -p nyxid-cli` — 234 + 1 pass (no change in count)
- [x] `cargo clippy -p nyxid-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hook (`cargo fmt` + `cargo clippy`) green
- [ ] Manual smoke (post-merge or locally): `NYXID_WIZARD_NO_OPEN=1 nyxid service add` — copy-paste URL into a browser within ~15 s, wizard stays alive (was: cancelled at ~9 s).
- [ ] Manual regression (post-merge or locally): `nyxid service add` (env var unset) — auto-launch browser still works, default 9 s deadline unchanged.

## Out of scope

- Doc/help text mentioning the new 20 s window — current docs don't quantify the timeout, so nothing to update.
- Changing the `Some(t)` `dead_after` window — intentional; an active browser going silent for >4 s should still be treated as a closed tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)