### PR TITLE
fix(oauth): surface account-mismatch error to browser and CLI (#695)

### DIFF
--- a/cli/src/commands/service.rs
+++ b/cli/src/commands/service.rs
@@ -1595,6 +1595,18 @@ async fn wait_for_authorized_key(api: &mut ApiClient, key_id: &str) -> Result<Va
                 eprintln!();
                 return Ok(key);
             }
+            "failed" => {
+                // The backend stores an actionable reason on the credential
+                // (issue #651, e.g. an account-mismatch message). Surface it
+                // verbatim instead of swallowing it under a generic status
+                // string -- issue #695.
+                eprintln!();
+                let msg = key["error_message"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("OAuth authorization failed");
+                bail!("{msg}");
+            }
             other => {
                 eprintln!();
                 bail!("OAuth flow finished with unexpected key status: {other}");

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -334,7 +334,14 @@ const connectionsRedirectRoute = createRoute({
 const providersRedirectRoute = createRoute({
   path: "/providers",
   getParentRoute: () => dashboardLayout,
-  beforeLoad: () => {
+  beforeLoad: ({ location }) => {
+    // The backend's OAuth callback redirects every authenticated user here
+    // with ?status=error&message=... on account mismatch (issue #695).
+    // ProvidersCallbackPage must render for non-admins too; otherwise the
+    // actionable error stored by issue #651 never reaches the user.
+    if (location.pathname === "/providers/callback") {
+      return;
+    }
     const { user } = useAuthStore.getState();
     if (user?.is_admin) {
       // Admin users can still access the providers management pages


### PR DESCRIPTION
## Summary

Closes #695. Minimal fix that surfaces the account-mismatch error message the backend already computes (#651), so it actually reaches the user.

## What changes (+20 / −1)

- **`frontend/src/router.tsx`** — `/providers` parent route's `beforeLoad` redirects non-admin users to `/keys` before `/providers/callback` can render, discarding `?status=error&message=…`. Change: allow `/providers/callback` past the guard so any signed-in user lands on the callback page and sees the message.
- **`cli/src/commands/service.rs`** — `wait_for_authorized_key` collapsed every non-`active` status into `"OAuth flow finished with unexpected key status: <other>"`, dropping `error_message`. Change: add a `"failed"` arm that bails with `error_message` verbatim (fallback `"OAuth authorization failed"` if empty).

No backend changes — `error_message` is already written by #651.

## Scope and trigger conditions

This is an **edge case**. The bug only fires when **all four** conditions align:

1. User has two NyxID accounts.
2. Both reachable from the same browser session.
3. CLI signed in as account A; the same browser's dashboard tab is signed in as account B.
4. OAuth provider has server-side `oauth_client_id` / `oauth_client_secret` configured in the catalog.

Mode B (pair mode) is already guarded at `backend/src/services/cli_pairing_service.rs:295` — cross-user pairing claims return 404. Only Mode A (single-machine wizard) can hit this, and only with the cross-account session collision above. For typical single-account users this code path is unreachable.

## Why ship it anyway

- The diff is trivial (20 lines, no backend, no schema, no new deps).
- #651 already paid the cost of computing the actionable message; throwing it away by gating it on an admin guard the FE shouldn't have on this route is silly.
- When the rare collision does fire, current behavior is actively misleading (browser appears to succeed → AI Services list; CLI prints a confusing generic error). Bad failure modes erode trust even when rare.

## Follow-ups (separate PRs, not blocking this one)

- Fail fast at wizard start — compare `oauth_state.user_id` to the browser session before redirecting to the provider, eliminating the wasted round-trip.
- Audit `/providers` parent guard — confirm `/providers/callback` was unintentionally caught and nothing else is wrongly gated.
- Reconcile Mode A / Mode B — Mode B guards cross-account claims; Mode A doesn't. Pick a single stance.

## Test plan

- [ ] Frontend type-check: `cd frontend && npm run build` → exit 0.
- [ ] CLI build: `cargo build -p nyxid-cli` → exit 0.
- [ ] Backend mismatch tests (already in place, covers the data this PR depends on): `cargo test -p nyxid-server -- generic_oauth_callback_session_mismatch`.
- [ ] Reproduce the full flow against an environment with a server-side-OAuth-configured provider (staging): CLI as A, dashboard as B, run `nyxid service add <slug> --oauth`. Expect callback page to render the masked-email mismatch message, and CLI to exit non-zero with the same message verbatim.
- [ ] Regression: as a non-admin, navigate to `/providers` (no `/callback`) — still redirects to `/keys`. Guard relaxation is callback-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)