### PR TITLE
chore: update Discord URLs to canonical discord.com/invite form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/ChronoAIProject/NyxID)](https://github.com/ChronoAIProject/NyxID)
-[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/QMvcs8UQBW)
+[![Discord](https://img.shields.io/discord/1422500823925264438?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.com/invite/QMvcs8UQBW)
 
 <p align="center">
   <img src="assets/banner.png" alt="NyxID — Connect AI agents to any API, anywhere. Securely." width="100%">

--- a/frontend/src/features/landing/components/landing-footer.tsx
+++ b/frontend/src/features/landing/components/landing-footer.tsx
@@ -7,7 +7,7 @@ export function LandingFooter() {
         </p>
         <div className="flex items-center gap-4">
           <a
-            href="https://discord.gg/QMvcs8UQBW"
+            href="https://discord.com/invite/QMvcs8UQBW"
             target="_blank"
             rel="noopener noreferrer"
             className="text-gray-500 transition-colors hover:text-white"


### PR DESCRIPTION
## Summary
- Replace `discord.gg/QMvcs8UQBW` with `https://discord.com/invite/QMvcs8UQBW` in the README badge link and the landing-page footer link.
- Both URLs resolve to the same invite; this just standardizes on the canonical `discord.com/invite/...` form.

## Test plan
- [ ] README badge click opens the correct Discord invite
- [ ] Landing footer Discord icon click opens the correct Discord invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)