### PR TITLE
docs(skills): align NyxID skill with CLI + deterministic AI flow rules

### DIFF
--- a/skills/nyxid/SKILL.md
+++ b/skills/nyxid/SKILL.md
@@ -119,21 +119,35 @@ Load the matching `references/<file>.md` when the user asks for one of these top
 |---|---|
 | "list my services", "what's connected", "discover services", "add a service", "connect OpenAI / GitHub / Lark / etc.", "OAuth scopes", browser-wizard / pairing-code questions, "where do I get the API key" | `references/services.md` |
 | "call the API", "proxy request", "send a message via Telegram/Discord/Slack" (single call), curl examples, raw HTTP integration, WebSocket auth-frame injection, Home Assistant connection | `references/proxy.md` |
-| "list / rename / delete a service", attaching an OpenAPI spec to a custom endpoint, default headers, "create / rotate / delete an API key", agent key bindings, callback URLs, scope/rate-limit edits | `references/managing.md` |
+| "list / rename / delete a service", attaching an OpenAPI spec to a custom endpoint, default headers, "create / rotate / delete an API key", agent key bindings, callback URLs, rate-limit edits, `nyxid endpoint` (UserEndpoint URLs), `nyxid external-key` (UserApiKey credentials) | `references/managing.md` |
 | Anything mentioning "org", "organization", "shared credentials", "family / company key", invites, role scopes, primary-org tiebreaker, org-level approval policies, `--via-service`, CLI profiles | `references/organizations.md` |
-| "set up a node", "credentials on my own machine", org-owned/shared nodes, node daemon (install/start/stop/logs), node credentials add/setup/list, SSH node-key credentials, SSH exec / terminal / cert-issue, SSH ProxyCommand | `references/nodes.md` |
+| "set up a node", "credentials on my own machine", org-owned/shared nodes, node daemon (install/start/stop/logs), `nyxid node docker` containerized agents, node credentials add/setup/list, SSH node-key credentials, SSH exec / terminal / cert-issue, SSH ProxyCommand | `references/nodes.md` |
 | "approve / deny", "set up notifications", Telegram link, push notifications, approval grants, per-service approval configs | `references/notifications.md` |
-| "channel bot", "register a bot", conversation routing, `/channel-relay/reply`, callback / reply tokens, ADR-013 passthrough semantics, device events / HTTP Event Gateway, `/channel-events/{id}` | `references/channels.md` |
+| "channel bot", "register a bot", conversation routing (`channel-bot route`), `/channel-relay/reply`, callback / reply tokens, ADR-013 passthrough semantics, device events / HTTP Event Gateway, `/channel-events/{id}` | `references/channels.md` |
 | OpenClaw setup, `llm-openclaw` transport selection, `x-openclaw-scopes` default header | `references/openclaw.md` |
-| `nyxid whoami / status / profile / mfa / session`, `nyxid admin invite-code`, `nyxid mcp config`, error codes (1001/1002/7000/7001/8003, downstream 403 / WAF / User-Agent override) | `references/admin.md` |
+| `nyxid whoami / status / profile / mfa / session / doctor / info / repo / telemetry`, `nyxid admin invite-code`, `nyxid mcp config`, error codes (1001/1002/7000/7001/8003, downstream 403 / WAF / User-Agent override) | `references/admin.md` |
 | "list / revoke broker authorizations", "what apps hold credentials for me", `/settings/authorizations`, `nyxid oauth bindings`, OAuth `binding_id` / token vault, distinction from "Authorized Apps" (consents) | `references/oauth-broker.md` |
+| `nyxid service-account` (machine identities for `client_credentials`), `nyxid developer-app` (OIDC clients for downstream apps), choosing between agent key vs SA vs OAuth client | `references/accounts.md` |
 
 Prefer the canonical reference over guessing. If a topic spans two files (e.g. "create an org-shared API key with rate limits"), load both `organizations.md` and `managing.md`.
 
 ## Working Rules
 
+### Capture user intent before acting
+
+- **List before you create.** When the user mentions a service, key, node, bot, or org, run the matching `list` (or `show`) first and look for an existing match before reaching for `create` / `add` / `register`. Most user requests are about something they already have.
+- **Match the verb the user used.** "Edit / change / update / rename / rotate / restrict / re-scope / re-route / re-bind / fix" → `update` / `rotate` / `bind` / `convert-ssh` / `rotate-credential` on the existing record. "Add / set up / create / connect / a new / another / a second" → `create` / `add` / `register`. When in doubt ask one short clarifying question rather than guessing — creating duplicates is harder to undo than asking.
+- **`api-key` vs `external-key` are different things — disambiguate before acting:**
+  - `nyxid api-key …` manages **NyxID's own** `nyxid_ag_…` agent keys (what an AI agent presents to NyxID on the way IN). Used for agent identity, scopes, bindings, callback URLs.
+  - `nyxid external-key …` (and `nyxid service rotate-credential …`) manages **third-party downstream credentials** stored inside NyxID (the OpenAI / Anthropic / GitHub key NyxID injects on the way OUT).
+  - When the user says "my OpenAI API key" / "my GitHub token" they almost always mean an external/downstream credential — don't run `nyxid api-key create` for that. When the user says "my agent key" / "my NyxID key" / "my Claude Code key" they mean the NyxID agent key.
 - Always discover services before assuming a slug exists.
-- Use `--output json` for machine-readable responses.
+
+### CLI invocation defaults
+
+- **Default to the browser wizard for one-time-secret commands.** Ten commands open a wizard: `service add`, `api-key create / rotate`, `node register-token / rotate-token`, `service-account create / rotate-secret`, `developer-app create / rotate-secret`, `mfa setup`. Run them with **no scripted flags** so the CLI auto-picks the right transport: local browser when one is reachable (incl. non-TTY GUI agent subprocesses via `open::that`), automatic remote-pairing fallback otherwise. Don't proactively add `--terminal`, `--credential-env`, `--output json`, `--oauth`, or `--device-code` "to be safe" — each of those triggers the scripted path and skips the wizard.
+- **Headless / streaming agent? Use `--no-wait --output json` instead.** That returns a machine-readable `{ pair_url, resume_cmd, … }` payload immediately so the agent can surface the pair URL to the user, exit, and pick up the result later with `nyxid pairing resume <PAIRING_ID>`. Required for runtimes that can't hold a long-running subprocess open.
+- **`--output json` everywhere else** — every read command (`list`, `show`, `discover`, `status`) and the non-wizard write commands (`update`, `bind`, `delete --yes`, `convert-ssh`, etc.). The wizard-capable creates are the only exception: there `--output json` alone bypasses the wizard, so use it only when you've already supplied every required arg via flags AND the user explicitly wants stdout output.
 - Prefer slug-based proxy URLs over UUID-based ones.
 - Use exact downstream API paths. Do not guess undocumented endpoints.
 - Keep request bodies minimal and service-correct.

