### PR TITLE
feat(landing): one-line install entry for AI agents (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them.
 
+> **Using Claude Code, Cursor, or another AI coding agent?**
+> Paste this one line into your agent and it will install the `nyxid` CLI and skill, then prompt you to log in:
+>
+> ```
+> Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
+> ```
+>
+> See [skills/INSTALL.md](skills/INSTALL.md) for what the agent will do. The skill talks to a running NyxID instance — pick hosted or self-hosted in step 1 below.
+
 ### 1. Install NyxID
 
 Choose hosted (we run it for you) or self-host (Docker on your machine).

--- a/frontend/src/features/landing/components/hero.tsx
+++ b/frontend/src/features/landing/components/hero.tsx
@@ -87,6 +87,11 @@ export function Hero() {
 
       {/* Content */}
       <div className="relative z-10 mt-[260px] flex flex-col items-center md:mt-[190px]">
+        <img
+          src="/nyxid-wordmark.svg"
+          alt="NyxID"
+          className="mb-8 h-12 w-auto drop-shadow-[0_0_24px_rgba(139,92,246,0.45)] md:h-14"
+        />
         <h1 className="max-w-[700px] text-center font-serif text-[32px] leading-tight text-white md:text-5xl lg:text-6xl">
           {t("hero.eyebrow")}
         </h1>

--- a/frontend/src/features/landing/components/install-skills.tsx
+++ b/frontend/src/features/landing/components/install-skills.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const INSTALL_COMMAND =
+  "Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md";
+
+export function InstallSkills() {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(INSTALL_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API requires HTTPS or localhost; user can still select+copy manually.
+    }
+  };
+
+  return (
+    <section className="border-y border-landing-border-subtle bg-landing-surface/40 px-6 py-20">
+      <div className="mx-auto max-w-3xl text-center">
+        <h2 className="font-serif text-3xl text-white md:text-4xl">
+          {t("install.heading")}
+        </h2>
+        <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-gray-400">
+          {t("install.subheading")}
+        </p>
+
+        <div className="mt-10 flex flex-col items-stretch overflow-hidden rounded-xl border border-primary/30 bg-black/50 backdrop-blur-md sm:flex-row">
+          <input
+            readOnly
+            value={INSTALL_COMMAND}
+            onFocus={(e) => e.currentTarget.select()}
+            aria-label={t("install.commandLabel")}
+            className="flex-1 truncate bg-transparent px-5 py-4 text-left font-mono text-sm text-gray-200 outline-none"
+          />
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center justify-center gap-2 border-t border-primary/30 bg-primary/15 px-6 py-4 text-sm font-semibold text-white transition-colors hover:bg-primary/30 sm:border-l sm:border-t-0"
+          >
+            {copied ? (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M5 10l3 3 7-7"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                {t("install.copied")}
+              </>
+            ) : (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <rect
+                    x="6"
+                    y="6"
+                    width="11"
+                    height="11"
+                    rx="2"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  />
+                  <path
+                    d="M4 14V5a2 2 0 012-2h9"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+                {t("install.copy")}
+              </>
+            )}
+          </button>
+        </div>
+
+        <p className="mt-5 text-sm text-gray-500">{t("install.helper")}</p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/landing/i18n/locales/en.json
+++ b/frontend/src/features/landing/i18n/locales/en.json
@@ -8,6 +8,13 @@
   "hero.cta": "Get Early Access",
   "hero.ctaSubtext": "Nyx guards the gate — Discord holds the key",
 
+  "install.heading": "Install Nyx skills",
+  "install.subheading": "Paste this into Claude Code, Cursor, or your AI coding agent — it handles the rest.",
+  "install.commandLabel": "Install command",
+  "install.copy": "Copy",
+  "install.copied": "Copied",
+  "install.helper": "Reads INSTALL.md from the NyxID GitHub repo. No agent? Use the manual install in our README.",
+
   "features.heading": "What Nyx protects",
   "features.subheading": "Every feature guards the threshold between access and breach. You always know exactly what you're approving — nothing passes unseen.",
   "features.pushApprovals.title": "Real-Time Push Approvals",

--- a/frontend/src/features/landing/i18n/locales/zh-CN.json
+++ b/frontend/src/features/landing/i18n/locales/zh-CN.json
@@ -8,6 +8,13 @@
   "hero.cta": "抢先体验",
   "hero.ctaSubtext": "Nyx 守护着大门 — Discord 持有钥匙",
 
+  "install.heading": "安装 Nyx 技能",
+  "install.subheading": "粘贴到 Claude Code、Cursor 或你的 AI 编程智能体 — 剩下的它会处理。",
+  "install.commandLabel": "安装命令",
+  "install.copy": "复制",
+  "install.copied": "已复制",
+  "install.helper": "从 NyxID GitHub 仓库读取 INSTALL.md。没有智能体？请参考 README 中的手动安装步骤。",
+
   "features.heading": "Nyx 守护什么",
   "features.subheading": "每项功能都守护着访问与入侵之间的门槛。你始终清楚自己在批准什么 — 一切尽在掌握。",
   "features.pushApprovals.title": "实时推送审批",

--- a/frontend/src/features/landing/i18n/locales/zh-TW.json
+++ b/frontend/src/features/landing/i18n/locales/zh-TW.json
@@ -8,6 +8,13 @@
   "hero.cta": "搶先體驗",
   "hero.ctaSubtext": "Nyx 守護著大門 — Discord 持有鑰匙",
 
+  "install.heading": "安裝 Nyx 技能",
+  "install.subheading": "貼到 Claude Code、Cursor 或你的 AI 編程代理 — 剩下的它會處理。",
+  "install.commandLabel": "安裝命令",
+  "install.copy": "複製",
+  "install.copied": "已複製",
+  "install.helper": "從 NyxID GitHub 倉庫讀取 INSTALL.md。沒有代理？請參考 README 中的手動安裝步驟。",
+
   "features.heading": "Nyx 守護什麼",
   "features.subheading": "每項功能都守護著存取與入侵之間的門檻。你始終清楚自己在批准什麼 — 一切盡在掌握。",
   "features.pushApprovals.title": "即時推送審批",

--- a/frontend/src/features/landing/landing-page.tsx
+++ b/frontend/src/features/landing/landing-page.tsx
@@ -5,6 +5,7 @@ import "./i18n";
 
 import { LandingNavbar } from "./components/landing-navbar";
 import { Hero } from "./components/hero";
+import { InstallSkills } from "./components/install-skills";
 import { FeaturesSection } from "./components/features-section";
 import { WhyNyx } from "./components/why-nyx";
 import { HowItWorks } from "./components/how-it-works";
@@ -30,6 +31,7 @@ export function LandingPage() {
       <ScrollFab />
       <main>
         <Hero />
+        <InstallSkills />
         <FeaturesSection />
         <WhyNyx />
         <HowItWorks />

--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -1,0 +1,109 @@
+# Nyx Skills — Install Manifest (for AI agents)
+
+You (the AI agent — Claude Code, Cursor, Codex, OpenClaw, etc.) have been asked to install **Nyx skills** on the user's machine. Follow the steps below, then hand control back to the user for the final login.
+
+This file is the canonical install entry point for any Nyx skill. It is intentionally short — the bulk of each skill's behavior lives in its own `SKILL.md` and `references/`.
+
+---
+
+## Skills available
+
+| Skill | Purpose | Source |
+|---|---|---|
+| `nyxid` | Credential broker for downstream APIs (OpenAI, Anthropic, GitHub, Slack, internal APIs, SSH, MCP tools). The skill is a thin wrapper over the `nyxid` CLI. | [`skills/nyxid/`](nyxid/) |
+
+There is one skill today. This manifest will list more as they ship.
+
+---
+
+## Install procedure
+
+Run the steps below in order. They are idempotent — safe to re-run.
+
+### Step 1 — Install the `nyxid` CLI
+
+Every Nyx skill calls the `nyxid` CLI under the hood, so install it first.
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
+```
+
+This downloads a Sigstore-attested prebuilt binary, installs it under `~/.local/share/nyxid/versions/<version>/`, links `~/.local/bin/nyxid` to it, and ensures `~/.local/bin` is on the user's shell `PATH`. It falls back to a Cargo source build only on platforms with no published binary. After install, verify with `nyxid doctor`.
+
+### Step 2 — Place the skill files in your agent's skill directory
+
+A Nyx skill is a folder of markdown + helper scripts:
+
+```
+skills/nyxid/
+├── SKILL.md            # entry-point manifest with frontmatter
+├── references/         # domain references loaded on demand
+└── scripts/            # helper shell scripts the skill calls
+```
+
+Copy the entire `skills/nyxid/` directory into wherever your runtime loads skills from. Common locations:
+
+- **Claude Code:** `~/.claude/skills/nyxid/`
+- **OpenClaw / clawdbot:** managed through the platform's skill registry — the `metadata.openclaw` / `metadata.clawdbot` block in `SKILL.md` is consumed automatically on registration
+- **Cursor / Codex / other runtimes:** consult your runtime's skills or instructions documentation
+
+Sparse-checkout fetch (preferred — pulls only what you need):
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/ChronoAIProject/NyxID /tmp/nyx-skills
+git -C /tmp/nyx-skills sparse-checkout set skills/nyxid
+# then copy /tmp/nyx-skills/skills/nyxid/ into your skill directory
+```
+
+Or fetch each file with `curl` from `https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/<path>` if your runtime prefers that.
+
+After copying, reload or re-index your agent if it caches its skill list.
+
+### Step 3 — Hand off to the user for login
+
+The agent **must not** run `nyxid login` on the user's behalf — the user chooses the NyxID instance.
+
+Print a message to the user similar to this:
+
+> The Nyx skill is installed. To finish setup, log in to your NyxID instance:
+>
+> ```
+> nyxid login --base-url <URL>
+> ```
+>
+> - Hosted instance: `https://nyx-api.chrono-ai.fun`
+> - Self-hosted: typically `http://localhost:3001` for a local Docker stack
+>
+> If you don't have an account yet, register at <https://nyx.chrono-ai.fun/register> (an invite code may be required during early access).
+
+---
+
+## What the skill does once loaded
+
+The skill itself describes the full surface — load `SKILL.md` for the canonical reference. Briefly, with `nyxid` you can:
+
+- Browse the catalog of broker-able services
+- Add and configure a service (`nyxid service add ...`)
+- Proxy requests through NyxID with automatic credential injection
+- Manage credential nodes for localhost / private-network reach
+- Wrap REST APIs as MCP tools for use across agents
+- Issue scoped per-agent API keys with isolation, rate limiting, and audit attribution
+
+---
+
+## Updating
+
+The CLI and any installed skills update from one command:
+
+```bash
+nyxid update              # update CLI and skills
+nyxid update --check      # report installed vs latest, install nothing
+nyxid update --skills-only
+```
+
+---
+
+## Reporting issues
+
+- GitHub: <https://github.com/ChronoAIProject/NyxID/issues>
+- Discord: <https://discord.gg/QMvcs8UQBW>


### PR DESCRIPTION
## Summary

Closes #188 — adds a one-line install entry on the landing page so users can hand the install to their AI coding agent (Claude Code, Cursor, OpenClaw, etc.) instead of digging through docs.

The install command surfaced on the homepage:

```
Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
```

### What changed

- **`skills/INSTALL.md`** (new) — agent-readable install manifest: skill catalog, 3-step procedure (CLI install → place skill files → hand off to user for `nyxid login`).
- **Landing page** — new `<InstallSkills />` section under the hero with a Homebrew/Rust-style copy box (input + Copy button with ✓ Copied feedback). i18n strings for en / zh-CN / zh-TW.
- **Hero** — NyxID wordmark added above the existing headline (drop-shadow purple glow).
- **README** — callout in Getting Started pointing AI agent users at `skills/INSTALL.md`.

## Test plan

- [x] Frontend type-check + Vite build pass clean (`npm run build`)
- [x] Pre-commit hooks pass (lint warnings exist in pre-existing files only)
- [ ] Visual: landing renders the install box below the hero on desktop and mobile
- [ ] Copy button copies the command and shows ✓ Copied feedback
- [ ] Language switcher updates the install section copy (en / zh-CN / zh-TW)
- [ ] Wordmark renders correctly above the hero headline at all breakpoints
- [ ] **End-to-end: paste the install line into a fresh Claude Code session and verify the CLI + skill install successfully** (not yet performed — see soft spots)

## Soft spots worth discussing in review

- `skills/INSTALL.md` Step 2 (skill placement) is concrete only for Claude Code and OpenClaw. Cursor / Codex are listed as "consult your runtime's documentation" — an agent reading this may stall. Consider trimming the agent list to what we can actually deliver before merge.
- The install URL on the homepage points at GitHub's blob view (HTML). Most LLMs convert it transparently to the raw URL, but `https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/INSTALL.md` is the strictly correct form.
- Wordmark in the hero is somewhat redundant with the navbar wordmark — included per request, easy to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)