### PR TITLE
fix(cli): open the wizard browser under WSL

### DIFF
--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -314,7 +314,7 @@ async fn run_browser_login(base_url: &str, profile: Option<&str>) -> Result<()> 
     eprintln!("(e.g. \"invite code required\" for new social sign-ups).");
     eprintln!();
 
-    let _ = open::that(&auth_url);
+    let _ = crate::browser::open_browser(&auth_url);
 
     let callback = wait_for_callback(listener, &state).await?;
     save_tokens_for(

--- a/cli/src/browser.rs
+++ b/cli/src/browser.rs
@@ -1,0 +1,161 @@
+//! WSL-aware browser launching.
+//!
+//! `open::that` is fine on native macOS / Linux / Windows, but under WSL
+//! it only knows `wslview` — which ships in the `wslu` package and is
+//! absent from a default Ubuntu WSL install. When `wslview` is missing
+//! the `open` crate falls through to `xdg-open` / `gio` / `gnome-open` /
+//! `kde-open`, none of which reach a Windows browser, so commands like
+//! `nyxid service add` printed the wizard URL but never opened it
+//! (issue #710).
+//!
+//! Under WSL we instead walk an explicit chain of Windows-side openers.
+//! WSL is the documented Windows path for the CLI, so it should get the
+//! same auto-open experience as macOS.
+
+use std::process::Command;
+
+/// True when running inside Windows Subsystem for Linux (WSL 1 or 2).
+///
+/// Checks the interop env vars first — `WSL_INTEROP` / `WSL_DISTRO_NAME`
+/// are set for the whole login session and are the cheapest signal. As a
+/// fallback (e.g. a `sudo` shell that dropped the session env), the
+/// kernel release string carries `microsoft` under both WSL 1 and WSL 2.
+pub fn is_wsl() -> bool {
+    if std::env::var_os("WSL_INTEROP").is_some() || std::env::var_os("WSL_DISTRO_NAME").is_some() {
+        return true;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(osrelease) = std::fs::read_to_string("/proc/sys/kernel/osrelease") {
+            return osrelease.to_ascii_lowercase().contains("microsoft");
+        }
+    }
+    false
+}
+
+/// Open `url` in the user's default browser.
+///
+/// Native platforms go straight through `open::that`. Under WSL we use
+/// [`open_browser_wsl`] so the URL actually reaches a Windows browser
+/// instead of silently failing on a missing `wslview`.
+pub fn open_browser(url: &str) -> std::io::Result<()> {
+    if is_wsl() {
+        open_browser_wsl(url)
+    } else {
+        open::that(url)
+    }
+}
+
+/// WSL bridge: try each Windows-side opener until one launches the URL,
+/// then fall back to the `open` crate's generic UNIX chain.
+fn open_browser_wsl(url: &str) -> std::io::Result<()> {
+    let mut last_err: Option<std::io::Error> = None;
+    for mut cmd in wsl_open_commands(url) {
+        match cmd.status() {
+            Ok(status) if status.success() => return Ok(()),
+            Ok(status) => {
+                last_err = Some(std::io::Error::other(format!(
+                    "{:?} exited with {status}",
+                    cmd.get_program()
+                )));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    // Last resort: hand off to `open`'s generic chain (xdg-open / gio /
+    // gnome-open / kde-open). Only reached when both Windows-side openers
+    // failed — e.g. WSL with interop disabled, where `powershell.exe` is
+    // off PATH but a Linux browser is still reachable under WSLg.
+    if open::that(url).is_ok() {
+        return Ok(());
+    }
+    // Report the Windows-side failure rather than `open`'s: on WSL the
+    // bridge is the expected path, so "powershell.exe exited with …" is
+    // the more actionable signal than a generic "xdg-open not found".
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no browser opener succeeded (tried wslview, powershell.exe, xdg-open)",
+        )
+    }))
+}
+
+/// Windows-side open attempts for WSL, most-preferred first:
+///   1. `wslview` — wslu's bridge; honors the Windows default browser.
+///   2. `powershell.exe Start-Process` — always on the WSL-exposed PATH
+///      even when `wslu` is not installed.
+///
+/// The PowerShell URL is single-quoted inside one `-Command` string so
+/// the `&` between query params is treated as a literal rather than a
+/// statement separator. Any literal `'` in the URL is doubled, which is
+/// how PowerShell escapes a quote inside a single-quoted string.
+fn wsl_open_commands(url: &str) -> Vec<Command> {
+    let mut wslview = Command::new("wslview");
+    wslview.arg(url);
+
+    let ps_command = format!("Start-Process -- '{}'", url.replace('\'', "''"));
+    let mut powershell = Command::new("powershell.exe");
+    powershell.args(["-NoProfile", "-NonInteractive", "-Command", &ps_command]);
+
+    vec![wslview, powershell]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wsl_open_commands_tries_wslview_then_powershell() {
+        let cmds = wsl_open_commands("http://127.0.0.1:5000/wizard");
+        let programs: Vec<_> = cmds
+            .iter()
+            .map(|c| c.get_program().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(programs, vec!["wslview", "powershell.exe"]);
+    }
+
+    #[test]
+    fn wslview_receives_the_raw_url() {
+        let url = "http://127.0.0.1:5000/wizard?slug=openai&label=key";
+        let cmds = wsl_open_commands(url);
+        let args: Vec<_> = cmds[0]
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec![url]);
+    }
+
+    #[test]
+    fn powershell_single_quotes_the_url_so_ampersands_stay_literal() {
+        // Query strings carry `&`; unquoted, PowerShell would parse it as
+        // a statement separator and only open the first param.
+        let url = "http://127.0.0.1:5000/wizard?slug=openai&label=key";
+        let cmds = wsl_open_commands(url);
+        let args: Vec<_> = cmds[1]
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Start-Process -- 'http://127.0.0.1:5000/wizard?slug=openai&label=key'",
+            ]
+        );
+    }
+
+    #[test]
+    fn powershell_escapes_embedded_single_quotes() {
+        let cmds = wsl_open_commands("http://x/?q='inject'");
+        let args: Vec<_> = cmds[1]
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args.last().unwrap(),
+            "Start-Process -- 'http://x/?q=''inject'''"
+        );
+    }
+}

