### PR TITLE
fix(mobile): recoverable push state + drop off-spec hero ambient

### DIFF
--- a/mobile/src/features/account/AccountSettingsScreen.tsx
+++ b/mobile/src/features/account/AccountSettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { Alert, Image, Pressable, ScrollView, StyleSheet, Switch, Text, View } from "react-native";
+import { Alert, Image, Linking, Pressable, ScrollView, StyleSheet, Switch, Text, View } from "react-native";
 import Svg, { Circle, Path } from "react-native-svg";
 import { RootStackParamList } from "../../app/AppNavigator";
 
@@ -23,6 +23,19 @@ import { BOTTOM_NAV_CLEARANCE, radius, spacing, typeScale } from "../../theme/de
 import { useEffect, useMemo, useState } from "react";
 
 type Props = NativeStackScreenProps<RootStackParamList, "AccountSettings">;
+
+// Push-register failure modes are surfaced as a tagged error so the
+// caller can branch on `reason` (e.g. iOS denial → Alert + Linking
+// to system Settings) instead of brittle string-matching the message.
+class PushRegisterError extends Error {
+  constructor(
+    public readonly reason: "permission_denied" | "token_unavailable" | "register_failed",
+    message: string,
+  ) {
+    super(message);
+    this.name = "PushRegisterError";
+  }
+}
 
 function resolveDeleteAccountError(error: unknown): {
   message: string;
@@ -178,20 +191,28 @@ export function AccountSettingsScreen({ navigation }: Props) {
   // Manual re-registration when the device isn't on the user's account
   // (permission denied at first launch, token fetch failed, or original
   // post-login registration silently failed). Surfaces the actual reason
-  // so the user can act — open Settings to flip permissions, or retry.
+  // so the user can act — `permission_denied` lifts them to OS settings,
+  // others fall back to a toast with a hint.
   const pushRegisterMutation = useMutation({
     mutationFn: async () => {
       const result = await activatePushAfterLogin({ forceRegister: true });
       if (!result.registered) {
         if (result.reason === "permission_denied") {
-          throw new Error(
-            "Notification permission is off. Enable it in Settings → NyxID → Notifications."
+          throw new PushRegisterError(
+            "permission_denied",
+            "Notification permission is off for NyxID.",
           );
         }
         if (result.reason === "token_unavailable") {
-          throw new Error("This device can't get a push token. Try a real device or reinstall.");
+          throw new PushRegisterError(
+            "token_unavailable",
+            "This device can't get a push token. Try a real device or reinstall.",
+          );
         }
-        throw new Error("Couldn't register this device. Check your connection and try again.");
+        throw new PushRegisterError(
+          "register_failed",
+          "Couldn't register this device. Check your connection and try again.",
+        );
       }
       return result;
     },
@@ -200,6 +221,27 @@ export function AccountSettingsScreen({ navigation }: Props) {
       showToast("Push enabled on this device", "success");
     },
     onError: (error) => {
+      if (error instanceof PushRegisterError && error.reason === "permission_denied") {
+        // Linking.openSettings() opens this app's settings page directly
+        // on iOS (and Android). Guarded by an Alert so the user opts in
+        // instead of being yanked out of the app on a tap.
+        Alert.alert(
+          "Enable Notifications",
+          "Push notifications are off for NyxID. Open Settings to enable them?",
+          [
+            { text: "Not now", style: "cancel" },
+            {
+              text: "Open Settings",
+              onPress: () => {
+                Linking.openSettings().catch(() => {
+                  showToast("Couldn't open Settings — open it manually.", "error");
+                });
+              },
+            },
+          ],
+        );
+        return;
+      }
       showToast(resolveErrorMessage(error), "error");
     },
   });

--- a/mobile/src/features/account/AccountSettingsScreen.tsx
+++ b/mobile/src/features/account/AccountSettingsScreen.tsx
@@ -15,6 +15,7 @@ import { useNetworkStatus } from "../../hooks/useNetworkStatus";
 import { mobileApi } from "../../lib/api/mobileApi";
 import { isApiError } from "../../lib/api/ApiError";
 import { resolveErrorMessage } from "../../lib/api/errorMessages";
+import { activatePushAfterLogin } from "../../lib/notifications/pushNotifications";
 import { useTheme } from "../../theme/ThemeContext";
 import type { ThemeColors } from "../../theme/mobileTheme";
 import { createFlowStyles } from "../../theme/flowStyles";
@@ -173,6 +174,35 @@ export function AccountSettingsScreen({ navigation }: Props) {
   });
 
   const [isTelegramLinkVisible, setIsTelegramLinkVisible] = useState(false);
+
+  // Manual re-registration when the device isn't on the user's account
+  // (permission denied at first launch, token fetch failed, or original
+  // post-login registration silently failed). Surfaces the actual reason
+  // so the user can act — open Settings to flip permissions, or retry.
+  const pushRegisterMutation = useMutation({
+    mutationFn: async () => {
+      const result = await activatePushAfterLogin({ forceRegister: true });
+      if (!result.registered) {
+        if (result.reason === "permission_denied") {
+          throw new Error(
+            "Notification permission is off. Enable it in Settings → NyxID → Notifications."
+          );
+        }
+        if (result.reason === "token_unavailable") {
+          throw new Error("This device can't get a push token. Try a real device or reinstall.");
+        }
+        throw new Error("Couldn't register this device. Check your connection and try again.");
+      }
+      return result;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["account", "notificationSettings"] });
+      showToast("Push enabled on this device", "success");
+    },
+    onError: (error) => {
+      showToast(resolveErrorMessage(error), "error");
+    },
+  });
 
   const telegramDisconnectMutation = useMutation({
     mutationFn: () => mobileApi.telegramDisconnect(),
@@ -463,7 +493,15 @@ export function AccountSettingsScreen({ navigation }: Props) {
                       trackColor={{ false: colors.borderSoft, true: colors.success }}
                     />
                   ) : (
-                    <Text style={styles.accountRowValue}>No device</Text>
+                    <Pressable
+                      onPress={() => pushRegisterMutation.mutate()}
+                      disabled={pushRegisterMutation.isPending}
+                      style={styles.linkPill}
+                    >
+                      <Text style={styles.linkPillText}>
+                        {pushRegisterMutation.isPending ? "Enabling…" : "Enable on this device"}
+                      </Text>
+                    </Pressable>
                   )}
                 </View>
               </View>

--- a/mobile/src/features/auth/AuthHomeScreen.tsx
+++ b/mobile/src/features/auth/AuthHomeScreen.tsx
@@ -3,7 +3,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import * as WebBrowser from "expo-web-browser";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { ActivityIndicator, Linking, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
-import Svg, { Path, Defs, LinearGradient, Stop, Circle as SvgCircle } from "react-native-svg";
+import Svg, { Path, Defs, LinearGradient, Stop } from "react-native-svg";
 import type { RootStackParamList } from "../../app/AppNavigator";
 
 import { ScreenContainer } from "../../components/ScreenContainer";
@@ -103,43 +103,6 @@ function parseSocialCallback(url: string): SocialCallback | null {
       error: e instanceof Error ? e.message : "social_auth_unknown",
     };
   }
-}
-
-// Ambient backdrop for the auth hero: three concentric rings with
-// rotating linear-gradient strokes (re-using the brand orbital motif
-// from NyxFAB) plus a soft purple wash. Pure decoration — sits behind
-// the logo, ignores touches.
-function PortalAmbient({ size = 380 }: { size?: number }) {
-  return (
-    <Svg
-      width={size}
-      height={size}
-      viewBox={`0 0 ${size} ${size}`}
-      pointerEvents="none"
-    >
-      <Defs>
-        <LinearGradient id="amb-ring1" gradientUnits="userSpaceOnUse" x1="0" y1={size / 2} x2={size} y2={size / 2}>
-          <Stop offset="0" stopColor="#A78BFA" stopOpacity={0.55} />
-          <Stop offset="0.5" stopColor="#A78BFA" stopOpacity={0} />
-        </LinearGradient>
-        <LinearGradient id="amb-ring2" gradientUnits="userSpaceOnUse" x1="0" y1={size / 2} x2={size} y2={size / 2} gradientTransform={`rotate(120 ${size / 2} ${size / 2})`}>
-          <Stop offset="0" stopColor="#C4B5FD" stopOpacity={0.4} />
-          <Stop offset="0.5" stopColor="#C4B5FD" stopOpacity={0} />
-        </LinearGradient>
-        <LinearGradient id="amb-ring3" gradientUnits="userSpaceOnUse" x1="0" y1={size / 2} x2={size} y2={size / 2} gradientTransform={`rotate(240 ${size / 2} ${size / 2})`}>
-          <Stop offset="0" stopColor="#DDD6FE" stopOpacity={0.3} />
-          <Stop offset="0.5" stopColor="#DDD6FE" stopOpacity={0} />
-        </LinearGradient>
-      </Defs>
-      <SvgCircle cx={size / 2} cy={size / 2} r={size / 2 - 4} fill="none" stroke="url(#amb-ring1)" strokeWidth={1} />
-      <SvgCircle cx={size / 2} cy={size / 2} r={size / 2 - 60} fill="none" stroke="url(#amb-ring2)" strokeWidth={1} />
-      <SvgCircle cx={size / 2} cy={size / 2} r={size / 2 - 110} fill="none" stroke="url(#amb-ring3)" strokeWidth={0.8} />
-      <SvgCircle cx={size * 0.18} cy={size * 0.32} r={2} fill="#C4B5FD" opacity={0.5} />
-      <SvgCircle cx={size * 0.84} cy={size * 0.58} r={1.5} fill="#C4B5FD" opacity={0.4} />
-      <SvgCircle cx={size * 0.72} cy={size * 0.22} r={1} fill="#C4B5FD" opacity={0.6} />
-      <SvgCircle cx={size * 0.28} cy={size * 0.78} r={1} fill="#C4B5FD" opacity={0.35} />
-    </Svg>
-  );
 }
 
 // Inline render of mobile/assets/sources/app_icon.svg
