### PR TITLE
feat(landing): one-line install entry for AI agents (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,7 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them.
 
-> **Using Claude Code, Cursor, or another AI coding agent?**
-> Paste this one line into your agent and it will install the `nyxid` CLI and skill, then prompt you to log in:
->
-> ```
-> Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
-> ```
->
-> See [skills/INSTALL.md](skills/INSTALL.md) for what the agent will do. The skill talks to a running NyxID instance — pick hosted or self-hosted in step 1 below.
+> Using an AI coding agent? See [Install the Nyx skill](#install-the-nyx-skill-for-ai-coding-agents) below for a one-line install your agent can drive.
 
 ### 1. Install NyxID
 
@@ -198,6 +191,18 @@ With NyxID running and an Agent Key in hand, pick the workflow that matches what
 ## Connecting AI Services (interface reference)
 
 [Pick a workflow](#2-pick-a-workflow) in Getting Started is organized by use case. For an interface-oriented reference that ends with a verified proxy call (`HTTP/1.1 200`) using your preferred entry point — Web UI, CLI, AI-driven (MCP), or Direct API — see **[docs/connecting-services/](docs/connecting-services/)**. The hub distinguishes external service credentials from NyxID Agent Keys and links to one walkthrough per interface.
+
+### Install the Nyx skill (for AI coding agents)
+
+If you drive NyxID from Claude Code, Cursor, OpenClaw, or another AI coding agent, hand it this single line:
+
+```
+Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
+```
+
+The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) and follows it end-to-end: installs the prebuilt `nyxid` CLI, copies the skill files into its own skill directory, and prompts you to run `nyxid login` against your NyxID instance.
+
+The skill teaches the agent how to use the `nyxid` CLI. Without it, the CLI still works — you just drive it manually.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 ## Getting Started
 
-NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them. An optional middle step installs the `nyxid` CLI for terminal or AI-agent use.
+NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them.
 
 ### 1. Install NyxID
 
@@ -119,6 +119,14 @@ Choose hosted (we run it for you) or self-host (Docker on your machine).
 | **What it is** | We run NyxID for you in the cloud | You run NyxID on your own machine |
 | **Best for** | Getting started quickly, no setup | Full control, private networks, offline use |
 | **Status** | Early access (invite code below) | Open — anyone can run it |
+
+> **Driving NyxID from an AI coding agent?** Hand it this single line at any point — it installs the `nyxid` CLI plus the Nyx skill files for the agent to drive:
+>
+> ```
+> Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
+> ```
+>
+> The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) end-to-end. You'll still need a hosted account or a self-host stack (below) for the agent to log into.
 
 #### Hosted (Recommended)
 
@@ -150,7 +158,7 @@ If you have Claude Code, Cursor, or any AI coding assistant open, paste the prom
 > 2. **Before cloning or generating anything, check whether NyxID install STATE is present** — look for a `./NyxID/.env.dev` file OR any Docker volume matching `nyx*_mongodb_data` (run `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$'` — this catches the default `nyxid_mongodb_data` plus any variant from a renamed checkout). A bare `./NyxID` directory alone does NOT count as "installed" — `uninstall.sh` leaves the source tree in place, so the directory can exist with no state. **If install state is present, stop and tell me the quickstart is a first-time-only install.** Ask whether I want to (a) uninstall first — if `./NyxID` exists, run `cd NyxID && ./scripts/uninstall.sh --yes && cd ..`; if only the stale Docker volume is orphaned (checkout was manually deleted earlier), run `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm` directly. Either path wipes the volume, containers, and (for the script path) `.env.dev`/keys — destroys all NyxID accounts and encrypted credentials. Or (b) keep my existing install and stop here — I can verify it's still running with `curl -sf http://localhost:3001/health`. Do not proceed to step 3 until I answer.
 > 3. If `./NyxID` already exists (post-uninstall reinstall), `cd` into it; otherwise clone the repo into the current directory and `cd` in. Generate `.env.dev` with a fresh `ENCRYPTION_KEY` and `MONGO_ROOT_PASSWORD` (set `ENVIRONMENT=development`, `INVITE_CODE_REQUIRED=false`, `AUTO_VERIFY_EMAIL=true`, and `EMAIL_AUTH_ENABLED=true` so I don't get stuck on email verification or a locked-down signup page), symlink it to `.env.production`, create the PKCS#1 JWT signing keys under `keys/` (with a LibreSSL fallback using `-pubout` if `-RSAPublicKey_out` isn't supported), then pull images and start the stack with `docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env.production up -d`. Wait up to 90 seconds for `http://localhost:3001/health` to return 200 — if it times out, tell me to run `docker logs nyxid-backend`. If the logs show `SCRAM failure: Authentication failed`, that means the MongoDB volume has a stale password from a previous install — tell me to run `./scripts/uninstall.sh --yes` (or, if the checkout is gone, `docker volume ls --format '{{.Name}}' | grep -E 'nyx.*_mongodb_data$' | xargs -r docker volume rm` to remove any nyx-flavored orphan volume) and retry. Show me the generated `ENCRYPTION_KEY` so I can back it up.
 > 4. Tell me to open http://localhost:3000 and register my account (no email verification needed — accounts are auto-verified in dev mode), and wait until I confirm I've done that.
-> 5. **Ask me whether I want to install the `nyxid` CLI.** Explain that it's optional, that the installer downloads a roughly 10 MB prebuilt binary in seconds with no Rust toolchain required, installs it into a versioned layout with rollback support, and that only unsupported OS/arch combinations fall back to a Rust source build. If I say yes, install it using https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh, then `export PATH="$HOME/.local/bin:$PATH"` if needed, verify the install with `nyxid doctor`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, then verify with `nyxid proxy request <slug> models` using the slug the previous `service add` command printed under `Slug:` (typically `llm-openai`, but suffixed if I already had a service with that slug). If I say no, walk me through adding the same OpenAI credential in the web console instead.
+> 5. **Ask me whether I want to install the `nyxid` CLI plus the Nyx skill** so you can drive NyxID from the terminal afterwards. Explain that it's optional, that the installer downloads a roughly 10 MB prebuilt binary plus a small set of skill files (no Rust toolchain required), installs the CLI into a versioned layout with rollback support, and that only unsupported OS/arch combinations fall back to a Rust source build. If I say yes, follow the install manifest at https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/INSTALL.md end-to-end (it installs the CLI under `~/.local/share/nyxid/`, drops the skill into your skill directory, and tells you to `export PATH="$HOME/.local/bin:$PATH"` if needed); verify with `nyxid doctor`, log me in with `nyxid login --base-url http://localhost:3001`, add my OpenAI key with `nyxid service add llm-openai --credential-env OPENAI_API_KEY`, then verify with `nyxid proxy request <slug> models` using the slug the previous `service add` command printed under `Slug:` (typically `llm-openai`, but suffixed if I already had a service with that slug). If I say no, walk me through adding the same OpenAI credential in the web console instead.
 > 6. Finish by connecting my AI tool to NyxID's MCP endpoint at `http://localhost:3001/mcp`. For Claude Code: `claude mcp add --transport http --scope user nyxid http://localhost:3001/mcp`. For Codex: `codex mcp add nyxid --url http://localhost:3001/mcp`. For Cursor: open `Settings` > `MCP` in the web console and click `Install to Cursor`.
 
 </details>
@@ -169,36 +177,11 @@ It covers:
 - Optional [CLI install](docs/SETUP.md#optional-install-the-nyxid-cli)
 - [Uninstall & reinstall](docs/SETUP.md#uninstall--reinstall), [orphan volume recovery](docs/SETUP.md#recovering-an-orphan-volume), and [SCRAM failure](docs/SETUP.md#stuck-on-scram-failure) troubleshooting
 
-Once NyxID is running and you've registered at `http://localhost:3000`, continue to [3. Pick a workflow](#3-pick-a-workflow).
+Once NyxID is running and you've registered at `http://localhost:3000`, continue to [2. Pick a workflow](#2-pick-a-workflow).
 
 For production deployment (TLS, custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
-### 2. (Optional) Install the `nyxid` CLI
-
-The `nyxid` CLI lets you drive NyxID from your terminal — adding services, proxying requests, managing nodes. AI coding agents can also drive the CLI on your behalf.
-
-**Path A — Let an AI coding agent do it for you**
-
-If you use Claude Code, Cursor, OpenClaw, or another AI coding agent, hand it this single line:
-
-```
-Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
-```
-
-The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) and follows it end-to-end: installs the prebuilt CLI, copies the Nyx skill files into the agent's skill directory (so the agent knows how to use the CLI), and prompts you to run `nyxid login` against your NyxID instance.
-
-**Path B — Install manually**
-
-```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
-nyxid login --base-url https://nyx-api.chrono-ai.fun   # or your self-hosted URL
-```
-
-The installer downloads a Sigstore-attested prebuilt binary, links `~/.local/bin/nyxid`, and adds it to your shell `PATH`. Verify with `nyxid doctor`.
-
-Path B installs only the CLI. The skill is a teach-the-agent layer that's only useful in Path A — without it, you drive the CLI yourself.
-
-### 3. Pick a workflow
+### 2. Pick a workflow
 
 With NyxID running and an Agent Key in hand, pick the workflow that matches what you want to build. Each is a step-by-step procedure that ends with a working integration; the four are independent and can be completed in any order.
 
@@ -213,7 +196,7 @@ With NyxID running and an Agent Key in hand, pick the workflow that matches what
 
 ## Connecting AI Services (interface reference)
 
-[Pick a workflow](#3-pick-a-workflow) in Getting Started is organized by use case. For an interface-oriented reference that ends with a verified proxy call (`HTTP/1.1 200`) using your preferred entry point — Web UI, CLI, AI-driven (MCP), or Direct API — see **[docs/connecting-services/](docs/connecting-services/)**. The hub distinguishes external service credentials from NyxID Agent Keys and links to one walkthrough per interface.
+[Pick a workflow](#2-pick-a-workflow) in Getting Started is organized by use case. For an interface-oriented reference that ends with a verified proxy call (`HTTP/1.1 200`) using your preferred entry point — Web UI, CLI, AI-driven (MCP), or Direct API — see **[docs/connecting-services/](docs/connecting-services/)**. The hub distinguishes external service credentials from NyxID Agent Keys and links to one walkthrough per interface.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 ## Getting Started
 
-NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them.
-
-> Using an AI coding agent? See [Install the Nyx skill](#install-the-nyx-skill-for-ai-coding-agents) below for a one-line install your agent can drive.
+NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them. If you drive NyxID from an AI coding agent, an optional step in the middle installs the Nyx skill so the agent can drive the CLI for you.
 
 ### 1. Install NyxID
 
@@ -171,11 +169,23 @@ It covers:
 - Optional [CLI install](docs/SETUP.md#optional-install-the-nyxid-cli)
 - [Uninstall & reinstall](docs/SETUP.md#uninstall--reinstall), [orphan volume recovery](docs/SETUP.md#recovering-an-orphan-volume), and [SCRAM failure](docs/SETUP.md#stuck-on-scram-failure) troubleshooting
 
-Once NyxID is running and you've registered at `http://localhost:3000`, continue to [2. Pick a workflow](#2-pick-a-workflow).
+Once NyxID is running and you've registered at `http://localhost:3000`, continue to [3. Pick a workflow](#3-pick-a-workflow).
 
 For production deployment (TLS, custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
-### 2. Pick a workflow
+### 2. (Optional) Install the Nyx skill
+
+If you drive NyxID from Claude Code, Cursor, OpenClaw, or another AI coding agent, hand it this single line:
+
+```
+Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
+```
+
+The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) and follows it end-to-end: installs the prebuilt `nyxid` CLI, copies the skill files into its own skill directory, and prompts you to run `nyxid login` against your NyxID instance.
+
+The skill teaches the agent how to use the `nyxid` CLI. Without it, the CLI still works — you just drive it manually.
+
+### 3. Pick a workflow
 
 With NyxID running and an Agent Key in hand, pick the workflow that matches what you want to build. Each is a step-by-step procedure that ends with a working integration; the four are independent and can be completed in any order.
 
@@ -190,19 +200,7 @@ With NyxID running and an Agent Key in hand, pick the workflow that matches what
 
 ## Connecting AI Services (interface reference)
 
-[Pick a workflow](#2-pick-a-workflow) in Getting Started is organized by use case. For an interface-oriented reference that ends with a verified proxy call (`HTTP/1.1 200`) using your preferred entry point — Web UI, CLI, AI-driven (MCP), or Direct API — see **[docs/connecting-services/](docs/connecting-services/)**. The hub distinguishes external service credentials from NyxID Agent Keys and links to one walkthrough per interface.
-
-### Install the Nyx skill (for AI coding agents)
-
-If you drive NyxID from Claude Code, Cursor, OpenClaw, or another AI coding agent, hand it this single line:
-
-```
-Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
-```
-
-The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) and follows it end-to-end: installs the prebuilt `nyxid` CLI, copies the skill files into its own skill directory, and prompts you to run `nyxid login` against your NyxID instance.
-
-The skill teaches the agent how to use the `nyxid` CLI. Without it, the CLI still works — you just drive it manually.
+[Pick a workflow](#3-pick-a-workflow) in Getting Started is organized by use case. For an interface-oriented reference that ends with a verified proxy call (`HTTP/1.1 200`) using your preferred entry point — Web UI, CLI, AI-driven (MCP), or Direct API — see **[docs/connecting-services/](docs/connecting-services/)**. The hub distinguishes external service credentials from NyxID Agent Keys and links to one walkthrough per interface.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them.
 
+> **Using Claude Code, Cursor, or another AI coding agent?**
+> Paste this one line into your agent and it will install the `nyxid` CLI and skill, then prompt you to log in:
+>
+> ```
+> Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
+> ```
+>
+> See [skills/INSTALL.md](skills/INSTALL.md) for what the agent will do. The skill talks to a running NyxID instance — pick hosted or self-hosted in step 1 below.
+
 ### 1. Install NyxID
 
 Choose hosted (we run it for you) or self-host (Docker on your machine).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Other tools solve parts of this — NyxID combines credential injection, NAT tra
 
 ## Getting Started
 
-NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them. If you drive NyxID from an AI coding agent, an optional step in the middle installs the Nyx skill so the agent can drive the CLI for you.
+NyxID is used in two phases — install once, then pick a workflow. The install gives you a NyxID instance and an Agent Key; the workflow shows what to build with them. An optional middle step installs the `nyxid` CLI for terminal or AI-agent use.
 
 ### 1. Install NyxID
 
@@ -173,17 +173,30 @@ Once NyxID is running and you've registered at `http://localhost:3000`, continue
 
 For production deployment (TLS, custom domain, email verification), see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
-### 2. (Optional) Install the Nyx skill
+### 2. (Optional) Install the `nyxid` CLI
 
-If you drive NyxID from Claude Code, Cursor, OpenClaw, or another AI coding agent, hand it this single line:
+The `nyxid` CLI lets you drive NyxID from your terminal — adding services, proxying requests, managing nodes. AI coding agents can also drive the CLI on your behalf.
+
+**Path A — Let an AI coding agent do it for you**
+
+If you use Claude Code, Cursor, OpenClaw, or another AI coding agent, hand it this single line:
 
 ```
 Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
 ```
 
-The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) and follows it end-to-end: installs the prebuilt `nyxid` CLI, copies the skill files into its own skill directory, and prompts you to run `nyxid login` against your NyxID instance.
+The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) and follows it end-to-end: installs the prebuilt CLI, copies the Nyx skill files into the agent's skill directory (so the agent knows how to use the CLI), and prompts you to run `nyxid login` against your NyxID instance.
 
-The skill teaches the agent how to use the `nyxid` CLI. Without it, the CLI still works — you just drive it manually.
+**Path B — Install manually**
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
+nyxid login --base-url https://nyx-api.chrono-ai.fun   # or your self-hosted URL
+```
+
+The installer downloads a Sigstore-attested prebuilt binary, links `~/.local/bin/nyxid`, and adds it to your shell `PATH`. Verify with `nyxid doctor`.
+
+Path B installs only the CLI. The skill is a teach-the-agent layer that's only useful in Path A — without it, you drive the CLI yourself.
 
 ### 3. Pick a workflow
 

--- a/frontend/src/features/landing/components/hero.tsx
+++ b/frontend/src/features/landing/components/hero.tsx
@@ -87,6 +87,11 @@ export function Hero() {
 
       {/* Content */}
       <div className="relative z-10 mt-[260px] flex flex-col items-center md:mt-[190px]">
+        <img
+          src="/nyxid-wordmark.svg"
+          alt="NyxID"
+          className="mb-8 h-12 w-auto drop-shadow-[0_0_24px_rgba(139,92,246,0.45)] md:h-14"
+        />
         <h1 className="max-w-[700px] text-center font-serif text-[32px] leading-tight text-white md:text-5xl lg:text-6xl">
           {t("hero.eyebrow")}
         </h1>

--- a/frontend/src/features/landing/components/install-skills.tsx
+++ b/frontend/src/features/landing/components/install-skills.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const INSTALL_COMMAND =
+  "Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md";
+
+export function InstallSkills() {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(INSTALL_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API requires HTTPS or localhost; user can still select+copy manually.
+    }
+  };
+
+  return (
+    <section className="border-y border-landing-border-subtle bg-landing-surface/40 px-6 py-20">
+      <div className="mx-auto max-w-3xl text-center">
+        <h2 className="font-serif text-3xl text-white md:text-4xl">
+          {t("install.heading")}
+        </h2>
+        <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-gray-400">
+          {t("install.subheading")}
+        </p>
+
+        <div className="mt-10 flex flex-col items-stretch overflow-hidden rounded-xl border border-primary/30 bg-black/50 backdrop-blur-md sm:flex-row">
+          <input
+            readOnly
+            value={INSTALL_COMMAND}
+            onFocus={(e) => e.currentTarget.select()}
+            aria-label={t("install.commandLabel")}
+            className="flex-1 truncate bg-transparent px-5 py-4 text-left font-mono text-sm text-gray-200 outline-none"
+          />
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex items-center justify-center gap-2 border-t border-primary/30 bg-primary/15 px-6 py-4 text-sm font-semibold text-white transition-colors hover:bg-primary/30 sm:border-l sm:border-t-0"
+          >
+            {copied ? (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M5 10l3 3 7-7"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                {t("install.copied")}
+              </>
+            ) : (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <rect
+                    x="6"
+                    y="6"
+                    width="11"
+                    height="11"
+                    rx="2"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  />
+                  <path
+                    d="M4 14V5a2 2 0 012-2h9"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+                {t("install.copy")}
+              </>
+            )}
+          </button>
+        </div>
+
+        <p className="mt-5 text-sm text-gray-500">{t("install.helper")}</p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/landing/i18n/locales/en.json
+++ b/frontend/src/features/landing/i18n/locales/en.json
@@ -8,6 +8,13 @@
   "hero.cta": "Get Early Access",
   "hero.ctaSubtext": "Nyx guards the gate — Discord holds the key",
 
+  "install.heading": "Install Nyx skills",
+  "install.subheading": "Paste this into Claude Code, Cursor, or your AI coding agent — it handles the rest.",
+  "install.commandLabel": "Install command",
+  "install.copy": "Copy",
+  "install.copied": "Copied",
+  "install.helper": "Reads INSTALL.md from the NyxID GitHub repo. No agent? Use the manual install in our README.",
+
   "features.heading": "What Nyx protects",
   "features.subheading": "Every feature guards the threshold between access and breach. You always know exactly what you're approving — nothing passes unseen.",
   "features.pushApprovals.title": "Real-Time Push Approvals",

--- a/frontend/src/features/landing/i18n/locales/zh-CN.json
+++ b/frontend/src/features/landing/i18n/locales/zh-CN.json
@@ -8,6 +8,13 @@
   "hero.cta": "抢先体验",
   "hero.ctaSubtext": "Nyx 守护着大门 — Discord 持有钥匙",
 
+  "install.heading": "安装 Nyx 技能",
+  "install.subheading": "粘贴到 Claude Code、Cursor 或你的 AI 编程智能体 — 剩下的它会处理。",
+  "install.commandLabel": "安装命令",
+  "install.copy": "复制",
+  "install.copied": "已复制",
+  "install.helper": "从 NyxID GitHub 仓库读取 INSTALL.md。没有智能体？请参考 README 中的手动安装步骤。",
+
   "features.heading": "Nyx 守护什么",
   "features.subheading": "每项功能都守护着访问与入侵之间的门槛。你始终清楚自己在批准什么 — 一切尽在掌握。",
   "features.pushApprovals.title": "实时推送审批",

--- a/frontend/src/features/landing/i18n/locales/zh-TW.json
+++ b/frontend/src/features/landing/i18n/locales/zh-TW.json
@@ -8,6 +8,13 @@
   "hero.cta": "搶先體驗",
   "hero.ctaSubtext": "Nyx 守護著大門 — Discord 持有鑰匙",
 
+  "install.heading": "安裝 Nyx 技能",
+  "install.subheading": "貼到 Claude Code、Cursor 或你的 AI 編程代理 — 剩下的它會處理。",
+  "install.commandLabel": "安裝命令",
+  "install.copy": "複製",
+  "install.copied": "已複製",
+  "install.helper": "從 NyxID GitHub 倉庫讀取 INSTALL.md。沒有代理？請參考 README 中的手動安裝步驟。",
+
   "features.heading": "Nyx 守護什麼",
   "features.subheading": "每項功能都守護著存取與入侵之間的門檻。你始終清楚自己在批准什麼 — 一切盡在掌握。",
   "features.pushApprovals.title": "即時推送審批",

--- a/frontend/src/features/landing/landing-page.tsx
+++ b/frontend/src/features/landing/landing-page.tsx
@@ -5,6 +5,7 @@ import "./i18n";
 
 import { LandingNavbar } from "./components/landing-navbar";
 import { Hero } from "./components/hero";
+import { InstallSkills } from "./components/install-skills";
 import { FeaturesSection } from "./components/features-section";
 import { WhyNyx } from "./components/why-nyx";
 import { HowItWorks } from "./components/how-it-works";
@@ -30,6 +31,7 @@ export function LandingPage() {
       <ScrollFab />
       <main>
         <Hero />
+        <InstallSkills />
         <FeaturesSection />
         <WhyNyx />
         <HowItWorks />

--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -1,0 +1,109 @@
+# Nyx Skills — Install Manifest (for AI agents)
+
+You (the AI agent — Claude Code, Cursor, Codex, OpenClaw, etc.) have been asked to install **Nyx skills** on the user's machine. Follow the steps below, then hand control back to the user for the final login.
+
+This file is the canonical install entry point for any Nyx skill. It is intentionally short — the bulk of each skill's behavior lives in its own `SKILL.md` and `references/`.
+
+---
+
+## Skills available
+
+| Skill | Purpose | Source |
+|---|---|---|
+| `nyxid` | Credential broker for downstream APIs (OpenAI, Anthropic, GitHub, Slack, internal APIs, SSH, MCP tools). The skill is a thin wrapper over the `nyxid` CLI. | [`skills/nyxid/`](nyxid/) |
+
+There is one skill today. This manifest will list more as they ship.
+
+---
+
+## Install procedure
+
+Run the steps below in order. They are idempotent — safe to re-run.
+
+### Step 1 — Install the `nyxid` CLI
+
+Every Nyx skill calls the `nyxid` CLI under the hood, so install it first.
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
+```
+
+This downloads a Sigstore-attested prebuilt binary, installs it under `~/.local/share/nyxid/versions/<version>/`, links `~/.local/bin/nyxid` to it, and ensures `~/.local/bin` is on the user's shell `PATH`. It falls back to a Cargo source build only on platforms with no published binary. After install, verify with `nyxid doctor`.
+
+### Step 2 — Place the skill files in your agent's skill directory
+
+A Nyx skill is a folder of markdown + helper scripts:
+
+```
+skills/nyxid/
+├── SKILL.md            # entry-point manifest with frontmatter
+├── references/         # domain references loaded on demand
+└── scripts/            # helper shell scripts the skill calls
+```
+
+Copy the entire `skills/nyxid/` directory into wherever your runtime loads skills from. Common locations:
+
+- **Claude Code:** `~/.claude/skills/nyxid/`
+- **OpenClaw / clawdbot:** managed through the platform's skill registry — the `metadata.openclaw` / `metadata.clawdbot` block in `SKILL.md` is consumed automatically on registration
+- **Cursor / Codex / other runtimes:** consult your runtime's skills or instructions documentation
+
+Sparse-checkout fetch (preferred — pulls only what you need):
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/ChronoAIProject/NyxID /tmp/nyx-skills
+git -C /tmp/nyx-skills sparse-checkout set skills/nyxid
+# then copy /tmp/nyx-skills/skills/nyxid/ into your skill directory
+```
+
+Or fetch each file with `curl` from `https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/<path>` if your runtime prefers that.
+
+After copying, reload or re-index your agent if it caches its skill list.
+
+### Step 3 — Hand off to the user for login
+
+The agent **must not** run `nyxid login` on the user's behalf — the user chooses the NyxID instance.
+
+Print a message to the user similar to this:
+
+> The Nyx skill is installed. To finish setup, log in to your NyxID instance:
+>
+> ```
+> nyxid login --base-url <URL>
+> ```
+>
+> - Hosted instance: `https://nyx-api.chrono-ai.fun`
+> - Self-hosted: typically `http://localhost:3001` for a local Docker stack
+>
+> If you don't have an account yet, register at <https://nyx.chrono-ai.fun/register> (an invite code may be required during early access).
+
+---
+
+## What the skill does once loaded
+
+The skill itself describes the full surface — load `SKILL.md` for the canonical reference. Briefly, with `nyxid` you can:
+
+- Browse the catalog of broker-able services
+- Add and configure a service (`nyxid service add ...`)
+- Proxy requests through NyxID with automatic credential injection
+- Manage credential nodes for localhost / private-network reach
+- Wrap REST APIs as MCP tools for use across agents
+- Issue scoped per-agent API keys with isolation, rate limiting, and audit attribution
+
+---
+
+## Updating
+
+The CLI and any installed skills update from one command:
+
+```bash
+nyxid update              # update CLI and skills
+nyxid update --check      # report installed vs latest, install nothing
+nyxid update --skills-only
+```
+
+---
+
+## Reporting issues
+
+- GitHub: <https://github.com/ChronoAIProject/NyxID/issues>
+- Discord: <https://discord.gg/QMvcs8UQBW>

--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -6,11 +6,36 @@ This file is the canonical install entry point for any Nyx skill. It is intentio
 
 ---
 
+## Agent safety requirements
+
+Before running anything, observe these constraints:
+
+- **Do not run `nyxid login`.** The user picks the NyxID instance and enters credentials themselves.
+- **Do not ask the user for NyxID credentials, API keys, tokens, or invite codes.** The CLI handles credential entry interactively when the user runs it.
+- **Do not print secrets, environment variables, or credential files** at any point during install.
+- **Do not use `sudo`** unless the user explicitly asks for a system-wide install. The default install is fully user-scoped under `~/.local/`.
+- In security-sensitive environments, show the user the install command before executing it, or pin to a release tag instead of `main`.
+
+---
+
+## Prerequisites
+
+The commands below assume a Unix-like shell with:
+
+- `bash`
+- `curl`
+- `git` — only if you use the sparse-checkout fetch in Step 2
+- `cargo` — only if the installer falls back to a source build (rare; most platforms have a prebuilt release)
+
+Windows is supported via WSL only.
+
+---
+
 ## Skills available
 
 | Skill | Purpose | Source |
 |---|---|---|
-| `nyxid` | Credential broker for downstream APIs (OpenAI, Anthropic, GitHub, Slack, internal APIs, SSH, MCP tools). The skill is a thin wrapper over the `nyxid` CLI. | [`skills/nyxid/`](nyxid/) |
+| `nyxid` | Credential broker for downstream APIs (OpenAI, Anthropic, GitHub, Slack, internal APIs, SSH, MCP tools). The skill is a thin wrapper over the `nyxid` CLI. | [`nyxid/`](nyxid/) |
 
 There is one skill today. This manifest will list more as they ship.
 
@@ -28,7 +53,19 @@ Every Nyx skill calls the `nyxid` CLI under the hood, so install it first.
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
 ```
 
-This downloads a Sigstore-attested prebuilt binary, installs it under `~/.local/share/nyxid/versions/<version>/`, links `~/.local/bin/nyxid` to it, and ensures `~/.local/bin` is on the user's shell `PATH`. It falls back to a Cargo source build only on platforms with no published binary. After install, verify with `nyxid doctor`.
+This downloads a prebuilt binary and verifies its Sigstore attestation before installing it under `~/.local/share/nyxid/versions/<version>/`, then links `~/.local/bin/nyxid` to the active version. It falls back to a Cargo source build only on platforms with no published binary.
+
+The installer adds `~/.local/bin` to the user's shell `PATH` by editing their shell rc file, but that change only takes effect on next shell load. If `nyxid` is not found in the current session, export it:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+After install, verify:
+
+```bash
+nyxid doctor
+```
 
 ### Step 2 — Place the skill files in your agent's skill directory
 
@@ -47,15 +84,27 @@ Copy the entire `skills/nyxid/` directory into wherever your runtime loads skill
 - **OpenClaw / clawdbot:** managed through the platform's skill registry — the `metadata.openclaw` / `metadata.clawdbot` block in `SKILL.md` is consumed automatically on registration
 - **Cursor / Codex / other runtimes:** consult your runtime's skills or instructions documentation
 
-Sparse-checkout fetch (preferred — pulls only what you need):
+Sparse-checkout fetch (preferred — pulls only the skill files):
 
 ```bash
 git clone --filter=blob:none --sparse https://github.com/ChronoAIProject/NyxID /tmp/nyx-skills
 git -C /tmp/nyx-skills sparse-checkout set skills/nyxid
-# then copy /tmp/nyx-skills/skills/nyxid/ into your skill directory
 ```
 
-Or fetch each file with `curl` from `https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/<path>` if your runtime prefers that.
+Then copy into the runtime's skill directory. For **Claude Code**:
+
+```bash
+mkdir -p ~/.claude/skills
+cp -R /tmp/nyx-skills/skills/nyxid ~/.claude/skills/
+```
+
+Clean up the temporary checkout:
+
+```bash
+rm -rf /tmp/nyx-skills
+```
+
+If your runtime prefers per-file fetches, pull each file from `https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/<path>` instead.
 
 After copying, reload or re-index your agent if it caches its skill list.
 
@@ -93,13 +142,15 @@ The skill itself describes the full surface — load `SKILL.md` for the canonica
 
 ## Updating
 
-The CLI and any installed skills update from one command:
+The CLI and any Nyx-managed skills update from one command:
 
 ```bash
 nyxid update              # update CLI and skills
 nyxid update --check      # report installed vs latest, install nothing
 nyxid update --skills-only
 ```
+
+Skills you copied manually into a runtime's skill directory (e.g. `~/.claude/skills/nyxid/`) are not tracked by the CLI and will not auto-update — re-run Step 2 to refresh them.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #188 — adds a one-line install entry on the landing page so users can hand the install to their AI coding agent (Claude Code, Cursor, OpenClaw, etc.) instead of digging through docs.

The install command surfaced on the homepage:

```
Install nyx skills from https://github.com/ChronoAIProject/NyxID/blob/main/skills/INSTALL.md
```

### What changed

- **`skills/INSTALL.md`** (new) — agent-readable install manifest: skill catalog, 3-step procedure (CLI install → place skill files → hand off to user for `nyxid login`).
- **Landing page** — new `<InstallSkills />` section under the hero with a Homebrew/Rust-style copy box (input + Copy button with ✓ Copied feedback). i18n strings for en / zh-CN / zh-TW.
- **Hero** — NyxID wordmark added above the existing headline (drop-shadow purple glow).
- **README** — callout in Getting Started pointing AI agent users at `skills/INSTALL.md`.

> Supersedes draft #675 (closed automatically when the source branch was renamed for clarity).

## Test plan

- [x] Frontend type-check + Vite build pass clean (`npm run build`)
- [x] Pre-commit hooks pass (lint warnings exist in pre-existing files only)
- [ ] Visual: landing renders the install box below the hero on desktop and mobile
- [ ] Copy button copies the command and shows ✓ Copied feedback
- [ ] Language switcher updates the install section copy (en / zh-CN / zh-TW)
- [ ] Wordmark renders correctly above the hero headline at all breakpoints
- [ ] **End-to-end: paste the install line into a fresh Claude Code session and verify the CLI + skill install successfully** (not yet performed — see soft spots)

## Soft spots worth discussing in review

- `skills/INSTALL.md` Step 2 (skill placement) is concrete only for Claude Code and OpenClaw. Cursor / Codex are listed as "consult your runtime's documentation" — an agent reading this may stall. Consider trimming the agent list to what we can actually deliver before merge.
- The install URL on the homepage points at GitHub's blob view (HTML). Most LLMs convert it transparently to the raw URL, but `https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/INSTALL.md` is the strictly correct form.
- Wordmark in the hero is somewhat redundant with the navbar wordmark — included per request, easy to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)