--- a/cli/src/commands/repo.rs
+++ b/cli/src/commands/repo.rs
@@ -13,7 +13,7 @@ pub fn issues_url() -> String {
 pub async fn run_repo(args: RepoArgs) -> Result<()> {
     println!("{REPO_URL}");
     if args.open
-        && let Err(e) = open::that(REPO_URL)
+        && let Err(e) = crate::browser::open_browser(REPO_URL)
     {
         eprintln!("Failed to open browser: {e}");
     }

--- a/cli/src/commands/service.rs
+++ b/cli/src/commands/service.rs
@@ -1253,7 +1253,7 @@ async fn run_oauth_add(
     eprintln!("  {authorization_url}");
     eprintln!();
 
-    let _ = open::that(authorization_url);
+    let _ = crate::browser::open_browser(authorization_url);
 
     let final_key = wait_for_authorized_key(api, key_id).await?;
     print_add_result(api, &final_key, auth.output)?;
@@ -1378,7 +1378,7 @@ async fn run_device_code_add(
     eprintln!();
     eprintln!("Enter the code at the URL above, then wait for authorization...");
 
-    let _ = open::that(verification_uri);
+    let _ = crate::browser::open_browser(verification_uri);
 
     // Poll for completion
     let poll_body = serde_json::json!({ "state": state });
@@ -1561,7 +1561,8 @@ fn prompt_password(prompt: &str, flag: &str) -> Result<String> {
 /// Checks, in order:
 /// - `NYXID_NO_WIZARD` set to anything → explicit opt-out
 /// - `SSH_CONNECTION` / `SSH_TTY` set → SSH session (no local display)
-/// - Linux-only: both `DISPLAY` and `WAYLAND_DISPLAY` unset → no X/Wayland
+/// - Linux-only: both `DISPLAY` and `WAYLAND_DISPLAY` unset → no X/Wayland,
+///   *unless* running under WSL, which bridges to the Windows browser
 ///
 /// We intentionally skip this detection on macOS / Windows when not in
 /// SSH — there's always a GUI available, so the wizard should run.
@@ -1580,7 +1581,10 @@ fn is_headless_environment() -> bool {
     }
     #[cfg(target_os = "linux")]
     {
-        if std::env::var_os("DISPLAY").is_none() && std::env::var_os("WAYLAND_DISPLAY").is_none() {
+        if !crate::browser::is_wsl()
+            && std::env::var_os("DISPLAY").is_none()
+            && std::env::var_os("WAYLAND_DISPLAY").is_none()
+        {
             return true;
         }
     }
@@ -2236,6 +2240,8 @@ mod tests {
             "SSH_TTY",
             "DISPLAY",
             "WAYLAND_DISPLAY",
+            "WSL_INTEROP",
+            "WSL_DISTRO_NAME",
         ]);
 
         // Explicit opt-out wins.
@@ -2254,12 +2260,16 @@ mod tests {
 
         // Linux-only: no display at all means headless. On non-Linux
         // we don't gate on display vars (macOS always has a GUI, Windows
-        // similar), so just assert the fallback.
+        // similar), so just assert the fallback. WSL is also exempt — it
+        // bridges to the Windows browser — and `is_wsl` reads `/proc`,
+        // which env stashing can't neutralize, so skip there.
         #[cfg(target_os = "linux")]
         {
-            assert!(is_headless_environment());
-            guard.set("DISPLAY", ":0");
-            assert!(!is_headless_environment());
+            if !crate::browser::is_wsl() {
+                assert!(is_headless_environment());
+                guard.set("DISPLAY", ":0");
+                assert!(!is_headless_environment());
+            }
         }
         #[cfg(not(target_os = "linux"))]
         {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod api;
 mod auth;
+mod browser;
 mod cli;
 mod commands;
 mod error_format;

--- a/cli/src/node/oauth.rs
+++ b/cli/src/node/oauth.rs
@@ -345,7 +345,7 @@ pub async fn run_authorization_code_flow(
     println!("  {authorization_url}");
     println!();
 
-    let _ = open::that(&authorization_url);
+    let _ = crate::browser::open_browser(&authorization_url);
 
     let code = wait_for_authorization_code(listener, &state).await?;
     exchange_authorization_code(

--- a/cli/src/wizard/mod.rs
+++ b/cli/src/wizard/mod.rs
@@ -1176,10 +1176,11 @@ pub async fn print_resume_summary(
 
 /// Returns true when the CLI is running somewhere we can reasonably
 /// open a local browser for the wizard. False on SSH / explicit opt-out
-/// / Linux without DISPLAY/WAYLAND, in which case the caller falls
-/// through to the remote-pairing transport (see
-/// [`is_browser_flow_eligible`]) — or ultimately to the scripted
-/// stdin path when the user opts out entirely.
+/// / Linux without DISPLAY/WAYLAND (WSL excepted — it bridges to the
+/// Windows browser), in which case the caller falls through to the
+/// remote-pairing transport (see [`is_browser_flow_eligible`]) — or
+/// ultimately to the scripted stdin path when the user opts out
+/// entirely.
 ///
 /// Mirrors `cli::commands::service::is_headless_environment` (kept
 /// private there to avoid widening the public surface) but inverts the
@@ -1193,7 +1194,13 @@ pub fn is_wizard_eligible() -> bool {
     }
     #[cfg(target_os = "linux")]
     {
-        if std::env::var_os("DISPLAY").is_none() && std::env::var_os("WAYLAND_DISPLAY").is_none() {
+        // WSL usually has no X / Wayland display, but the wizard can
+        // still bridge to the Windows browser (see `crate::browser`), so
+        // a missing display there is not disqualifying.
+        if !crate::browser::is_wsl()
+            && std::env::var_os("DISPLAY").is_none()
+            && std::env::var_os("WAYLAND_DISPLAY").is_none()
+        {
             return false;
         }
     }

--- a/cli/src/wizard/server.rs
+++ b/cli/src/wizard/server.rs
@@ -1993,9 +1993,19 @@ pub async fn run_flow(
     eprintln!("→ Opening {url} … (Ctrl-C to cancel)");
     eprintln!("  Waiting for browser …");
     if std::env::var_os("NYXID_WIZARD_NO_OPEN").is_none() {
-        if let Err(e) = open::that(&url) {
-            eprintln!("  Couldn't auto-open browser: {e}");
-            eprintln!("  Visit the URL above manually.");
+        if let Err(e) = crate::browser::open_browser(&url) {
+            if crate::browser::is_wsl() {
+                // WSL without `wslu`, or with interop disabled: the URL is
+                // still reachable from a Windows browser, so spell out the
+                // copy/paste path instead of a generic open error.
+                eprintln!("  WSL detected — couldn't auto-open a Windows browser: {e}");
+                eprintln!("  Copy this URL into your Windows browser to continue:");
+                eprintln!("    {url}");
+                eprintln!("  (installing the `wslu` package enables `wslview` auto-open)");
+            } else {
+                eprintln!("  Couldn't auto-open browser: {e}");
+                eprintln!("  Visit the URL above manually.");
+            }
         }
     } else {
         eprintln!("  (NYXID_WIZARD_NO_OPEN set — not opening a browser)");


### PR DESCRIPTION
## Problem

On Windows the recommended CLI path is WSL, but `nyxid service add` (and other `open::that` call sites) printed the wizard URL and never opened a browser — macOS opens it automatically. Closes #710.

**Root cause:** `open` 5.3.x only knows `wslview` on WSL, which ships in the `wslu` package and is **absent from a default Ubuntu WSL install**. With no `wslview`, the crate falls through to `xdg-open`/`gio`/`gnome-open`/`kde-open` — none of which reach a Windows browser.

## Changes

- **New `cli/src/browser.rs`** — WSL-aware `open_browser()`:
  - `is_wsl()` detects WSL via `WSL_INTEROP`/`WSL_DISTRO_NAME`, falling back to `microsoft` in `/proc/sys/kernel/osrelease`
  - On WSL, walks `wslview` → `powershell.exe Start-Process` → `open::that`. The PowerShell URL is single-quoted (embedded quotes doubled) so a query-string `&` stays literal instead of acting as a statement separator
  - On total failure, reports the Windows-side error (more actionable for WSL users than `open`'s generic `xdg-open not found`)
- **Routed all `open::that` call sites** through it — browser login, `repo --open`, OAuth + device-code add, node OAuth, wizard server
- **Stopped classifying WSL-without-`DISPLAY` as headless** in `is_wizard_eligible` / `is_headless_environment` — WSL can bridge to the Windows browser, so a missing X/Wayland display there is not disqualifying
- **WSL-specific fallback message** — when auto-open still fails under WSL, the wizard prints a copy-this-URL message with a `wslu` install hint (as suggested in the issue)

## Testing

- ✅ 359 CLI tests pass; 4 new unit tests cover the WSL command chain (order, raw-URL passthrough, `&` handling, embedded-quote escaping)
- ✅ `cargo fmt` + `cargo clippy` clean (pre-commit hook)
- ⚠️ **Built/tested on macOS** — the `#[cfg(target_os = "linux")]` blocks (the `/proc` fallback in `is_wsl()`, the Linux branches of both eligibility checks) were not compiled here, and the fix has **not been smoke-tested on a real WSL machine**. Recommend a `cargo test` on any Linux host + one manual WSL run before relying on it in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)