### PR TITLE
fix(quickstart): chmod JWT keys readable so backend starts on WSL2

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -175,6 +175,12 @@ $EDITOR .env.production
 mkdir -p keys
 openssl genrsa -out keys/private.pem 4096
 openssl rsa -in keys/private.pem -pubout -out keys/public.pem
+chmod 755 keys
+chmod 644 keys/private.pem keys/public.pem
+# 644 lets the non-root `nyxid` user inside the backend container read the
+# bind-mounted keys when host UID != container UID (common on Windows WSL2).
+# For tighter perms in production, align host ownership with the container
+# `nyxid` user — see "RSA Key Management" below.
 
 # Pull published images and start the stack
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -91,6 +91,8 @@ mkdir -p keys
 openssl genrsa -out keys/private.pem 4096 2>/dev/null
 openssl rsa -in keys/private.pem -RSAPublicKey_out -out keys/public.pem 2>/dev/null \
   || openssl rsa -in keys/private.pem -pubout -out keys/public.pem 2>/dev/null
+chmod 755 keys
+chmod 644 keys/private.pem keys/public.pem
 
 echo "Downloading NyxID (this may take a few minutes on first run)..."
 docker compose -f docker-compose.yml -f docker-compose.prod.yml \
@@ -210,6 +212,18 @@ Then re-paste Step 2 — the pre-flight will pass and Step 2 will clone fresh.
 ### Stuck on SCRAM failure?
 
 If `docker logs nyxid-backend` shows `SCRAM failure: Authentication failed`, your MongoDB volume still has the previous `MONGO_ROOT_PASSWORD` baked in from a prior run, and `.env.dev` no longer matches. Run `./scripts/uninstall.sh --yes` to wipe the volume, then re-run [Step 2](#step-2-of-3--install-and-start).
+
+### Stuck on `Permission denied (os error 13)`?
+
+If `docker logs nyxid-backend` shows `Permission denied (os error 13)` while reading `/app/keys/*.pem`, the bind-mounted JWT key files aren't readable by the non-root `nyxid` user inside the backend container — common on Windows WSL2 because the host UID and container UID don't match. Fix in place without re-running Step 2:
+
+```bash
+chmod 755 keys
+chmod 644 keys/private.pem keys/public.pem
+docker compose -f docker-compose.yml -f docker-compose.prod.yml restart backend
+```
+
+The Step 2 block now sets these permissions automatically; this note is for checkouts created before that fix.
 
 ## Done when...
 


### PR DESCRIPTION
## Summary
- Fix `Permission denied (os error 13)` from `docs/QUICKSTART.md` Step 2 on Windows WSL2 by `chmod`'ing the generated JWT keys so the backend container's non-root `nyxid` user can read them.
- Apply the same fix to the `docs/DEPLOYMENT.md` production install block, with a comment pointing to the canonical `RSA Key Management` section for stricter prod hardening.
- Add a `Stuck on Permission denied (os error 13)?` troubleshooting subsection so anyone on a pre-fix checkout can recover in place without re-running Step 2.

## Why
`openssl genrsa` creates `keys/private.pem` at mode `0600`. On Windows WSL2 the host UID (typically 1000) and the backend container's `nyxid` UID don't match, so the bind-mounted file is unreadable inside the container — backend boots fail with `Permission denied (os error 13)`. macOS Docker Desktop hides this via FUSE-layer ownership translation, which is why the same Quickstart works there.

Mechanism verified empirically inside a single Linux container (host FS layer factored out): a different-UID reader fails on `0600`, succeeds after `chmod 644`.

## Test plan
- [ ] Re-run `docs/QUICKSTART.md` Step 2 on Windows WSL2 — backend reaches `http://localhost:3001/health`
- [ ] Re-run `docs/QUICKSTART.md` Step 2 on macOS — still healthy (no regression)
- [ ] On a pre-fix checkout (mode `0600`), follow the new troubleshooting subsection — backend recovers without re-running Step 2 or wiping the volume

Fixes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)