### PR TITLE
docs(connecting-services): structure Direct API Connect and verify as numbered steps (#649)

### DIFF
--- a/docs/connecting-services/direct-api.md
+++ b/docs/connecting-services/direct-api.md
@@ -14,20 +14,33 @@ The recommended auth method for unattended automation is `X-API-Key`. Generate o
 4. Under `Scopes`, select `proxy` (required for `/api/v1/proxy/...` — without it the proxy returns 403). If your script will also create / update / delete services via `POST /api/v1/keys`, add `write` as well — the management routes gate on `write` or `admin` only (the `services:write` badge is valid as a scope but is **not** honored by the management write check, so don't use it on its own).
 5. Click `Create` and copy the raw key (starts with `nyx_...`). It's shown once.
 
-Set it in your shell. `<BASE_URL>` is `https://nyx-api.chrono-ai.fun` for hosted, `http://localhost:3001` for self-host:
+`<BASE_URL>` in the steps below is `https://nyx-api.chrono-ai.fun` for hosted, `http://localhost:3001` for self-host.
+
+> **Windows users:** Each step below shows a separate macOS / Linux / Git Bash block and a Windows PowerShell block — pick one and use it consistently. For CMD, replace `$env:NAME="value"` with `set NAME=value` and use `^` for line continuations. In PowerShell, call `curl.exe` so it doesn't invoke PowerShell's built-in `curl` alias.
+
+## Connect and verify
+
+`<EXTERNAL_CREDENTIAL>` below is the **provider's** key (e.g. an OpenAI `sk-...` key), **not** your `NYX_API_KEY`.
+
+### Step 1 — Set shell variables
+
+macOS / Linux / Git Bash:
 
 ```bash
 export NYX_API_KEY=nyx_...
 export NYXID_BASE=<BASE_URL>
 ```
 
-> **Windows users:** The examples below use bash syntax. In PowerShell, use `$env:NYX_API_KEY="nyx_..."` and `$env:NYXID_BASE="<BASE_URL>"`; in CMD, use `set NYX_API_KEY=nyx_...` and `set NYXID_BASE=<BASE_URL>`. Replace bash `\` continuations with PowerShell backticks or CMD `^`, and call `curl.exe` so PowerShell does not invoke its `curl` alias.
+Windows PowerShell:
 
-## Connect and verify
+```powershell
+$env:NYX_API_KEY = "nyx_..."
+$env:NYXID_BASE = "<BASE_URL>"
+```
 
-`<EXTERNAL_CREDENTIAL>` below is the **provider's** key (e.g. an OpenAI `sk-...` key), **not** your `NYX_API_KEY`.
+### Step 2 — Connect the service
 
-Connect a service from the catalog:
+macOS / Linux / Git Bash:
 
 ```bash
 curl -X POST "$NYXID_BASE/api/v1/keys" \
@@ -40,7 +53,7 @@ curl -X POST "$NYXID_BASE/api/v1/keys" \
   }'
 ```
 
-PowerShell equivalent:
+Windows PowerShell:
 
 ```powershell
 $body = @{
@@ -55,16 +68,45 @@ curl.exe -X POST "$env:NYXID_BASE/api/v1/keys" `
   -d $body
 ```
 
-Verify the proxy. It should return a real OpenAI models response:
+### Step 3 — Copy the returned slug
+
+The response includes a top-level `slug` field. If `llm-openai` already existed on your account, the new entry may be suffixed (e.g. `llm-openai-2`, `llm-openai-3`, or a random-suffixed variant once the numeric range is exhausted). **Use that exact value in Step 4** — it is the only handle that addresses your specific service instance.
+
+Example response excerpt:
+
+```json
+{
+  "id": "...",
+  "label": "production-openai",
+  "slug": "llm-openai-2",
+  "status": "connected",
+  ...
+}
+```
+
+### Step 4 — Verify with a proxied request
+
+Substitute `<RETURNED_SERVICE_SLUG>` with the `slug` value you copied in Step 3.
+
+macOS / Linux / Git Bash:
 
 ```bash
-curl -X GET "$NYXID_BASE/api/v1/proxy/s/llm-openai/models" \
+curl -X GET "$NYXID_BASE/api/v1/proxy/s/<RETURNED_SERVICE_SLUG>/models" \
   -H "X-API-Key: $NYX_API_KEY"
 ```
 
-If step 2 returns a real downstream response (not a 401 / 403), the service is connected.
+Windows PowerShell:
 
-## Bearer token alternative
+```powershell
+curl.exe -X GET "$env:NYXID_BASE/api/v1/proxy/s/<RETURNED_SERVICE_SLUG>/models" `
+  -H "X-API-Key: $env:NYX_API_KEY"
+```
+
+Success looks like a real downstream response (for OpenAI's `models` endpoint, a JSON list of models). If you see `401`, `403`, `5xx`, or an HTML error page instead, see [Did it work?](README.md#did-it-work) in the hub.
+
+You're done with the required path. The sections below are **optional** — skip them unless you need them.
+
+## Optional — Bearer token alternative
 
 If you specifically need `Authorization: Bearer ...` (short-lived user-session token, not recommended for unattended automation):
 
@@ -80,13 +122,13 @@ export NYX_TOKEN="$(
   | jq -r '.access_token'
 )"
 
-curl -X GET "$NYXID_BASE/api/v1/proxy/s/llm-openai/models" \
+curl -X GET "$NYXID_BASE/api/v1/proxy/s/<RETURNED_SERVICE_SLUG>/models" \
   -H "Authorization: Bearer $NYX_TOKEN"
 ```
 
 Bearer tokens expire (default 15 min). Prefer `X-API-Key` for anything unattended.
 
-## Listing the catalog
+## Optional — Browse the catalog
 
 List connectable catalog entries:
 
@@ -100,10 +142,10 @@ Include system services too:
 curl "$NYXID_BASE/api/v1/catalog?include_all=true" -H "X-API-Key: $NYX_API_KEY"
 ```
 
-List parsed OpenAPI endpoints for a slug:
+List parsed OpenAPI endpoints for a slug. This returns an empty list when the catalog entry has no parsed OpenAPI spec — which can happen for `llm-openai`. Try a slug whose catalog entry advertises an `openapi_spec_url` (visible via `GET /api/v1/catalog/<SLUG>`) if you want to see structured endpoint output:
 
 ```bash
-curl "$NYXID_BASE/api/v1/catalog/llm-openai/endpoints" -H "X-API-Key: $NYX_API_KEY"
+curl "$NYXID_BASE/api/v1/catalog/<SLUG>/endpoints" -H "X-API-Key: $NYX_API_KEY"
 ```
 
 ## Next


### PR DESCRIPTION
## Summary

Closes #649. Mirrors the structure landed for the CLI doc in #659, applied to `docs/connecting-services/direct-api.md`:

- "Connect and verify" is now four numbered steps: set shell vars → connect → copy the returned slug → verify with `<RETURNED_SERVICE_SLUG>`.
- Each step has separate macOS / Linux / Git Bash and Windows PowerShell blocks instead of a mixed bash example plus a Windows-only callout.
- Step 3 spells out the suffix-on-collision behavior (`llm-openai-2`, random-suffixed variants) and includes an example response excerpt so users see which field to copy.
- "Bearer token alternative" and "Browse the catalog" are explicitly marked **Optional** so the required path stays focused.
- The catalog endpoints example is qualified — empty result is expected for catalog entries without a parsed OpenAPI spec (which is currently the case for `llm-openai`); pick a slug whose entry advertises an `openapi_spec_url` for structured output.

The connecting-services [hub README](docs/connecting-services/README.md) was audited and is already in sync (it labels Direct API as a separate path, says "verification is the explicit final step in those guides" — now literally Step 4 — and the 401/403/5xx troubleshooting still applies). No edits to the hub were required.

## Test plan

- [ ] Render `docs/connecting-services/direct-api.md` on GitHub and confirm the four numbered steps are visible under `Connect and verify`.
- [ ] Walk through Steps 1–4 with a fresh user account that already has a `llm-openai` connection, observe a suffixed slug in the response, and confirm Step 4 instructs copying that exact slug.
- [ ] Run the PowerShell blocks under Steps 1, 2, and 4 against a hosted backend and confirm they succeed end-to-end without translation from bash.
- [ ] Hit `GET /api/v1/catalog/llm-openai/endpoints` and confirm the empty-list caveat in the optional section is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)