### PR TITLE
fix(landing): restore hero wordmark image and Register CTAs

### DIFF
--- a/frontend/src/features/landing/components/hero.tsx
+++ b/frontend/src/features/landing/components/hero.tsx
@@ -87,6 +87,11 @@ export function Hero() {
 
       {/* Content */}
       <div className="relative z-10 mt-[260px] flex flex-col items-center md:mt-[190px]">
+        <img
+          src="/nyxid-wordmark.svg"
+          alt="NyxID"
+          className="mb-8 h-12 w-auto drop-shadow-[0_0_24px_rgba(90,42,241,0.45)] md:h-14"
+        />
         <h1 className="max-w-[700px] text-center font-serif text-[32px] leading-tight text-white md:text-5xl lg:text-6xl">
           {t("hero.eyebrow")}
         </h1>
@@ -99,27 +104,35 @@ export function Hero() {
           {t("hero.subtitle")}
         </p>
 
-        <a
-          href="#beta"
-          className="mt-10 inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-4 text-lg font-semibold text-white transition-all hover:bg-nyx-400 hover:shadow-lg hover:shadow-primary/25"
-        >
-          {t("hero.cta")}
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 20 20"
-            fill="none"
-            aria-hidden="true"
+        <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+          <a
+            href={`/register${typeof window !== "undefined" ? window.location.search : ""}`}
+            className="inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-4 text-lg font-semibold text-white transition-all hover:bg-nyx-400 hover:shadow-lg hover:shadow-primary/25"
           >
-            <path
-              d="M4 10h12m0 0l-4-4m4 4l-4 4"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </a>
+            {t("hero.ctaRegister")}
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 10h12m0 0l-4-4m4 4l-4 4"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </a>
+          <a
+            href="#beta"
+            className="inline-flex items-center gap-2 rounded-xl border border-primary/40 px-8 py-4 text-lg font-semibold text-white transition-colors hover:bg-primary/10"
+          >
+            {t("hero.ctaEarlyAccess")}
+          </a>
+        </div>
 
         <p className="mt-4 text-sm text-gray-500">{t("hero.ctaSubtext")}</p>
       </div>

--- a/frontend/src/features/landing/components/landing-navbar.tsx
+++ b/frontend/src/features/landing/components/landing-navbar.tsx
@@ -9,6 +9,11 @@ export function LandingNavbar() {
 
   useScroll((scrollY) => setScrolled(scrollY > 0));
 
+  const search =
+    typeof window !== "undefined" ? window.location.search : "";
+  const loginHref = `/login${search}`;
+  const registerHref = `/register${search}`;
+
   return (
     <nav
       className={`fixed top-0 left-0 right-0 z-50 border-b backdrop-blur-md transition-all duration-500 ${
@@ -25,16 +30,16 @@ export function LandingNavbar() {
         <div className="flex items-center gap-3">
           <LanguageSwitcher />
           <a
-            href="/login"
+            href={loginHref}
             className="rounded-lg border border-primary/40 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/10"
           >
             {t("nav.login")}
           </a>
           <a
-            href="#beta"
+            href={registerHref}
             className="hidden rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-nyx-400 md:inline-block"
           >
-            {t("nav.requestBeta")}
+            {t("nav.register")}
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Surgically reverts the landing-page regressions introduced by **#733** (UI consistency sweep), while keeping that PR's legitimate `nyx-*` color-token renames.

**What #733 broke:**
- Removed the NyxID wordmark `<img>` from the hero section
- Swapped the hero + navbar Register CTAs for `#beta` anchors that call `t("hero.cta")` / `t("nav.requestBeta")` — i18n keys that **don't exist in any locale file**, so the buttons rendered with broken/empty labels

**What this restores (pre-#733 content):**
- `hero.tsx`: NyxID wordmark hero image + dual CTA — primary **Register** → `/register`, secondary **Request Early Access** → `#beta`
- `landing-navbar.tsx`: **Register** CTA → `/register`, plus query-string preservation on the login/register links (carries invite/referral params into signup)

**Why not a blind `git checkout` revert:** #733 also renamed `void-*` → `nyx-*` Tailwind tokens, and the `void-*` tokens were deleted from `app.css` repo-wide. A full revert of the landing folder would reintroduce dead tokens and break colors. This keeps the working `nyx-*` tokens and reverts only the content regressions in the 2 affected files. The hero image glow uses the new brand color `rgba(90,42,241,...)` for consistency with #733's CSS.

## Test Coverage

No new code paths — presentational JSX revert restoring previously-shipped, previously-reviewed markup. Landing components have no existing unit tests; behavior verified via build, full test suite, and a live browser check.

## Pre-Landing Review

No issues found. No SQL/concurrency/LLM/shell surface. The i18n key swaps *fix* a value-completeness bug (target keys `hero.ctaRegister`, `hero.ctaEarlyAccess`, `nav.register` verified present in en/zh-CN/zh-TW). `window.location.search` href interpolation has an SSR-safe guard and restores pre-#733 behavior.

## Design Review

Verified live in a headless browser against the dev server:
- Hero NyxID wordmark image renders (`/nyxid-wordmark.svg`, 198x56, visible)
- Three Register touchpoints with correct hrefs: navbar Register -> `/register`, hero Register -> `/register`, hero Request Early Access -> `#beta`

## Adversarial Review

Independent fresh-context review — **NO FINDINGS**. Checked: XSS via `window.location.search` interpolation (not vulnerable — always resolves to a relative same-origin path, React escapes attributes), SSR/hydration (N/A — pure client SPA), i18n keys (all exist), Tailwind tokens (all defined), asset path (`/nyxid-wordmark.svg` exists and valid), accessibility (no regression), JSX balance (clean).

## Test plan

- [x] `npm run build` (tsc -b && vite build) — clean
- [x] `npm run lint` — 0 errors (18 pre-existing warnings in unrelated files)
- [x] `npm run test` — 559 passed, 1 skipped (43 files)
- [x] Visual browser check — hero image + Register CTAs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)