### PR TITLE
feat(catalog): seed unauthenticated public APIs (arXiv, OpenAlex, Crossref)

### DIFF
--- a/backend/src/services/catalog_service.rs
+++ b/backend/src/services/catalog_service.rs
@@ -205,6 +205,21 @@ fn legacy_service_category_filter(categories: &[&str]) -> mongodb::bson::Documen
     }
 }
 
+fn user_addable_catalog_filter() -> mongodb::bson::Document {
+    doc! {
+        "$or": [
+            { "requires_user_credential": true },
+            { "requires_user_credential": { "$exists": false } },
+            { "provider_config_id": { "$ne": null } },
+            {
+                "auth_method": "none",
+                "service_category": "internal",
+                "provider_config_id": null,
+            },
+        ],
+    }
+}
+
 /// List catalog entries available for user key creation.
 /// Filters to connection-category + provider-linked services.
 ///
@@ -228,13 +243,7 @@ pub async fn list_catalog(
             "service_type": "http",
             "is_active": true,
             "$and": [
-                {
-                    "$or": [
-                        { "requires_user_credential": true },
-                        { "requires_user_credential": { "$exists": false } },
-                        { "provider_config_id": { "$ne": null } },
-                    ],
-                },
+                user_addable_catalog_filter(),
                 legacy_service_category_filter(&["connection", "internal"]),
                 visibility_filter(user_id),
             ],
@@ -585,10 +594,13 @@ pub(crate) fn any_org_service_reachable(
 
 #[cfg(test)]
 mod tests {
-    use super::{any_org_service_reachable, caller_may_read_catalog_entry};
+    use super::{
+        any_org_service_reachable, caller_may_read_catalog_entry, user_addable_catalog_filter,
+    };
     use crate::models::org_membership::OrgMembership;
     use crate::models::user_service::UserService;
     use chrono::Utc;
+    use mongodb::bson::Bson;
 
     // The visibility decision is the load-bearing piece of the
     // information-disclosure fix in NyxID#356: any path that broadens
@@ -650,6 +662,28 @@ mod tests {
         assert!(!caller_may_read_catalog_entry(
             "private", "alice", "bob", false, false,
         ));
+    }
+
+    #[test]
+    fn default_catalog_filter_includes_no_auth_internal_public_apis() {
+        let filter = user_addable_catalog_filter();
+        let clauses = filter
+            .get_array("$or")
+            .expect("user-addable catalog filter should be an $or");
+
+        assert_eq!(
+            clauses.len(),
+            4,
+            "keep the three existing catalog visibility arms plus the no-auth public API arm"
+        );
+        assert!(clauses.iter().any(|clause| {
+            let Some(doc) = clause.as_document() else {
+                return false;
+            };
+            doc.get_str("auth_method") == Ok("none")
+                && doc.get_str("service_category") == Ok("internal")
+                && matches!(doc.get("provider_config_id"), Some(Bson::Null))
+        }));
     }
 
     // ---- org visibility tests for any_org_service_reachable ----

--- a/backend/src/services/provider_service.rs
+++ b/backend/src/services/provider_service.rs
@@ -2014,6 +2014,61 @@ const DEFAULT_SERVICE_SEEDS: &[DefaultServiceSeed] = &[
     },
 ];
 
+/// Catalog seed for unauthenticated public APIs (e.g. arXiv, OpenAlex,
+/// Crossref). Distinct from `DefaultServiceSeed` because there's no
+/// `ProviderConfig` to bind to — the proxy injects nothing, we just route
+/// requests through NyxID for centralised audit logging and future
+/// rate-limit / polite-pool management.
+///
+/// The resulting `DownstreamService` has `provider_config_id: None`,
+/// `auth_method: "none"`, `requires_user_credential: false`, and no
+/// `ServiceProviderRequirement`. `build_catalog_entry` already handles
+/// `provider: None` and emits `requires_credential: false`, so the AI
+/// Services dialog renders these as one-click no-auth services.
+struct DefaultPublicServiceSeed {
+    service_slug: &'static str,
+    service_name: &'static str,
+    base_url: &'static str,
+    description: &'static str,
+    homepage_url: Option<&'static str>,
+}
+
+const DEFAULT_PUBLIC_SERVICE_SEEDS: &[DefaultPublicServiceSeed] = &[
+    DefaultPublicServiceSeed {
+        service_slug: "arxiv-api",
+        service_name: "arXiv API",
+        base_url: "http://export.arxiv.org/api",
+        description: "arXiv search and metadata API. Returns Atom XML feeds; no \
+                      authentication required. Routing through NyxID provides \
+                      centralised audit logging and a single place to manage \
+                      polite-pool / rate-limit headers across agents. Docs: \
+                      https://info.arxiv.org/help/api/index.html",
+        homepage_url: Some("https://arxiv.org"),
+    },
+    DefaultPublicServiceSeed {
+        service_slug: "api-openalex",
+        service_name: "OpenAlex API",
+        base_url: "https://api.openalex.org",
+        description: "Open scholarly database covering 240M+ works, authors, \
+                      institutions, concepts, and citations. No authentication \
+                      required. Polite pool: append `?mailto=you@example.com` \
+                      (or set as a default request header) for higher rate limits. \
+                      Docs: https://docs.openalex.org",
+        homepage_url: Some("https://openalex.org"),
+    },
+    DefaultPublicServiceSeed {
+        service_slug: "api-crossref",
+        service_name: "Crossref API",
+        base_url: "https://api.crossref.org",
+        description: "DOI metadata and citation graph for ~150M scholarly works. \
+                      No authentication required. Polite pool: set \
+                      `User-Agent: <app>/<version> (mailto:you@example.com)` for \
+                      higher rate limits. Docs: \
+                      https://api.crossref.org/swagger-ui/index.html",
+        homepage_url: Some("https://www.crossref.org"),
+    },
+];
+
 /// Apply per-slug capability / streaming overrides to pre-existing seeded
 /// downstream services. Designed to be a one-shot migration that runs on
 /// every startup but only mutates rows that still carry the legacy
@@ -2560,6 +2615,77 @@ pub async fn seed_default_services(
             provider = seed.provider_slug,
             direct_auth = is_direct_auth,
             "Seeded default downstream service"
+        );
+        seeded_count += 1;
+    }
+
+    // Seed unauthenticated public APIs (e.g. arXiv, OpenAlex, Crossref).
+    // These have no provider binding — `provider_config_id` stays None and
+    // no SPR is created. `build_catalog_entry` already tolerates `provider:
+    // None` and emits `requires_credential: false`.
+    for seed in DEFAULT_PUBLIC_SERVICE_SEEDS {
+        let existing = service_col
+            .find_one(doc! { "slug": seed.service_slug })
+            .await?;
+        if existing.is_some() {
+            continue;
+        }
+
+        let empty_credential = encryption_keys.encrypt(b"").await?;
+        let service_id = Uuid::new_v4().to_string();
+
+        let service = DownstreamService {
+            id: service_id.clone(),
+            name: seed.service_name.to_string(),
+            slug: seed.service_slug.to_string(),
+            description: Some(seed.description.to_string()),
+            base_url: seed.base_url.to_string(),
+            service_type: "http".to_string(),
+            visibility: "public".to_string(),
+            auth_method: "none".to_string(),
+            auth_key_name: String::new(),
+            credential_encrypted: empty_credential,
+            auth_type: None,
+            openapi_spec_url: None,
+            asyncapi_spec_url: None,
+            streaming_supported: false,
+            ssh_config: None,
+            oauth_client_id: None,
+            service_category: "internal".to_string(),
+            requires_user_credential: false,
+            is_active: true,
+            created_by: "system".to_string(),
+            identity_propagation_mode: "none".to_string(),
+            identity_include_user_id: false,
+            identity_include_email: false,
+            identity_include_name: false,
+            identity_jwt_audience: None,
+            forward_access_token: false,
+            inject_delegation_token: false,
+            delegation_token_scope: "proxy:*".to_string(),
+            provider_config_id: None,
+            homepage_url: seed.homepage_url.map(String::from),
+            repository_url: None,
+            issues_url: None,
+            capabilities: None,
+            auth_notes: None,
+            known_limitations: None,
+            required_permissions: None,
+            examples_url: None,
+            recommended_skills: None,
+            custom_user_agent: None,
+            default_request_headers: None,
+            ws_frame_injections: Vec::new(),
+            developer_app_ids: None,
+            token_exchange_config: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        service_col.insert_one(&service).await?;
+        tracing::info!(
+            slug = seed.service_slug,
+            "Seeded default public (no-auth) downstream service"
         );
         seeded_count += 1;
     }
@@ -3356,9 +3482,9 @@ pub async fn delete_provider(db: &mongodb::Database, provider_id: &str) -> AppRe
 #[cfg(test)]
 mod tests {
     use super::{
-        ANTHROPIC_DEFAULT_HEADERS, DEFAULT_SERVICE_SEEDS, SeededHeader,
-        normalize_telegram_bot_token, normalize_telegram_bot_username, reconcile_seeded_headers,
-        seed_capability_override,
+        ANTHROPIC_DEFAULT_HEADERS, DEFAULT_PUBLIC_SERVICE_SEEDS, DEFAULT_SERVICE_SEEDS,
+        SeededHeader, normalize_telegram_bot_token, normalize_telegram_bot_username,
+        reconcile_seeded_headers, seed_capability_override,
     };
     use crate::errors::AppError;
     use crate::models::default_request_header::DefaultRequestHeader;
@@ -3381,6 +3507,50 @@ mod tests {
 
         assert_eq!(seed.service_auth_method, Some("path"));
         assert_eq!(seed.service_auth_key_name, Some("bot"));
+    }
+
+    #[test]
+    fn public_service_seeds_have_unique_slugs_and_no_collision_with_default_seeds() {
+        let mut public_slugs: Vec<&str> = DEFAULT_PUBLIC_SERVICE_SEEDS
+            .iter()
+            .map(|s| s.service_slug)
+            .collect();
+        public_slugs.sort_unstable();
+        let dedup_count = public_slugs
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len();
+        assert_eq!(
+            dedup_count,
+            DEFAULT_PUBLIC_SERVICE_SEEDS.len(),
+            "DEFAULT_PUBLIC_SERVICE_SEEDS must have unique slugs"
+        );
+
+        let default_slugs: std::collections::BTreeSet<&str> = DEFAULT_SERVICE_SEEDS
+            .iter()
+            .map(|s| s.service_slug)
+            .collect();
+        for s in &public_slugs {
+            assert!(
+                !default_slugs.contains(s),
+                "public seed slug {s} collides with a provider-backed seed slug"
+            );
+        }
+    }
+
+    #[test]
+    fn arxiv_public_seed_is_present_and_unauthenticated() {
+        let seed = DEFAULT_PUBLIC_SERVICE_SEEDS
+            .iter()
+            .find(|s| s.service_slug == "arxiv-api")
+            .expect("arxiv-api seed should be in DEFAULT_PUBLIC_SERVICE_SEEDS");
+
+        assert_eq!(seed.base_url, "http://export.arxiv.org/api");
+        assert_eq!(seed.homepage_url, Some("https://arxiv.org"));
+        assert!(
+            !seed.description.is_empty(),
+            "arxiv-api description should explain the no-auth policy and audit-logging benefit"
+        );
     }
 
     #[test]

--- a/backend/src/services/provider_service.rs
+++ b/backend/src/services/provider_service.rs
@@ -2037,7 +2037,7 @@ const DEFAULT_PUBLIC_SERVICE_SEEDS: &[DefaultPublicServiceSeed] = &[
     DefaultPublicServiceSeed {
         service_slug: "arxiv-api",
         service_name: "arXiv API",
-        base_url: "http://export.arxiv.org/api",
+        base_url: "https://export.arxiv.org/api",
         description: "arXiv search and metadata API. Returns Atom XML feeds; no \
                       authentication required. Routing through NyxID provides \
                       centralised audit logging and a single place to manage \
@@ -3545,7 +3545,7 @@ mod tests {
             .find(|s| s.service_slug == "arxiv-api")
             .expect("arxiv-api seed should be in DEFAULT_PUBLIC_SERVICE_SEEDS");
 
-        assert_eq!(seed.base_url, "http://export.arxiv.org/api");
+        assert_eq!(seed.base_url, "https://export.arxiv.org/api");
         assert_eq!(seed.homepage_url, Some("https://arxiv.org"));
         assert!(
             !seed.description.is_empty(),


### PR DESCRIPTION
## Summary

Adds three first-class catalog entries for unauthenticated public academic APIs:

- `arxiv-api` (`https://export.arxiv.org/api`) -- Atom feed search/metadata for arXiv papers.
- `api-openalex` (`https://api.openalex.org`) -- OpenAlex scholarly works, authors, institutions, concepts, and citations.
- `api-crossref` (`https://api.crossref.org`) -- Crossref DOI metadata and citation graph.

These have no `ProviderConfig` to bind to. The implementation introduces a parallel `DEFAULT_PUBLIC_SERVICE_SEEDS` table and a second seed loop in `seed_default_services` that produces `DownstreamService` rows with `provider_config_id: None`, `auth_method: "none"`, `requires_user_credential: false`, and no `ServiceProviderRequirement`.

`build_catalog_entry` already tolerates `provider: None` and returns `requires_credential: false`, so these services are represented as no-auth catalog entries rather than credential setup flows.

## Why route public APIs through NyxID?

The proxy injects nothing on these calls. The benefit is operational:

- **Ergonomics**: users and agents get a stable catalog slug such as `arxiv-api` instead of repeating `--custom --base-url ...` setup on each machine.
- **Single source of truth**: catalog-level URL, description, category, and future metadata are managed once instead of drifting across local custom service definitions.
- **Admin-managed default headers**: polite-pool / contact / User-Agent defaults can be populated once via catalog `default_request_headers` and inherited by every agent that enables the service.
- **Future rate-limit / circuit-breaker hooks**: if NyxID later adds per-service rate limiting, public APIs can use the same service-level control point as credentialed APIs.
- **Discoverability**: `nyxid catalog show arxiv-api` can explain the no-auth policy and official API docs from inside NyxID.

This is not an audit-log distinction between catalog and custom services: custom services also route through NyxID and are audited. The PR is about reducing per-user boilerplate and avoiding drift for common public academic sources.

## Motivation

I am using NyxID to broker external APIs for an outreach/research pipeline that scans scholarly sources while working on open mathematical problems. arXiv, OpenAlex, and Crossref are common enough in agent literature workflows that they are better represented as shared catalog entries than as repeated local custom definitions.

The same argument extends to citation mining, paper deduplication, related-work search, and research-board refresh tasks.

## Implementation notes

- New seed table is distinct from `DEFAULT_SERVICE_SEEDS` rather than threading `Option<&str>` through the existing `provider_slug` field. This isolates the no-provider path from the existing provider-backed seeds, so the SPR / token-exchange logic stays unchanged for credentialed cases.
- `list_catalog` now includes no-auth public API catalog rows by accepting the explicit `auth_method: "none"`, `service_category: "internal"`, `provider_config_id: null` case.
- Slug uniqueness is enforced by a unit test that also asserts no collision with `DEFAULT_SERVICE_SEEDS`.
- arXiv uses `https://export.arxiv.org/api`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test -p nyxid provider_service::tests --no-fail-fast`
- [x] `cargo test -p nyxid catalog_service::tests --no-fail-fast`

## Follow-up ideas

- Populate catalog `default_request_headers` for polite-pool conventions where appropriate.
- Add `documentation_url` to `DownstreamService` and move documentation links out of descriptions.
- Add Semantic Scholar as a credentialed API seed if desired.
- Add ORCID public API under the same no-auth path.
