### PR TITLE
docs(quickstart): add PowerShell variant; rename Bash quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,10 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste the prom
 
 #### Manual Setup
 
-Prefer to run each step yourself, or need the full troubleshooting guide? The complete manual flow lives in **[docs/QUICKSTART_BASH.md](docs/QUICKSTART_BASH.md)** (or **[docs/QUICKSTART_POWERSHELL.md](docs/QUICKSTART_POWERSHELL.md)** for native Windows PowerShell):
+Prefer to run each step yourself, or need the full troubleshooting guide? Pick the quickstart matching your shell — both cover preflight, paste-block install, registration, optional CLI install, uninstall & reinstall, orphan-volume recovery, and SCRAM-failure troubleshooting:
 
-- System preflight check — [Step 1](docs/QUICKSTART_BASH.md#step-1-of-3--check-your-system)
-- One paste-block install — [Step 2](docs/QUICKSTART_BASH.md#step-2-of-3--install-and-start)
-- Register your account — [Step 3](docs/QUICKSTART_BASH.md#step-3-of-3--register-and-connect)
-- Optional [CLI install](docs/QUICKSTART_BASH.md#optional-install-the-nyxid-cli)
-- [Uninstall & reinstall](docs/QUICKSTART_BASH.md#uninstall--reinstall), [orphan volume recovery](docs/QUICKSTART_BASH.md#recovering-an-orphan-volume), and [SCRAM failure](docs/QUICKSTART_BASH.md#stuck-on-scram-failure) troubleshooting
+- **Bash** — [docs/QUICKSTART_BASH.md](docs/QUICKSTART_BASH.md) (macOS, Linux, WSL, or Git Bash on Windows)
+- **PowerShell** — [docs/QUICKSTART_POWERSHELL.md](docs/QUICKSTART_POWERSHELL.md) (native Windows, PowerShell 7+ and OpenSSL)
 
 Once NyxID is running and you've registered at `http://localhost:3000`:
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The full click-through flow is in **[Add your first AI Service](docs/connecting-
 
 Run NyxID on your own machine. This sets up three Docker containers (database, backend, frontend) — takes about 2 minutes.
 
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a bash-compatible terminal. The `nyxid` CLI is optional. Full prereqs and disk budgets in [docs/QUICKSTART.md](docs/QUICKSTART.md#prerequisites).
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and a terminal — bash *or* PowerShell, whichever your machine has. Pick the matching quickstart: **[Bash](docs/QUICKSTART_BASH.md)** (macOS, Linux, [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), or [Git Bash](https://gitforwindows.org/) on Windows) or **[PowerShell](docs/QUICKSTART_POWERSHELL.md)** (native Windows, PS 7+ and OpenSSL). The `nyxid` CLI is optional. Per-shell prereqs and disk budgets are listed in each quickstart's intro.
 
 #### AI-Assisted (Recommended)
 
@@ -141,7 +141,7 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste the prom
 <details>
 <summary><strong>Click to expand the full AI-assisted self-host prompt</strong></summary>
 
-> I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively. If anything fails or I'd prefer to follow the manual steps myself, the full step-by-step with troubleshooting is at https://github.com/ChronoAIProject/NyxID/blob/main/docs/QUICKSTART.md.
+> I want to self-host NyxID on this machine (the repo is https://github.com/ChronoAIProject/NyxID). Walk me through the full quickstart interactively. If anything fails or I'd prefer to follow the manual steps myself, the full step-by-step with troubleshooting is at https://github.com/ChronoAIProject/NyxID/blob/main/docs/QUICKSTART_BASH.md (or https://github.com/ChronoAIProject/NyxID/blob/main/docs/QUICKSTART_POWERSHELL.md if I'm on native Windows PowerShell).
 > 1. Confirm Docker is installed and running before touching anything (check `git`, `docker`, `openssl`, `curl`, `docker compose` v2, and `docker info`).
 > 2. **Before cloning or generating anything, check whether NyxID install STATE is present** — look for a `./NyxID/.env.dev` file OR any Docker volume matching `nyx*_mongodb_data` (run `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$'` — this catches the default `nyxid_mongodb_data` plus any variant from a renamed checkout). A bare `./NyxID` directory alone does NOT count as "installed" — `uninstall.sh` leaves the source tree in place, so the directory can exist with no state. **If install state is present, stop and tell me the quickstart is a first-time-only install.** Ask whether I want to (a) uninstall first — if `./NyxID` exists, run `cd NyxID && ./scripts/uninstall.sh --yes && cd ..`; if only the stale Docker volume is orphaned (checkout was manually deleted earlier), run `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm` directly. Either path wipes the volume, containers, and (for the script path) `.env.dev`/keys — destroys all NyxID accounts and encrypted credentials. Or (b) keep my existing install and stop here — I can verify it's still running with `curl -sf http://localhost:3001/health`. Do not proceed to step 3 until I answer.
 > 3. If `./NyxID` already exists (post-uninstall reinstall), `cd` into it; otherwise clone the repo into the current directory and `cd` in. Generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker logs nyxid-backend`. If the logs show `SCRAM failure: Authentication failed`, that means the MongoDB volume has a stale password from a previous install — tell me to run `./scripts/uninstall.sh --yes` (or, if the checkout is gone, `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm` to remove any nyx-flavored orphan volume) and retry. Show me the generated `ENCRYPTION_KEY` so I can back it up.
@@ -155,13 +155,13 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste the prom
 
 #### Manual Setup
 
-Prefer to run each step yourself, or need the full troubleshooting guide? The complete manual flow lives in **[docs/QUICKSTART.md](docs/QUICKSTART.md)**:
+Prefer to run each step yourself, or need the full troubleshooting guide? The complete manual flow lives in **[docs/QUICKSTART_BASH.md](docs/QUICKSTART_BASH.md)** (or **[docs/QUICKSTART_POWERSHELL.md](docs/QUICKSTART_POWERSHELL.md)** for native Windows PowerShell):
 
-- System preflight check — [Step 1](docs/QUICKSTART.md#step-1-of-3--check-your-system)
-- One paste-block install — [Step 2](docs/QUICKSTART.md#step-2-of-3--install-and-start)
-- Register your account — [Step 3](docs/QUICKSTART.md#step-3-of-3--register-and-connect)
-- Optional [CLI install](docs/QUICKSTART.md#optional-install-the-nyxid-cli)
-- [Uninstall & reinstall](docs/QUICKSTART.md#uninstall--reinstall), [orphan volume recovery](docs/QUICKSTART.md#recovering-an-orphan-volume), and [SCRAM failure](docs/QUICKSTART.md#stuck-on-scram-failure) troubleshooting
+- System preflight check — [Step 1](docs/QUICKSTART_BASH.md#step-1-of-3--check-your-system)
+- One paste-block install — [Step 2](docs/QUICKSTART_BASH.md#step-2-of-3--install-and-start)
+- Register your account — [Step 3](docs/QUICKSTART_BASH.md#step-3-of-3--register-and-connect)
+- Optional [CLI install](docs/QUICKSTART_BASH.md#optional-install-the-nyxid-cli)
+- [Uninstall & reinstall](docs/QUICKSTART_BASH.md#uninstall--reinstall), [orphan volume recovery](docs/QUICKSTART_BASH.md#recovering-an-orphan-volume), and [SCRAM failure](docs/QUICKSTART_BASH.md#stuck-on-scram-failure) troubleshooting
 
 Once NyxID is running and you've registered at `http://localhost:3000`:
 
@@ -202,7 +202,8 @@ nyxid catalog endpoints my-local-api
 | Topic | Link | Description |
 |-------|------|-------------|
 | Connecting AI Services | [docs/connecting-services/](docs/connecting-services/) | Add your first (or Nth) AI Service — Web UI / CLI / AI-driven / Direct API |
-| Quickstart (manual) | [docs/QUICKSTART.md](docs/QUICKSTART.md) | Step-by-step self-host + troubleshooting |
+| Quickstart (Bash, default) | [docs/QUICKSTART_BASH.md](docs/QUICKSTART_BASH.md) | Step-by-step self-host + troubleshooting |
+| Quickstart (PowerShell) | [docs/QUICKSTART_POWERSHELL.md](docs/QUICKSTART_POWERSHELL.md) | Native Windows PowerShell equivalent |
 | Deployment | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Start here for production setup |
 | AI Agent Playbook | [docs/AI_AGENT_PLAYBOOK.md](docs/AI_AGENT_PLAYBOOK.md) | Start here for agent integration |
 | Architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System design and data flows |

--- a/README.md
+++ b/README.md
@@ -155,10 +155,18 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste the prom
 
 #### Manual Setup
 
-Prefer to run each step yourself, or need the full troubleshooting guide? Pick the quickstart matching your shell — both cover preflight, paste-block install, registration, optional CLI install, uninstall & reinstall, orphan-volume recovery, and SCRAM-failure troubleshooting:
+Prefer to run each step yourself, or need the full troubleshooting guide? Pick the quickstart matching your shell:
 
 - **Bash** — [docs/QUICKSTART_BASH.md](docs/QUICKSTART_BASH.md) (macOS, Linux, WSL, or Git Bash on Windows)
 - **PowerShell** — [docs/QUICKSTART_POWERSHELL.md](docs/QUICKSTART_POWERSHELL.md) (native Windows, PowerShell 7+ and OpenSSL)
+
+Each covers:
+
+- System preflight check — [Step 1](docs/QUICKSTART_BASH.md#step-1-of-3--check-your-system)
+- One paste-block install — [Step 2](docs/QUICKSTART_BASH.md#step-2-of-3--install-and-start)
+- Register your account — [Step 3](docs/QUICKSTART_BASH.md#step-3-of-3--register-and-connect)
+- Optional [CLI install](docs/QUICKSTART_BASH.md#optional-install-the-nyxid-cli)
+- [Uninstall & reinstall](docs/QUICKSTART_BASH.md#uninstall--reinstall), [orphan volume recovery](docs/QUICKSTART_BASH.md#recovering-an-orphan-volume), and [SCRAM failure](docs/QUICKSTART_BASH.md#stuck-on-scram-failure) troubleshooting
 
 Once NyxID is running and you've registered at `http://localhost:3000`:
 

--- a/docs/QUICKSTART_BASH.md
+++ b/docs/QUICKSTART_BASH.md
@@ -209,7 +209,7 @@ Then re-paste Step 2 — the pre-flight will pass and Step 2 will clone fresh.
 
 ### Stuck on SCRAM failure?
 
-If `docker logs nyxid-backend` shows `SCRAM failure: Authentication failed`, your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run `./scripts/uninstall.sh --yes` to wipe the volume, then re-run [Step 2](#step-2-of-3--install-and-start). See [#280](https://github.com/ChronoAIProject/NyxID/issues/280).
+If `docker logs nyxid-backend` shows `SCRAM failure: Authentication failed`, your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run `./scripts/uninstall.sh --yes` to wipe the volume, then re-run [Step 2](#step-2-of-3--install-and-start).
 
 ## Done when...
 

--- a/docs/QUICKSTART_BASH.md
+++ b/docs/QUICKSTART_BASH.md
@@ -1,6 +1,8 @@
-# NyxID Self-Host Quickstart
+# NyxID Self-Host Quickstart (Bash)
 
 Step-by-step manual setup for running NyxID on your own machine, plus troubleshooting, uninstall/reinstall, and post-install AI-agent wiring.
+
+> **On Windows native PowerShell?** This quickstart uses bash heredocs, `openssl`, and POSIX path tools. See **[QUICKSTART_POWERSHELL.md](QUICKSTART_POWERSHELL.md)** for the PowerShell equivalent. Otherwise, run this from macOS Terminal, a Linux shell, [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), or [Git Bash](https://gitforwindows.org/).
 
 For the one-paragraph overview and the AI-assisted setup prompt (drive the whole flow from Claude Code / Cursor), see the [README Quick Start](../README.md#quick-start).
 
@@ -8,8 +10,8 @@ For the one-paragraph overview and the AI-assisted setup prompt (drive the whole
 
 ## Prerequisites
 
+- **A bash-compatible shell** — required. macOS Terminal, any Linux shell, [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install), or [Git Bash](https://gitforwindows.org/) on Windows. Steps 1 and 2 use bash heredocs (`<< 'CHECK'`, `<< 'INSTALL'`) and POSIX tools (`openssl`, `xargs`, `grep -E`) that don't run in raw PowerShell or CMD. *On native PowerShell? Use [QUICKSTART_POWERSHELL.md](QUICKSTART_POWERSHELL.md) instead.*
 - [Docker](https://docs.docker.com/get-docker/) — required for the server stack (backend, frontend, MongoDB). ~2 GB disk for images on first pull.
-- A bash-compatible terminal — macOS Terminal, Linux shell, or [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows.
 - [Rust / Cargo](https://www.rust-lang.org/tools/install) — **optional**, only needed if you install the `nyxid` CLI (see [Install the `nyxid` CLI](#optional-install-the-nyxid-cli) below). The installer will set this up automatically if missing. Budget ~1.5 GB disk (~300 MB for the toolchain plus ~1 GB for the build cache) and 3–10 minutes for the first compile.
 
 Total disk footprint: ~2 GB for the server only, ~3.5 GB if you also install the CLI from source.

--- a/docs/QUICKSTART_POWERSHELL.md
+++ b/docs/QUICKSTART_POWERSHELL.md
@@ -1,0 +1,242 @@
+# NyxID Self-Host Quickstart (PowerShell)
+
+Step-by-step manual setup for running NyxID on Windows using native PowerShell, plus troubleshooting, uninstall/reinstall, and post-install AI-agent wiring.
+
+> **Looking for the bash version?** macOS, Linux, WSL, and Git Bash users should follow **[QUICKSTART_BASH.md](QUICKSTART_BASH.md)** — it is the default and is kept in lockstep with the AI-assisted setup prompt in the README.
+
+For the one-paragraph overview and the AI-assisted setup prompt (drive the whole flow from Claude Code / Cursor), see the [README Quick Start](../README.md#quick-start).
+
+---
+
+## Prerequisites
+
+- **PowerShell 7+** — required. `winget install Microsoft.PowerShell`. Windows 10/11 ships PowerShell 5.1, but several commands below rely on .NET Core APIs that are only available in PowerShell 7+. Verify with `$PSVersionTable.PSVersion`. *Have bash available (Git Bash, WSL, macOS, Linux)? Use [QUICKSTART_BASH.md](QUICKSTART_BASH.md) instead — it's simpler and is kept in lockstep with the AI-assisted setup prompt in the README.*
+- **[Docker Desktop](https://docs.docker.com/desktop/install/windows-install/)** — required for the server stack (backend, frontend, MongoDB). ~2 GB disk for images on first pull. Make sure Docker Desktop is running before Step 1.
+- **OpenSSL** — required for the encryption key and JWT signing keys. Install via:
+  ```powershell
+  winget install ShiningLight.OpenSSL.Light
+  ```
+  After installation, restart PowerShell so `openssl.exe` is on `PATH`. Alternatively, if you have Git for Windows installed, use its bundled binary at `C:\Program Files\Git\usr\bin\openssl.exe`.
+- **`curl.exe`** — ships with Windows 10/11. PowerShell aliases `curl` to `Invoke-WebRequest`, so the snippets below explicitly call `curl.exe` to avoid the alias.
+- **[Rust / Cargo](https://www.rust-lang.org/tools/install)** — **optional**, only needed if you install the `nyxid` CLI (see [Install the `nyxid` CLI](#optional-install-the-nyxid-cli) below). Budget ~1.5 GB disk and 3–10 minutes for the first compile.
+
+Total disk footprint: ~2 GB for the server only, ~3.5 GB if you also install the CLI from source.
+
+> **Symlink note:** Step 2 creates `.env.production` as a copy of `.env.dev` rather than a symlink. PowerShell's `New-Item -ItemType SymbolicLink` requires either administrator rights or Windows Developer Mode enabled, so the bash version's `ln -sf` is replaced with `Copy-Item` for friction-free setup. If you later edit `.env.dev`, copy it over `.env.production` again.
+
+---
+
+## Step 1 of 3 — Check your system
+
+Paste this into PowerShell:
+
+```powershell
+$err = $false
+foreach ($cmd in @('git', 'docker', 'openssl', 'curl.exe')) {
+  if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+    Write-Host "Missing: $cmd"
+    $err = $true
+  }
+}
+try { docker compose version | Out-Null } catch { Write-Host "Missing: docker compose (v2 plugin)"; $err = $true }
+try { docker info 2>&1 | Out-Null; if ($LASTEXITCODE -ne 0) { throw } } catch { Write-Host "Docker is not running. Start Docker Desktop and re-run."; $err = $true }
+if ($err) { exit 1 }
+Write-Host "All good - proceed to Step 2."
+```
+
+---
+
+## Step 2 of 3 — Install and start
+
+> **This is a first-time install.** If you already have NyxID set up locally, run `.\scripts\uninstall.sh --yes` from inside `NyxID/` first via Git Bash or WSL (see [Uninstall & reinstall](#uninstall--reinstall) below), then come back here. PowerShell does not run `.sh` scripts directly.
+
+> **If you've run NyxID before:** a stale MongoDB volume can keep the old `MONGO_ROOT_PASSWORD` even after `.env.dev` is regenerated, which shows up as `SCRAM failure: Authentication failed` in `docker logs nyxid-backend`. To intentionally wipe local test data before re-running with a fresh password, run this from the existing `NyxID/` checkout:
+>
+> ```powershell
+> docker compose -f docker-compose.yml -f docker-compose.prod.yml down -v
+> ```
+>
+> This deletes local NyxID accounts, encrypted credentials, and audit logs. It does not change the quickstart automatically because deleting user data must be explicit.
+
+The block below checks install state, reuses an existing checkout when safe, generates development env files and signing keys, starts Docker, and waits for `/health`.
+
+```powershell
+$ErrorActionPreference = 'Stop'
+
+# Detect existing install state
+$volumes = docker volume ls --format '{{.Name}}' 2>$null
+$staleVolume = $volumes | Where-Object { $_ -match '^nyx.*_mongodb_data$' }
+if ((Test-Path 'NyxID/.env.dev') -or $staleVolume) {
+  Write-Host "Existing NyxID install state detected."
+  if (Test-Path 'NyxID') {
+    Write-Host "Uninstall first via Git Bash, then re-paste this block:"
+    Write-Host "    cd NyxID; bash ./scripts/uninstall.sh --yes; cd .."
+  } else {
+    Write-Host "NyxID/ is gone but a stale MongoDB volume remains. Remove it, then re-paste:"
+    Write-Host "    docker volume ls --format '{{.Name}}' | Select-String 'nyx.*_mongodb_data$' | ForEach-Object { docker volume rm \$_.ToString().Trim() }"
+  }
+  return
+}
+
+if (-not (Test-Path 'NyxID')) {
+  git clone https://github.com/ChronoAIProject/NyxID.git
+}
+Set-Location NyxID
+
+$EK = (openssl rand -hex 32).Trim()
+$MONGO_PASS = (openssl rand -hex 24).Trim()
+
+@"
+MONGO_ROOT_PASSWORD=$MONGO_PASS
+ENCRYPTION_KEY=$EK
+BASE_URL=http://localhost:3001
+FRONTEND_URL=http://localhost:3000
+ENVIRONMENT=development
+JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
+JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
+INVITE_CODE_REQUIRED=false
+AUTO_VERIFY_EMAIL=true
+EMAIL_AUTH_ENABLED=true
+RUST_LOG=nyxid=info,tower_http=info
+"@ | Set-Content -Path .env.dev -NoNewline
+
+# Windows symlink requires admin / Developer Mode; copy instead
+Copy-Item .env.dev .env.production -Force
+
+New-Item -ItemType Directory -Force -Path keys | Out-Null
+openssl genrsa -out keys/private.pem 4096 2>$null
+# PKCS#1 with LibreSSL fallback to PKCS#8
+openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>$null
+if ($LASTEXITCODE -ne 0) {
+  openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>$null
+}
+
+Write-Host "Downloading NyxID (this may take a few minutes on first run)..."
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d
+
+Write-Host "Waiting for NyxID to start..."
+$ok = $false
+for ($n = 0; $n -lt 45; $n++) {
+  try {
+    $resp = Invoke-WebRequest -Uri 'http://localhost:3001/health' -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+    if ($resp.StatusCode -eq 200) { $ok = $true; break }
+  } catch { }
+  Start-Sleep -Seconds 2
+}
+
+if ($ok) {
+  Write-Host ""
+  Write-Host "OK: NyxID is running at http://localhost:3000"
+  Write-Host "  Save your encryption key (needed if you reset the database): $EK"
+} else {
+  Write-Host ""
+  Write-Host "ERROR: Timed out waiting for NyxID to start."
+  Write-Host "  Check logs:  docker logs nyxid-backend"
+  Write-Host "  Reset state: see the 'Uninstall & reinstall' section below"
+}
+```
+
+---
+
+## Step 3 of 3 — Register and connect
+
+1. Open `http://localhost:3000` in your browser
+2. Register with your name, email, and a password — no email verification needed (accounts are auto-verified in dev mode)
+3. Log in and connect your AI agent using one of the methods in [Connect your AI tool](#connect-your-ai-tool) below
+
+To stop NyxID: `docker compose -f docker-compose.yml -f docker-compose.prod.yml down`
+
+---
+
+## Optional: Install the `nyxid` CLI
+
+The server stack above is fully usable from the web console — the CLI (Command Line Interface) is only needed if you want to script credential setup, manage credential nodes, or drive NyxID from your terminal. Skip this section if you'd rather stay in the browser.
+
+> **Heads-up:** the bash installer script (`install.sh`) is the recommended path on macOS / Linux but does not run natively in PowerShell. Use one of these alternatives:
+
+**Option A — Git Bash (one-liner):** if you have Git for Windows, open Git Bash and run:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
+```
+
+**Option B — Cargo (PowerShell-native):** install [Rust](https://www.rust-lang.org/tools/install) first, then:
+
+```powershell
+cargo install --git https://github.com/ChronoAIProject/NyxID.git nyxid-cli --locked
+nyxid --version
+```
+
+> **Note:** Some `nyxid node daemon` subcommands (`install`, `start`, `stop`, `restart`, `status`, `logs`, `uninstall`) only support macOS launchd and Linux systemd. On Windows, run `nyxid node start` in the foreground or use `nyxid node docker` instead. See [Section 6 of CLAUDE.md](../CLAUDE.md#6-node-proxy-conventions) for the supported subcommand set.
+
+---
+
+## Connect your AI tool
+
+Once your stack is up and you've registered an account, the next step is to connect a real downstream AI Service (OpenAI, Anthropic, GitHub, etc.) and verify the proxy actually works. **Wiring MCP alone won't show real tools** — until a real service is connected and verified, your AI agent will only see NyxID's `nyx__...` meta-tools and you'll wonder why nothing's working.
+
+The full flow lives in **[docs/connecting-services/](connecting-services/)**. Start with the [Web UI walkthrough](connecting-services/web-ui.md) if it's your first service; for CLI / AI-driven (MCP) / Direct API, the [hub](connecting-services/README.md) links to one walkthrough per path. Use `http://localhost:3001` as your `<BASE_URL>` for self-host.
+
+---
+
+## Uninstall & reinstall
+
+Quickstart is a **first-time install**. To reinstall — e.g. to try a new config, wipe test data, or recover from a broken state — uninstall first, then re-run [Step 2](#step-2-of-3--install-and-start).
+
+The shipped uninstall scripts are bash. From PowerShell, invoke them via Git Bash or WSL:
+
+```powershell
+Set-Location NyxID
+bash ./scripts/uninstall.sh         # interactive
+bash ./scripts/uninstall.sh --yes   # non-interactive (CI / repeat testing)
+bash ./scripts/uninstall.sh --keep-config  # keep .env.dev and keys/
+```
+
+If Git Bash / WSL is not available, run the equivalent steps directly in PowerShell:
+
+```powershell
+Set-Location NyxID
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down -v
+docker rm -f nyxid-mongodb nyxid-mailpit nyxid-backend nyxid-frontend 2>$null
+Remove-Item -Force -ErrorAction SilentlyContinue .env.dev, .env.production, keys/private.pem, keys/public.pem
+```
+
+By default this removes:
+
+- Docker containers (`nyxid-mongodb`, `nyxid-mailpit`, `nyxid-backend`, `nyxid-frontend`)
+- The MongoDB named volume (`nyxid_mongodb_data`) — all NyxID accounts, encrypted credentials, and audit log entries
+- `.env.dev`, `.env.production`, `keys/private.pem`, `keys/public.pem`
+
+Docker images are preserved (no re-download). Skip the `Remove-Item` line if you want to preserve your existing `ENCRYPTION_KEY` across reinstall (e.g. to keep encrypted database backups readable).
+
+After uninstall, `Set-Location ..` out of `NyxID/` and re-paste **Step 2** above. The pre-flight now checks for install *state* (`.env.dev` or the Mongo volume), not the source tree — so the existing `NyxID/` checkout is reused and only regeneration runs.
+
+### Recovering an orphan volume
+
+If you hit issue [#280](https://github.com/ChronoAIProject/NyxID/issues/280) on an older quickstart and manually deleted your `NyxID/` checkout, but a stale MongoDB volume survived, you don't need to re-clone just to run `uninstall.sh`. Remove any nyx-flavored volume directly — this matches `nyxid_mongodb_data` (default), `nyx_mongodb_data`, or any `nyx*_mongodb_data` variant from a renamed checkout:
+
+```powershell
+docker volume ls --format '{{.Name}}' |
+  Select-String 'nyx.*_mongodb_data$' |
+  ForEach-Object { docker volume rm $_.ToString().Trim() }
+docker rm -f nyxid-mongodb nyxid-mailpit nyxid-backend nyxid-frontend 2>$null
+```
+
+Then re-paste Step 2 — the pre-flight will pass and Step 2 will clone fresh.
+
+### Stuck on SCRAM failure?
+
+If `docker logs nyxid-backend` shows `SCRAM failure: Authentication failed`, your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run the PowerShell uninstall block above to wipe the volume, then re-run [Step 2](#step-2-of-3--install-and-start). See [#280](https://github.com/ChronoAIProject/NyxID/issues/280).
+
+## Done when...
+
+- `curl.exe -sf http://localhost:3001/health` returns 200 (or `Invoke-WebRequest http://localhost:3001/health` returns 200).
+- `http://localhost:3000` loads in your browser.
+- You can register a user and log in.
+
+---
+
+## Production deployment
+
+For production deployment (TLS (Transport Layer Security), custom domain, email verification), see [DEPLOYMENT.md](DEPLOYMENT.md). The deployment guide assumes a Linux host; PowerShell is for local self-host only.

--- a/docs/QUICKSTART_POWERSHELL.md
+++ b/docs/QUICKSTART_POWERSHELL.md
@@ -227,7 +227,7 @@ Then re-paste Step 2 — the pre-flight will pass and Step 2 will clone fresh.
 
 ### Stuck on SCRAM failure?
 
-If `docker logs nyxid-backend` shows `SCRAM failure: Authentication failed`, your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run the PowerShell uninstall block above to wipe the volume, then re-run [Step 2](#step-2-of-3--install-and-start). See [#280](https://github.com/ChronoAIProject/NyxID/issues/280).
+If `docker logs nyxid-backend` shows `SCRAM failure: Authentication failed`, your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run the PowerShell uninstall block above to wipe the volume, then re-run [Step 2](#step-2-of-3--install-and-start).
 
 ## Done when...
 

--- a/docs/QUICKSTART_POWERSHELL.md
+++ b/docs/QUICKSTART_POWERSHELL.md
@@ -73,7 +73,9 @@ if ((Test-Path 'NyxID/.env.dev') -or $staleVolume) {
     Write-Host "    cd NyxID; bash ./scripts/uninstall.sh --yes; cd .."
   } else {
     Write-Host "NyxID/ is gone but a stale MongoDB volume remains. Remove it, then re-paste:"
-    Write-Host "    docker volume ls --format '{{.Name}}' | Select-String 'nyx.*_mongodb_data$' | ForEach-Object { docker volume rm \$_.ToString().Trim() }"
+    Write-Host @'
+    docker volume ls --format '{{.Name}}' | Select-String 'nyx.*_mongodb_data$' | ForEach-Object { docker volume rm $_.ToString().Trim() }
+'@
   }
   return
 }

--- a/docs/connecting-services/README.md
+++ b/docs/connecting-services/README.md
@@ -48,7 +48,7 @@ For private APIs the catalog doesn't know about, see the **Custom services** sec
 
 ## Related
 
-- [docs/QUICKSTART.md](../QUICKSTART.md) — self-host setup
+- [docs/QUICKSTART_BASH.md](../QUICKSTART_BASH.md) — self-host setup (Bash, default; [PowerShell variant](../QUICKSTART_POWERSHELL.md))
 - [docs/MCP_DELEGATION_FLOW.md](../MCP_DELEGATION_FLOW.md) — MCP auth + delegation under the hood
 - [docs/AI_AGENT_PLAYBOOK.md](../AI_AGENT_PLAYBOOK.md) — patterns for using NyxID from agent code
 - [docs/API.md](../API.md) — full REST endpoint reference

--- a/docs/connecting-services/web-ui.md
+++ b/docs/connecting-services/web-ui.md
@@ -57,7 +57,19 @@ The example curl on the service detail page authenticates to NyxID with `X-API-K
 3. Paste it in your terminal. **Replace the literal `nyx_...` placeholder with the Agent Key you just copied** (the example block is a template — the placeholder won't work as-is).
 4. Run it.
 
-> **Windows users:** This curl is bash. Run it from [Git Bash](https://gitforwindows.org/) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) — pasting into raw PowerShell or CMD will fail on the `\` line continuations.
+> **Windows users:** This curl is bash. The simplest path is to run it from [Git Bash](https://gitforwindows.org/) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) — pasting into raw PowerShell or CMD will fail on the `\` line continuations.
+>
+> Staying in raw PowerShell? The equivalent for the OpenAI verification path the walkthrough prescribes is:
+>
+> ```powershell
+> $env:NYX_API_KEY = "nyx_..."  # replace with your Agent Key
+> curl.exe -X POST "https://nyx.chrono-ai.fun/api/v1/proxy/s/llm-openai/v1/chat/completions" `
+>   -H "X-API-Key: $env:NYX_API_KEY" `
+>   -H "Content-Type: application/json" `
+>   -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}'
+> ```
+>
+> Use `curl.exe`, not `curl` — `curl` in PowerShell is an alias for `Invoke-WebRequest`. For services other than OpenAI, copy the bash curl from the UI and replace each `\` continuation with a backtick.
 
 You should see a chat-completion JSON response from OpenAI — the body has `"choices": [...]` with a generated message. That's your first proxied call. The same Agent Key works for every service you add later (as long as the key has the `proxy` scope).
 

--- a/docs/connecting-services/web-ui.md
+++ b/docs/connecting-services/web-ui.md
@@ -57,7 +57,7 @@ The example curl on the service detail page authenticates to NyxID with `X-API-K
 3. Paste it in your terminal. **Replace the literal `nyx_...` placeholder with the Agent Key you just copied** (the example block is a template — the placeholder won't work as-is).
 4. Run it.
 
-> **Windows users:** If you paste the copied curl into PowerShell, change bash `\` continuations to backticks and run `curl.exe`. In CMD, use `^` for continuations. If you set environment variables manually, PowerShell uses `$env:NAME="value"` and CMD uses `set NAME=value`.
+> **Windows users:** This curl is bash. Run it from [Git Bash](https://gitforwindows.org/) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) — pasting into raw PowerShell or CMD will fail on the `\` line continuations.
 
 You should see a chat-completion JSON response from OpenAI — the body has `"choices": [...]` with a generated message. That's your first proxied call. The same Agent Key works for every service you add later (as long as the key has the `proxy` scope).
 
@@ -65,7 +65,7 @@ You should see a chat-completion JSON response from OpenAI — the body has `"ch
 
 Console URL: **http://localhost:3000** (port 3000, while the API runs on 3001).
 
-Same steps as hosted, except you sign in with the account you registered against your local instance. If you don't have NyxID running locally yet, see [docs/QUICKSTART.md](../QUICKSTART.md) first.
+Same steps as hosted, except you sign in with the account you registered against your local instance. If you don't have NyxID running locally yet, see [docs/QUICKSTART_BASH.md](../QUICKSTART_BASH.md) first (or [docs/QUICKSTART_POWERSHELL.md](../QUICKSTART_POWERSHELL.md) on native Windows PowerShell).
 
 ## What if the curl errors?
 


### PR DESCRIPTION
Closes #643.

## Summary

- Add `docs/QUICKSTART_POWERSHELL.md` — first-class native-Windows self-host quickstart (faithful port of the bash version: preflight, install, register, optional CLI, uninstall, orphan-volume recovery, SCRAM failure).
- Rename `docs/QUICKSTART.md` → `docs/QUICKSTART_BASH.md` (history preserved via `git mv`) and retitle to "NyxID Self-Host Quickstart (Bash)".
- Reframe `README.md` prereqs so neither shell is the default — users pick the quickstart matching their shell. README's manual-setup pointer is split one-line-per-platform.
- Add a runnable PowerShell snippet for the OpenAI verification curl in `docs/connecting-services/web-ui.md` — the literal ask in #643. The walkthrough explicitly prescribes OpenAI for verification (web-ui.md:25), so this static snippet does not drift with the dynamically-generated `ApiUsageSection`; it targets the prescribed path only.
- Repointed all 10 internal references from `QUICKSTART.md` → `QUICKSTART_BASH.md`.

## Approach (vs the issue's literal ask)

#643 asked for a runnable PowerShell example next to the bash curl in `web-ui.md`. The PR addresses it two ways:

1. **Native-PowerShell self-host path** (the bigger fix) — `QUICKSTART_POWERSHELL.md` gives Windows users a complete bash-free path through the install.
2. **Static PS snippet for the OpenAI verification curl** (the literal #643 fix) — `web-ui.md` now includes the PowerShell equivalent for the verification step the doc explicitly prescribes. Drift risk is bounded because the walkthrough anchors verification to OpenAI; for non-prescribed services, users still need to translate or use Git Bash.

## Key PowerShell-port decisions

- **Requires PowerShell 7+.** PS 5.1 lacks the .NET Core crypto APIs the install relies on.
- **Requires OpenSSL via `winget install ShiningLight.OpenSSL.Light`.** Documented; Git-for-Windows fallback path noted.
- **`Copy-Item` instead of `ln -sf`** for `.env.dev` → `.env.production` to avoid Windows' admin / Developer Mode requirement on symlinks.
- **`nyxid node daemon` Windows gap explicitly called out** — only macOS launchd / Linux systemd are supported. Windows users foreground-run with `nyxid node start` or use `nyxid node docker`.
- **Uninstall path:** `scripts/uninstall.sh` is bash; PS equivalent inlined for PS-only environments.

## Maintenance flag

`QUICKSTART_BASH.md`'s Step 2 has subtle state checks (orphan volume detection across `nyx*_mongodb_data` variants, SCRAM failure path, `--keep-config` semantics). Any future change to that block should land a paired update to `QUICKSTART_POWERSHELL.md` or the two will drift. Worth a `CONTRIBUTING.md` note if drift recurs.

## Review status

- **Claude (self-review):** PASS on #643 after applying P1 fix + OpenAI PS snippet.
- **Codex:** unable to run for this PR — local `codex` CLI is misconfigured to route through `https://llm.aelf.dev/responses` and hits `401 INVALID_API_KEY`. No independent second opinion captured. Re-running once the gateway key is rotated is straightforward but not blocking on this PR.

**P1 fix applied during review:** `docs/QUICKSTART_POWERSHELL.md` install-state-detected branch had a `Write-Host` instruction with `\$_.ToString()` inside a double-quoted PS string. Backslash isn't an escape character in PowerShell — backtick is — so the printed instruction came out as `\.ToString().Trim()` (broken). Fixed by switching to a single-quoted here-string `@'...'@` so the line is treated as literal.

## Test plan

- [ ] On macOS / Linux / WSL / Git Bash, follow `QUICKSTART_BASH.md` end-to-end and confirm `curl -sf http://localhost:3001/health` returns 200.
- [ ] On native Windows PowerShell 7+, follow `QUICKSTART_POWERSHELL.md` end-to-end and confirm `Invoke-WebRequest http://localhost:3001/health` returns 200.
- [ ] On native PowerShell, paste the new `web-ui.md` PowerShell verification snippet and confirm OpenAI returns a chat-completion response.
- [ ] Verify the 10 repointed internal references resolve in the GitHub markdown viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)