### PR TITLE
feat(landing): Register CTA in nav + dual hero CTAs

### DIFF
--- a/frontend/src/features/landing/components/hero.tsx
+++ b/frontend/src/features/landing/components/hero.tsx
@@ -104,27 +104,35 @@ export function Hero() {
           {t("hero.subtitle")}
         </p>
 
-        <a
-          href="#beta"
-          className="mt-10 inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-4 text-lg font-semibold text-white transition-all hover:bg-void-400 hover:shadow-lg hover:shadow-primary/25"
-        >
-          {t("hero.cta")}
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 20 20"
-            fill="none"
-            aria-hidden="true"
+        <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+          <a
+            href={`/register${typeof window !== "undefined" ? window.location.search : ""}`}
+            className="inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-4 text-lg font-semibold text-white transition-all hover:bg-void-400 hover:shadow-lg hover:shadow-primary/25"
           >
-            <path
-              d="M4 10h12m0 0l-4-4m4 4l-4 4"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </a>
+            {t("hero.ctaRegister")}
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 10h12m0 0l-4-4m4 4l-4 4"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </a>
+          <a
+            href="#beta"
+            className="inline-flex items-center gap-2 rounded-xl border border-primary/40 px-8 py-4 text-lg font-semibold text-white transition-colors hover:bg-primary/10"
+          >
+            {t("hero.ctaEarlyAccess")}
+          </a>
+        </div>
 
         <p className="mt-4 text-sm text-gray-500">{t("hero.ctaSubtext")}</p>
       </div>

--- a/frontend/src/features/landing/components/landing-navbar.tsx
+++ b/frontend/src/features/landing/components/landing-navbar.tsx
@@ -9,9 +9,10 @@ export function LandingNavbar() {
 
   useScroll((scrollY) => setScrolled(scrollY > 0));
 
-  const loginHref = `/login${
-    typeof window !== "undefined" ? window.location.search : ""
-  }`;
+  const search =
+    typeof window !== "undefined" ? window.location.search : "";
+  const loginHref = `/login${search}`;
+  const registerHref = `/register${search}`;
 
   return (
     <nav
@@ -35,10 +36,10 @@ export function LandingNavbar() {
             {t("nav.login")}
           </a>
           <a
-            href="#beta"
+            href={registerHref}
             className="hidden rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-void-400 md:inline-block"
           >
-            {t("nav.requestBeta")}
+            {t("nav.register")}
           </a>
         </div>
       </div>

--- a/frontend/src/features/landing/i18n/locales/en.json
+++ b/frontend/src/features/landing/i18n/locales/en.json
@@ -1,11 +1,12 @@
 {
-  "nav.requestBeta": "Request Beta",
+  "nav.register": "Register",
   "nav.login": "Login",
 
   "hero.eyebrow": "Open-source Agent Connectivity Gateway",
   "hero.title": "Connect Claude, Cursor, or your own agents to public, internal, and localhost APIs — with secure access control.",
   "hero.subtitle": "Approve every connection from your phone. Your credentials never leave NyxID.",
-  "hero.cta": "Get Early Access",
+  "hero.ctaRegister": "Register",
+  "hero.ctaEarlyAccess": "Request Early Access",
   "hero.ctaSubtext": "Nyx guards the gate — Discord holds the key",
 
   "install.heading": "Install Nyx skills",

--- a/frontend/src/features/landing/i18n/locales/zh-CN.json
+++ b/frontend/src/features/landing/i18n/locales/zh-CN.json
@@ -1,11 +1,12 @@
 {
-  "nav.requestBeta": "申请内测",
+  "nav.register": "注册",
   "nav.login": "登录",
 
   "hero.eyebrow": "开源智能体连接网关",
   "hero.title": "将 Claude、Cursor 或你自己的智能体连接到公共、内部和本地 API — 并具备安全访问控制。",
   "hero.subtitle": "在手机上审批每一个连接。你的凭证永远不会离开 NyxID。",
-  "hero.cta": "抢先体验",
+  "hero.ctaRegister": "注册",
+  "hero.ctaEarlyAccess": "申请抢先体验",
   "hero.ctaSubtext": "Nyx 守护着大门 — Discord 持有钥匙",
 
   "install.heading": "安装 Nyx 技能",

--- a/frontend/src/features/landing/i18n/locales/zh-TW.json
+++ b/frontend/src/features/landing/i18n/locales/zh-TW.json
@@ -1,11 +1,12 @@
 {
-  "nav.requestBeta": "申請內測",
+  "nav.register": "註冊",
   "nav.login": "登入",
 
   "hero.eyebrow": "開源智慧代理連接閘道",
   "hero.title": "將 Claude、Cursor 或你自己的代理連接到公共、內部和本地 API — 並具備安全存取控制。",
   "hero.subtitle": "在手機上審批每一個連接。你的憑證永遠不會離開 NyxID。",
-  "hero.cta": "搶先體驗",
+  "hero.ctaRegister": "註冊",
+  "hero.ctaEarlyAccess": "申請搶先體驗",
   "hero.ctaSubtext": "Nyx 守護著大門 — Discord 持有鑰匙",
 
   "install.heading": "安裝 Nyx 技能",


### PR DESCRIPTION
## Summary
- **Top-right nav CTA**: "Request Beta" → **Register**, links to `/register` (preserves `?code=` invite param like the login link).
- **Hero CTAs**: single "Get Early Access" replaced with two side-by-side buttons — primary purple **Register** (→ `/register?code=…`) and outlined secondary **Request Early Access** (→ existing `#beta` section).
- i18n keys renamed across en / zh-CN / zh-TW: `nav.requestBeta` → `nav.register`, `hero.cta` → `hero.ctaRegister` + `hero.ctaEarlyAccess`.

No backend or route changes — `/register` already exists and the `?code=` flow was wired up in #705.

## Test plan
- [ ] `npm run dev` in `frontend/`, open `http://localhost:3000/`
- [ ] Nav top-right "Register" button visible (desktop ≥ md), clicking goes to `/register`
- [ ] Hero shows two CTAs side-by-side on desktop, stacked on mobile
- [ ] Primary "Register" → `/register`; secondary "Request Early Access" → scrolls to `#beta`
- [ ] Visit `http://localhost:3000/?code=NYX-ABCD1234`, click either Register CTA — `?code=` rides through to `/register`
- [ ] Language switcher: zh-CN shows 注册 / 申请抢先体验; zh-TW shows 註冊 / 申請搶先體驗
- [ ] `npm run build` succeeds (lint passes; only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)