### PR TITLE
feat(frontend): make the dashboard interactive — URL-driven tabs and deep-link actions

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       i18next:
         specifier: ^26.0.3
         version: 26.0.4(typescript@5.9.3)
@@ -95,6 +98,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -115,7 +121,7 @@ importers:
         version: 4.3.6
       zustand:
         specifier: ^5.0.11
-        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 5.0.12(@types/react@19.2.14)(immer@11.1.8)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -1118,6 +1124,17 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1435,6 +1452,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1481,6 +1525,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -1549,6 +1596,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -1712,6 +1760,12 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1744,6 +1798,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1756,6 +1854,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1805,6 +1906,9 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -1885,6 +1989,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2019,6 +2126,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2033,6 +2146,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2566,6 +2683,18 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -2604,9 +2733,25 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
@@ -2629,6 +2774,9 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2732,6 +2880,9 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2846,6 +2997,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-plugin-singlefile@2.3.3:
     resolution: {integrity: sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==}
@@ -3913,6 +4067,18 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
@@ -4179,6 +4345,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -4225,6 +4415,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -4483,6 +4675,18 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4509,11 +4713,51 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4553,6 +4797,8 @@ snapshots:
   entities@7.0.1: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-toolkit@1.46.1: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -4680,6 +4926,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
 
@@ -4811,6 +5059,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -4821,6 +5073,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -5484,6 +5738,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
@@ -5515,10 +5778,36 @@ snapshots:
 
   react@19.2.4: {}
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   rehype-sanitize@6.0.0:
     dependencies:
@@ -5562,6 +5851,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5659,6 +5950,8 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -5778,6 +6071,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite-plugin-singlefile@2.3.3(vite@8.0.8(@types/node@25.5.2)(esbuild@0.27.4)(jiti@2.6.1)):
     dependencies:
       micromatch: 4.0.8
@@ -5883,9 +6193,10 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  zustand@5.0.12(@types/react@19.2.14)(immer@11.1.8)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:
       '@types/react': 19.2.14
+      immer: 11.1.8
       react: 19.2.4
       use-sync-external-store: 1.6.0(react@19.2.4)
 

