### PR TITLE
docs: wrap UI labels in backticks for translation resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Start using NyxID in under a minute — no Docker, no setup.
 1. Open **[nyx.chrono-ai.fun/register](https://nyx.chrono-ai.fun/register)** in a new tab (Cmd/Ctrl-click, or right-click → Open Link in New Tab) so you can keep this checklist open.
 2. Enter invite code: **`NYX-FGNY85AF`**
 3. Sign in with Google, GitHub, or Apple
-4. Open **AI Services**, add and connect your first external service, and run the API Usage verification curl
+4. Open `AI Services`, add and connect your first external service, and run the API Usage verification curl
 5. After the service is verified, wire your AI tool to NyxID's MCP endpoint
 
 The full click-through flow is in **[Add your first AI Service](docs/connecting-services/web-ui.md)**. Early access is limited to 20 users.

--- a/docs/connecting-services/direct-api.md
+++ b/docs/connecting-services/direct-api.md
@@ -9,10 +9,10 @@ For Web UI / CLI / AI-driven, see the [hub](README.md).
 The recommended auth method for unattended automation is `X-API-Key`. Generate one in the web console:
 
 1. Sign in.
-2. Open **AI Services**, switch to the **Agent Keys** tab.
-3. Click **Create API Key**, give it a name.
-4. Under **Scopes**, select `proxy` (required for `/api/v1/proxy/...` — without it the proxy returns 403). If your script will also create / update / delete services via `POST /api/v1/keys`, add `write` as well — the management routes gate on `write` or `admin` only (the `services:write` badge is valid as a scope but is **not** honored by the management write check, so don't use it on its own).
-5. Click **Create** and copy the raw key (starts with `nyx_...`). It's shown once.
+2. Open `AI Services`, switch to the `Agent Keys` tab.
+3. Click `Create API Key`, give it a name.
+4. Under `Scopes`, select `proxy` (required for `/api/v1/proxy/...` — without it the proxy returns 403). If your script will also create / update / delete services via `POST /api/v1/keys`, add `write` as well — the management routes gate on `write` or `admin` only (the `services:write` badge is valid as a scope but is **not** honored by the management write check, so don't use it on its own).
+5. Click `Create` and copy the raw key (starts with `nyx_...`). It's shown once.
 
 Set it in your shell. `<BASE_URL>` is `https://nyx-api.chrono-ai.fun` for hosted, `http://localhost:3001` for self-host:
 

--- a/docs/connecting-services/web-ui.md
+++ b/docs/connecting-services/web-ui.md
@@ -14,46 +14,46 @@ If you don't have an account yet, register at [nyx.chrono-ai.fun/register](https
 
 ### 2. Add an AI Service
 
-1. Click **AI Services** in the left sidebar (you'll be on the **External Services** tab). The page shows your existing services and the **Add Service** button at top right.
+1. Click `AI Services` in the left sidebar (you'll be on the `External Services` tab). The page shows your existing services and the `Add Service` button at top right.
 
    ![AI Services page](img/01-ai-services.png)
 
-2. Click **Add Service**. The **Add AI Service** dialog opens with the catalog.
+2. Click `Add Service`. The `Add AI Service` dialog opens with the catalog.
 
    ![Add AI Service catalog](img/02-add-service-catalog.png)
 
-3. Pick **OpenAI** from the catalog. (Use OpenAI for verification — its example curl works out of the box. You can add Anthropic, GitHub, etc. afterward.)
+3. Pick `OpenAI` from the catalog. (Use OpenAI for verification — its example curl works out of the box. You can add Anthropic, GitHub, etc. afterward.)
 
-4. The **Configure Routing** step appears. Click the **Direct** card (NyxID proxies to OpenAI directly — the **Via Node** option is for self-hosted services behind a firewall). Then click **Next: Enter Credentials**.
+4. The `Configure Routing` step appears. Click the `Direct` card (NyxID proxies to OpenAI directly — the `Via Node` option is for self-hosted services behind a firewall). Then click `Next: Enter Credentials`.
 
    ![Configure Routing — Direct vs Via Node](img/03-routing-step.png)
 
-5. The **Configure Service** step appears. Paste your **provider API key** in the **API Key / Credential** field — for OpenAI, an `sk-...` key. This is the **external service's** credential, **not** a NyxID `nyx_...` key. NyxID stores it encrypted.
+5. The `Configure Service` step appears. Paste your **provider API key** in the `API Key / Credential` field — for OpenAI, an `sk-...` key. This is the **external service's** credential, **not** a NyxID `nyx_...` key. NyxID stores it encrypted.
 
    ![Configure Service — credential entry](img/04-credential-entry.png)
 
-6. Click **Create Service**. You land on the new service's detail page. Keep this tab open.
+6. Click `Create Service`. You land on the new service's detail page. Keep this tab open.
 
 ### 3. Create a NyxID Agent Key
 
 The example curl on the service detail page authenticates to NyxID with `X-API-Key: nyx_...` — that's a placeholder. You need to create the real key separately.
 
-1. Open a new tab on **AI Services** and switch to the **Agent Keys** tab.
-2. Click **Create API Key**. The **Create API Key** dialog opens.
+1. Open a new tab on `AI Services` and switch to the `Agent Keys` tab.
+2. Click `Create API Key`. The `Create API Key` dialog opens.
 
    ![Create API Key dialog with scope picker](img/06-create-agent-key.png)
 
 3. Give it a name (anything — `quickstart-test` is fine).
-4. Under **Scopes**, click the `proxy` badge so it's highlighted. The `proxy` scope is required for `/api/v1/proxy/...` requests; without it the proxy returns 403.
-5. Click **Create key**. The dialog shows your `nyx_...` key **once** — copy it now.
+4. Under `Scopes`, click the `proxy` badge so it's highlighted. The `proxy` scope is required for `/api/v1/proxy/...` requests; without it the proxy returns 403.
+5. Click `Create key`. The dialog shows your `nyx_...` key **once** — copy it now.
 
 ### 4. Run the verification curl
 
-1. Switch back to the service detail tab. Scroll to the **API Usage** section.
+1. Switch back to the service detail tab. Scroll to the `API Usage` section.
 
    ![API Usage section on service detail page](img/05-service-detail.png)
 
-2. Click the **copy icon** on the **Example (with API key)** curl block.
+2. Click the **copy icon** on the `Example (with API key)` curl block.
 3. Paste it in your terminal. **Replace the literal `nyx_...` placeholder with the Agent Key you just copied** (the example block is a template — the placeholder won't work as-is).
 4. Run it.
 
@@ -70,13 +70,13 @@ Same steps as hosted, except you sign in with the account you registered against
 ## What if the curl errors?
 
 - **401 Unauthorized from OpenAI** (downstream): the **provider** key you pasted in section 2 is wrong or revoked. Open the service's detail page and update the credential.
-- **403 Forbidden from NyxID**: your Agent Key is missing the `proxy` scope. Go back to **Agent Keys**, edit the key (or create a new one), and add `proxy`.
+- **403 Forbidden from NyxID**: your Agent Key is missing the `proxy` scope. Go back to `Agent Keys`, edit the key (or create a new one), and add `proxy`.
 - **401 from NyxID with `Missing API key`**: you forgot to replace the literal `nyx_...` placeholder in the copied curl with your real Agent Key.
 
 For other failure modes, see the **Did it work?** section in the [hub](README.md#did-it-work).
 
 ## Next
 
-- **Want your AI agent to use this service?** After the service is added, connected, and verified from **AI Services**, wire MCP — see [ai-driven.md](ai-driven.md).
+- **Want your AI agent to use this service?** After the service is added, connected, and verified from `AI Services`, wire MCP — see [ai-driven.md](ai-driven.md).
 - **Want to script this for more services?** See [cli.md](cli.md) or [direct-api.md](direct-api.md).
 - **Want to expose a private API behind your firewall?** See [docs/NODE_PROXY.md](../NODE_PROXY.md).


### PR DESCRIPTION
Closes #645.

## Summary
- Wrap clickable UI labels (buttons, tabs, dialog titles, fields) in backticks instead of bold across the step-by-step Web UI walkthroughs.
- Backticks render as `<code>`; Google Translate and similar browser translators skip `<code>` content. `<strong>` (from `**bold**`) gets translated.
- Bold preserved for non-label emphasis: callouts (`**Windows users:**`), error names (`**401 Unauthorized from OpenAI**`), URLs, and conceptual stress (`**not**`, `**once**`).

## Why
Surfaced by #645, where a reporter followed our docs through Google Translate, saw `AI Services` rendered as `AI 服务` etc., and filed a bug claiming the source docs were translated. The actual cause was the browser extension visible in the reporter's screenshot — but the proposed fix in the issue (backtick UI labels) is the right docs-style mitigation, and it makes click targets more scannable in English too.

## Files changed
- `README.md` — Hosted Quick Start checklist (1 label: `AI Services`)
- `docs/connecting-services/web-ui.md` — full click-through (18 labels: sidebar/tab/button/field/dialog/section)
- `docs/connecting-services/direct-api.md` — Web UI prelude before curl (5 labels: `AI Services`, `Agent Keys`, `Create API Key`, `Scopes`, `Create`)

Net diff: 19 insertions, 19 deletions across 3 files.

## Out of scope
Other docs that have step-by-step bold UI labels (`docs/SOCIAL_TOKEN_EXCHANGE_MOBILE_INTEGRATION.md`, `docs/MOBILE_APP_INTEGRATION.md`) describe Firebase / Apple Developer Portal / NyxID Developer Apps flows for engineers integrating against NyxID — lower probability of browser-translation use, lower blast radius if it happens. Can do those in a follow-up if useful.

## Test plan
- [ ] Render the three changed docs on GitHub and confirm UI labels render as inline code (monospace, light gray background).
- [ ] Sanity-check no orphan asterisks or unbalanced backticks.
- [ ] Optional manual: enable Google Translate on the rendered README and `web-ui.md`, confirm UI labels remain English while surrounding prose translates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)