### PR TITLE
feat(frontend): persist ?code= invite from landing through login/register

### DIFF
--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -128,13 +128,17 @@ interface AuthFlowProps {
   readonly initialPanel?: AuthPanel;
   readonly returnTo?: string;
   readonly socialError?: string;
+  readonly initialInviteCode?: string;
 }
 
 export function AuthFlow({
   initialPanel = 0,
   returnTo,
   socialError,
+  initialInviteCode,
 }: AuthFlowProps) {
+  const normalizedInitialInviteCode =
+    initialInviteCode?.trim().toUpperCase() ?? "";
   const { data: publicConfig } = usePublicConfig();
   const inviteRequired = publicConfig?.invite_code_required ?? true;
   const emailAuthEnabled = publicConfig?.email_auth_enabled ?? false;
@@ -162,7 +166,7 @@ export function AuthFlow({
   const registerForm = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
     defaultValues: {
-      inviteCode: "",
+      inviteCode: normalizedInitialInviteCode,
       name: "",
       email: "",
       password: "",
@@ -203,10 +207,15 @@ export function AuthFlow({
       setTimeout(() => {
         setPanel(target);
         const path = target === 0 ? "/login" : "/register";
-        const qs = returnTo
-          ? `?return_to=${encodeURIComponent(returnTo)}`
-          : "";
-        window.history.replaceState(null, "", `${path}${qs}`);
+        const nextParams = new URLSearchParams();
+        if (returnTo) nextParams.set("return_to", returnTo);
+        if (initialInviteCode) nextParams.set("code", initialInviteCode);
+        const qs = nextParams.toString();
+        window.history.replaceState(
+          null,
+          "",
+          `${path}${qs ? `?${qs}` : ""}`,
+        );
         // Small delay for React to render new content before fading in
         requestAnimationFrame(() => {
           setFadeOpacity(1);

--- a/frontend/src/features/landing/components/landing-navbar.tsx
+++ b/frontend/src/features/landing/components/landing-navbar.tsx
@@ -9,6 +9,10 @@ export function LandingNavbar() {
 
   useScroll((scrollY) => setScrolled(scrollY > 0));
 
+  const loginHref = `/login${
+    typeof window !== "undefined" ? window.location.search : ""
+  }`;
+
   return (
     <nav
       className={`fixed top-0 left-0 right-0 z-50 border-b backdrop-blur-md transition-all duration-500 ${
@@ -25,7 +29,7 @@ export function LandingNavbar() {
         <div className="flex items-center gap-3">
           <LanguageSwitcher />
           <a
-            href="/login"
+            href={loginHref}
             className="rounded-lg border border-primary/40 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/10"
           >
             {t("nav.login")}

--- a/frontend/src/features/landing/landing-page.tsx
+++ b/frontend/src/features/landing/landing-page.tsx
@@ -18,7 +18,7 @@ import { LandingFooter } from "./components/landing-footer";
 // Stopgap: auto-applied for Reddit-referred users without an explicit ?code=.
 // Operator must keep a matching invite code active in admin UI with high max_uses.
 // Remove when proper attribution/campaign codes are wired up.
-const REDDIT_DEFAULT_INVITE_CODE = "NYX-37YR43OH";
+const REDDIT_DEFAULT_INVITE_CODE = "NYX-QJGT6NHN";
 
 function injectRedditDefaultCode() {
   if (typeof window === "undefined") return;

--- a/frontend/src/features/landing/landing-page.tsx
+++ b/frontend/src/features/landing/landing-page.tsx
@@ -15,7 +15,41 @@ import { BetaAccess } from "./components/beta-access";
 import { ScrollFab } from "./components/scroll-fab";
 import { LandingFooter } from "./components/landing-footer";
 
+// Stopgap: auto-applied for Reddit-referred users without an explicit ?code=.
+// Operator must keep a matching invite code active in admin UI with high max_uses.
+// Remove when proper attribution/campaign codes are wired up.
+const REDDIT_DEFAULT_INVITE_CODE = "NYX-37YR43OH";
+
+function injectRedditDefaultCode() {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("code")) return;
+
+  let referrerHost = "";
+  try {
+    referrerHost = new URL(document.referrer).hostname.toLowerCase();
+  } catch {
+    referrerHost = "";
+  }
+  const fromReddit =
+    /(^|\.)reddit\.com$|(^|\.)redd\.it$/.test(referrerHost) ||
+    params.get("utm_source")?.toLowerCase() === "reddit";
+
+  if (fromReddit) {
+    params.set("code", REDDIT_DEFAULT_INVITE_CODE);
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}?${params.toString()}`,
+    );
+  }
+}
+
 export function LandingPage() {
+  // Run synchronously before children render so LandingNavbar's loginHref
+  // (computed at render time) sees the injected ?code=.
+  injectRedditDefaultCode();
+
   useEffect(() => {
     const timer = setTimeout(() => {
       if (window.location.hash === "#beta") {

--- a/frontend/src/pages/admin-invite-codes.tsx
+++ b/frontend/src/pages/admin-invite-codes.tsx
@@ -49,7 +49,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Ticket, Plus, Copy, Check, Ban } from "lucide-react";
+import { Ticket, Plus, Copy, Check, Ban, Link2 } from "lucide-react";
 import { toast } from "sonner";
 import type { InviteCode } from "@/types/admin";
 
@@ -64,6 +64,7 @@ export function AdminInviteCodesPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [createdCode, setCreatedCode] = useState<InviteCode | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copiedLinkId, setCopiedLinkId] = useState<string | null>(null);
   const [deactivateTarget, setDeactivateTarget] = useState<InviteCode | null>(
     null,
   );
@@ -143,6 +144,20 @@ export function AdminInviteCodesPage() {
       toast.success("Code copied to clipboard");
       setTimeout(() => {
         setCopiedId((current) => (current === id ? null : current));
+      }, 2000);
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  }
+
+  async function handleCopyLink(code: string, id: string) {
+    try {
+      const link = `${window.location.origin}/register?code=${encodeURIComponent(code)}`;
+      await copyToClipboard(link);
+      setCopiedLinkId(id);
+      toast.success("Invite link copied to clipboard");
+      setTimeout(() => {
+        setCopiedLinkId((current) => (current === id ? null : current));
       }, 2000);
     } catch {
       toast.error("Failed to copy to clipboard");
@@ -307,6 +322,26 @@ export function AdminInviteCodesPage() {
                           />
                         ) : (
                           <Copy className="h-4 w-4" aria-hidden="true" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleCopyLink(ic.code, ic.id);
+                        }}
+                        aria-label={`Copy invite link for ${ic.code}`}
+                        title="Copy invite link"
+                      >
+                        {copiedLinkId === ic.id ? (
+                          <Check
+                            className="h-4 w-4 text-success"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <Link2 className="h-4 w-4" aria-hidden="true" />
                         )}
                       </Button>
                       {ic.is_active && (

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -8,12 +8,18 @@ export function LoginPage() {
   const params = new URLSearchParams(window.location.search);
   const returnTo = params.get("return_to") ?? undefined;
   const socialError = params.get("error") ?? undefined;
+  const inviteCode = params.get("code") ?? undefined;
 
   if (mfaRequired) {
     return <MfaVerifyForm returnTo={returnTo} />;
   }
 
   return (
-    <AuthFlow initialPanel={0} returnTo={returnTo} socialError={socialError} />
+    <AuthFlow
+      initialPanel={0}
+      returnTo={returnTo}
+      socialError={socialError}
+      initialInviteCode={inviteCode}
+    />
   );
 }

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -7,10 +7,17 @@ export function RegisterPage() {
 
   const params = new URLSearchParams(window.location.search);
   const returnTo = params.get("return_to") ?? undefined;
+  const inviteCode = params.get("code") ?? undefined;
 
   if (mfaRequired) {
     return <MfaVerifyForm returnTo={returnTo} />;
   }
 
-  return <AuthFlow initialPanel={1} returnTo={returnTo} />;
+  return (
+    <AuthFlow
+      initialPanel={1}
+      returnTo={returnTo}
+      initialInviteCode={inviteCode}
+    />
+  );
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -113,9 +113,14 @@ const loginRoute = createRoute({
   getParentRoute: () => authLayout,
   validateSearch: (
     search: Record<string, unknown>,
-  ): { return_to?: string } => ({
+  ): { return_to?: string; code?: string } => ({
     ...(typeof search.return_to === "string"
       ? { return_to: search.return_to }
+      : {}),
+    ...(typeof search.code === "string" &&
+    search.code.length > 0 &&
+    search.code.length <= 64
+      ? { code: search.code }
       : {}),
   }),
   component: LoginPage,
@@ -126,9 +131,14 @@ const registerRoute = createRoute({
   getParentRoute: () => authLayout,
   validateSearch: (
     search: Record<string, unknown>,
-  ): { return_to?: string } => ({
+  ): { return_to?: string; code?: string } => ({
     ...(typeof search.return_to === "string"
       ? { return_to: search.return_to }
+      : {}),
+    ...(typeof search.code === "string" &&
+    search.code.length > 0 &&
+    search.code.length <= 64
+      ? { code: search.code }
       : {}),
   }),
   component: RegisterPage,


### PR DESCRIPTION
Closes #702

## Summary
- Persists `?code=` query param end-to-end from landing → `/login` → `/register` (was being dropped at the navbar `<a href>` and stripped by TanStack Router's `validateSearch`)
- Auto-injects a hardcoded stopgap invite code (`NYX-37YR43OH`) when the landing page detects a Reddit referrer or `utm_source=reddit`
- Adds a chain-link "copy invite link" icon in `/admin/invite-codes` row actions that copies `${origin}/register?code=…` to clipboard

See #702 for the full context, file-by-file changes, out-of-scope notes, and verification scenarios.

## Operator prerequisite
Before merging, an admin must create an active invite code with the exact value `NYX-37YR43OH` in `/admin/invite-codes` with a high `max_uses`. Without it, Reddit-referred users will hit `InviteCodeInvalid` on submit.

## Test plan
- [ ] `http://localhost:3000/?code=NYX-ABCDEF01` → click Login navbar → URL is `/login?code=NYX-ABCDEF01`, invite field pre-filled with green checkmark
- [ ] Click "Create account" inside auth flow → URL becomes `/register?code=NYX-ABCDEF01`, code still pre-filled
- [ ] `http://localhost:3000/register?code=NYX-ABCDEF01` directly → invite field pre-filled
- [ ] `http://localhost:3000/?utm_source=reddit` → URL rewrites to add `code=NYX-37YR43OH`, persists through Login click
- [ ] In DevTools, fake `document.referrer = "https://www.reddit.com/r/AINews/"` then visit `/` → same Reddit-default injection
- [ ] `http://localhost:3000/?code=NYX-CUSTOM01&utm_source=reddit` → explicit code wins, no injection
- [ ] `/admin/invite-codes` → new chain-link icon copies `${origin}/register?code=…` with 2s green-check feedback and toast confirmation
- [ ] `npm run build`, `npm run lint`, `npm run test` (schemas) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)