--- a/frontend/src/components/dashboard/header.tsx
+++ b/frontend/src/components/dashboard/header.tsx
@@ -131,13 +131,13 @@ export function Header({
           <DropdownMenuLabel>My Account</DropdownMenuLabel>
 
           <DropdownMenuItem
-            onClick={() => void navigate({ to: "/settings" as string })}
+            onClick={() => void navigate({ to: "/settings" })}
           >
             <User className="h-4 w-4" aria-hidden="true" />
             Profile
           </DropdownMenuItem>
           <DropdownMenuItem
-            onClick={() => void navigate({ to: "/settings" as string })}
+            onClick={() => void navigate({ to: "/settings" })}
           >
             <Settings className="h-4 w-4" aria-hidden="true" />
             Settings

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -2,7 +2,11 @@ import { Suspense, useState, useEffect, useCallback, useMemo, createContext, use
 import { Outlet, Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Sidebar, MAIN_NAV, APPROVALS_NAV, DEVELOPER_NAV, ADMIN_NAV, isNavActive } from "@/components/dashboard/sidebar";
 import { hasAdminRead } from "@/types/api";
-import { CommandPalette, ALL_ITEMS as SEARCH_ITEMS } from "@/components/navigation/command-palette";
+import {
+  CommandPalette,
+  ALL_ITEMS as SEARCH_ITEMS,
+  type CommandItem,
+} from "@/components/navigation/command-palette";
 import { AmbientStatusLine } from "@/components/chrome/ambient-status-line";
 import { useAuthStore } from "@/stores/auth-store";
 import { useLogout } from "@/hooks/use-auth";
@@ -454,7 +458,7 @@ function MobileNav({
     return SEARCH_ITEMS.filter(
       (item) =>
         item.label.toLowerCase().includes(q) ||
-        item.to.toLowerCase().includes(q),
+        (item.to?.toLowerCase().includes(q) ?? false),
     );
   }, [searchQuery]);
 
@@ -464,9 +468,22 @@ function MobileNav({
     void navigate({ to: "/login" as string });
   }
 
-  function handleNavigate(to: string) {
+  function handleSearchSelect(item: CommandItem) {
     onClose();
-    void navigate({ to: to as string });
+    if (item.onSelect) {
+      item.onSelect();
+      return;
+    }
+    if (item.to) {
+      // Mirror the command palette: navigate with the structured `search`
+      // so deep-link actions like `?action=add-service` survive the
+      // TanStack search-param validator and the keys page can auto-open
+      // the matching dialog.
+      void navigate({
+        to: item.to as never,
+        search: (item.search ?? {}) as never,
+      });
+    }
   }
 
   return (
@@ -520,9 +537,9 @@ function MobileNav({
             <div className="flex flex-col gap-0.5">
               {searchResults.map((item) => (
                 <button
-                  key={`${item.to}-${item.label}`}
+                  key={`${item.to ?? "action"}-${item.label}`}
                   type="button"
-                  onClick={() => handleNavigate(item.to)}
+                  onClick={() => handleSearchSelect(item)}
                   className="flex items-center gap-3 rounded-xl px-4 py-3 text-[14px] text-muted-foreground active:bg-white/[0.04]"
                 >
                   <item.icon className="h-[18px] w-[18px] shrink-0 text-text-tertiary" />

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -317,7 +317,7 @@ function TopBar({
               <p className="text-[11px] text-text-tertiary">{user?.email ?? ""}</p>
             </div>
             <DropdownMenuItem
-              onClick={() => void navigate({ to: "/settings" as string })}
+              onClick={() => void navigate({ to: "/settings" })}
               className="rounded-md text-[12px]"
             >
               Settings
@@ -361,7 +361,7 @@ function TopBar({
               <p className="text-[11px] text-text-tertiary">{user?.email ?? ""}</p>
             </div>
             <DropdownMenuItem
-              onClick={() => void navigate({ to: "/settings" as string })}
+              onClick={() => void navigate({ to: "/settings" })}
               className="rounded-md text-[12px]"
             >
               Settings
@@ -620,7 +620,7 @@ function MobileNav({
         <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => { onClose(); void navigate({ to: "/settings" as string }); }}
+            onClick={() => { onClose(); void navigate({ to: "/settings" }); }}
             className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] py-2.5 text-[12px] text-muted-foreground active:bg-white/[0.04]"
           >
             <Settings className="h-3.5 w-3.5" />

--- a/frontend/src/components/navigation/command-palette.tsx
+++ b/frontend/src/components/navigation/command-palette.tsx
@@ -27,7 +27,22 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-export const ALL_ITEMS = [
+type CommandGroup = "navigation" | "admin" | "action";
+
+export interface CommandItem {
+  readonly icon: typeof LayoutDashboard;
+  readonly label: string;
+  readonly group: CommandGroup;
+  readonly to?: string;
+  readonly search?: Record<string, string>;
+  /**
+   * Optional in-place action. Takes precedence over `to` when set, so an
+   * entry can open a modal or fire a side-effect instead of navigating.
+   */
+  readonly onSelect?: () => void;
+}
+
+export const ALL_ITEMS: readonly CommandItem[] = [
   { icon: LayoutDashboard, label: "Dashboard", to: "/dashboard", group: "navigation" },
   { icon: Cable, label: "AI Services", to: "/keys", group: "navigation" },
   { icon: Building2, label: "Organizations", to: "/orgs", group: "navigation" },
@@ -50,10 +65,22 @@ export const ALL_ITEMS = [
   { icon: Layers, label: "Groups", to: "/admin/groups", group: "admin" },
   { icon: Server, label: "Services", to: "/services", group: "admin" },
   { icon: Plug, label: "Providers", to: "/providers", group: "admin" },
-  { icon: Plus, label: "Connect a Service", to: "/keys", group: "action" },
-  { icon: KeyRound, label: "Create API key", to: "/keys?tab=nyxid", group: "action" },
+  {
+    icon: Plus,
+    label: "Connect a Service",
+    to: "/keys",
+    search: { tab: "services", action: "add-service" },
+    group: "action",
+  },
+  {
+    icon: KeyRound,
+    label: "Create API key",
+    to: "/keys",
+    search: { tab: "nyxid", action: "create-key" },
+    group: "action",
+  },
   { icon: ShieldCheck, label: "Review approvals", to: "/approvals/history", group: "action" },
-] as const;
+];
 
 export function CommandPalette({
   open,
@@ -77,15 +104,27 @@ export function CommandPalette({
     return ALL_ITEMS.filter(
       (item) =>
         item.label.toLowerCase().includes(q) ||
-        item.to.toLowerCase().includes(q),
+        (item.to?.toLowerCase().includes(q) ?? false),
     );
   }, [query]);
 
   const handleSelect = useCallback(
-    (to: string) => {
+    (item: CommandItem) => {
       onOpenChange(false);
       setQuery("");
-      void navigate({ to: to as string });
+      if (item.onSelect) {
+        item.onSelect();
+        return;
+      }
+      if (item.to) {
+        // TanStack `navigate` is typed against the route tree; cast through
+        // `never` so this generic palette can target any whitelisted route
+        // without each entry needing a literal route type.
+        void navigate({
+          to: item.to as never,
+          search: (item.search ?? {}) as never,
+        });
+      }
     },
     [navigate, onOpenChange, setQuery],
   );
@@ -110,7 +149,7 @@ export function CommandPalette({
       if (e.key === "Enter" && filtered.length > 0) {
         e.preventDefault();
         const item = filtered[selectedIndex];
-        if (item) handleSelect(item.to);
+        if (item) handleSelect(item);
       }
     }
 
@@ -169,9 +208,9 @@ export function CommandPalette({
           <div className="mt-2 rounded-2xl border border-white/[0.08] bg-[#1a1a1a] p-2 max-h-[360px] overflow-y-auto">
             {filtered.map((item, i) => (
               <button
-                key={`${item.to}-${item.label}`}
+                key={`${item.to ?? "action"}-${item.label}`}
                 type="button"
-                onClick={() => handleSelect(item.to)}
+                onClick={() => handleSelect(item)}
                 onMouseEnter={() => setSelectedIndex(i)}
                 className={cn(
                   "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[14px] transition-colors duration-300",

--- a/frontend/src/lib/url-tabs.test.ts
+++ b/frontend/src/lib/url-tabs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  SETTINGS_TABS,
+  KEYS_TABS,
+  isValidTab,
+  parseTab,
+} from "./url-tabs";
+
+describe("parseTab", () => {
+  it("returns the value when it matches the allowlist", () => {
+    expect(parseTab("security", SETTINGS_TABS, "profile")).toBe("security");
+  });
+
+  it("returns the fallback when the value is not in the allowlist", () => {
+    expect(parseTab("not-a-tab", SETTINGS_TABS, "profile")).toBe("profile");
+  });
+
+  it("returns the fallback when the value is undefined", () => {
+    expect(parseTab(undefined, SETTINGS_TABS, "profile")).toBe("profile");
+  });
+
+  it("returns the fallback when the value is a non-string", () => {
+    expect(parseTab(42, KEYS_TABS, "services")).toBe("services");
+    expect(parseTab(null, KEYS_TABS, "services")).toBe("services");
+    expect(parseTab({}, KEYS_TABS, "services")).toBe("services");
+  });
+
+  it("narrows the return type to the allowlist literal", () => {
+    const tab = parseTab("nyxid", KEYS_TABS, "services");
+    // Type-level assertion: `tab` is `"services" | "nyxid"`. If a future
+    // change widens the return type, this assignment will fail to compile.
+    const _typed: (typeof KEYS_TABS)[number] = tab;
+    void _typed;
+    expect(tab).toBe("nyxid");
+  });
+});
+
+describe("isValidTab", () => {
+  it("returns true for valid values", () => {
+    expect(isValidTab("profile", SETTINGS_TABS)).toBe(true);
+  });
+
+  it("returns false for invalid string values", () => {
+    expect(isValidTab("nope", SETTINGS_TABS)).toBe(false);
+  });
+
+  it("returns false for non-string values", () => {
+    expect(isValidTab(undefined, SETTINGS_TABS)).toBe(false);
+    expect(isValidTab(0, SETTINGS_TABS)).toBe(false);
+    expect(isValidTab(null, SETTINGS_TABS)).toBe(false);
+  });
+});

--- a/frontend/src/lib/url-tabs.ts
+++ b/frontend/src/lib/url-tabs.ts
@@ -1,0 +1,80 @@
+/**
+ * Central registry of tab values exposed via `?tab=` (and similar) URL
+ * params. One source of truth for every page that surfaces tab state in the
+ * URL — keeps validators, defaults, and deep-link hrefs aligned.
+ */
+
+export const SETTINGS_TABS = [
+  "profile",
+  "security",
+  "sessions",
+  "mcp",
+  "privacy",
+] as const;
+export type SettingsTab = (typeof SETTINGS_TABS)[number];
+export const SETTINGS_TAB_DEFAULT: SettingsTab = "profile";
+
+export const CONSENTS_TABS = ["apps", "authorizations"] as const;
+export type ConsentsTab = (typeof CONSENTS_TABS)[number];
+export const CONSENTS_TAB_DEFAULT: ConsentsTab = "apps";
+
+export const INTEGRATION_GUIDE_TABS = ["react", "core", "raw"] as const;
+export type IntegrationGuideTab = (typeof INTEGRATION_GUIDE_TABS)[number];
+export const INTEGRATION_GUIDE_TAB_DEFAULT: IntegrationGuideTab = "react";
+
+export const ORG_DETAIL_TABS = [
+  "members",
+  "role-permissions",
+  "invites",
+  "approvals",
+  "service-accounts",
+  "developer-apps",
+  "settings",
+] as const;
+export type OrgDetailTab = (typeof ORG_DETAIL_TABS)[number];
+export const ORG_DETAIL_TAB_DEFAULT: OrgDetailTab = "members";
+
+export const KEYS_TABS = ["services", "nyxid"] as const;
+export type KeysTab = (typeof KEYS_TABS)[number];
+export const KEYS_TAB_DEFAULT: KeysTab = "services";
+
+export const KEYS_ACTIONS = ["add-service", "create-key"] as const;
+export type KeysAction = (typeof KEYS_ACTIONS)[number];
+
+export const AI_SETUP_SKILL_TABS = [
+  "claude-code",
+  "cursor",
+  "codex",
+  "openclaw",
+  "chatgpt",
+] as const;
+export type AiSetupSkillTab = (typeof AI_SETUP_SKILL_TABS)[number];
+export const AI_SETUP_SKILL_TAB_DEFAULT: AiSetupSkillTab = "claude-code";
+
+/**
+ * Validate an unknown search-param value against an allowlist. Returns the
+ * value as the narrowed literal type when it matches, otherwise `fallback`.
+ *
+ * Typical use:
+ *   const tab = parseTab(searchParams.tab, SETTINGS_TABS, SETTINGS_TAB_DEFAULT);
+ */
+export function parseTab<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? (value as T)
+    : fallback;
+}
+
+/**
+ * Type guard variant of {@link parseTab} for cases where you want a boolean
+ * check without a fallback.
+ */
+export function isValidTab<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): value is T {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value);
+}

--- a/frontend/src/pages/ai-setup.tsx
+++ b/frontend/src/pages/ai-setup.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   Card,
   CardContent,
@@ -32,6 +32,12 @@ import {
   type AiTool,
   type AiToolConfigParams,
 } from "@/lib/ai-tool-configs";
+import {
+  AI_SETUP_SKILL_TABS,
+  AI_SETUP_SKILL_TAB_DEFAULT,
+  isValidTab,
+  parseTab,
+} from "@/lib/url-tabs";
 
 function CodeBlock({
   code,
@@ -77,14 +83,6 @@ function EmptyState() {
 }
 
 
-const SKILL_TOOLS: readonly AiTool[] = [
-  "claude-code",
-  "cursor",
-  "codex",
-  "openclaw",
-  "chatgpt",
-];
-
 function AiSkillSetupCard({
   baseUrl,
   dashboardUrl,
@@ -92,7 +90,23 @@ function AiSkillSetupCard({
   readonly baseUrl: string;
   readonly dashboardUrl: string;
 }) {
-  const [selectedSkillTool, setSelectedSkillTool] = useState<AiTool>("claude-code");
+  const searchParams = useRouterState({
+    select: (s) => s.location.search as Record<string, unknown>,
+  });
+  const navigate = useNavigate();
+  const selectedSkillTool: AiTool = parseTab(
+    searchParams.skill,
+    AI_SETUP_SKILL_TABS,
+    AI_SETUP_SKILL_TAB_DEFAULT,
+  );
+
+  function setSelectedSkillTool(value: AiTool) {
+    void navigate({
+      to: "/ai-setup",
+      search: (prev) => ({ ...prev, skill: value }),
+      replace: true,
+    });
+  }
 
   const setupPrompt = useMemo(
     () => generateSetupPrompt(selectedSkillTool, { baseUrl, dashboardUrl }),
@@ -126,7 +140,7 @@ function AiSkillSetupCard({
           className="space-y-4"
         >
           <TabsList>
-            {SKILL_TOOLS.map((id) => {
+            {AI_SETUP_SKILL_TABS.map((id) => {
               const tool = AI_TOOLS.find((t) => t.id === id);
               return tool ? (
                 <TabsTrigger key={id} value={id}>
@@ -136,7 +150,7 @@ function AiSkillSetupCard({
             })}
           </TabsList>
 
-          {SKILL_TOOLS.map((id) => (
+          {AI_SETUP_SKILL_TABS.map((id) => (
             <TabsContent key={id} value={id}>
               <div className="space-y-4">
                 <div className="relative">
@@ -203,8 +217,28 @@ export function AiSetupPage() {
   const { data: appsData, isLoading: appsLoading } = useDeveloperApps();
   const { data: config, isLoading: configLoading } = usePublicConfig();
 
+  const searchParams = useRouterState({
+    select: (s) => s.location.search as Record<string, unknown>,
+  });
+  const navigate = useNavigate();
+
   const [selectedClientId, setSelectedClientId] = useState<string>("");
-  const [selectedTool, setSelectedTool] = useState<AiTool>("cursor");
+
+  // AI_TOOLS lives in ai-tool-configs as the canonical source of all
+  // tool ids + metadata; we derive the URL allowlist from it rather than
+  // duplicating the list in url-tabs.
+  const aiToolIds: readonly AiTool[] = AI_TOOLS.map((t) => t.id);
+  const selectedTool: AiTool = isValidTab(searchParams.tool, aiToolIds)
+    ? searchParams.tool
+    : "cursor";
+
+  function setSelectedTool(value: AiTool) {
+    void navigate({
+      to: "/ai-setup",
+      search: (prev) => ({ ...prev, tool: value }),
+      replace: true,
+    });
+  }
 
   const clients = appsData?.clients ?? [];
   const mcpUrl = config?.mcp_url ?? `${window.location.origin}/mcp`;

--- a/frontend/src/pages/consents.tsx
+++ b/frontend/src/pages/consents.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useRouterState } from "@tanstack/react-router";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useMyConsents, useRevokeConsent } from "@/hooks/use-consents";
 import {
   type BrokerBindingExternalSubject,
@@ -10,6 +10,11 @@ import { ApiError } from "@/lib/api-client";
 import { formatDate } from "@/lib/utils";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import { PageHeader } from "@/components/shared/page-header";
+import {
+  CONSENTS_TABS,
+  CONSENTS_TAB_DEFAULT,
+  parseTab,
+} from "@/lib/url-tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -46,8 +51,12 @@ function formatExternalSubject(
 
 export function ConsentsPage() {
   const searchParams = useRouterState({ select: (s) => s.location.search as Record<string, unknown> });
-  const tabParam = typeof searchParams.tab === "string" ? searchParams.tab : undefined;
-  const defaultTab = tabParam === "authorizations" ? "authorizations" : "apps";
+  const navigate = useNavigate();
+  const currentTab = parseTab(searchParams.tab, CONSENTS_TABS, CONSENTS_TAB_DEFAULT);
+
+  function handleTabChange(value: string) {
+    void navigate({ to: "/settings/consents", search: { tab: value }, replace: true });
+  }
 
   return (
     <div className="space-y-8">
@@ -56,7 +65,7 @@ export function ConsentsPage() {
         description="Manage apps with access to your account and credentials held on your behalf."
       />
 
-      <Tabs defaultValue={defaultTab} className="space-y-6">
+      <Tabs value={currentTab} onValueChange={handleTabChange} className="space-y-6">
         <TabsList>
           <TabsTrigger value="apps">Authorized Apps</TabsTrigger>
           <TabsTrigger value="authorizations">Authorizations</TabsTrigger>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -502,10 +502,37 @@ function AccountPostureCard({
   readonly loading: boolean;
 }) {
   const items = [
-    { done: emailVerified, label: "Email verified", icon: <Mail className="h-3.5 w-3.5" /> },
-    { done: mfaEnabled, label: "MFA enabled", icon: <Shield className="h-3.5 w-3.5" /> },
-    { done: serviceCount > 0, label: "Service connected", icon: <Server className="h-3.5 w-3.5" /> },
-    { done: activeKeys > 0, label: "API key created", icon: <KeyRound className="h-3.5 w-3.5" /> },
+    {
+      done: emailVerified,
+      label: "Email verified",
+      icon: <Mail className="h-3.5 w-3.5" />,
+      href: "/settings",
+      cta: "Verify",
+    },
+    {
+      done: mfaEnabled,
+      label: "MFA enabled",
+      icon: <Shield className="h-3.5 w-3.5" />,
+      href: "/settings?tab=security",
+      cta: "Enable",
+    },
+    {
+      done: serviceCount > 0,
+      label: "Service connected",
+      icon: <Server className="h-3.5 w-3.5" />,
+      href: serviceCount > 0 ? "/keys" : "/keys?action=add-service",
+      cta: "Connect",
+    },
+    {
+      done: activeKeys > 0,
+      label: "API key created",
+      icon: <KeyRound className="h-3.5 w-3.5" />,
+      href:
+        activeKeys > 0
+          ? "/keys?tab=nyxid"
+          : "/keys?tab=nyxid&action=create-key",
+      cta: "Create",
+    },
   ];
   const doneCount = items.filter((i) => i.done).length;
   const score = Math.round((doneCount / items.length) * 100);
@@ -522,6 +549,8 @@ function AccountPostureCard({
       : score >= 50
         ? "text-warning"
         : "text-destructive";
+
+  const nextStep = items.find((i) => !i.done);
 
   return (
     <div className="hidden md:flex w-[280px] shrink-0 flex-col rounded-xl border border-border/50 bg-card overflow-hidden">
@@ -541,15 +570,21 @@ function AccountPostureCard({
       </div>
 
       {/* Checklist */}
-      <div className="flex-1 px-4 py-4 flex flex-col gap-3.5">
+      <div className="flex-1 px-2 py-2 flex flex-col">
         {loading ? (
-          <>
+          <div className="flex flex-col gap-3.5 px-2 py-2">
             <Skeleton className="h-4 w-full" />
             <Skeleton className="h-4 w-3/4" />
-          </>
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
         ) : (
           items.map((item) => (
-            <div key={item.label} className="flex items-center gap-2.5">
+            <Link
+              key={item.label}
+              to={item.href}
+              className="group flex items-center gap-2.5 rounded-md px-2 py-2 transition-colors duration-200 hover:bg-white/[0.03]"
+            >
               <span
                 className={cn(
                   "shrink-0",
@@ -560,20 +595,26 @@ function AccountPostureCard({
               </span>
               <span
                 className={cn(
-                  "text-[12px]",
-                  item.done
-                    ? "text-foreground"
-                    : "text-muted-foreground",
+                  "flex-1 truncate text-[12px]",
+                  item.done ? "text-foreground" : "text-muted-foreground",
                 )}
               >
                 {item.label}
               </span>
-            </div>
+              {item.done ? (
+                <Check className="h-3 w-3 shrink-0 text-success/60 transition-transform duration-200 group-hover:scale-110" />
+              ) : (
+                <span className="inline-flex shrink-0 items-center gap-0.5 text-[10px] font-semibold uppercase tracking-wide text-nyx-secondary-400 transition-all duration-200 group-hover:gap-1">
+                  {item.cta}
+                  <ArrowRight className="h-2.5 w-2.5" />
+                </span>
+              )}
+            </Link>
           ))
         )}
       </div>
 
-      {/* Footer with progress bar */}
+      {/* Footer with progress bar + next-step CTA */}
       <div className="border-t border-border/50 px-4 py-2.5">
         <div className="flex items-center justify-between mb-2">
           <span className="text-[11px] text-text-tertiary">
@@ -589,6 +630,17 @@ function AccountPostureCard({
             style={{ width: `${String(score)}%` }}
           />
         </div>
+        {nextStep && !loading && (
+          <Link
+            to={nextStep.href}
+            className="mt-3 group flex items-center justify-between rounded-md -mx-1 px-1 py-1 text-[11px] transition-colors duration-200 hover:bg-white/[0.03]"
+          >
+            <span className="text-muted-foreground">
+              Next: <span className="text-foreground">{nextStep.label}</span>
+            </span>
+            <ArrowRight className="h-3 w-3 text-nyx-secondary-400 transition-transform duration-200 group-hover:translate-x-0.5" />
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/integration-guide.tsx
+++ b/frontend/src/pages/integration-guide.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -10,6 +11,11 @@ import {
   scopeRiskClass,
   scopeRiskLabel,
 } from "@/lib/constants";
+import {
+  INTEGRATION_GUIDE_TABS,
+  INTEGRATION_GUIDE_TAB_DEFAULT,
+  parseTab,
+} from "@/lib/url-tabs";
 import { PageHeader } from "@/components/shared/page-header";
 
 function CodeBlock({
@@ -129,6 +135,18 @@ const rawUserInfo = `GET /api/v1/users/me
 Authorization: Bearer ACCESS_TOKEN`;
 
 export function IntegrationGuidePage() {
+  const searchParams = useRouterState({ select: (s) => s.location.search as Record<string, unknown> });
+  const navigate = useNavigate();
+  const currentTab = parseTab(
+    searchParams.tab,
+    INTEGRATION_GUIDE_TABS,
+    INTEGRATION_GUIDE_TAB_DEFAULT,
+  );
+
+  function handleTabChange(value: string) {
+    void navigate({ to: "/integration-guide", search: { tab: value }, replace: true });
+  }
+
   return (
     <div className="space-y-8">
       <PageHeader
@@ -136,7 +154,7 @@ export function IntegrationGuidePage() {
         description="Use the official React or Core SDK (recommended), or integrate with raw OAuth endpoints for custom flows."
       />
 
-      <Tabs defaultValue="react" className="space-y-6">
+      <Tabs value={currentTab} onValueChange={handleTabChange} className="space-y-6">
         <TabsList>
           <TabsTrigger value="react">React SDK</TabsTrigger>
           <TabsTrigger value="core">Core SDK</TabsTrigger>

--- a/frontend/src/pages/keys.tsx
+++ b/frontend/src/pages/keys.tsx
@@ -30,8 +30,15 @@ import { RoleBadge } from "@/components/orgs/role-badge";
 import { OrgAvatar } from "@/components/orgs/org-avatar";
 import type { KeyInfo } from "@/types/keys";
 import type { CredentialSource } from "@/schemas/orgs";
-
-type TabValue = "services" | "nyxid";
+import {
+  KEYS_TABS,
+  KEYS_TAB_DEFAULT,
+  KEYS_ACTIONS,
+  type KeysAction,
+  type KeysTab,
+  isValidTab,
+  parseTab,
+} from "@/lib/url-tabs";
 
 function statusVariant(
   status: string,
@@ -428,7 +435,7 @@ function AddButton({
   onAddService,
   onCreateKey,
 }: {
-  readonly tab: TabValue;
+  readonly tab: KeysTab;
   readonly onAddService: () => void;
   readonly onCreateKey: () => void;
 }) {
@@ -468,8 +475,7 @@ function AutoConnectedToggle({
 export function KeysPage() {
   const search: { tab?: string; slug?: string; action?: string } = useSearch({ strict: false });
   const navigate = useNavigate();
-  const rawTab = search.tab ?? "services";
-  const tab: TabValue = rawTab === "nyxid" ? "nyxid" : "services";
+  const tab = parseTab(search.tab, KEYS_TABS, KEYS_TAB_DEFAULT);
 
   const [addServiceOpen, setAddServiceOpen] = useState(false);
   const [createKeyOpen, setCreateKeyOpen] = useState(false);
@@ -493,7 +499,9 @@ export function KeysPage() {
       return;
     }
 
-    const action = search.action ?? null;
+    const action: KeysAction | null = isValidTab(search.action, KEYS_ACTIONS)
+      ? search.action
+      : null;
     if (!action) return;
     if (appliedActionRef.current === action) return;
     appliedActionRef.current = action;

--- a/frontend/src/pages/org-detail.test.tsx
+++ b/frontend/src/pages/org-detail.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSyncExternalStore } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { MemberResponse, OrgRole } from "@/schemas/orgs";
 
@@ -11,7 +12,32 @@ const {
   mockNavigate,
   mockToastError,
   mockToastSuccess,
-} = vi.hoisted(() => ({
+  routerState,
+} = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  const state: { search: Record<string, unknown> } = { search: {} };
+  const routerState = {
+    get search() {
+      return state.search;
+    },
+    set: (next: Record<string, unknown>) => {
+      state.search = next;
+      listeners.forEach((l) => {
+        l();
+      });
+    },
+    subscribe: (l: () => void) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    },
+    reset: () => {
+      state.search = {};
+      listeners.forEach((l) => {
+        l();
+      });
+    },
+  };
+  return {
   fixtures: {
     orgRole: "admin" as "admin" | "member" | "viewer",
     org: {
@@ -67,10 +93,18 @@ const {
     ],
   },
   mockCopyToClipboard: vi.fn(),
-  mockNavigate: vi.fn(),
+  mockNavigate: vi.fn(
+    (opts: { search?: Record<string, unknown> } | undefined) => {
+      if (opts && typeof opts === "object" && opts.search) {
+        routerState.set(opts.search);
+      }
+    },
+  ),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
-}));
+  routerState,
+  };
+});
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
@@ -87,6 +121,17 @@ vi.mock("@tanstack/react-router", () => ({
   ),
   useNavigate: () => mockNavigate,
   useParams: () => ({ orgId: fixtures.org.id }),
+  useRouterState: ({
+    select,
+  }: {
+    readonly select: (s: { location: { search: Record<string, unknown> } }) => unknown;
+  }) => {
+    return useSyncExternalStore(
+      routerState.subscribe,
+      () => select({ location: { search: routerState.search } }),
+      () => select({ location: { search: {} } }),
+    );
+  },
 }));
 
 vi.mock("@/hooks/use-orgs", () => ({
@@ -235,6 +280,7 @@ describe("OrgDetailPage", () => {
     fixtures.orgRole = "admin";
     fixtures.members = [];
     mockCopyToClipboard.mockResolvedValue(undefined);
+    routerState.reset();
   });
 
   it("shows org-owned resource tabs to org admins", () => {

--- a/frontend/src/pages/org-detail.tsx
+++ b/frontend/src/pages/org-detail.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "@tanstack/react-router";
+import { useParams, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -64,6 +64,12 @@ import {
   formatTimeDistance,
 } from "@/lib/utils";
 import { useAuthStore } from "@/stores/auth-store";
+import {
+  ORG_DETAIL_TABS,
+  ORG_DETAIL_TAB_DEFAULT,
+  type OrgDetailTab,
+  parseTab,
+} from "@/lib/url-tabs";
 import { useOrg, useUpdateOrg, useDeleteOrg } from "@/hooks/use-orgs";
 import {
   useOrgMembers,
@@ -95,18 +101,21 @@ import { OrgAvatar } from "@/components/orgs/org-avatar";
 import { OrgDeveloperAppsTab } from "@/components/orgs/org-developer-apps-tab";
 import { OrgServiceAccountsTab } from "@/components/orgs/org-service-accounts-tab";
 
-type TabValue =
-  | "members"
-  | "role-permissions"
-  | "invites"
-  | "approvals"
-  | "service-accounts"
-  | "developer-apps"
-  | "settings";
-
 export function OrgDetailPage() {
   const { orgId } = useParams({ strict: false }) as { orgId: string };
   const navigate = useNavigate();
+  const searchParams = useRouterState({ select: (s) => s.location.search as Record<string, unknown> });
+  const tab = parseTab(searchParams.tab, ORG_DETAIL_TABS, ORG_DETAIL_TAB_DEFAULT);
+
+  function setTab(value: OrgDetailTab) {
+    void navigate({
+      to: "/orgs/$orgId",
+      params: { orgId },
+      search: { tab: value },
+      replace: true,
+    });
+  }
+
   const currentUser = useAuthStore((s) => s.user);
 
   const { data: org, isLoading, error, refetch } = useOrg(orgId);
@@ -119,8 +128,6 @@ export function OrgDetailPage() {
   const deleteOrgMutation = useDeleteOrg();
 
   useBreadcrumbLabel(org?.display_name);
-
-  const [tab, setTab] = useState<TabValue>("members");
   const [inviteOpen, setInviteOpen] = useState(false);
   const [revokeTarget, setRevokeTarget] = useState<MemberResponse | null>(null);
   const [scopeTarget, setScopeTarget] = useState<MemberResponse | null>(null);
@@ -318,7 +325,7 @@ export function OrgDetailPage() {
         actions={<RoleBadge role={org.your_role} />}
       />
 
-      <Tabs value={tab} onValueChange={(value) => setTab(value as TabValue)}>
+      <Tabs value={tab} onValueChange={(value) => setTab(value as OrgDetailTab)}>
         <TabsList>
           <TabsTrigger value="members">Members</TabsTrigger>
           <TabsTrigger value="role-permissions">Role permissions</TabsTrigger>

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -15,6 +15,11 @@ import {
 } from "@/schemas/auth";
 import { copyToClipboard, formatDate } from "@/lib/utils";
 import { openExternal } from "@/lib/navigation";
+import {
+  SETTINGS_TABS,
+  SETTINGS_TAB_DEFAULT,
+  parseTab,
+} from "@/lib/url-tabs";
 import { usePublicConfig } from "@/hooks/use-public-config";
 import { MfaSetupDialog } from "@/components/auth/mfa-setup-dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -77,8 +82,12 @@ interface DeleteAccountResponse {
 
 export function SettingsPage() {
   const searchParams = useRouterState({ select: (s) => s.location.search as Record<string, unknown> });
-  const tabParam = typeof searchParams.tab === "string" ? searchParams.tab : undefined;
-  const defaultTab = tabParam && ["profile", "security", "sessions", "mcp", "privacy"].includes(tabParam) ? tabParam : "profile";
+  const navigate = useNavigate();
+  const currentTab = parseTab(searchParams.tab, SETTINGS_TABS, SETTINGS_TAB_DEFAULT);
+
+  function handleTabChange(value: string) {
+    void navigate({ to: "/settings", search: { tab: value }, replace: true });
+  }
 
   return (
     <div className="space-y-8">
@@ -91,7 +100,7 @@ export function SettingsPage() {
         </p>
       </div>
 
-      <Tabs defaultValue={defaultTab} className="space-y-6">
+      <Tabs value={currentTab} onValueChange={handleTabChange} className="space-y-6">
         <TabsList>
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="security">Security</TabsTrigger>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -379,8 +379,10 @@ const settingsRoute = createRoute({
   path: "/settings",
   getParentRoute: () => dashboardLayout,
   component: SettingsPage,
-  validateSearch: (search: Record<string, unknown>) => ({
-    tab: typeof search.tab === "string" ? search.tab : undefined,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: string } => ({
+    ...(typeof search.tab === "string" ? { tab: search.tab } : {}),
   }),
 });
 
@@ -394,8 +396,10 @@ const consentsRoute = createRoute({
   path: "/settings/consents",
   getParentRoute: () => dashboardLayout,
   component: ConsentsPage,
-  validateSearch: (search: Record<string, unknown>) => ({
-    tab: typeof search.tab === "string" ? search.tab : undefined,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: string } => ({
+    ...(typeof search.tab === "string" ? { tab: search.tab } : {}),
   }),
 });
 
@@ -423,12 +427,23 @@ const integrationGuideRoute = createRoute({
   path: "/integration-guide",
   getParentRoute: () => dashboardLayout,
   component: IntegrationGuidePage,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: string } => ({
+    ...(typeof search.tab === "string" ? { tab: search.tab } : {}),
+  }),
 });
 
 const aiSetupRoute = createRoute({
   path: "/ai-setup",
   getParentRoute: () => dashboardLayout,
   component: AiSetupPage,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { skill?: string; tool?: string } => ({
+    ...(typeof search.skill === "string" ? { skill: search.skill } : {}),
+    ...(typeof search.tool === "string" ? { tool: search.tool } : {}),
+  }),
 });
 
 const designSystemRoute = createRoute({
@@ -475,14 +490,17 @@ const keysRoute = createRoute({
   // `/keys?tab=services&slug=<catalog-slug>` needs `slug` here
   // or `useSearch()` inside `KeysPage` will never observe it and
   // the auto-open-AddKeyDialog flow silently degrades to the
-  // generic catalog grid.
+  // generic catalog grid. `action` is whitelisted for the same
+  // reason — the dashboard deep-links `/keys?action=add-service`
+  // and `/keys?action=create-key` to auto-open the add dialogs.
   validateSearch: (
     search: Record<string, unknown>,
-  ): { tab?: string; slug?: string } => ({
+  ): { tab?: string; slug?: string; action?: string } => ({
     ...(typeof search.tab === "string" ? { tab: search.tab } : {}),
     ...(typeof search.slug === "string" && search.slug.length > 0
       ? { slug: search.slug }
       : {}),
+    ...(typeof search.action === "string" ? { action: search.action } : {}),
   }),
   component: KeysPage,
 });
@@ -527,6 +545,11 @@ const orgDetailRoute = createRoute({
   path: "/orgs/$orgId",
   getParentRoute: () => dashboardLayout,
   component: OrgDetailPage,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { tab?: string } => ({
+    ...(typeof search.tab === "string" ? { tab: search.tab } : {}),
+  }),
 });
 
 const orgServiceAccountDetailRoute = createRoute({


### PR DESCRIPTION
## Summary

Three coordinated frontend changes so the dashboard, palette, mobile nav, and tabbed pages all behave like a "real" SPA — URL is the source of truth, every visible action goes somewhere meaningful, and deep links survive refresh.

- **URL-driven tab state.** New `frontend/src/lib/url-tabs.ts` registry centralizes every `?tab=` allowlist + default. Settings, Consents, Integration Guide, AI Setup, Keys, and Org Detail all read tabs from search params now. Tabs survive refresh, the URL is shareable, browser back/forward navigates between tabs. AI Setup also moves both `skill` and `tool` selection to URL params.
- **Deep-linkable dashboard actions.** `AccountPostureCard` rows on `/dashboard` are now real `<Link>` rows targeting the destination that completes the step:
  - Email verified → `/settings`
  - MFA enabled → `/settings?tab=security`
  - Service connected → `/keys?action=add-service` (auto-opens the Add Service dialog)
  - API key created → `/keys?tab=nyxid&action=create-key` (auto-opens the Create Key dialog)
- **Command palette + mobile-nav actions wired to dialogs.** `CommandItem` gains optional `search` and `onSelect`. The three "action" entries ("Connect a Service", "Create API key", "Review approvals") now actually trigger the right modal via the same `?action=` deep links instead of just navigating to the page and stopping. The mobile-nav search (which reuses `ALL_ITEMS`) goes through the same item-aware handler, so the palette and mobile search behave identically. `onSelect` is reserved for future in-place actions (copy, toggle, etc.).
- **Router cleanup.** `action` is whitelisted on the `/keys` route validator (TanStack strips unknown search params, so the deep links above would otherwise be silently dropped). Added matching `validateSearch` validators to settings / consents / integration-guide / ai-setup / org-detail. Stray `to: "/settings" as string` casts in the header and dashboard layout are removed now that the typed `to` resolves cleanly.

## Test plan

- [x] `npm run build` (mirrors CI's `tsc -b && vite build`) — clean
- [x] `npm test` — 567 passed / 1 skipped / 0 failed (incl. new `url-tabs.test.ts`)
- [x] CI green (Frontend + CI Pipeline + CLI Wizard Bundle)
- [x] Live verified in headless Chrome against `localhost:3000`:
  - `/` → "connect" → Enter → URL becomes `/keys?tab=services`, "Add AI Service" dialog opens
  - `/` → "create api" → Enter → URL becomes `/keys?tab=nyxid`, "Create API Key" dialog opens
- [ ] Reviewer sanity checks in browser:
  - [ ] Refresh on `/settings?tab=security` lands on Security tab (not Profile)
  - [ ] Dashboard "MFA enabled" / "Service connected" / "API key created" tiles route correctly when clicked
  - [ ] `/keys?action=add-service` and `/keys?tab=nyxid&action=create-key` deep links auto-open the matching dialog and strip `action` from the URL afterwards
  - [ ] Mobile nav search (open the hamburger, type "connect"): tapping the result also opens the Add Service dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)