### PR TITLE
fix(frontend): dashboard status cell truncation and equal height

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -555,7 +555,7 @@ function StatusCell({
   return (
     <Link
       to={href}
-      className="group flex items-center gap-3 rounded-xl border border-border/50 bg-card px-4 py-3 transition-colors duration-200 hover:bg-white/[0.03]"
+      className="group flex h-full items-center gap-3 rounded-xl border border-border/50 bg-card px-4 py-3 transition-colors duration-200 hover:bg-white/[0.03]"
     >
       <div
         className={cn(

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -566,7 +566,7 @@ function StatusCell({
         {icon}
       </div>
       <div className="min-w-0">
-        <p className="text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
+        <p className="truncate text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
           {label}
         </p>
         {loading ? (


### PR DESCRIPTION
## Summary

- Add `truncate` to status cell labels so text doesn't overflow on narrow screens
- Add `h-full` to status cell links for equal height rows in the grid

## Test plan

- [ ] Resize browser to narrow width — status cell labels and values should truncate with ellipsis
- [ ] Verify all status cells in the same row have equal height

🤖 Generated with [Claude Code](https://claude.com/claude-code)