### PR TITLE
chore(cli): bump nyxid-cli to 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "nyxid-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nyxid-cli"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Bumps `cli/Cargo.toml` (and refreshes `Cargo.lock`) from `0.5.5` to `0.5.6` to cut a release that ships the issue #653 wizard fixes from PR #723 (merged in `faa1fbf0`) to end users on prebuilt binaries.

## Why now

PR #723 landed on main at `2026-05-13T01:47:01Z`, but the latest tagged release `v0.5.5` was cut at `2026-05-12T08:14:09Z` — ~17h earlier. End users running `nyxid update` today still receive the v0.5.5 binary, which has the broken Lark OAuth wizard (polling never fires, popup-blocked dead-end, no standardized panel). They need a v0.5.6 release to pick up the fix.

## What's in v0.5.6 (delta over v0.5.5)

All from PR #723:

- **Root-cause fix**: OAuthFlow's main `useEffect` cleanup was setting the shared `cancelledRef.current = true` on every phase change. That killed the polling loop's first iteration before it issued any `GET /api/v1/keys/{id}` request. Wizard appeared to hang forever even though backend had completed OAuth.
- **OAuth callback in-flight race fix**: `handle_oauth_callback` no longer deletes the OAuth state up-front — it claims via `find_one_and_update { consumed: true }` and deletes after the new token is durable. Closes the ~1s window where `reconcile_pending_oauth_placeholder` would prematurely mark a successful OAuth as failed.
- **Org-scope reconcile query fix**: Pass 2's "no live OAuth state ⇒ abandoned" check now `$or`s on both `user_id` and `target_user_id`, so org-scoped (`--org`) wizard runs are no longer marked failed on the first poll.
- **Standardized waiting screen**: new `ProviderWaitingPanel` shared by OAuth and device-code flows. Same layout for every provider: title / status spinner / instructions / prominent "Open {provider} sign-in" button / docs link / cancel.
- **Terminal-error layout**: when polling has terminally failed, no more polling spinner + Open button.
- **No more auto `window.open`**: the popup is opened from the user's click on the "Open {provider} sign-in" button (always allowed by browsers — never popup-blocked).
- **Frontend escalations**: 5 consecutive polling errors → "Lost contact" terminal; 20s of failed heartbeats → "Wizard interrupted" terminal panel.

## How to release

After this PR merges, push the tag to trigger `release.yml`:

```bash
git checkout main && git pull
git tag v0.5.6
git push origin v0.5.6
```

## Test plan

- [ ] CI green (just a version bump — no behavior change in this PR itself; the behavior change is what was already merged in #723)
- [ ] After release: `nyxid update` shows v0.5.6 available
- [ ] After update: `nyxid --version` reports `0.5.6`, Lark wizard works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)