--- a/skills/nyxid/references/accounts.md
+++ b/skills/nyxid/references/accounts.md
@@ -1,0 +1,176 @@
+# Service Accounts and Developer OAuth Apps
+
+NyxID has two machine-identity surfaces beyond agent API keys (`nyxid_ag_…`). Both live under the admin gate but are user-facing for org admins.
+
+- **Service accounts (`nyxid service-account`)** — `grant_type=client_credentials` machine identities. The SA gets a `client_id` + `client_secret` and exchanges them at `/oauth/token` for short-lived bearer tokens. Use this when a backend service (CI, scheduled job, internal tool) needs to call NyxID without holding a long-lived agent key.
+- **Developer OAuth apps (`nyxid developer-app`)** — OIDC clients downstream apps register so end-users can sign in with NyxID. Distinct from service accounts: developer apps act on behalf of a user (authorization code / token exchange), not as themselves.
+
+Both commands gate on admin role at the backend and accept `--org <ID|SLUG|NAME>` to scope creation to an organization.
+
+> **Wizard defaults.** `service-account create / rotate-secret` and `developer-app create / rotate-secret` are wizard-capable: the bare form opens the local browser wizard or auto-falls-through to remote pairing on a headless box. Append `--no-wait --output json` only when the agent specifically can't hold a subprocess open (it returns a `{ pairing_id, pair_url, resume_cmd, … }` payload you can hand to the user, then resume with `nyxid pairing resume <pairing_id>`). Don't add `--terminal` or `--output json` (without `--no-wait`) on user-facing flows — those skip the wizard and dump the new `client_secret` to stdout where it may be captured by tool transcripts.
+
+> **Before creating, list.** `nyxid service-account list --output json` and `nyxid developer-app list --output json` will tell you whether the user already has the identity they're describing. Most "create me a service account for CI" follow-ups are actually requests to *update* (rename, change scopes, rotate secret) an existing one.
+
+## Table of contents
+
+- [Service Accounts](#service-accounts)
+- [Developer OAuth Apps](#developer-oauth-apps)
+- [Choosing between API key, service account, developer app](#choosing-between-api-key-service-account-developer-app)
+
+## Service Accounts
+
+```bash
+# Create a SA — bare wizard form. The wizard mints client_id + client_secret
+# and shows the secret with click-to-reveal (DisplayOnce). On a headless
+# agent the CLI auto-falls-through to remote pairing.
+nyxid service-account create \
+  --name "ci-runner" \
+  --scopes "openid profile" \
+  --description "Internal CI"
+
+# Create scoped to an org (admin of that org required)
+nyxid service-account create \
+  --name "acme-ci" \
+  --scopes "openid profile proxy" \
+  --org acme-corp
+
+# Override the per-second token-refresh rate limit (admin-only)
+nyxid service-account create \
+  --name "high-throughput-job" \
+  --scopes "openid proxy" \
+  --rate-limit-override 50
+
+# Pre-assign role IDs at creation time (comma-separated)
+nyxid service-account create \
+  --name "release-bot" \
+  --scopes "openid profile" \
+  --role-ids "<role-id-1>,<role-id-2>"
+
+# Headless agent — get a pairing handoff JSON and resume later
+nyxid service-account create --name "ci-runner" --scopes "openid profile" \
+  --no-wait --output json
+nyxid pairing resume <pairing_id>
+
+# List, search, paginate (read commands always use --output json)
+nyxid service-account list --output json
+nyxid service-account list --search "ci-" --page 1 --per-page 50 --output json
+nyxid service-account list --org acme-corp --output json
+
+# Show one SA
+nyxid service-account show <SERVICE_ACCOUNT_ID> --output json
+
+# Update metadata (no wizard — pure REST). Also accepts --is-active true|false
+# to disable / re-enable without deleting (preferred over delete when you
+# might restore later).
+nyxid service-account update <SERVICE_ACCOUNT_ID> \
+  --name "ci-runner-v2" \
+  --description "Updated" \
+  --scopes "openid profile proxy"
+nyxid service-account update <SERVICE_ACCOUNT_ID> --is-active false   # disable
+nyxid service-account update <SERVICE_ACCOUNT_ID> --is-active true    # re-enable
+
+# Rotate the client secret. Wizard-capable: bare form opens DisplayOnce on
+# the new secret. On headless agents, use --no-wait --output json then
+# resume with `nyxid pairing resume <pairing_id>` once the user finishes.
+nyxid service-account rotate-secret <SERVICE_ACCOUNT_ID>
+nyxid service-account rotate-secret <SERVICE_ACCOUNT_ID> --no-wait --output json
+nyxid pairing resume <pairing_id>
+
+# Revoke every active token without rotating the secret
+nyxid service-account revoke-tokens <SERVICE_ACCOUNT_ID>
+
+# Soft-delete the SA (also revokes outstanding tokens)
+nyxid service-account delete <SERVICE_ACCOUNT_ID> --yes
+```
+
+> SA tokens default to a 1-hour TTL (`SA_TOKEN_TTL_SECS`). Rotation revokes existing tokens immediately — running services keep working until their cached access token expires, then their next exchange returns the new token.
+
+> The rate-limit-override flag controls the SA's token-refresh rate at `/oauth/token`, not the proxy throughput limit. Use per-API-key rate limits for proxy throttling.
+
+## Developer OAuth Apps
+
+```bash
+# Create a public OAuth client (no secret; PKCE-only flows). Public clients
+# don't enter the secret-display wizard at all because there's nothing to show.
+nyxid developer-app create \
+  --name "MyDesktopApp" \
+  --redirect-uri "myapp://callback" \
+  --client-type public \
+  --allowed-scopes "openid profile email"
+
+# Create a confidential client — bare wizard form. The wizard mints the
+# client_secret and shows it once with click-to-reveal.
+nyxid developer-app create \
+  --name "BackendIntegration" \
+  --redirect-uri "https://app.example.com/callback" \
+  --client-type confidential \
+  --allowed-scopes "openid profile email" \
+  --delegation-scopes "proxy:read proxy:write" \
+  --broker-capability true
+
+# Register multiple redirect URIs (repeat the flag)
+nyxid developer-app create \
+  --name "MultiHostApp" \
+  --redirect-uri "https://app.example.com/callback" \
+  --redirect-uri "https://staging.example.com/callback" \
+  --client-type confidential \
+  --allowed-scopes "openid profile"
+
+# Scope the client to an org (admin of that org required)
+nyxid developer-app create \
+  --name "AcmeDashboard" \
+  --redirect-uri "https://dashboard.acme.com/callback" \
+  --client-type confidential \
+  --allowed-scopes "openid profile" \
+  --org acme-corp
+
+# Headless agent — get a pairing handoff JSON and resume later
+nyxid developer-app create --name "BackendIntegration" \
+  --redirect-uri "https://app.example.com/callback" \
+  --client-type confidential --allowed-scopes "openid profile email" \
+  --no-wait --output json
+nyxid pairing resume <pairing_id>
+
+# List, show
+nyxid developer-app list --output json
+nyxid developer-app list --org acme-corp --output json
+nyxid developer-app show <CLIENT_ID> --output json
+
+# Update metadata (no wizard — pure REST). Repeating --redirect-uri REPLACES
+# the full list with the values you pass; pass `--allowed-scopes ""` to
+# canonicalize back to "openid".
+nyxid developer-app update <CLIENT_ID> \
+  --name "Renamed App" \
+  --redirect-uri "https://app.example.com/callback-v2" \
+  --redirect-uri "https://app.example.com/callback-old" \
+  --allowed-scopes "openid profile email"
+
+# Toggle delegated-token-exchange capability on / off
+nyxid developer-app update <CLIENT_ID> --broker-capability false
+nyxid developer-app update <CLIENT_ID> --delegation-scopes ""    # disable token exchange
+
+# Rotate the confidential client's secret (public clients have no secret).
+# Wizard-capable: bare form opens DisplayOnce on the new secret. On headless
+# agents, use --no-wait --output json then resume with `nyxid pairing resume
+# <pairing_id>` once the user finishes.
+nyxid developer-app rotate-secret <CLIENT_ID>
+nyxid developer-app rotate-secret <CLIENT_ID> --no-wait --output json
+nyxid pairing resume <pairing_id>
+
+# Soft-delete the client
+nyxid developer-app delete <CLIENT_ID> --yes
+```
+
+> The `--broker-capability` flag controls whether the client can mint OAuth broker bindings (RFC 8693 token exchange to opaque `binding_id` handles). See [`oauth-broker.md`](oauth-broker.md) for what bindings are and how end users see them at `/settings/authorizations`.
+
+> `--delegation-scopes` controls which scopes the client may request via token exchange. Pass `""` to disable token exchange entirely on the client.
+
+## Choosing between API key, service account, developer app
+
+| Use case | Pick | Token shape |
+|---|---|---|
+| AI agent (Claude Code, Codex, Cursor, OpenClaw) calls NyxID's proxy | `nyxid api-key create` | `Authorization: Bearer nyxid_ag_…` |
+| Backend / CI job calls NyxID without a human in the loop | `nyxid service-account create` | exchange `client_id` + `client_secret` at `/oauth/token` for a short-lived bearer |
+| End-user-facing OAuth integration where users sign in with NyxID | `nyxid developer-app create` | standard OIDC authorization code (+ optional broker bindings) |
+
+API keys are the simplest path for agents — no token exchange, no expiry by default. Reach for service accounts when you need rotatable secrets + automatic short-lived tokens, and developer apps when human end users are doing the consenting.

--- a/skills/nyxid/references/admin.md
+++ b/skills/nyxid/references/admin.md
@@ -6,6 +6,7 @@
 - [Admin Operations](#admin-operations)
   - [Invite Codes](#invite-codes)
 - [MCP Configuration](#mcp-configuration)
+- [Repo, Info, Telemetry](#repo-info-telemetry)
 - [Approval and Errors](#approval-and-errors)
 
 ## Account Management
@@ -13,9 +14,17 @@
 ```bash
 nyxid whoami --output json                             # current user info
 nyxid status --output json                             # full account overview
+nyxid info                                             # CLI version + project links
+nyxid doctor                                           # run local install + auth health checks
+nyxid doctor --json                                    # machine-readable doctor output
 nyxid profile update --name "New Name"                 # update display name
-nyxid mfa setup                                        # enable MFA (shows QR code)
-nyxid mfa verify --code 123456                         # verify MFA setup
+nyxid profile consents --output json                   # list OAuth consents (web UI: /settings/consents)
+nyxid profile revoke-consent <CLIENT_ID> --yes         # revoke an OAuth consent
+nyxid profile delete --yes                             # delete the account (irreversible)
+nyxid mfa setup                                        # enable MFA (idempotent: re-running before verify rotates the secret)
+nyxid mfa setup --terminal                             # scripted enrollment (skip browser wizard)
+nyxid mfa verify --code 123456                         # complete enrollment from the scripted path
+nyxid mfa status --output json                         # show current MFA enrollment state
 nyxid session list --output json                       # list active sessions
 ```
 
@@ -51,7 +60,24 @@ Notes for admins helping new users:
 nyxid mcp config --tool cursor                         # generate MCP config for Cursor
 nyxid mcp config --tool claude-code                    # generate MCP config for Claude Code
 nyxid mcp config --tool vscode                         # generate MCP config for VS Code
+nyxid mcp config --tool generic                        # default: generic MCP shape (any compatible tool)
 ```
+
+## Repo, Info, Telemetry
+
+```bash
+# Project links
+nyxid repo                                             # print the NyxID GitHub repo URL
+nyxid repo --open                                      # also open it in the default browser
+nyxid info                                             # CLI version, build commit, project links
+
+# Telemetry consent (~/.nyxid/config.toml)
+nyxid telemetry status                                 # show resolved consent state and source
+nyxid telemetry enable                                 # opt in (persists {enabled=true, asked=true})
+nyxid telemetry disable                                # opt out (clears the local anon UUID so a re-enable starts fresh)
+```
+
+`nyxid telemetry` is the canonical editor for the persisted consent flag. Set `NYXID_TELEMETRY=0` in the environment for a per-invocation opt-out without touching the persisted state. See `docs/TELEMETRY.md` §3 for the precedence ladder.
 
 ## Approval and Errors
 

--- a/skills/nyxid/references/channels.md
+++ b/skills/nyxid/references/channels.md
@@ -160,19 +160,19 @@ NyxID is a **pure passthrough gateway** (ADR-013): it never stores message bodie
 
 ```bash
 # Telegram
-nyxid channel-bot register --platform telegram --label "My Support Bot" --token-env TELEGRAM_BOT_TOKEN
+nyxid channel-bot register --platform telegram --label "My Support Bot" --token-env TELEGRAM_BOT_TOKEN --output json
 
 # Discord (requires public key for signature verification)
-nyxid channel-bot register --platform discord --label "My Discord Bot" --token-env DISCORD_BOT_TOKEN --public-key "ed25519_public_key_hex"
+nyxid channel-bot register --platform discord --label "My Discord Bot" --token-env DISCORD_BOT_TOKEN --public-key "ed25519_public_key_hex" --output json
 
 # Lark (requires app credentials + verification token; optional encrypt key)
-nyxid channel-bot register --platform lark --label "My Lark Bot" --token-env LARK_BOT_TOKEN --app-id "cli_xxx" --app-secret-env LARK_APP_SECRET --verification-token "vtoken_xxx" --encrypt-key "encrypt_key_xxx"
+nyxid channel-bot register --platform lark --label "My Lark Bot" --token-env LARK_BOT_TOKEN --app-id "cli_xxx" --app-secret-env LARK_APP_SECRET --verification-token "vtoken_xxx" --encrypt-key "encrypt_key_xxx" --output json
 
 # Feishu (same flags as Lark)
-nyxid channel-bot register --platform feishu --label "My Feishu Bot" --token-env FEISHU_BOT_TOKEN --app-id "cli_xxx" --app-secret-env FEISHU_APP_SECRET --verification-token "vtoken_xxx" --encrypt-key "encrypt_key_xxx"
+nyxid channel-bot register --platform feishu --label "My Feishu Bot" --token-env FEISHU_BOT_TOKEN --app-id "cli_xxx" --app-secret-env FEISHU_APP_SECRET --verification-token "vtoken_xxx" --encrypt-key "encrypt_key_xxx" --output json
 
 # Slack (pass the xoxb- bot user token and the app's signing secret)
-nyxid channel-bot register --platform slack --label "My Slack Bot" --token-env SLACK_BOT_TOKEN --app-secret-env SLACK_SIGNING_SECRET
+nyxid channel-bot register --platform slack --label "My Slack Bot" --token-env SLACK_BOT_TOKEN --app-secret-env SLACK_SIGNING_SECRET --output json
 ```
 
 For Telegram, NyxID auto-registers the webhook. For Discord/Lark/Feishu/Slack, configure the webhook URL in the platform's developer console: `https://<your-nyxid>/api/v1/webhooks/channel/<platform>/<bot-id>`. Telegram/Discord/Slack bots auto-activate on first successful webhook delivery. Lark/Feishu bots promote from `pending_webhook` to `active` only after inbound webhook verification passes, which requires the bot's Verification Token to be set correctly. Encrypt Key is optional, but if it is enabled in the Lark/Feishu console it must also be set on the bot. The CLI falls back to `NYXID_LARK_VERIFICATION_TOKEN` and `NYXID_LARK_ENCRYPT_KEY` when `--verification-token` or `--encrypt-key` are omitted. For Slack, paste the URL into the app's **Event Subscriptions** page — Slack's `url_verification` handshake is answered automatically.
@@ -182,8 +182,8 @@ For Telegram, NyxID auto-registers the webhook. For Discord/Lark/Feishu/Slack, c
 ### Manage bots
 
 ```bash
-nyxid channel-bot list                          # list registered bots
-nyxid channel-bot show <ID>                     # bot details + conversation count
+nyxid channel-bot list --output json            # list registered bots
+nyxid channel-bot show <ID> --output json       # bot details + conversation count
 nyxid channel-bot update <ID> --label "New Label" --verification-token "vtoken_xxx" --encrypt-key "encrypt_key_xxx" --app-id "cli_xxx" --app-secret "secret_xxx"
 nyxid channel-bot verify <ID>                   # re-verify token and webhook
 nyxid channel-bot delete <ID> --yes             # deregister bot
@@ -206,25 +206,29 @@ If the bot is also missing required scopes (a common parallel symptom), surface 
 Each conversation route maps a platform chat to an AI agent (via API key with `callback_url`):
 
 ```bash
-# Set up an API key with a callback URL first
+# Set up an API key with a callback URL first. `api-key create` is wizard-capable;
+# the bare form opens the scope-picker / DisplayOnce wizard. Add --no-wait --output json
+# only when the calling agent can't block on the wizard subprocess.
 nyxid api-key create --name "my-agent" --platform claude-code --callback-url "https://my-agent.example.com/webhook"
 
-# Route all messages from a bot to this agent (default/catch-all)
-nyxid channel-bot route create --bot <BOT_ID> --agent <API_KEY_ID_OR_NAME>
+# Route all messages from a bot to this agent (default/catch-all).
+# `--agent-key-id` accepts an API key UUID; pass the value from
+# `nyxid api-key list --output json`.
+nyxid channel-bot route create --bot-id <BOT_ID> --agent-key-id <API_KEY_ID> --default-agent
 
 # Route a specific DM or group chat to a specific agent
-nyxid channel-bot route create --bot <BOT_ID> --conversation-id "<chat_id>" --agent <API_KEY_ID_OR_NAME>
+nyxid channel-bot route create --bot-id <BOT_ID> --conversation-id "<chat_id>" --agent-key-id <API_KEY_ID>
 
 # Route a specific group chat with conversation type hint
-nyxid channel-bot route create --bot <BOT_ID> --conversation-id "<group_chat_id>" --conversation-type group --agent <API_KEY_ID_OR_NAME>
+nyxid channel-bot route create --bot-id <BOT_ID> --conversation-id "<group_chat_id>" --conversation-type group --agent-key-id <API_KEY_ID>
 
 # Per-user routing in a group (different agents for different users)
-nyxid channel-bot route create --bot <BOT_ID> --conversation-id "<group_chat_id>" --sender-id "<user_id>" --agent <AGENT_A>
-nyxid channel-bot route create --bot <BOT_ID> --conversation-id "<group_chat_id>" --sender-id "<user_id_2>" --agent <AGENT_B>
+nyxid channel-bot route create --bot-id <BOT_ID> --conversation-id "<group_chat_id>" --sender-id "<user_id>" --agent-key-id <AGENT_A_KEY_ID>
+nyxid channel-bot route create --bot-id <BOT_ID> --conversation-id "<group_chat_id>" --sender-id "<user_id_2>" --agent-key-id <AGENT_B_KEY_ID>
 
 # List and manage routes
-nyxid channel-bot route list --bot-id <BOT_ID>
-nyxid channel-bot route update <ROUTE_ID> --agent <NEW_KEY>
+nyxid channel-bot route list --bot-id <BOT_ID> --output json
+nyxid channel-bot route update <ROUTE_ID> --agent-key-id <NEW_KEY_ID>
 nyxid channel-bot route delete <ROUTE_ID> --yes
 ```
 
@@ -325,7 +329,9 @@ Device channels are **first-class** and **not backed by a bot** — no Telegram/
 Before pushing events, create a device channel (once) and bind it to an agent API key with a `callback_url`:
 
 ```bash
-# Create the agent key first if you don't have one
+# Create the agent key first if you don't have one. `api-key create` is
+# wizard-capable; the bare form opens the scope-picker wizard. Add
+# --no-wait --output json only on agents that can't hold the subprocess open.
 nyxid api-key create --name "household-agent" --platform custom \
   --callback-url "https://my-agent.example.com/webhook"
 
@@ -333,10 +339,11 @@ nyxid api-key create --name "household-agent" --platform custom \
 nyxid channel-event channel create \
   --conversation-id household-camera \
   --agent-key-id <API_KEY_ID> \
-  --conversation-type camera     # optional; defaults to "device"
+  --conversation-type camera \
+  --output json     # `--conversation-type` is optional; defaults to "device"
 
 # List device channels
-nyxid channel-event channel list
+nyxid channel-event channel list --output json
 
 # Delete a device channel (takes the NyxID-assigned _id, not the logical name)
 nyxid channel-event channel delete <CONVERSATION_ROW_ID> --yes

--- a/skills/nyxid/references/managing.md
+++ b/skills/nyxid/references/managing.md
@@ -2,25 +2,88 @@
 
 ## Table of contents
 
+- [Capturing user intent: edit vs. create](#capturing-user-intent-edit-vs-create)
 - [Managing Services](#managing-services)
   - [Attaching an OpenAPI spec to a custom endpoint](#attaching-an-openapi-spec-to-a-custom-endpoint)
+- [Managing User Endpoints (`nyxid endpoint`)](#managing-user-endpoints-nyxid-endpoint)
+- [Managing External Credentials (`nyxid external-key`)](#managing-external-credentials-nyxid-external-key)
 - [Managing API Keys](#managing-api-keys)
   - [Scope requirements for management writes](#scope-requirements-for-management-writes)
   - [Browser wizard for one-time secrets (v2 + v3.0 + v3.1 + v4)](#browser-wizard-for-one-time-secrets-v2--v30--v31--v4)
 
+## Capturing user intent: edit vs. create
+
+Most NyxID requests look like "manage X" — and most of the time, X already exists. Before reaching for `create` / `add` / `register`, list what's there and try to match the user's reference. **The single most common skill failure mode is creating a new record when the user wanted to edit an existing one** (e.g. minting a fresh `nyxid_ag_…` agent key when the user said "change my agent key's scopes").
+
+### Quick decision tree
+
+1. **List first.** Run the matching read command — `nyxid api-key list --output json`, `nyxid service list --output json`, `nyxid node list --output json`, `nyxid channel-bot list --output json`, etc. — before doing anything that mutates state.
+2. **Match by what the user said.** If they referenced a name, label, slug, or "the OpenAI one / my coding agent / the Telegram bot", look for a matching entry in the list output. If you find exactly one, that's the target. If you find more than one, ask which.
+3. **Classify the verb.** Map the user's wording to a command family:
+   - "Change / edit / update / rename / fix / add a service to / remove a service from / re-scope / restrict / re-route / move / re-bind" → **update / bind** (no new record)
+   - "Rotate / replace / refresh / it leaked / regenerate the secret" → **rotate / rotate-secret / rotate-credential / rotate-token**
+   - "Connect / add / set up / register / a new / another / a second / I don't have one yet" → **create / add / register**
+   - "Disable / pause / take offline / turn off" → **`update --is-active false`** (service-account / api-key) or **`disable`** (approval) — not delete
+   - "Remove / delete / get rid of / I'm not using this anymore" → **delete --yes**
+4. **Ask once if intent is genuinely ambiguous.** "I see one existing agent key called `coding-agent`. Do you want to (a) update its scopes, (b) rotate its secret, or (c) create a second key?" One short clarifying question beats minting an unwanted record.
+
+### "API key" disambiguation — `api-key` vs `external-key`
+
+NyxID uses the phrase "API key" for two different things. Confusing them is the second-most-common failure mode (right after "kept creating instead of editing").
+
+| User says… | They probably mean… | Use |
+|---|---|---|
+| "my OpenAI API key" / "my GitHub token" / "my Anthropic key" / "the key I got from \<provider\>" | The third-party credential NyxID stores and injects on outbound requests | `nyxid external-key …` or `nyxid service rotate-credential …` |
+| "my NyxID API key" / "my agent key" / "my Claude Code key" / "the key my agent uses" / `nyxid_ag_…` | NyxID's own bearer token an agent presents on the way IN | `nyxid api-key …` |
+| "rotate my OpenAI key" | Provider-side credential rotation | `nyxid service rotate-credential <SERVICE_ID> --credential-env NEW_TOKEN` |
+| "rotate my agent key" | NyxID-side identity rotation (the wizard mints a new `nyxid_ag_…`) | `nyxid api-key rotate <ID_OR_NAME>` |
+
+When the noun is ambiguous and the user hasn't said which they mean, **list both and ask**:
+
+```bash
+nyxid api-key list --output json        # NyxID agent keys (nyxid_ag_…)
+nyxid external-key list --output json   # downstream credentials (OpenAI / Lark / etc.)
+```
+
+Then ask "Which one — your NyxID agent key (used to call NyxID) or the downstream provider credential (the OpenAI key NyxID stores)?"
+
+### Edits agents commonly mistake for "create"
+
+| User intent | Wrong command (don't do this) | Right command |
+|---|---|---|
+| "Add `proxy` scope to my agent key" | `nyxid api-key create --scopes "read write proxy"` | `nyxid api-key update <ID> --scopes "read write proxy"` |
+| "Restrict my agent to only the OpenAI service" | `nyxid api-key create --allowed-services <ID>` | `nyxid api-key bind <ID> --service llm-openai` then `nyxid api-key update <ID> --allow-all-services false` |
+| "Set a callback URL on my agent" | `nyxid api-key create --callback-url "https://…"` | `nyxid api-key update <ID> --callback-url "https://…"` |
+| "Change the OpenAI key I gave NyxID" | `nyxid service add llm-openai` (creates a duplicate) | `nyxid service rotate-credential <SERVICE_ID> --credential-env NEW_KEY` |
+| "Switch which OpenAI account my service uses" | `nyxid service add llm-openai` | `nyxid service rotate-credential …` (different value) or replace via `nyxid external-key rotate <KEY_ID>` if shared |
+| "Move the routing for my llm-openai service to my new node" | `nyxid service add llm-openai --via-node …` | `nyxid service route <ID> --node <NEW_NODE>` |
+| "Change which node my SSH service uses" | `nyxid service add-ssh …` | `nyxid service update <ID> --node-id <NEW_NODE_ID>` (or `--no-node` for direct) |
+| "Add a redirect URI to my OAuth client" | `nyxid developer-app create …` | `nyxid developer-app update <ID> --redirect-uri "…"` (repeat to set multiple — replaces the list) |
+| "Disable a service-account" | `nyxid service-account create …` | `nyxid service-account update <ID> --is-active false` |
+| "Rename my org" | `nyxid org create …` | `nyxid org update <ORG_ID> --display-name "…"` |
+| "Re-route a channel-bot conversation to a different agent" | `nyxid channel-bot route create …` (creates a second route) | `nyxid channel-bot route update <ROUTE_ID> --agent-key-id <NEW_KEY_ID>` |
+
 ## Managing Services
 
 ```bash
-nyxid catalog list                                             # browse catalog (connectable services)
-nyxid catalog list --all                                       # all services (including system/no-auth)
-nyxid catalog endpoints <slug>                                 # list API endpoints from OpenAPI spec
-nyxid service add <slug>                                       # add from catalog (CLI prompts for credential)
-nyxid service add <slug> --oauth                               # add with OAuth (opens browser)
-nyxid service add <slug> --device-code                         # add with device code flow
-nyxid service add <slug> --via-node <name>                     # add via node (CLI prompts for credential)
-nyxid service add --custom                                     # add custom endpoint (CLI prompts for details)
+nyxid catalog list --output json                               # browse catalog (connectable services)
+nyxid catalog list --all --output json                         # all services (including system/no-auth)
+nyxid catalog endpoints <slug> --output json                   # list API endpoints from OpenAPI spec
+
+# `service add` is wizard-capable — DEFAULT to the bare form. The CLI auto-picks
+# local browser vs remote pairing. Adding `--output json` here without
+# `--no-wait` skips the wizard entirely.
+nyxid service add <slug>                                       # add from catalog (wizard prompts for credential)
+nyxid service add <slug> --oauth                               # OAuth flow (wizard opens upstream consent page)
+nyxid service add <slug> --device-code                         # device code flow (wizard guides through code entry)
+nyxid service add <slug> --via-node <name>                     # add via node (wizard prompts for credential)
+nyxid service add --custom                                     # custom endpoint (wizard prompts for URL/auth/details)
+# Headless agent variant: append --no-wait --output json and resume with
+#   nyxid pairing resume <pairing_id>
+nyxid service add <slug> --oauth --no-wait --output json
+
 nyxid service list --output json                               # list services (includes IDs)
-nyxid service show <id>                                        # show service details
+nyxid service show <id> --output json                          # show service details
 nyxid service update <id> --label "My Custom Name"             # rename service
 nyxid service update <id> --openapi-spec-url https://api.example.com/openapi.json  # attach an OpenAPI spec
 nyxid service update <id> --openapi-spec-url ""                # clear the OpenAPI spec URL
@@ -29,6 +92,9 @@ nyxid service update <id> --default-header 'x-api-version=v2:overridable'
 nyxid service update <id> --default-header 'x-secret-token=abc123:sensitive'   # redact value in audit logs / API responses
 nyxid service update <id> --clear-default-headers
 nyxid service delete <id> --yes                                # remove service (no prompt)
+nyxid service rotate-credential <id> --credential-env NEW_KEY  # rotate stored credential value (NOT wizard-driven; use this for "change my OpenAI key")
+nyxid service route <id> --node <NODE_NAME>                    # change node routing without re-creating the service (also --direct)
+nyxid service convert-ssh <slug> --to-node-key                 # SSH services: switch auth mode (also --to-cert / --to-proxy-only)
 ```
 
 > Default request header precedence is `catalog defaults -> UserService defaults -> caller`. The default is non-overridable unless `:overridable` is set on the value.
@@ -69,28 +135,74 @@ nyxid service update <id> --openapi-spec-url https://api.example.com/openapi.jso
 
 URLs must be `http(s)://` and cannot contain `user:pass@` userinfo. The backend fetches them through a hardened path (DNS pinning, 5 MB size cap, no redirects, per-user cache scoping) and falls back to the generic proxy tool if the spec can't be fetched or parsed, so a broken spec URL never takes the service offline. SSH services ignore this field.
 
+## Managing User Endpoints (`nyxid endpoint`)
+
+`nyxid service add` auto-provisions a `UserEndpoint` (the target URL the proxy hits) alongside the `UserService` routing record and the `UserApiKey` credential. Most users never touch endpoints directly — but when a downstream URL changes (region migration, rebrand, custom DNS) you can edit the endpoint in place rather than recreating the service.
+
+```bash
+nyxid endpoint list --output json                  # list user-managed endpoints
+nyxid endpoint update <ENDPOINT_ID> --url https://new.example.com/v1
+nyxid endpoint delete <ENDPOINT_ID> --yes          # only safe when no UserService still points to it
+```
+
+Get the `<ENDPOINT_ID>` from the `endpoint_id` field on `nyxid service list --output json`.
+
+## Managing External Credentials (`nyxid external-key`)
+
+`UserApiKey` records (the external credentials NyxID injects on outbound requests) can be inspected and rotated independently of the service that owns them. This is useful when one credential backs multiple services, or when a rotation is happening on the provider side and you need to push the new value into NyxID without recreating the service binding.
+
+```bash
+nyxid external-key list --output json                          # list all external credentials
+nyxid external-key rotate <KEY_ID> --credential-env NEW_TOKEN  # rotate without re-creating the binding
+nyxid external-key delete <KEY_ID> --yes                       # remove unused credential
+```
+
+`<KEY_ID>` is the `api_key_id` field on `nyxid service list --output json`. `--credential-env` reads the new value from an environment variable; omit the flag to be prompted securely.
+
+> Don't confuse `nyxid external-key` (third-party credentials NyxID stores on the user's behalf) with `nyxid api-key` (NyxID's own `nyxid_ag_…` keys agents use to call NyxID). External keys are the credentials NyxID injects into proxied requests; API keys are the credentials NyxID itself accepts on inbound requests.
+
 ## Managing API Keys
 
 Each AI agent or integration should use its own NyxID API key (agent key). This gives each caller independent audit trail, optional service bindings, and rate limits.
 
 ```bash
-# CRUD
-nyxid api-key create                                       # interactive: opens scope-picker wizard (v3.1)
-nyxid api-key create --name "My Key" --scopes "proxy read"
-nyxid api-key create --name "coding-agent" --platform claude-code  # any prefill flag is picked up by the wizard
-nyxid api-key create --name "relay-agent" --callback-url "https://..."  # for channel bot relay
-nyxid api-key create --name "My Key" --output json         # scripted: prints raw key to stdout (legacy shape)
+# Create — DEFAULT to the bare wizard form. The CLI auto-opens the local
+# scope-picker wizard (v3.1) on a GUI machine, falls through to a remote
+# pairing URL on a headless agent. Prefill flags seed the form; the user
+# can still change anything inside the wizard.
+nyxid api-key create                                       # full wizard
+nyxid api-key create --name "coding-agent" --platform claude-code         # wizard with prefill
+nyxid api-key create --name "relay-agent" --callback-url "https://..."    # wizard with prefill (channel bot relay)
+
+# Headless agent that can't block on the wizard? Get a machine-readable
+# pairing handoff and resume later:
+nyxid api-key create --name "coding-agent" --platform claude-code --no-wait --output json
+# → { pairing_id, pair_url, resume_cmd, requires_access_token_on_resume, expires_at }
+nyxid pairing resume <pairing_id>
+
+# Read commands — always use --output json to parse the response
 nyxid api-key list --output json
 nyxid api-key show <ID_OR_NAME> --output json
-nyxid api-key rotate <ID_OR_NAME>                          # interactive: opens browser wizard
-nyxid api-key rotate <ID_OR_NAME> --output json            # scripted: prints raw secret to stdout (legacy shape)
+
+# Rotate — same wizard semantics (interactive by default, --no-wait for handoff)
+nyxid api-key rotate <ID_OR_NAME>
+nyxid api-key rotate <ID_OR_NAME> --no-wait --output json
+
 nyxid api-key delete <ID_OR_NAME> --yes
 
+# Scripted-only escape hatch — bypasses the wizard and prints the raw key
+# / new secret on stdout. Use only when every required arg is supplied as
+# a flag AND the caller explicitly wants stdout (CI, Dockerfile, scripts).
+# Don't pick this on user-facing flows: it dumps secrets where they may be
+# captured by tool transcripts.
+nyxid api-key create --name "ci-bot" --scopes "proxy" --output json
+nyxid api-key rotate <ID_OR_NAME> --output json
+
 # Org-owned agent keys (for sharing one agent identity across the whole org)
-nyxid api-key create --name "shared-coding-agent" --org <ID|SLUG|NAME> --platform claude-code
-nyxid api-key list --org <ID|SLUG|NAME>               # list all keys owned by this org
-nyxid api-key rotate <ID> --output json               # any org admin can rotate
-nyxid api-key delete <ID> --yes                       # any org admin can delete
+nyxid api-key create --name "shared-coding-agent" --org <ID|SLUG|NAME> --platform claude-code   # wizard with org pre-selected
+nyxid api-key list --org <ID|SLUG|NAME> --output json     # list all keys owned by this org
+nyxid api-key rotate <ID>                                 # any org admin can rotate (wizard)
+nyxid api-key delete <ID> --yes                           # any org admin can delete
 
 # Consumers authenticate as the org: the agent's NYXID_ACCESS_TOKEN is the
 # org's key, proxy calls see org-shared services directly without needing
@@ -110,8 +222,12 @@ nyxid api-key update <ID> --allow-all-services false
 nyxid api-key update <ID> --callback-url "https://my-agent.example.com/webhook"
 nyxid api-key update <ID> --callback-url ""    # clear
 
-# Per-key rate limits
-nyxid api-key update <ID> --rate-limit-per-second 10 --rate-limit-burst 30
+# Per-key rate limits — the CLI does NOT expose flags for these. Configure
+# them on the key's detail page in the web UI, or via raw HTTP:
+#   PUT /api/v1/api-keys/{id} with body
+#     {"rate_limit_per_second": 10, "rate_limit_burst": 30}
+# The browser-wizard `nyxid api-key create` form also includes a rate-limits
+# section that posts the same fields on creation.
 ```
 
 Set `NYXID_ACCESS_TOKEN` in your agent's environment to authenticate:
@@ -126,17 +242,22 @@ Agent keys need `write` or `admin` scope to call management endpoints via REST (
 
 ### Browser wizard for one-time secrets (v2 + v3.0 + v3.1 + v4)
 
-Five commands now open a browser-based wizard for interactive use, so the secret (either collected from the user or minted by the backend) lands in the user's browser tab instead of the terminal / agent context:
+Ten commands open a browser-based wizard for interactive use, so the secret (either collected from the user or minted by the backend) lands in the user's browser tab instead of the terminal / agent context:
 
-| Command                           | Version | Wizard role                                                                                            |
-|-----------------------------------|:-------:|--------------------------------------------------------------------------------------------------------|
-| `nyxid service add [<slug>]`      |   v2    | Collects a paste-key / OAuth / device-code credential; creates the service + key record.               |
-| `nyxid api-key rotate <id>`       |   v3.0  | DisplayOnce: backend mints a new `nyxid_ag_…`, rendered masked with click-to-reveal + copy.            |
-| `nyxid node rotate-token <id>`    |   v3.0  | DisplayOnce: backend mints a new auth token + signing secret (two rows).                               |
-| `nyxid node register-token`       |   v3.1  | DisplayOnce: backend mints a new `nyx_nreg_…` for bootstrapping a fresh node.                          |
-| `nyxid api-key create`            |   v3.1  | Scope picker (name + owner + platform + scopes + expiry + service/node multi-select + rate limits) → DisplayOnce on the new `nyxid_ag_…`. |
+| Command                                | Version | Wizard role                                                                                            |
+|----------------------------------------|:-------:|--------------------------------------------------------------------------------------------------------|
+| `nyxid service add [<slug>]`           |   v2    | Collects a paste-key / OAuth / device-code credential; creates the service + key record.               |
+| `nyxid api-key rotate <id>`            |   v3.0  | DisplayOnce: backend mints a new `nyxid_ag_…`, rendered masked with click-to-reveal + copy.            |
+| `nyxid node rotate-token <id>`         |   v3.0  | DisplayOnce: backend mints a new auth token + signing secret (two rows).                               |
+| `nyxid node register-token`            |   v3.1  | DisplayOnce: backend mints a new `nyx_nreg_…` for bootstrapping a fresh node.                          |
+| `nyxid api-key create`                 |   v3.1  | Scope picker (name + owner + platform + scopes + expiry + service/node multi-select + rate limits) → DisplayOnce on the new `nyxid_ag_…`. |
+| `nyxid mfa setup`                      |   v3.1  | TOTP enrollment: QR-code render, verify TOTP, recovery codes shown once.                               |
+| `nyxid service-account create`         |   v3.2  | Owner picker + scopes + role IDs → DisplayOnce on the new `client_secret`.                             |
+| `nyxid service-account rotate-secret`  |   v3.2  | DisplayOnce on the new `client_secret`; old secret + tokens revoked atomically.                        |
+| `nyxid developer-app create`           |   v3.2  | Owner picker + redirect URIs + scopes + broker capability; DisplayOnce on the secret for confidential clients (public clients skip the secret panel). |
+| `nyxid developer-app rotate-secret`    |   v3.2  | DisplayOnce on the new `client_secret`; old secret revoked.                                            |
 
-All five commands automatically pick between two transports depending on environment, added in v4 (PR #438):
+All ten commands automatically pick between two transports depending on environment, added in v4 (PR #438):
 
 - **Mode A — Local wizard** (v2/v3 original): picked when `is_wizard_eligible()` returns `true`, i.e. the CLI can launch a local browser via `open::that()` (macOS `open`, Linux `xdg-open`, Windows `start`). The CLI boots an axum server on `127.0.0.1:<random-port>`, opens the wizard SPA there, and the browser talks back through a narrow allowlist of proxied endpoints. Access tokens never hit the browser; 10-second heartbeat cancels on tab-close. CLI prints `→ Opening http://127.0.0.1:…/wizard …`. This is the path taken **on any machine with a desktop environment**, including non-TTY agent subprocesses on macOS / Windows / Linux-with-DISPLAY — the subprocess not having a TTY doesn't prevent `open` / `xdg-open` / `start` from reaching the user's default browser.
 
@@ -152,7 +273,7 @@ Full specs: [`docs/CLI_WIZARD_V2.md`](../../docs/CLI_WIZARD_V2.md) (v2) + [`docs
 
 For scripted / agent use, the wizard is **bypassed** (falls through to the pre-wizard stdin / rpassword path) when ANY of these is true:
 
-- `--terminal` (alias `--no-wizard`) is passed — per-invocation override, available on all five wizard commands.
+- `--terminal` (alias `--no-wizard`) is passed — per-invocation override, available on all ten wizard commands.
 - `NYXID_NO_WIZARD=1` is set in the environment.
 - `--output json` is passed AND `--no-wait` is NOT — agents that want machine-readable output stay scripted, unless they explicitly opt into the pairing transport via `--no-wait`.
 - stdin is a TTY AND stdout is piped / redirected — the user is scripting output but has an interactive shell for prompts.

--- a/skills/nyxid/references/nodes.md
+++ b/skills/nyxid/references/nodes.md
@@ -23,7 +23,12 @@ Nodes are for users who do not want their credentials stored on the NyxID server
 Org admins can mint registration tokens for an org:
 
 ```bash
+# Default — opens the browser wizard (v3.1 DisplayOnce on the new nyx_nreg_…)
 nyxid node register-token --org <ID|SLUG|NAME>
+
+# Headless agent — get a machine-readable pairing URL and resume later
+nyxid node register-token --org <ID|SLUG|NAME> --no-wait --output json
+nyxid pairing resume <pairing_id>
 ```
 
 The redeemed node belongs to the org. All current org admins can manage it; org members can list it and proxy through org services routed to it. Only org admins can create org-scoped registration tokens, delete org-owned nodes, rotate node auth tokens, or manage node bindings.
@@ -40,7 +45,7 @@ For confidential shared infrastructure, keep user login on the admin's laptop an
 
 | Machine | Runs |
 |---|---|
-| Laptop | `nyxid login`, `nyxid node register-token --org`, `nyxid keys create --service-slug ... --node-id ...`, all node management ops (`rotate-token`, `transfer`, `delete`, manage bindings) |
+| Laptop | `nyxid login`, `nyxid node register-token --org`, `nyxid service add <slug> --org <ORG> --via-node <NODE>` to mint the org-owned `UserService`, all node management ops (`rotate-token`, `transfer`, `delete`, manage bindings) |
 | VM | `nyxid node register --token`, `nyxid node credentials add` (purely local), `nyxid node start` / daemon. Never `nyxid login` on the VM. |
 
 The node's local credential store is keyed by service slug (`config.toml: credentials[<slug>]`). The binding to a NyxID `UserService` is established by matching slugs. Both ends must agree on the slug; no user identity passes through the VM.
@@ -49,8 +54,8 @@ Fresh shared-box checklist:
 
 1. Admin on laptop: `nyxid node register-token --org <ID|SLUG|NAME>` -> copy the `nyx_nreg_...` token.
 2. Operator on VM: `nyxid node register --token nyx_nreg_... --url wss://...` -> token is consumed, node receives its own `nyx_nauth_...` stored in the OS keychain or local secret backend.
-3. Admin on laptop: `nyxid keys create --service-slug <slug> --node-id <node-id>` -> creates the org-owned `UserService` routing through the node.
-4. Operator on VM: `nyxid node credentials add <slug> --header X-API-Key` (interactive secret prompt) -> credential stored locally, encrypted.
+3. Admin on laptop: `nyxid service add <slug> --org <ID|SLUG|NAME> --via-node <node-id-or-name>` -> creates the org-owned `UserService` routing through the node.
+4. Operator on VM: `nyxid node credentials add --service <slug> --header X-API-Key` (interactive secret prompt) -> credential stored locally, encrypted.
 5. Operator on VM: `nyxid node start` (or `nyxid node daemon install` + `start`).
 6. Optional: Admin on laptop: `nyxid node transfer <node-id> --to <org-id>` if the node was registered to a person owner first.
 
@@ -64,11 +69,11 @@ Remote credential provisioning lets an org admin push setup metadata to a node o
 
 | Laptop (admin) | VM (operator) |
 |---|---|
-| `nyxid node-credential push <node-id-or-name> --slug <slug> --injection-method header --field-name X-API-Key [--target-url ...] [--label ...]` |  |
+| `nyxid node-credential push <node-id-or-name> --slug <slug> --injection-method header --field-name X-API-Key [--target-url ...] [--label ...] --output json` |  |
 | Relay the slug, injection method, and field name to the operator. Do not send a secret value. | `nyxid node credentials pending` |
 |  | Verify the slug, method, field name, and target URL. |
 |  | `nyxid node credentials accept <slug>` and enter the secret when prompted. For non-interactive provisioning, use `--value-env <ENVVAR>`. |
-| `nyxid node-credential list <node-id-or-name>` |  |
+| `nyxid node-credential list <node-id-or-name> --output json` |  |
 | `nyxid node-credential cancel <node-id-or-name> <pending-id>` if the push is wrong or stale. | `nyxid node credentials decline <slug> --reason "wrong target"` if the operator refuses it. |
 
 Pending credentials expire automatically. The default TTL is 24 hours (`NODE_PENDING_CREDENTIAL_TTL_SECS`). Expired entries are not returned to admins or nodes; create a fresh push if the operator misses the window.
@@ -86,7 +91,10 @@ Transfer changes only server-side ownership. The node auth token is per-node, so
 Registration must happen before installing the daemon. Credentials can be added before or after starting -- the agent reloads them automatically within 5 seconds.
 
 ```bash
-# Step 1: Generate a registration token (on any machine with nyxid CLI)
+# Step 1: Generate a registration token (on any machine with nyxid CLI).
+# The wizard mints the nyx_nreg_… and shows it once with click-to-reveal.
+# On a headless agent, append --no-wait --output json to get a pairing URL
+# you can hand to the user and resume with `nyxid pairing resume <ID>`.
 nyxid node register-token
 
 # Step 2: Install nyxid CLI on the target machine
@@ -102,36 +110,50 @@ nyxid node register \
 nyxid node daemon install                              # install as system service
 nyxid node daemon start                                # start the service
 
-# Step 5: Add credentials (auto-registers catalog services in the backend)
+# Step 5 — CANONICAL for catalog services (llm-openai, llm-anthropic,
+# api-github, etc.). One command: it auto-registers the UserService in the
+# backend with this node's ID AND prompts for the credential locally.
+# DO NOT also run `nyxid service add <slug> --via-node …` — that creates
+# a duplicate backend record and the agent will get confused about which
+# one to route through.
 nyxid node credentials setup --service llm-openai      # agent picks up new credentials automatically
 
-# For custom endpoints: register first, then add credentials locally
+# Step 5 — for CUSTOM endpoints only (anything not in `nyxid catalog list`).
+# Custom services have no catalog config, so the backend record must be
+# created explicitly first; only then can the credential be stored locally.
 nyxid service add --custom --via-node my-node           # creates backend record (prompts for URL, auth, etc.)
 nyxid node credentials add --service my-api --header Authorization --secret-format bearer
 
 # Or run in foreground (for debugging)
 nyxid node start
 
-# Or run via Docker
-docker build -f cli/Dockerfile.node -t nyxid-node .    # build image (once)
-
-# Option A: auto-register + start (no host setup needed)
-docker run --user "$(id -u):$(id -g)" \
-  -v ~/.nyxid-node:/app/config \
-  -e NYXID_NODE_TOKEN=nyx_nreg_... \
-  -e NYXID_NODE_URL=wss://<server>/api/v1/nodes/ws \
-  nyxid-node
-
-# Option B: mount existing config (registered on host)
-docker run --user "$(id -u):$(id -g)" \
-  -v ~/.nyxid-node:/app/config \
-  nyxid-node
+# Or run via Docker. The CLI ships a `nyxid node docker` family that wraps
+# the underlying `docker build` / `docker run` calls. It mounts the profile's
+# config directory automatically and sets a profile-aware container name so
+# multiple node instances can run side-by-side on one host.
+nyxid node docker build                                # build the image once
+nyxid node docker start                                # start container (default profile)
+nyxid node docker start --profile edge-tokyo          # start a second profile
+nyxid node docker status                               # show container state
+nyxid node docker logs --follow                        # tail container logs
+nyxid node docker stop                                 # stop and remove container
+nyxid node docker restart                              # restart in place
 ```
 
-> `credentials setup` works for **catalog services only** -- it fetches config from the catalog and automatically registers the service in the backend with the node's ID.
-> For **custom endpoints**, use `nyxid service add --custom --via-node <node-name>` first to create the backend record, then `nyxid node credentials add` to store the credential locally on the node.
+> **Decision rule for AI agents** (deterministic — pick one path, don't mix):
+>
+> Two axes: (a) is the slug in the catalog? (b) is the operator on the SAME machine as the node, or on a different machine (e.g. admin laptop + shared VM)?
+>
+> | Same machine, catalog slug | → | `nyxid node credentials setup --service <slug>` (one command, auto-registers + stores credential) |
+> | Same machine, custom endpoint | → | `nyxid service add --custom --via-node <node>` then `nyxid node credentials add --service <slug> …` |
+> | Different machines (laptop + VM), catalog or custom | → | Admin on laptop: `nyxid service add <slug> [--org …] --via-node <node>` (catalog) or `nyxid service add --custom --via-node <node>` (custom). Operator on VM: `nyxid node credentials add --service <slug> …`. **Do NOT run `credentials setup` on the VM** — the service is already registered by the admin, so `setup` would duplicate state. |
+>
+> Auto-detect cheats:
+> - Catalog vs custom: if `nyxid catalog show <slug> --output json` returns metadata, it's catalog. Otherwise custom.
+> - Same-machine vs split: if you're on the same shell where the daemon is running, same-machine. If the user is describing a "shared / org-owned / company VM" or asks you to walk them through two machines, split.
 > Credentials can be added, updated, or removed while the agent is running. The agent watches the config file and reloads credentials automatically (no restart needed). This works for both native daemons and Docker containers (config is mounted as a volume).
 > Docker containers use the file backend (AES-GCM encrypted) -- OS keychain is not available in containers.
+> The `nyxid node docker` wrapper accepts `--profile <name>` on every subcommand. Each profile becomes a separate container with its own config volume at `~/.nyxid-node/profiles/<name>/`, so you can run multiple node instances on the same host (one per org / one per environment).
 
 ### Managing the node service
 
@@ -154,15 +176,22 @@ nyxid node daemon uninstall                             # remove service (stops 
 # nyxid CLI (manage nodes from user side)
 nyxid node list --output json                          # list nodes (includes IDs)
 nyxid node show <ID_OR_NAME> --output json             # show node details + metrics
-nyxid node register-token                              # interactive: opens browser wizard (v3.1)
-nyxid node register-token --org <ID|SLUG|NAME>         # org-owned node token (admin only)
-nyxid node register-token --name "edge-tokyo" --output json  # scripted: prints raw nyx_nreg_... (legacy shape)
+
+# register-token + rotate-token are wizard-capable: default to the bare form
+# (auto-picks local-browser vs remote-pairing); use --no-wait --output json
+# only when the agent specifically can't hold a subprocess open.
+nyxid node register-token                              # opens browser wizard (v3.1)
+nyxid node register-token --org <ID|SLUG|NAME>         # org-owned node token (admin only); wizard pre-selects org
+nyxid node register-token --name "edge-tokyo" --no-wait --output json   # headless: pairing handoff JSON
+nyxid pairing resume <pairing_id>                                       # …then resume once the user finishes
+nyxid node rotate-token <ID_OR_NAME>                   # opens browser wizard (shows new auth_token + signing_secret)
+nyxid node rotate-token <ID_OR_NAME> --no-wait --output json            # headless: pairing handoff JSON
+nyxid pairing resume <pairing_id>                                       # …then resume once the user finishes
+
 nyxid node delete <ID_OR_NAME> --yes                   # delete node
-nyxid node rotate-token <ID_OR_NAME>                   # interactive: opens browser wizard (shows new auth_token + signing_secret)
-nyxid node rotate-token <ID_OR_NAME> --output json     # scripted: prints raw secret to stdout (legacy shape)
 nyxid node transfer <ID_OR_NAME> --to <USER_OR_ORG_ID> # move node ownership, detaches cross-owner routing
-nyxid node-credential push <ID_OR_NAME> --slug <SLUG> --injection-method header --field-name X-API-Key
-nyxid node-credential list <ID_OR_NAME>                # list pending credential pushes
+nyxid node-credential push <ID_OR_NAME> --slug <SLUG> --injection-method header --field-name X-API-Key --output json
+nyxid node-credential list <ID_OR_NAME> --output json  # list pending credential pushes
 nyxid node-credential cancel <ID_OR_NAME> <PENDING_ID> # cancel a pending credential push
 
 # nyxid node CLI (run on the node machine)
@@ -214,7 +243,7 @@ nyxid node ssh-credentials list --service <SLUG>
 nyxid node ssh-credentials show --service <SLUG> --principal <USER>
 nyxid node ssh-credentials test --service <SLUG> --principal <USER>
 nyxid node ssh-credentials remove --service <SLUG> --principal <USER>
-nyxid node ssh-credentials prune --stale
+nyxid node ssh-credentials prune --stale  # all node `--profile <name>` flags also work here
 ```
 
 > `credentials setup` works for **catalog services**: it auto-detects whether the service needs an API key, OAuth, or gateway URL, guides the user through the right flow, and auto-registers the service in the backend with the node's ID. For **custom endpoints**, use `nyxid service add --custom --via-node <node>` first, then `nyxid node credentials add`.
@@ -242,6 +271,9 @@ nyxid ssh proxy <SERVICE>                              # ProxyCommand for OpenSS
 
 # List SSH services
 nyxid service list --output json | jq '.keys[] | select(.service_type == "ssh")'
+
+# Show one SSH service (handy when you need its UserService ID for `--via-service` later)
+nyxid service show <SERVICE_ID_OR_SLUG> --output json
 ```
 
 The SSH `--org` behavior matches `nyxid service add --org`: the service is created under the org owner, and members discover it through their own account. See [`organizations.md`](organizations.md#sharing-a-service-with-the-org) for org-scoped service ownership details.
@@ -257,7 +289,7 @@ SSH services have an `ssh_auth_mode`:
 Create a node-key service:
 
 ```bash
-nyxid service add-ssh routeros --host 10.0.0.1 --port 22 --via-node edge-node --node-key --principals nyxid-ro,nyxid-admin
+nyxid service add-ssh --label routeros --host 10.0.0.1 --port 22 --via-node edge-node --node-key --principals nyxid-ro,nyxid-admin
 nyxid node ssh-credentials add --service routeros --principal nyxid-ro --key-file ~/.ssh/routeros_ro --host 10.0.0.1 --port 22
 ```
 

--- a/skills/nyxid/references/notifications.md
+++ b/skills/nyxid/references/notifications.md
@@ -38,7 +38,7 @@ nyxid approval disable                                 # disable (auto-approve a
 ## Step 3: Check your notification settings
 
 ```bash
-nyxid notification settings                            # show current notification & approval status
+nyxid notification settings --output json              # show current notification & approval status
 ```
 
 If the user has not set up any notification channel yet, **proactively suggest** they do so before making proxy requests. Walk them through the steps above.
@@ -49,11 +49,11 @@ Approvals default to **per-request** mode: every proxy call needs fresh approval
 
 ```bash
 nyxid approval list --output json                      # list pending approvals (includes action_description)
-nyxid approval show <ID>                               # show approval details + action_description
+nyxid approval show <ID> --output json                 # show approval details + action_description
 nyxid approval approve <ID>                            # approve a request
 nyxid approval deny <ID>                               # deny a request
 nyxid approval enable                                  # enable global approval protection
-nyxid approval disable                                 # disable global approval protection
+nyxid approval disable --yes                           # disable global approval protection
 nyxid approval grants --output json                    # list active grants (grant mode only)
 nyxid approval service-configs --output json           # list per-service approval configs (includes approval_mode)
 nyxid approval set-config <SERVICE_ID> --require-approval true                    # per-request (default)
@@ -73,8 +73,10 @@ nyxid approval set-config <SERVICE_ID> --org <ID|SLUG|NAME> --require-approval t
 nyxid approval set-config <SERVICE_ID> --org <ID|SLUG|NAME> --require-approval true --approval-mode grant
 nyxid approval list --org <ID|SLUG|NAME> --output json # list requests against org services
 
-nyxid notification settings                            # show notification settings
+nyxid notification settings --output json              # show notification settings
 nyxid notification update --approval-telegram true     # enable telegram notifications
 nyxid notification update --approval-push true         # enable push notifications
+nyxid notification update --approval-email true        # enable email approvals (also accepts false to disable)
 nyxid notification telegram-link                       # link telegram account
+nyxid notification telegram-disconnect                 # unlink telegram account
 ```

--- a/skills/nyxid/references/organizations.md
+++ b/skills/nyxid/references/organizations.md
@@ -30,14 +30,15 @@ Wherever a command takes `--org <ID|SLUG|NAME>`, you can pass the org UUID, slug
 ## Creating and managing an org
 
 ```bash
-# Create an org. You become the first admin.
-nyxid org create --display-name "Chrono AI"
+# Create an org. You become the first admin. (`org create` is not a
+# wizard-capable command — `--output json` here just controls stdout shape.)
+nyxid org create --display-name "Chrono AI" --output json
 
 # List all orgs you belong to. Output includes the org slug.
-nyxid org list
+nyxid org list --output json
 
 # Show details (member count, your role, slug)
-nyxid org show <ORG_ID>
+nyxid org show <ORG_ID> --output json
 
 # Update metadata (admin only). Pass --avatar-url "" to clear.
 # Slugs are auto-generated on create and can be edited later.
@@ -55,8 +56,10 @@ nyxid org delete <ORG_ID> --yes
 
 An org admin creates a shared service by passing `--org <ID|SLUG|NAME>` to `nyxid service add`. The resulting `UserService`, `UserEndpoint`, and `UserApiKey` rows are written with `user_id = <org_user_id>`, so every member of the org immediately sees the service in their `nyxid service list` (tagged with `credential_source.type = "org"`) and can proxy through it using their own NyxID account.
 
+All `service add` examples below default to the wizard form. Append `--no-wait --output json` (and resume with `nyxid pairing resume <pairing_id>`) when the calling agent can't hold the wizard subprocess open.
+
 ```bash
-# Shared OpenAI key for the whole org (API key credential)
+# Shared OpenAI key for the whole org (API key credential — wizard prompts for the secret)
 nyxid service add llm-openai --org chrono-ai
 
 # OAuth flow targeted at the org. The browser opens under YOUR login, you
@@ -67,7 +70,7 @@ nyxid service add api-google --oauth --org chrono-ai
 # Device-code flow targeted at the org
 nyxid service add llm-anthropic --device-code --org chrono-ai
 
-# Custom endpoint targeted at the org
+# Custom endpoint targeted at the org (wizard prompts for credential)
 nyxid service add --custom --org chrono-ai \
   --label "Shared Home Assistant" \
   --endpoint-url https://ha.home.local:8123 \
@@ -119,14 +122,14 @@ nyxid provider disconnect <PROVIDER_ID> --org <ID|SLUG|NAME>
 
 ```bash
 # Issue a one-time invite (admin only). Default role is member, default TTL 24h.
-nyxid org invite create <ORG_ID> --role member
-nyxid org invite create <ORG_ID> --role viewer --ttl-hours 168
+nyxid org invite create <ORG_ID> --role member --output json
+nyxid org invite create <ORG_ID> --role viewer --ttl-hours 168 --output json
 
 # Restrict the invitee to specific UserService IDs (comma-separated, implies override)
-nyxid org invite create <ORG_ID> --role member --allowed-service-ids "<svc1>,<svc2>"
+nyxid org invite create <ORG_ID> --role member --allowed-service-ids "<svc1>,<svc2>" --output json
 
 # Force inherit mode (ignores any --allowed-service-ids you also pass)
-nyxid org invite create <ORG_ID> --role member --scope-source inherit
+nyxid org invite create <ORG_ID> --role member --scope-source inherit --output json
 
 # The output includes a join link AND a bare nonce. Share whichever is convenient:
 #   Join link: https://<frontend>/orgs/join/ORGINV-...
@@ -137,7 +140,7 @@ nyxid org join ORGINV-ABCDEF12345678
 nyxid org join "https://nyx.example.com/orgs/join/ORGINV-..."   # full URL also works
 
 # List or cancel pending invites
-nyxid org invite list <ORG_ID>
+nyxid org invite list <ORG_ID> --output json
 nyxid org invite cancel <ORG_ID> <INVITE_ID> --yes
 ```
 
@@ -152,7 +155,7 @@ nyxid org member add <ORG_ID> --user-id <USER_ID> --role member
 ```bash
 # List members of an org (any member can read). Shows each member's role,
 # scope mode (inherit/override), and effective allowed services.
-nyxid org member list <ORG_ID>
+nyxid org member list <ORG_ID> --output json
 
 # Change a member's role (admin only)
 nyxid org member update <ORG_ID> <MEMBER_USER_ID> --role admin
@@ -182,7 +185,7 @@ member.
 
 ```bash
 # Show defaults for admin / member / viewer (admin only)
-nyxid org role-scope list <ORG_ID>
+nyxid org role-scope list <ORG_ID> --output json
 
 # Restrict the `member` role to two specific services
 nyxid org role-scope set <ORG_ID> --role member \

--- a/skills/nyxid/references/proxy.md
+++ b/skills/nyxid/references/proxy.md
@@ -138,6 +138,8 @@ nyxid proxy request api-twitter /tweets -m POST \
 nyxid proxy discover --output json
 ```
 
+> When piping `nyxid proxy request ...` output through `jq` or other tools, the proxy already prints the downstream response on stdout — pass `--output json` only to commands that have multiple shapes (`list`, `show`, `status`, `discover`). The proxy itself is shape-passthrough.
+
 NyxID injects the user's credentials automatically. Do not ask for or log raw downstream credentials.
 
 ## WebSocket-authenticated services

--- a/skills/nyxid/references/services.md
+++ b/skills/nyxid/references/services.md
@@ -1,5 +1,24 @@
 # Services: discover, add, and connect credentials
 
+## Quick reference for AI agents (deterministic flow)
+
+When the user asks to add / connect / set up a service, follow this exact decision tree. Long-form rationale is later in the file; this block is the canonical path so the agent doesn't have to derive it.
+
+1. **`nyxid service list --output json`** — does the user already have this service? If yes, treat the request as an edit (see `managing.md` "Capturing user intent: edit vs. create"). Do NOT proceed to `service add`.
+2. **`nyxid catalog list --output json`** (or `nyxid catalog show <slug> --output json`) — is the service in the catalog?
+   - **In catalog → use the catalog slug.** Run `nyxid service add <slug>` (bare wizard form, no flags). The CLI auto-picks the right transport (local browser when available, remote pairing on headless boxes).
+   - **Not in catalog → use `--custom`.** Run `nyxid service add --custom` and let the wizard prompt for endpoint URL, auth method, and credential.
+3. **Pick auth-flow flag based on what the catalog says (`auth_type` field on `catalog show`):**
+   - `oauth` → add `--oauth`
+   - `device-code` → add `--device-code`
+   - `api-key` / paste-key → no flag needed; the wizard's paste-key form handles it
+4. **Headless agent (no TTY, no browser, can't hold subprocess open)?** Append `--no-wait --output json`, surface the printed `pair_url` to the user, then run `nyxid pairing resume <pairing_id>` after they confirm. **Don't add `--output json` without `--no-wait`** — that bypasses the wizard and dumps the secret to stdout.
+5. **Don't add `--terminal`, `--credential-env`, `--credential`** unless the user has *already handed the agent the credential bytes in this conversation*. These flags skip the wizard, which means the secret bypasses the browser tab and lands in tool transcripts. The bare wizard form is the default for a reason.
+6. **Org-shared service?** Add `--org <ID|SLUG|NAME>`. The wizard pre-selects the org as the owner.
+7. **Node-routed service?** Use `nyxid node credentials setup --service <slug>` (catalog services) or `nyxid service add --custom --via-node <node>` (custom). See `nodes.md` for the canonical path.
+
+If any step is genuinely ambiguous, ask the user one clarifying question — duplicates are harder to undo than a one-line clarification.
+
 ## Table of contents
 
 - [Discover Services](#discover-services)
@@ -38,15 +57,22 @@ If the target service is missing, help the user add it:
 nyxid catalog list --output json                          # browse available services
 nyxid catalog list --all --output json                    # include system services without auth
 nyxid catalog show <slug> --output json                   # full metadata: links, capabilities, auth notes
-nyxid catalog endpoints <slug>                            # list API endpoints from OpenAPI spec
-nyxid service add <slug> --oauth                          # OAuth flow (opens browser -- easiest)
-nyxid service add <slug> --device-code                    # device code flow (enter code on website)
-nyxid service add <slug>                                  # API key (CLI prompts securely)
-nyxid service add --custom                                # add custom endpoint (CLI prompts for details)
+nyxid catalog endpoints <slug> --output json              # list API endpoints from OpenAPI spec
+
+# Adding a service — DEFAULT to the bare wizard form. The CLI auto-picks the
+# right transport (local browser when reachable, remote pairing otherwise).
+nyxid service add <slug>                                  # API key wizard (paste-key form)
+nyxid service add <slug> --oauth                          # OAuth flow (opens upstream consent page)
+nyxid service add <slug> --device-code                    # device code flow (enter code on provider's site)
+nyxid service add --custom                                # custom endpoint (wizard prompts for URL, auth, etc.)
+
+# Headless agent that can't block on the wizard? Use --no-wait --output json
+# to get back a machine-readable pairing handoff and resume later:
+nyxid service add <slug> --oauth --no-wait --output json  # → {pairing_id, pair_url, resume_cmd, …}
+nyxid pairing resume <pairing_id>                          # pick up the result once the user finishes
 ```
 
-> For API key services, just run `nyxid service add <slug>` without flags. The CLI securely prompts for the key (input hidden). Never ask the user to paste secrets into chat or set environment variables manually.
-> For automation/scripting only: `--credential-env <VAR>` reads from an environment variable.
+> For API key services, just run `nyxid service add <slug>` without flags. The CLI auto-detects whether to open a local wizard or print a remote-pairing URL — never ask the user to paste secrets into chat. The `--credential-env <VAR>` flag is the scripted escape hatch for CI / automation; don't use it on user-facing flows because it skips the wizard.
 
 ## Slug rules for `service add`
 
@@ -60,7 +86,7 @@ nyxid service add --custom                                # add custom endpoint 
 Some OAuth providers (Lark, Google, GitHub, Atlassian, ...) expose many scopes but NyxID's catalog only configures a sensible default set. When a user needs a capability that isn't covered -- for example Lark's contact/attendance APIs -- add extra scopes on top of the defaults with `--scope`:
 
 ```bash
-# Single scope
+# Single scope (wizard pre-fills the rest of the form)
 nyxid service add api-lark --oauth --scope contact:contact.base:readonly
 
 # Multiple scopes (repeat the flag or comma-separate)
@@ -73,6 +99,9 @@ nyxid service add api-lark --oauth \
 
 # Works the same way for device-code services
 nyxid service add llm-openai --device-code --scope "custom-scope-1,custom-scope-2"
+
+# Headless variant for any of the above:
+nyxid service add api-lark --oauth --scope contact:contact.base:readonly --no-wait --output json
 ```
 
 The extra scopes are merged (deduped) on top of the provider's `default_scopes` and forwarded in the authorization URL (or device code request). The upstream provider decides whether to grant them -- if the user's app/client doesn't have a scope enabled on the provider side, the authorization flow will still fail there.
@@ -242,12 +271,18 @@ nyxid service add llm-openai --credential-env OPENAI_KEY --output json
 nyxid service add llm-openai --no-wait --output json
 ```
 
-**Guidance for AI agents using this skill:** prefer scripted flags (`--credential-env`, `--output json`) when the agent already has the credential in hand — this stays fully non-interactive and never touches a browser. When the agent doesn't have the credential (e.g. the user needs to log into an OAuth provider), pass `--no-wait --output json` to print a machine-readable pairing URL the agent can surface to the user, then `nyxid pairing resume <id>` once the user confirms they've completed the browser flow. Agents should NOT rely on `--terminal` without supplying all required args — the scripted path will hang on the first stdin prompt.
+**Guidance for AI agents using this skill:** the bare wizard form is the right default — it auto-picks local browser vs remote pairing, never asks the agent to handle raw secrets, and works on both interactive and headless boxes. Reach for the alternatives only in these specific cases:
+
+- **`--no-wait --output json` (recommended for headless agents).** When the agent can't hold a long-running subprocess open, this returns a machine-readable pairing handoff (`{ pairing_id, pair_url, resume_cmd, … }`) so the agent can surface the pair URL to the user, exit, and pick up the result later with `nyxid pairing resume <pairing_id>`.
+- **Scripted flags (`--credential-env`, `--output json` without `--no-wait`).** Only when the user has *explicitly handed the agent the credential bytes already* (e.g. they pasted an OpenAI key into chat and asked the agent to set it up). This skips the wizard, so the secret bypasses the browser tab — appropriate when the agent already holds it, inappropriate as a default.
+- **Don't rely on `--terminal`** without supplying all required args — the scripted path will hang on the first stdin prompt.
 
 ### Step 1: Check the catalog
 
 ```bash
-nyxid catalog show <slug> --output json
+nyxid catalog list --output json                          # list all available services
+nyxid catalog show <slug> --output json                   # full metadata for one service
+nyxid catalog endpoints <slug> --output json              # OpenAPI endpoints (when published)
 ```
 
 The response includes `auth_type` which tells you what the service needs. Use this to guide the user.
@@ -257,21 +292,24 @@ The response includes `auth_type` which tells you what the service needs. Use th
 - **OAuth** (`--oauth`): Best for non-technical users. Opens a browser -- the user signs in with their existing account. No API key needed. Use this for Google, GitHub, Twitter, and any service that supports OAuth.
   ```bash
   nyxid service add api-github --oauth
+  # Headless variant: nyxid service add api-github --oauth --no-wait --output json
   ```
 
 - **Device code** (`--device-code`): Good when the user can't open a browser from the terminal. Shows a short code to enter on the provider's website. Works well for services like OpenAI Codex.
   ```bash
   nyxid service add llm-openai --device-code
+  # Headless variant: nyxid service add llm-openai --device-code --no-wait --output json
   ```
 
 - **API key**: The user needs to get an API key from the provider's website. Guide them:
   1. Check the common portals table below for the provider's developer portal URL
   2. If the provider is not listed, search the web for "<provider name> API key" to find the right page, then tell the user exactly where to go
   3. Walk them through creating a key on the provider's site
-  4. Tell them to run the command **without** `--credential-env` -- the CLI will securely prompt for the key (input is hidden, never shown on screen):
+  4. Tell them to run the command **without** `--credential-env` -- the wizard handles credential entry in the browser (or via remote pairing on headless boxes), never asks the agent to paste secrets:
      ```bash
      nyxid service add llm-openai
-     # CLI prompts: "Enter API key/credential:" (input hidden)
+     # Wizard opens the paste-key form; on a headless agent without a TTY,
+     # falls through to the remote-pairing URL automatically.
      ```
   Never ask the user to paste secrets into chat. The CLI's secure prompt keeps the key out of shell history and conversation logs.
 


### PR DESCRIPTION
## Summary

The `skills/nyxid/` bundle had drifted from the actual `nyxid` CLI in ways that would cause AI agents to fail silently or take wrong paths. This PR is a deliberate sweep to:

1. **Fix CLI drift** — 7 HIGH-severity issues where the docs claimed flags or commands that don't exist (or use different syntax) in `cli/src/cli.rs`.
2. **Fix wizard-bypass bias** — examples were leading agents to add `--output json` to wizard-capable create/rotate commands, which silently skips the browser wizard and dumps secrets to stdout.
3. **Fix edit-vs-create intent miscapture** — agents kept reaching for `nyxid api-key create` when users asked to *update* an existing key. Partly because the skill never told them to list-first, partly because "API key" is overloaded (NyxID `nyxid_ag_…` agent key vs third-party downstream credential).
4. **Document missing CLI surface** — `service-account`, `developer-app`, `endpoint`, `external-key`, `node docker`, `info`/`repo`/`telemetry` were not covered anywhere in the skill.
5. **Pin deterministic AI flows** — added explicit decision trees so an agent reading the skill cold can pick the right command on the first try.

## Highlights

- **`SKILL.md`** — rewrote "Working Rules" into two subsections: "Capture user intent before acting" (list-first, edit-vs-create, `api-key` vs `external-key` disambiguation) and "CLI invocation defaults" (wizard is the default, `--no-wait --output json` for headless agents, scripted-flag exceptions narrowed).
- **`references/services.md`** — added a 7-step "Quick reference for AI agents (deterministic flow)" at the top so agents don't have to derive the path from prose.
- **`references/managing.md`** — new "Capturing user intent: edit vs. create" section with a 10-row "Edits agents commonly mistake for create" table mapping wrong invocations to right ones. Added new `nyxid endpoint` and `nyxid external-key` reference sections.
- **`references/nodes.md`** — replaced ambiguous setup guidance with a 3-case decision matrix (same machine + catalog → `credentials setup`; same machine + custom → two-step; different machines → admin runs `service add --via-node`, operator runs `credentials add`).
- **`references/accounts.md`** *(new)* — full `nyxid service-account` and `nyxid developer-app` reference plus a "which identity to pick" decision table.
- **HIGH drift fixes** — `channel-bot route create` flag renames (`--bot` → `--bot-id`, `--agent` → `--agent-key-id`), phantom `nyxid keys create` removed, positional → flag fixes for `service add-ssh --label` and `node credentials add --service`, removed false claim that `nyxid api-key update --rate-limit-per-second` exists (rate limits are set via web UI / raw HTTP).
- **JSON sweep** — `--output json` added to read commands (`list`, `show`, `discover`, `status`); deliberately NOT added to wizard-capable creates/rotates as a default (only as labeled "scripted escape hatch" with warnings).

## Verification

Three independent sub-agent reviews:

1. **CLI cross-check** (round 1) — diffed every `nyxid …` invocation in the docs against `cli/src/cli.rs` clap definitions. Found 7 HIGH drifts; all fixed in this PR.
2. **Post-edit verification** (round 2) — re-checked the new edits against the CLI surface. Status: clean across 7 audit items.
3. **Fresh-reader usability test** (round 3) — a reviewer with no prior NyxID context traced 8 realistic user flows through the docs and reported pass/fail for each. **All 8 PASS**, including the previously-broken "edit my agent key's scopes" case and the api-key-vs-external-key disambiguation.

Net change: 542 insertions / 121 deletions across 9 modified files + 1 new file (`references/accounts.md`).

## Test plan

- [ ] `nyxid channel-bot route create --bot-id … --agent-key-id …` parses and creates a route
- [ ] `nyxid service add-ssh --label … --host …` parses (was previously documented with positional label)
- [ ] `nyxid node credentials add --service … --header …` parses (was previously documented as positional slug)
- [ ] `nyxid service-account create --name … --scopes "…"` opens the wizard by default
- [ ] `nyxid api-key create --no-wait --output json` returns the pairing handoff JSON; `nyxid pairing resume <id>` completes the flow
- [ ] Agent flow check: "edit my agent key's scopes" should NOT spawn `nyxid api-key create`
- [ ] Agent flow check: "rotate my OpenAI API key" should disambiguate to `nyxid service rotate-credential` (not `nyxid api-key rotate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)