### PR TITLE
docs: clarify service detail tab flow in web UI quickstart (#646)

### DIFF
--- a/docs/connecting-services/web-ui.md
+++ b/docs/connecting-services/web-ui.md
@@ -32,7 +32,11 @@ If you don't have an account yet, register at [nyx.chrono-ai.fun/register](https
 
    ![Configure Service — credential entry](img/04-credential-entry.png)
 
-6. Click `Create Service`. You land on the new service's detail page. Keep this tab open.
+6. Click `Create Service`. NyxID opens the new service's detail page automatically.
+
+   Keep this service detail tab open. You will come back here later to copy the `API Usage` curl example.
+
+   Before that curl can work, you need to create a NyxID Agent Key. The `nyx_...` shown in the example is only a placeholder.
 
 ### 3. Create a NyxID Agent Key
 
@@ -49,7 +53,9 @@ The example curl on the service detail page authenticates to NyxID with `X-API-K
 
 ### 4. Run the verification curl
 
-1. Switch back to the service detail tab. Scroll to the `API Usage` section.
+1. Return to the service detail tab. Scroll to the `API Usage` section.
+
+   If you lost that tab, go to `AI Services` → `External Services`, find the service you just created, and click its service card to reopen the service detail page.
 
    ![API Usage section on service detail page](img/05-service-detail.png)
 


### PR DESCRIPTION
## Summary

Closes #646. Two surgical edits to `docs/connecting-services/web-ui.md` that make the tab flow explicit for first-time users:

- **Step 6 (`Create Service`)** — expand the "Keep this tab open" line into three short paragraphs that say *why* (the curl lives there), warn that the next section takes the user away to create an Agent Key, and call out that the `nyx_...` in the example is a placeholder until that real key exists.
- **Step 4 (`Run the verification curl`)** — add a fallback path for users who already closed the service detail tab: `AI Services` → `External Services` → click the service card to reopen it.

UI labels use backticks to stay consistent with #655 (which switched the doc-wide style for translation resilience).

## Test plan

- [ ] Read the rendered diff on GitHub and confirm the step-6 paragraphs flow naturally and the step-4 fallback callout reads cleanly above the screenshot.
- [ ] Walk through `docs/connecting-services/web-ui.md` end-to-end as if onboarding for the first time and confirm the tab-flow loop is unambiguous.
- [ ] Sanity-check that `Create Service`, `API Usage`, `AI Services`, `External Services` all appear as exact UI labels (backticks, not bold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)