@@ -406,10 +369,6 @@ export function AuthHomeScreen({ navigation }: Props) {
       >
         {/* Hero branding */}
         <View style={styles.heroWrap}>
-          <View style={styles.heroAmbient} pointerEvents="none">
-            <View style={styles.heroGlow} />
-            <PortalAmbient />
-          </View>
           <PortalMarkLogo />
           <Text style={styles.heroTitle}>NyxID</Text>
           <Text style={styles.heroTagline}>Your companion for approvals and notifications</Text>
@@ -546,23 +505,6 @@ const createStyles = (c: ThemeColors) => StyleSheet.create({
     gap: spacing.sm,
     marginBottom: spacing.sm,
     paddingTop: spacing.huge,
-    position: "relative",
-  },
-  heroAmbient: {
-    position: "absolute",
-    top: -40,
-    width: 380,
-    height: 380,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  heroGlow: {
-    position: "absolute",
-    width: 240,
-    height: 240,
-    borderRadius: radius.full,
-    backgroundColor: c.primaryGlow,
-    opacity: 0.9,
   },
   heroTitle: {
     ...typeScale.h1,


### PR DESCRIPTION
## Summary

Two follow-up fixes after PR #728:

### `574638d4` Drop ambient orbital rings + glow wash behind auth hero
User flagged the orbital rings I added in #728's `8befe695` as reading like an old icon behind the brand mark. The decoration was off-spec anyway — DESIGN.md line 44 explicitly excludes purple from "decorative backgrounds" and the orbital motif isn't a documented brand element. Login hero is back to the spec-pure layout: logo + wordmark + tagline on a flat surface.

The brand-purple shadow on the primary CTA (also off-spec but separate concern) stays for now — happy to drop that too if you'd rather be strict.

### `b9d8b887` Make push "No device" state recoverable in account settings
**Bug:** if `activatePushAfterLogin` fails silently at sign-in time (permission denied at the first iOS prompt, APNs token fetch failed, network hiccup on `/notifications/devices`), the user sees an inert "No device" label in **Account → Notifications → Push Notifications** with no path to recover. Re-installing the app is the only workaround.

**Fix:** the no-device row becomes a tappable **"Enable on this device"** pill. Tapping re-runs `activatePushAfterLogin({ forceRegister: true })` and reports the actual failure mode:

| `result.reason` | Toast message |
|---|---|
| `permission_denied` | "Notification permission is off. Enable it in Settings → NyxID → Notifications." |
| `token_unavailable` | "This device can't get a push token. Try a real device or reinstall." |
| `register_failed` | "Couldn't register this device. Check your connection and try again." |

On success: invalidates the `notificationSettings` query, row flips to the real toggle.

## Test plan

- [ ] iOS device (real, not sim — APNs doesn't work in sim): sign in, deny notification permission at the iOS prompt, go to Account → Notifications. See "Enable on this device" pill. Tap → toast tells you to enable in iOS Settings.
- [ ] iOS device: grant permission, then go to Account → Notifications. If push_device_count > 0, see toggle. If still 0 (network failure during sign-in), see pill. Tap → toggle appears after success.
- [ ] Existing users with `push_device_count > 0`: row continues to show the toggle (no regression).
- [ ] Web frontend privacy + terms still serve `contact@chrono-ai.fun` (already in main via #728).

🤖 Generated with [Claude Code](https://claude.com/claude-code)