### PR TITLE
fix(frontend): cache-bust favicon URLs with ?v=2

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,10 +2,10 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=2" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=2" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>NyxID - Open-source Agent Connectivity Gateway</title>

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -4,12 +4,12 @@
   "description": "Open-source Agent Connectivity Gateway",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "/icon-192.png?v=2",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icon-512.png",
+      "src": "/icon-512.png?v=2",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary
- Append `?v=2` to favicon hrefs in `frontend/index.html` and PWA icon srcs in `frontend/public/site.webmanifest` so browsers see them as new resources.
- Works around `frontend/nginx.conf.template:65-72`, which serves every `.ico`/`.png` (including unhashed `/public/` assets) with `Cache-Control: public, immutable, max-age=31536000` — meaning browsers that cached the old icons after #654 will not refetch them until the URL changes.
- Pure URL bump for existing users; does **not** change the nginx rule itself (worth a follow-up to scope `immutable` to `/assets/` only so this doesn't recur).

## Test plan
- [ ] Deploy and visit a previously-loaded page in a browser that has the pre-#654 favicon cached — confirm the new icon appears without a hard reload.
- [ ] DevTools Network tab: `/favicon.ico?v=2`, `/favicon-32x32.png?v=2`, `/favicon-16x16.png?v=2`, `/apple-touch-icon.png?v=2` all return `200` (not `(disk cache)`) on first load post-deploy.
- [ ] `site.webmanifest` still parses (no JSON syntax errors); PWA install on Android/Chrome picks up the new 192/512 icons.
- [ ] Wizard route (served by the embedded wizard server, not nginx) is unaffected — its `GET /favicon.ico` handler is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)