### PR TITLE
feat(cli): preflight session validation before authed commands

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
+use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
 
 /// User-Agent string sent on all CLI HTTP requests.
 pub const CLI_USER_AGENT: &str = concat!("nyxid-cli/", env!("CARGO_PKG_VERSION"));
@@ -83,12 +83,6 @@ pub struct ApiClient {
     refresh_disabled: bool,
 }
 
-#[derive(Deserialize)]
-struct RefreshResponse {
-    access_token: String,
-    refresh_token: String,
-}
-
 impl ApiClient {
     pub fn new(base_url: &str, access_token: String) -> Result<Self> {
         Self::new_with_profile(base_url, access_token, None)
@@ -116,6 +110,24 @@ impl ApiClient {
         Self::new_with_profile(&base_url, token, auth.profile.clone())
     }
 
+    /// Build a client after validating the saved session up front.
+    ///
+    /// Runs [`crate::auth::ensure_session`] first: a no-op when the access
+    /// token is still valid (local `exp` check, no network), a silent refresh
+    /// when it's expired, or a prompt/clean-error when the session is dead.
+    /// Only then does it build the client. Use this for session-authenticated
+    /// commands so a dead session is handled before the command does anything
+    /// user-visible, instead of surfacing a raw 401 mid-operation.
+    ///
+    /// Do NOT use for flows that authenticate with a non-session credential
+    /// (e.g. an agent API key passed via env) -- those should keep
+    /// [`Self::from_auth`] / [`Self::without_token_refresh`], since
+    /// `ensure_session` would have nothing to validate there anyway.
+    pub async fn from_auth_checked(auth: &crate::cli::AuthArgs) -> Result<Self> {
+        crate::auth::ensure_session(auth).await?;
+        Self::from_auth(auth)
+    }
+
     /// Disable the automatic 401 → session-refresh retry path.
     ///
     /// Returns `self` as a fluent builder. Use this when the caller is
@@ -135,7 +147,10 @@ impl ApiClient {
     }
 
     /// Attempt to refresh the access token using the saved refresh token.
-    /// Returns `true` if the token was refreshed successfully.
+    /// Returns `true` if the token was refreshed successfully. Delegates the
+    /// wire protocol to [`crate::auth::exchange_refresh_token`] (the single
+    /// source of truth) and owns only the token I/O: read the saved refresh
+    /// token, persist the rotated pair, and update this client's in-memory copy.
     async fn try_refresh_token(&mut self) -> bool {
         if self.refresh_disabled {
             return false;
@@ -146,32 +161,28 @@ impl ApiClient {
             None => return false,
         };
 
-        let url = format!("{}/auth/refresh", self.base_url);
-        let resp = self
-            .client
-            .post(&url)
-            .json(&serde_json::json!({ "refresh_token": refresh_token }))
-            .send()
-            .await;
-
-        let resp = match resp {
-            Ok(r) if r.status().is_success() => r,
-            _ => return false,
-        };
-
-        let tokens: RefreshResponse = match resp.json().await {
-            Ok(t) => t,
-            Err(_) => return false,
-        };
-
-        if crate::auth::save_tokens_for(profile, &tokens.access_token, Some(&tokens.refresh_token))
-            .is_err()
+        match crate::auth::exchange_refresh_token(
+            &self.client,
+            self.base_url_root(),
+            &refresh_token,
+        )
+        .await
         {
-            return false;
+            crate::auth::RefreshExchange::Renewed {
+                access_token,
+                refresh_token,
+            } => {
+                if crate::auth::save_tokens_for(profile, &access_token, Some(&refresh_token))
+                    .is_err()
+                {
+                    return false;
+                }
+                self.access_token = access_token;
+                true
+            }
+            crate::auth::RefreshExchange::Unauthorized
+            | crate::auth::RefreshExchange::Network(_) => false,
         }
-
-        self.access_token = tokens.access_token;
-        true
     }
 
     pub async fn get<T: DeserializeOwned>(&mut self, path: &str) -> Result<T> {

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -2,13 +2,29 @@ use std::io::Write;
 use std::net::TcpListener;
 use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::{Duration, Utc};
 use serde::Deserialize;
 
 use crate::api::{CLI_USER_AGENT, build_cli_http_client};
 use crate::cli::{AuthArgs, LoginArgs};
+
+/// Default NyxID base URL used when prompting for re-login on a session that
+/// was never associated with a saved base URL. Mirrors the `LoginArgs::base_url`
+/// clap default in `cli.rs`; kept in sync so the prompt path and the explicit
+/// `nyxid login` command target the same server by default.
+const DEFAULT_LOGIN_BASE_URL: &str = "https://nyx-api.chrono-ai.fun";
+
+/// Clock-skew cushion: an access token is treated as still usable only if it
+/// has more than this many seconds of validity left. Small on purpose -- the
+/// goal is to refresh tokens that just crossed the line, not to refresh tokens
+/// that are still good for several minutes (every refresh rotates the token and
+/// counts against the backend's reuse-detection grace window). If the local
+/// clock is wrong, the worst case is one wasted refresh; `ApiClient`'s in-flight
+/// 401-refresh is the backstop.
+const SESSION_SKEW_SECS: i64 = 60;
 
 const TOKEN_DIR_NAME: &str = ".nyxid";
 const PROFILES_DIR_NAME: &str = "profiles";
@@ -250,6 +266,252 @@ pub fn resolve_access_token(auth: &AuthArgs) -> Result<String> {
          set {}, or pass --access-token",
         auth.access_token_env
     )
+}
+
+// ---- Session preflight ----
+
+/// Why a saved session can't be used without re-authenticating.
+#[derive(Debug, Clone, Copy)]
+enum DeadSessionReason {
+    /// No saved access token for this profile (never logged in / logged out).
+    NoToken,
+    /// Access token expired and the refresh token could not renew it
+    /// (missing, expired, revoked, or rejected by the server).
+    Expired,
+}
+
+impl DeadSessionReason {
+    fn headline(self) -> &'static str {
+        match self {
+            DeadSessionReason::NoToken => "You are not logged in.",
+            DeadSessionReason::Expired => "Your session has expired.",
+        }
+    }
+}
+
+/// Outcome of a single silent refresh attempt.
+enum SessionRefresh {
+    /// New tokens were issued and persisted.
+    Refreshed,
+    /// The server (or local state) says this session is done; caller should
+    /// fall through to the dead-session path (prompt or error).
+    Unauthorized,
+    /// Could not reach the server to find out; caller should hard-fail with a
+    /// connectivity message rather than prompt for a login that also needs
+    /// the network.
+    Network(anyhow::Error),
+}
+
+/// Validate the saved session BEFORE a command does any user-visible work
+/// (opening a browser wizard, connecting an SSH socket, firing a proxy
+/// request). The fast path is local and free: parse the stored access token's
+/// `exp` and return immediately if it has time left. Only when the token is
+/// expired do we touch the network (one `/auth/refresh`).
+///
+/// There is no auto-login: when the session is genuinely dead, an interactive
+/// terminal is *prompted* to log in (and, on success, asked to re-run the
+/// command), while a headless/non-TTY caller gets a clean error and a non-zero
+/// exit -- never a hang.
+///
+/// A user-supplied token (`--access-token` or `NYXID_ACCESS_TOKEN`) is left
+/// untouched: the caller chose that credential explicitly, so we don't try to
+/// refresh it or judge its expiry -- any 401 surfaces from the real request.
+pub async fn ensure_session(auth: &AuthArgs) -> Result<()> {
+    if auth.access_token.is_some()
+        || std::env::var(&auth.access_token_env)
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let profile = auth.profile.as_deref();
+
+    let Some(access_token) = read_saved_token_for(profile) else {
+        return handle_dead_session(auth, DeadSessionReason::NoToken).await;
+    };
+
+    // Opaque / unparseable token: we can't judge its validity offline, so let
+    // the real request decide (and `ApiClient` refresh-on-401 handle it).
+    let Some(exp) = jwt_exp_from_token(&access_token) else {
+        return Ok(());
+    };
+
+    // Still comfortably valid -> proceed with zero network cost.
+    if exp > Utc::now() + Duration::seconds(SESSION_SKEW_SECS) {
+        return Ok(());
+    }
+
+    // Access token expired -> one silent refresh attempt.
+    match refresh_saved_session(auth).await {
+        SessionRefresh::Refreshed => Ok(()),
+        SessionRefresh::Unauthorized => handle_dead_session(auth, DeadSessionReason::Expired).await,
+        SessionRefresh::Network(e) => Err(anyhow!(
+            "Couldn't reach NyxID to refresh your session ({e}). \
+             Check your connection and try again."
+        )),
+    }
+}
+
+/// Result of the raw `POST /auth/refresh` exchange. This is the single source
+/// of truth for the refresh wire protocol; it performs NO token storage so
+/// callers can decide how to persist / apply the rotated pair.
+pub(crate) enum RefreshExchange {
+    /// Server issued a new access + refresh token pair.
+    Renewed {
+        access_token: String,
+        refresh_token: String,
+    },
+    /// Server rejected the refresh token (4xx) -- the session is not renewable.
+    Unauthorized,
+    /// Could not determine the outcome (network error, 5xx, malformed body).
+    Network(anyhow::Error),
+}
+
+/// Canonical `POST /api/v1/auth/refresh` exchange, shared by the session
+/// preflight ([`refresh_saved_session`]), the in-flight 401 retry
+/// ([`crate::api::ApiClient`]), and the wizard's local proxy
+/// (`wizard::server`). `base_url_root` is the NyxID origin WITHOUT the
+/// `/api/v1` suffix; this function appends the path. Token I/O (reading the
+/// refresh token, persisting the result, updating any in-memory copy) is the
+/// caller's responsibility.
+pub(crate) async fn exchange_refresh_token(
+    client: &reqwest::Client,
+    base_url_root: &str,
+    refresh_token: &str,
+) -> RefreshExchange {
+    let url = format!(
+        "{}/api/v1/auth/refresh",
+        base_url_root.trim_end_matches('/')
+    );
+    let resp = match client
+        .post(&url)
+        .json(&serde_json::json!({ "refresh_token": refresh_token }))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return RefreshExchange::Network(anyhow!(e)),
+    };
+
+    let status = resp.status();
+    // 429 (rate limited) and 408 (request timeout) are transient, not "session
+    // dead" -- surface them as retryable connectivity-style failures so a
+    // logged-in user isn't pushed through a full re-login over a temporary blip.
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+    {
+        return RefreshExchange::Network(anyhow!(
+            "refresh temporarily unavailable (HTTP {status})"
+        ));
+    }
+    if status.is_client_error() {
+        // 401/403/400 etc. -> the refresh token is genuinely not renewable.
+        return RefreshExchange::Unauthorized;
+    }
+    if !status.is_success() {
+        return RefreshExchange::Network(anyhow!("refresh failed (HTTP {status})"));
+    }
+
+    #[derive(Deserialize)]
+    struct RefreshBody {
+        access_token: String,
+        refresh_token: String,
+    }
+    match resp.json::<RefreshBody>().await {
+        Ok(b) => RefreshExchange::Renewed {
+            access_token: b.access_token,
+            refresh_token: b.refresh_token,
+        },
+        Err(e) => RefreshExchange::Network(anyhow!(e)),
+    }
+}
+
+/// Attempt to renew the access token using the saved refresh token, persisting
+/// the rotated pair on success. Standalone so the preflight can run before any
+/// client exists; the wire protocol itself lives in [`exchange_refresh_token`].
+async fn refresh_saved_session(auth: &AuthArgs) -> SessionRefresh {
+    let profile = auth.profile.as_deref();
+
+    let Some(refresh_token) = read_saved_refresh_token_for(profile) else {
+        return SessionRefresh::Unauthorized;
+    };
+
+    // If the refresh token itself is already expired, skip the round trip --
+    // the server would only reject it (and reuse-detection could revoke the
+    // whole session).
+    if let Some(exp) = jwt_exp_from_token(&refresh_token)
+        && exp <= Utc::now()
+    {
+        return SessionRefresh::Unauthorized;
+    }
+
+    let base_url = match auth.resolved_base_url() {
+        Ok(url) => url,
+        Err(e) => return SessionRefresh::Network(e),
+    };
+    let client = match build_cli_http_client(profile) {
+        Ok(c) => c,
+        Err(e) => return SessionRefresh::Network(e),
+    };
+
+    match exchange_refresh_token(&client, &base_url, &refresh_token).await {
+        RefreshExchange::Renewed {
+            access_token,
+            refresh_token,
+        } => {
+            if save_tokens_for(profile, &access_token, Some(&refresh_token)).is_err() {
+                return SessionRefresh::Network(anyhow!("failed to persist refreshed tokens"));
+            }
+            SessionRefresh::Refreshed
+        }
+        RefreshExchange::Unauthorized => SessionRefresh::Unauthorized,
+        RefreshExchange::Network(e) => SessionRefresh::Network(e),
+    }
+}
+
+/// Handle a session that can't be used: prompt for re-login when interactive,
+/// otherwise return a clean error. Never hangs in a non-TTY context.
+async fn handle_dead_session(auth: &AuthArgs, reason: DeadSessionReason) -> Result<()> {
+    let headline = reason.headline();
+
+    // Only prompt when we can actually read an answer AND surface the prompt.
+    let interactive = std::io::IsTerminal::is_terminal(&std::io::stdin())
+        && std::io::IsTerminal::is_terminal(&std::io::stderr());
+    if !interactive {
+        bail!("{headline} Run `nyxid login` to continue.");
+    }
+
+    eprint!("{headline} Log in again now? [Y/n] ");
+    std::io::stderr().flush().ok();
+
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("Failed to read response")?;
+    let answer = answer.trim().to_ascii_lowercase();
+    if !(answer.is_empty() || answer == "y" || answer == "yes") {
+        bail!("{headline} Run `nyxid login` when you're ready.");
+    }
+
+    // No auto-login: only after explicit consent do we open the login flow.
+    let base_url = auth
+        .resolved_base_url()
+        .unwrap_or_else(|_| DEFAULT_LOGIN_BASE_URL.to_string());
+    run_login(LoginArgs {
+        base_url,
+        password: false,
+        email: None,
+        profile: auth.profile.clone(),
+    })
+    .await?;
+
+    // Deliberately do NOT resume the original command: the user re-runs it with
+    // the fresh token. This keeps the process simple and the behavior
+    // predictable.
+    eprintln!();
+    eprintln!("Logged in. Re-run your command to continue.");
+    std::process::exit(0);
 }
 
 // ---- Login ----
@@ -780,5 +1042,204 @@ mod tests {
                 None => env::remove_var("HOME"),
             }
         }
+    }
+
+    // ---- ensure_session preflight ----
+
+    use crate::cli::{AuthArgs, OutputFormat};
+
+    /// AuthArgs wired so `ensure_session` won't take the user-supplied-token
+    /// shortcut: `access_token` is None and `access_token_env` points at a var
+    /// we keep unset. Profile isolates token storage under the temp HOME.
+    fn preflight_auth_args() -> AuthArgs {
+        AuthArgs {
+            base_url: Some("http://127.0.0.1:0".to_string()),
+            access_token: None,
+            access_token_env: "NYXID_ACCESS_TOKEN_PREFLIGHT_UNSET".to_string(),
+            profile: Some("ensure-session-test".to_string()),
+            output: OutputFormat::Table,
+        }
+    }
+
+    /// RAII: lock the shared env mutex, point HOME at a fresh temp dir, and
+    /// guarantee the preflight env var is unset. Restores HOME on drop. Mirrors
+    /// `api.rs`'s `HomeGuard`; holding the lock across `.await` is intentional
+    /// (the single-threaded test runtime never moves threads).
+    struct PreflightHome {
+        _dir: tempfile::TempDir,
+        prev_home: Option<std::ffi::OsString>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl PreflightHome {
+        fn set() -> Self {
+            let guard = crate::test_support::env_lock()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let dir = tempfile::tempdir().expect("tempdir");
+            let prev_home = std::env::var_os("HOME");
+            // SAFETY: serialized by `env_lock`.
+            unsafe {
+                std::env::set_var("HOME", dir.path());
+                std::env::remove_var("NYXID_ACCESS_TOKEN_PREFLIGHT_UNSET");
+            }
+            Self {
+                _dir: dir,
+                prev_home,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for PreflightHome {
+        fn drop(&mut self) {
+            // SAFETY: serialized by `env_lock`.
+            unsafe {
+                match &self.prev_home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_session_skips_when_explicit_token_flag_set() {
+        // The explicit-token shortcut returns before touching token storage or
+        // the network, so no HOME mutation is needed.
+        let mut auth = preflight_auth_args();
+        auth.access_token = Some("explicit-token".to_string());
+        super::ensure_session(&auth)
+            .await
+            .expect("explicit token is honored");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // serializes HOME/env mutations across tests
+    async fn ensure_session_ok_for_unexpired_saved_token() {
+        let _home = PreflightHome::set();
+        let auth = preflight_auth_args();
+        let token = build_jwt(&serde_json::json!({
+            "sub": "11111111-2222-3333-4444-555555555555",
+            "exp": 9999999999i64,
+        }));
+        super::save_tokens_for(auth.profile.as_deref(), &token, Some("refresh"))
+            .expect("save token");
+
+        super::ensure_session(&auth)
+            .await
+            .expect("unexpired token needs no network and is accepted");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn ensure_session_errors_when_no_token_and_headless() {
+        // Test stdin is not a TTY, so handle_dead_session takes the
+        // non-interactive branch and returns a clean error instead of hanging.
+        let _home = PreflightHome::set();
+        let auth = preflight_auth_args();
+
+        let err = super::ensure_session(&auth)
+            .await
+            .expect_err("no token must error");
+        let msg = format!("{err}");
+        assert!(msg.contains("not logged in"), "unexpected message: {msg}");
+        assert!(msg.contains("nyxid login"), "should point at login: {msg}");
+    }
+
+    /// Minimal one-shot HTTP server that answers the first request with a
+    /// 200 `/auth/refresh` body. Returns the base URL to point the client at.
+    async fn spawn_refresh_ok_server(access: &str, refresh: &str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let body = format!(
+            r#"{{"access_token":"{access}","expires_in":900,"refresh_token":"{refresh}"}}"#
+        );
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 2048];
+                let _ = socket.read(&mut buf).await; // body unparsed; respond regardless
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(resp.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn ensure_session_silently_refreshes_expired_access_token() {
+        // The headline behavior: expired access token + a usable refresh token
+        // -> one silent /auth/refresh -> command proceeds with the new token,
+        // no prompt. Exercises the `Refreshed` arm end to end through the
+        // consolidated `exchange_refresh_token`.
+        let _home = PreflightHome::set();
+        let base = spawn_refresh_ok_server("new-access-token", "new-refresh-token").await;
+        let mut auth = preflight_auth_args();
+        auth.base_url = Some(base);
+
+        let expired = build_jwt(&serde_json::json!({
+            "sub": "11111111-2222-3333-4444-555555555555",
+            "exp": 1_000_000_000i64, // 2001, expired
+        }));
+        // A non-JWT refresh token: `jwt_exp_from_token` returns None, so the
+        // local short-circuit is skipped and the network refresh is attempted.
+        super::save_tokens_for(
+            auth.profile.as_deref(),
+            &expired,
+            Some("usable-refresh-token"),
+        )
+        .expect("save initial tokens");
+
+        super::ensure_session(&auth)
+            .await
+            .expect("silent refresh should succeed without prompting");
+
+        assert_eq!(
+            super::read_saved_token_for(auth.profile.as_deref()).as_deref(),
+            Some("new-access-token"),
+            "preflight should persist the refreshed access token"
+        );
+        assert_eq!(
+            super::read_saved_refresh_token_for(auth.profile.as_deref()).as_deref(),
+            Some("new-refresh-token"),
+            "preflight should persist the rotated refresh token"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn ensure_session_errors_when_expired_and_no_refresh_token() {
+        // Expired access token + no refresh token -> Unauthorized without any
+        // network call -> dead-session path -> clean headless error.
+        let _home = PreflightHome::set();
+        let auth = preflight_auth_args();
+        let expired = build_jwt(&serde_json::json!({
+            "sub": "11111111-2222-3333-4444-555555555555",
+            "exp": 1_000_000_000i64, // year 2001, well past
+        }));
+        // Save only the access token; leave no refresh token file.
+        super::write_token_file(
+            &super::token_file_path_for(auth.profile.as_deref()).expect("path"),
+            &expired,
+        )
+        .expect("write access token");
+
+        let err = super::ensure_session(&auth)
+            .await
+            .expect_err("expired token with no refresh must error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("session has expired"),
+            "unexpected message: {msg}"
+        );
+        assert!(msg.contains("nyxid login"), "should point at login: {msg}");
     }
 }

--- a/cli/src/commands/admin.rs
+++ b/cli/src/commands/admin.rs
@@ -19,7 +19,7 @@ async fn run_invite_code(command: InviteCodeCommands) -> Result<()> {
             note,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = json!({});
             if let Some(n) = max_uses {
@@ -56,7 +56,7 @@ async fn run_invite_code(command: InviteCodeCommands) -> Result<()> {
         }
 
         InviteCodeCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api.get("/admin/invite-codes").await?;
 
             match auth.output {
@@ -103,7 +103,7 @@ async fn run_invite_code(command: InviteCodeCommands) -> Result<()> {
         }
 
         InviteCodeCommands::Deactivate { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/admin/invite-codes/{id}"))
                 .await?;
             match auth.output {
@@ -139,7 +139,7 @@ async fn run_user(command: AdminUserCommands) -> Result<()> {
             search,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let mut path = format!("/admin/users?page={page}&per_page={per_page}");
             if let Some(s) = search.as_deref().filter(|s| !s.is_empty()) {
                 path.push_str(&format!("&search={}", urlencoding::encode(s)));
@@ -211,7 +211,7 @@ async fn run_user(command: AdminUserCommands) -> Result<()> {
         }
 
         AdminUserCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let user: Value = api.get(&format!("/admin/users/{id}")).await?;
 
             match auth.output {
@@ -256,7 +256,7 @@ async fn run_user(command: AdminUserCommands) -> Result<()> {
         }
 
         AdminUserCommands::SetRole { id, role, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let path = format!("/admin/users/{id}/role");
 
             // Backwards compatibility: older backends only understand the

--- a/cli/src/commands/api_key.rs
+++ b/cli/src/commands/api_key.rs
@@ -25,7 +25,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
             no_wait,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -143,7 +143,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
         }
 
         ApiKeyCommands::List { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -223,7 +223,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
         }
 
         ApiKeyCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let key: Value = api.get(&format!("/api-keys/{id}")).await?;
 
             match auth.output {
@@ -285,7 +285,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
                 && (no_wait || (interactive_output && crate::wizard::is_browser_flow_eligible()));
 
             if wizard_eligible {
-                let mut api = ApiClient::from_auth(&auth)?;
+                let mut api = ApiClient::from_auth_checked(&auth).await?;
                 // Resolve id-or-name → canonical id BEFORE handing off to
                 // the wizard. Refuses on ambiguous names (see
                 // `find_key_by_name`) so we can never rotate the wrong key.
@@ -308,7 +308,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
 
             // Scripted / headless path — UNCHANGED from pre-wizard
             // behavior so existing CI / scripts keep working.
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api
                 .post(&format!("/api-keys/{id}/rotate"), &serde_json::json!({}))
                 .await?;
@@ -338,7 +338,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/api-keys/{id}")).await?;
             match auth.output {
                 OutputFormat::Json => println!(
@@ -361,7 +361,7 @@ pub async fn run(command: ApiKeyCommands) -> Result<()> {
             callback_url,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = serde_json::Map::new();
 
@@ -468,7 +468,7 @@ async fn bind_credential(
     service_slug: &str,
     credential_label: Option<&str>,
 ) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
 
     // Resolve API key ID
     let key_id = resolve_key_id(&mut api, id_or_name).await?;

--- a/cli/src/commands/approval.rs
+++ b/cli/src/commands/approval.rs
@@ -11,7 +11,7 @@ use crate::org_resolver::resolve_org_id;
 pub async fn run(command: ApprovalCommands) -> Result<()> {
     match command {
         ApprovalCommands::List { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = resolve_optional_org(&mut api, org).await?;
             let path = match org {
                 Some(ref id) => {
@@ -74,7 +74,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
         }
 
         ApprovalCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let req: Value = api.get(&format!("/approvals/requests/{id}")).await?;
 
             match auth.output {
@@ -111,7 +111,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
         }
 
         ApprovalCommands::Approve { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let body = serde_json::json!({ "decision": "approved" });
             let result: Value = api
                 .post(&format!("/approvals/requests/{id}/decide"), &body)
@@ -129,7 +129,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
         }
 
         ApprovalCommands::Deny { id, reason, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let mut body = serde_json::json!({ "decision": "denied" });
             if let Some(reason) = reason {
                 body["reason"] = Value::String(reason);
@@ -150,7 +150,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
         }
 
         ApprovalCommands::Grants { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = resolve_optional_org(&mut api, org).await?;
             let path = match org {
                 Some(ref id) => {
@@ -213,7 +213,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = resolve_optional_org(&mut api, org).await?;
             let path = match org {
                 Some(ref org_id) => format!(
@@ -234,7 +234,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
         }
 
         ApprovalCommands::Enable { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let body = serde_json::json!({ "approval_required": true });
             let result: Value = api.put("/notifications/settings", &body).await?;
 
@@ -265,7 +265,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let body = serde_json::json!({ "approval_required": false });
             let result: Value = api.put("/notifications/settings", &body).await?;
 
@@ -283,7 +283,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
         }
 
         ApprovalCommands::ServiceConfigs { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = resolve_optional_org(&mut api, org).await?;
             let path = match org {
                 Some(ref id) => {
@@ -340,7 +340,7 @@ pub async fn run(command: ApprovalCommands) -> Result<()> {
             org,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = resolve_optional_org(&mut api, org).await?;
             let mut body = serde_json::Map::new();
 

--- a/cli/src/commands/catalog.rs
+++ b/cli/src/commands/catalog.rs
@@ -8,7 +8,7 @@ use crate::cli::{CatalogCommands, OutputFormat};
 pub async fn run(command: CatalogCommands) -> Result<()> {
     match command {
         CatalogCommands::List { all, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let path = if all {
                 "/catalog?include_all=true"
             } else {
@@ -87,7 +87,7 @@ pub async fn run(command: CatalogCommands) -> Result<()> {
             Ok(())
         }
         CatalogCommands::Show { slug, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let item: Value = api.get(&format!("/catalog/{slug}")).await?;
 
             match auth.output {
@@ -261,7 +261,7 @@ pub async fn run(command: CatalogCommands) -> Result<()> {
             Ok(())
         }
         CatalogCommands::Endpoints { slug, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api.get(&format!("/catalog/{slug}/endpoints")).await?;
 
             match auth.output {

--- a/cli/src/commands/channel_bot.rs
+++ b/cli/src/commands/channel_bot.rs
@@ -44,7 +44,7 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
                 );
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -177,7 +177,7 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
                 bail!("No update fields provided");
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api.patch(&format!("/channel-bots/{id}"), &body).await?;
 
             match auth.output {
@@ -197,7 +197,7 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
         }
 
         ChannelBotCommands::List { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -252,7 +252,7 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
         }
 
         ChannelBotCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let bot: Value = api.get(&format!("/channel-bots/{id}")).await?;
 
             match auth.output {
@@ -312,7 +312,7 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/channel-bots/{id}")).await?;
             match auth.output {
                 OutputFormat::Json => println!(
@@ -325,7 +325,7 @@ pub async fn run(command: ChannelBotCommands) -> Result<()> {
         }
 
         ChannelBotCommands::Verify { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api
                 .post(
                     &format!("/channel-bots/{id}/verify"),
@@ -368,7 +368,7 @@ async fn run_route(command: ChannelRouteCommands) -> Result<()> {
             org,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -420,7 +420,7 @@ async fn run_route(command: ChannelRouteCommands) -> Result<()> {
         }
 
         ChannelRouteCommands::List { bot_id, org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -509,7 +509,7 @@ async fn run_route(command: ChannelRouteCommands) -> Result<()> {
             active,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = serde_json::Map::new();
 
@@ -556,7 +556,7 @@ async fn run_route(command: ChannelRouteCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/channel-conversations/{id}"))
                 .await?;
             match auth.output {

--- a/cli/src/commands/channel_event.rs
+++ b/cli/src/commands/channel_event.rs
@@ -108,7 +108,7 @@ async fn run_channel(command: ChannelEventChannelCommands) -> Result<()> {
             org,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -152,7 +152,7 @@ async fn run_channel(command: ChannelEventChannelCommands) -> Result<()> {
         }
 
         ChannelEventChannelCommands::List { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -226,7 +226,7 @@ async fn run_channel(command: ChannelEventChannelCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/channel-conversations/{id}"))
                 .await?;
             match auth.output {

--- a/cli/src/commands/developer_app.rs
+++ b/cli/src/commands/developer_app.rs
@@ -34,7 +34,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
                 bail!("At least one --redirect-uri is required");
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -137,7 +137,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
         }
 
         DeveloperAppCommands::List { org, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -207,7 +207,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
         }
 
         DeveloperAppCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api.get(&format!("/developer/oauth-clients/{id}")).await?;
             match auth.output {
                 OutputFormat::Json => {
@@ -229,7 +229,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
             broker_capability,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = Map::new();
             if let Some(n) = name {
@@ -280,7 +280,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
             if !yes && !confirm(&format!("Delete developer app {id}?"))? {
                 return Ok(());
             }
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/developer/oauth-clients/{id}"))
                 .await?;
             match auth.output {
@@ -309,7 +309,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
                 && (no_wait || (interactive_output && crate::wizard::is_browser_flow_eligible()));
 
             if wizard_eligible {
-                let mut api = ApiClient::from_auth(&auth)?;
+                let mut api = ApiClient::from_auth_checked(&auth).await?;
                 // Best-effort fetch of the display name (client_name)
                 // for the confirm panel. Fallback to id if the fetch
                 // fails — non-fatal.
@@ -333,7 +333,7 @@ pub async fn run(command: DeveloperAppCommands) -> Result<()> {
                 .await;
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api
                 .post(
                     &format!("/developer/oauth-clients/{id}/rotate-secret"),

--- a/cli/src/commands/endpoint.rs
+++ b/cli/src/commands/endpoint.rs
@@ -10,7 +10,7 @@ use crate::cli::{EndpointCommands, OutputFormat};
 pub async fn run(command: EndpointCommands) -> Result<()> {
     match command {
         EndpointCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let endpoints: Value = api.get("/endpoints").await?;
 
             match auth.output {
@@ -50,7 +50,7 @@ pub async fn run(command: EndpointCommands) -> Result<()> {
         }
 
         EndpointCommands::Update { id, url, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let body = serde_json::json!({ "url": url });
             let result: Value = api.put(&format!("/endpoints/{id}"), &body).await?;
 
@@ -77,7 +77,7 @@ pub async fn run(command: EndpointCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/endpoints/{id}")).await?;
             match auth.output {
                 OutputFormat::Json => println!(

--- a/cli/src/commands/external_key.rs
+++ b/cli/src/commands/external_key.rs
@@ -10,7 +10,7 @@ use crate::cli::{ExternalKeyCommands, OutputFormat};
 pub async fn run(command: ExternalKeyCommands) -> Result<()> {
     match command {
         ExternalKeyCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let keys: Value = api.get("/api-keys/external").await?;
 
             match auth.output {
@@ -56,7 +56,7 @@ pub async fn run(command: ExternalKeyCommands) -> Result<()> {
             credential,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let credential = if let Some(c) = credential {
                 c
@@ -97,7 +97,7 @@ pub async fn run(command: ExternalKeyCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/api-keys/external/{id}"))
                 .await?;
             match auth.output {

--- a/cli/src/commands/mfa.rs
+++ b/cli/src/commands/mfa.rs
@@ -35,7 +35,7 @@ pub async fn run(command: MfaCommands) -> Result<()> {
             // working. Note this prints the TOTP secret + URL to
             // the terminal; that's exactly the leak the wizard
             // closes for the default interactive path.
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api.post("/auth/mfa/setup", &serde_json::json!({})).await?;
 
             match auth.output {
@@ -62,7 +62,7 @@ pub async fn run(command: MfaCommands) -> Result<()> {
         }
 
         MfaCommands::Verify { code, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let body = serde_json::json!({ "code": code });
             // Backend route is `/auth/mfa/confirm` — MFA endpoints are
             // nested under `/auth` in `backend/src/routes.rs:63`. The
@@ -93,7 +93,7 @@ pub async fn run(command: MfaCommands) -> Result<()> {
         }
 
         MfaCommands::Status { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let user: Value = api.get("/users/me").await?;
 
             match auth.output {

--- a/cli/src/commands/node.rs
+++ b/cli/src/commands/node.rs
@@ -12,7 +12,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
     match command {
         // --- User-side commands (API calls) ---
         NodeCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let nodes: Value = api.get("/nodes").await?;
             let current_user_id = match auth.output {
                 OutputFormat::Json => None,
@@ -61,7 +61,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
         }
 
         NodeCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             // Try direct ID first; if 404, resolve by name
             let node: Value = match api.get_value(&format!("/nodes/{id}")).await {
@@ -161,7 +161,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
         }
 
         NodeCommands::Transfer { id, to, yes, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let resolved_id = resolve_node_id(&mut api, &id).await?;
             let node: Value = api.get(&format!("/nodes/{resolved_id}")).await?;
             let bindings: Value = api.get(&format!("/nodes/{resolved_id}/bindings")).await?;
@@ -259,7 +259,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
             // behavior. Still prompts from stdin when --name is absent
             // so existing interactive-but-not-wizardable sessions (SSH)
             // keep working the same way they always did.
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let owner_user_id = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -311,7 +311,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
         }
 
         NodeCommands::Delete { id, yes, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let resolved_id = resolve_node_id(&mut api, &id).await?;
 
             if !yes {
@@ -353,7 +353,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
                 && (no_wait || (interactive_output && crate::wizard::is_browser_flow_eligible()));
 
             if wizard_eligible {
-                let mut api = ApiClient::from_auth(&auth)?;
+                let mut api = ApiClient::from_auth_checked(&auth).await?;
                 let resolved_id = resolve_node_id(&mut api, &id).await?;
                 // Best-effort fetch of the display name for the confirm
                 // panel. Falls back to id if the GET fails.
@@ -372,7 +372,7 @@ pub async fn run(command: NodeCommands) -> Result<()> {
             }
 
             // Scripted / headless path — UNCHANGED from pre-wizard behavior.
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let resolved_id = resolve_node_id(&mut api, &id).await?;
             let result: Value = api
                 .post(

--- a/cli/src/commands/node_credential.rs
+++ b/cli/src/commands/node_credential.rs
@@ -18,7 +18,7 @@ pub async fn run(command: NodeCredentialAdminCommands) -> Result<()> {
             label,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let node_id = crate::commands::node::resolve_node_id(&mut api, &node).await?;
             let body = serde_json::json!({
                 "service_slug": slug,
@@ -54,7 +54,7 @@ pub async fn run(command: NodeCredentialAdminCommands) -> Result<()> {
             Ok(())
         }
         NodeCredentialAdminCommands::List { node, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let node_id = crate::commands::node::resolve_node_id(&mut api, &node).await?;
             let response: Value = api
                 .get(&format!("/nodes/{node_id}/credentials/pending"))
@@ -103,7 +103,7 @@ pub async fn run(command: NodeCredentialAdminCommands) -> Result<()> {
             yes,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let node_id = crate::commands::node::resolve_node_id(&mut api, &node).await?;
 
             if !yes {

--- a/cli/src/commands/notification.rs
+++ b/cli/src/commands/notification.rs
@@ -7,7 +7,7 @@ use crate::cli::{NotificationCommands, OutputFormat};
 pub async fn run(command: NotificationCommands) -> Result<()> {
     match command {
         NotificationCommands::Settings { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let settings: Value = api.get("/notifications/settings").await?;
 
             match auth.output {
@@ -47,7 +47,7 @@ pub async fn run(command: NotificationCommands) -> Result<()> {
             approval_telegram,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let mut body = serde_json::Map::new();
 
             if let Some(v) = approval_email {
@@ -81,7 +81,7 @@ pub async fn run(command: NotificationCommands) -> Result<()> {
         }
 
         NotificationCommands::TelegramLink { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api
                 .post("/notifications/telegram/link", &serde_json::json!({}))
                 .await?;
@@ -109,7 +109,7 @@ pub async fn run(command: NotificationCommands) -> Result<()> {
         }
 
         NotificationCommands::TelegramDisconnect { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty("/notifications/telegram").await?;
             match auth.output {
                 OutputFormat::Json => println!(

--- a/cli/src/commands/oauth.rs
+++ b/cli/src/commands/oauth.rs
@@ -24,7 +24,7 @@ pub async fn run(command: OauthCommands) -> Result<()> {
 async fn run_bindings(command: BindingCommands) -> Result<()> {
     match command {
         BindingCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let response: Value = api.get("/users/me/broker-bindings").await?;
             match auth.output {
                 OutputFormat::Json => {
@@ -38,7 +38,7 @@ async fn run_bindings(command: BindingCommands) -> Result<()> {
         }
 
         BindingCommands::Show { id_or_hash, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let response: Value = api.get("/users/me/broker-bindings").await?;
             let binding = resolve_binding(&response, &id_or_hash)?;
             match auth.output {
@@ -57,7 +57,7 @@ async fn run_bindings(command: BindingCommands) -> Result<()> {
             yes,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let response: Value = api.get("/users/me/broker-bindings").await?;
             let binding = resolve_binding(&response, &id_or_hash)?;
             let binding_hash = binding["binding_hash"]

--- a/cli/src/commands/openclaw.rs
+++ b/cli/src/commands/openclaw.rs
@@ -13,7 +13,7 @@ pub async fn run(command: OpenClawCommands) -> Result<()> {
             token_env,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let gateway_url = match url {
                 Some(u) => u,

--- a/cli/src/commands/org.rs
+++ b/cli/src/commands/org.rs
@@ -185,7 +185,7 @@ async fn create_org(
     contact_email: Option<&str>,
     avatar_url: Option<&str>,
 ) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
 
     let mut body = serde_json::json!({ "display_name": display_name });
     if let Some(email) = contact_email
@@ -222,7 +222,7 @@ async fn create_org(
 }
 
 async fn list_orgs(auth: &AuthArgs) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let resp: Value = api.get("/orgs").await?;
 
     match auth.output {
@@ -258,7 +258,7 @@ async fn list_orgs(auth: &AuthArgs) -> Result<()> {
 }
 
 async fn show_org(auth: &AuthArgs, id: &str) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let org: Value = api.get(&format!("/orgs/{id}")).await?;
 
     match auth.output {
@@ -292,7 +292,7 @@ async fn update_org(
     slug: Option<&str>,
     avatar_url: Option<&str>,
 ) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let mut body = serde_json::Map::new();
     if let Some(name) = display_name {
         body.insert("display_name".into(), Value::String(name.to_string()));
@@ -329,7 +329,7 @@ async fn delete_org(auth: &AuthArgs, id: &str, yes: bool) -> Result<()> {
         }
     }
 
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     api.delete_empty(&format!("/orgs/{id}")).await?;
     match auth.output {
         OutputFormat::Json => println!(
@@ -365,7 +365,7 @@ async fn join_org(auth: &AuthArgs, nonce_or_url: &str) -> Result<()> {
         return Err(anyhow!("Empty invite nonce"));
     }
 
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let resp: Value = api
         .post(&format!("/orgs/join/{nonce}"), &serde_json::json!({}))
         .await
@@ -387,7 +387,7 @@ async fn join_org(auth: &AuthArgs, nonce_or_url: &str) -> Result<()> {
 }
 
 async fn set_primary_org(auth: &AuthArgs, org_id: Option<&str>, clear: bool) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
 
     let body = if clear {
         serde_json::json!({ "primary_org_id": Value::Null })
@@ -416,7 +416,7 @@ async fn set_primary_org(auth: &AuthArgs, org_id: Option<&str>, clear: bool) -> 
 // ─────────────────────────────────────────────────────────────────────────────
 
 async fn list_members(auth: &AuthArgs, org_id: &str) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let resp: Value = api.get(&format!("/orgs/{org_id}/members")).await?;
 
     match auth.output {
@@ -476,7 +476,7 @@ async fn add_member(
     if let Some(src) = scope_source {
         validate_scope_source(src)?;
     }
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
 
     let mut body = serde_json::json!({
         "user_id": user_id,
@@ -526,7 +526,7 @@ async fn update_member(
         ));
     }
 
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let mut body = serde_json::Map::new();
     if let Some(role) = role {
         body.insert("role".into(), Value::String(role.to_string()));
@@ -570,7 +570,7 @@ async fn remove_member(auth: &AuthArgs, org_id: &str, member_id: &str, yes: bool
         }
     }
 
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     api.delete_empty(&format!("/orgs/{org_id}/members/{member_id}"))
         .await?;
     match auth.output {
@@ -599,7 +599,7 @@ async fn create_invite(
     if let Some(src) = scope_source {
         validate_scope_source(src)?;
     }
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
 
     let mut body = serde_json::json!({ "role": role });
     if let Some(src) = scope_source {
@@ -663,7 +663,7 @@ fn build_join_url(auth: &AuthArgs, nonce: &str) -> String {
 }
 
 async fn list_invites(auth: &AuthArgs, org_id: &str) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let resp: Value = api.get(&format!("/orgs/{org_id}/invites")).await?;
 
     match auth.output {
@@ -723,7 +723,7 @@ async fn cancel_invite(auth: &AuthArgs, org_id: &str, invite_id: &str, yes: bool
             return Ok(());
         }
     }
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     api.delete_empty(&format!("/orgs/{org_id}/invites/{invite_id}"))
         .await?;
     match auth.output {
@@ -741,7 +741,7 @@ async fn cancel_invite(auth: &AuthArgs, org_id: &str, invite_id: &str, yes: bool
 // ─────────────────────────────────────────────────────────────────────────────
 
 async fn list_role_scopes(auth: &AuthArgs, org_id: &str) -> Result<()> {
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let resp: Value = api.get(&format!("/orgs/{org_id}/role-scopes")).await?;
 
     match auth.output {
@@ -804,7 +804,7 @@ async fn set_role_scope(
         serde_json::json!({ "allowed_service_ids": ids })
     };
 
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     let updated: Value = api
         .put(&format!("/orgs/{org_id}/role-scopes/{role}"), &body)
         .await?;
@@ -827,7 +827,7 @@ async fn set_role_scope(
 
 async fn clear_role_scope(auth: &AuthArgs, org_id: &str, role: &str) -> Result<()> {
     validate_role(role)?;
-    let mut api = ApiClient::from_auth(auth)?;
+    let mut api = ApiClient::from_auth_checked(auth).await?;
     api.delete_empty(&format!("/orgs/{org_id}/role-scopes/{role}"))
         .await?;
     match auth.output {

--- a/cli/src/commands/profile.rs
+++ b/cli/src/commands/profile.rs
@@ -10,7 +10,7 @@ use crate::cli::{OutputFormat, ProfileCommands};
 pub async fn run(command: ProfileCommands) -> Result<()> {
     match command {
         ProfileCommands::Update { name, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let mut body = serde_json::Map::new();
 
             if let Some(name) = name {
@@ -50,7 +50,7 @@ pub async fn run(command: ProfileCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty("/users/me").await?;
             match auth.output {
                 OutputFormat::Json => println!(
@@ -63,7 +63,7 @@ pub async fn run(command: ProfileCommands) -> Result<()> {
         }
 
         ProfileCommands::Consents { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let consents: Value = api.get("/users/me/consents").await?;
 
             match auth.output {
@@ -115,7 +115,7 @@ pub async fn run(command: ProfileCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/users/me/consents/{client_id}"))
                 .await?;
             match auth.output {

--- a/cli/src/commands/provider.rs
+++ b/cli/src/commands/provider.rs
@@ -12,7 +12,7 @@ pub async fn run(command: ProviderCommands) -> Result<()> {
             org,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,

--- a/cli/src/commands/proxy.rs
+++ b/cli/src/commands/proxy.rs
@@ -9,7 +9,7 @@ use crate::cli::{OutputFormat, ProxyCommands};
 pub async fn run(command: ProxyCommands) -> Result<()> {
     match command {
         ProxyCommands::Discover { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let services: Value = api.get("/proxy/services").await?;
 
             match auth.output {
@@ -64,7 +64,7 @@ pub async fn run(command: ProxyCommands) -> Result<()> {
             via_service,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             // Build proxy path
             let trimmed_path = path.trim_start_matches('/');

--- a/cli/src/commands/service.rs
+++ b/cli/src/commands/service.rs
@@ -278,7 +278,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             // `NYXID_NO_WIZARD=1` to restore the pre-wizard stdin
             // prompt path for CI jobs or scripts that rely on it.
             let mut api = if org.is_some() {
-                Some(ApiClient::from_auth(&auth)?)
+                Some(ApiClient::from_auth_checked(&auth).await?)
             } else {
                 None
             };
@@ -336,7 +336,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
 
             let mut api = match api {
                 Some(api) => api,
-                None => ApiClient::from_auth(&auth)?,
+                None => ApiClient::from_auth_checked(&auth).await?,
             };
 
             // Resolve `--via-node <ID_OR_NAME>` to a node ID up-front so that
@@ -720,7 +720,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             org,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             // Accept either a node ID or a node name (from `nyxid node list`).
             let via_node = crate::commands::node::resolve_node_id(&mut api, &via_node)
@@ -827,7 +827,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             to_proxy_only,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let mode = match (to_node_key, to_cert, to_proxy_only) {
                 (true, false, false) => "node_key",
                 (false, true, false) => "cert",
@@ -875,7 +875,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
         }
 
         ServiceCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let resp: Value = api.get("/keys").await?;
 
             match auth.output {
@@ -917,7 +917,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
         }
 
         ServiceCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let svc: Value = api.get(&format!("/keys/{id}")).await?;
 
             match auth.output {
@@ -998,7 +998,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
                 }
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/keys/{id}")).await?;
             match auth.output {
                 OutputFormat::Json => println!(
@@ -1025,7 +1025,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             ws_frame_clear,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = serde_json::Map::new();
             let ws_frame_injections =
@@ -1110,7 +1110,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             credential,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             // Fetch service to get the external api_key_id
             let svc: Value = api.get(&format!("/keys/{id}")).await?;
@@ -1149,7 +1149,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             direct,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             // Accept either a node ID or a node name (from `nyxid node list`).
             let node = match node {
@@ -1189,7 +1189,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             client_secret,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             // Fetch catalog entry to get provider_id
             let catalog: Value = api.get(&format!("/catalog/{slug}")).await?;

--- a/cli/src/commands/service_account.rs
+++ b/cli/src/commands/service_account.rs
@@ -29,7 +29,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
             no_wait,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -116,7 +116,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
             per_page,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let org = match org {
                 Some(raw) => Some(resolve_org_id(&mut api, &raw).await?),
                 None => None,
@@ -181,7 +181,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
         }
 
         ServiceAccountCommands::Show { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api.get(&format!("/admin/service-accounts/{id}")).await?;
             match auth.output {
                 OutputFormat::Json => {
@@ -203,7 +203,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
             is_active,
             auth,
         } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = Map::new();
             if let Some(n) = name {
@@ -250,7 +250,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
             if !yes && !confirm(&format!("Delete service account {id}?"))? {
                 return Ok(());
             }
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             api.delete_empty(&format!("/admin/service-accounts/{id}"))
                 .await?;
             match auth.output {
@@ -279,7 +279,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
                 && (no_wait || (interactive_output && crate::wizard::is_browser_flow_eligible()));
 
             if wizard_eligible {
-                let mut api = ApiClient::from_auth(&auth)?;
+                let mut api = ApiClient::from_auth_checked(&auth).await?;
                 // Best-effort fetch of the display name for the
                 // confirm panel. Fallback to id if the fetch fails —
                 // non-fatal; the confirm panel just shows the raw id.
@@ -303,7 +303,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
                 .await;
             }
 
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api
                 .post(
                     &format!("/admin/service-accounts/{id}/rotate-secret"),
@@ -327,7 +327,7 @@ pub async fn run(command: ServiceAccountCommands) -> Result<()> {
         }
 
         ServiceAccountCommands::RevokeTokens { id, auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let result: Value = api
                 .post(
                     &format!("/admin/service-accounts/{id}/revoke-tokens"),

--- a/cli/src/commands/session.rs
+++ b/cli/src/commands/session.rs
@@ -8,7 +8,7 @@ use crate::cli::{OutputFormat, SessionCommands};
 pub async fn run(command: SessionCommands) -> Result<()> {
     match command {
         SessionCommands::List { auth } => {
-            let mut api = ApiClient::from_auth(&auth)?;
+            let mut api = ApiClient::from_auth_checked(&auth).await?;
             let sessions: Value = api.get("/sessions").await?;
 
             match auth.output {

--- a/cli/src/commands/ssh.rs
+++ b/cli/src/commands/ssh.rs
@@ -56,6 +56,9 @@ pub async fn run(cli: SshCli) -> Result<()> {
             certificate_file,
             ca_public_key_file,
         } => {
+            // Gate before reading the raw token: the SSH WebSocket path uses
+            // this token directly and has no in-flight refresh of its own.
+            crate::auth::ensure_session(&auth).await?;
             let token = crate::auth::resolve_access_token(&auth)?;
             let base_url = auth.resolved_base_url()?;
             let mut api = ApiClient::from_auth(&auth)?;
@@ -81,6 +84,9 @@ pub async fn run(cli: SshCli) -> Result<()> {
             certificate_file,
             ca_public_key_file,
         } => {
+            // Gate before reading the raw token: the SSH WebSocket path uses
+            // this token directly and has no in-flight refresh of its own.
+            crate::auth::ensure_session(&auth).await?;
             let token = crate::auth::resolve_access_token(&auth)?;
             let base_url = auth.resolved_base_url()?;
             let mut api = ApiClient::from_auth(&auth)?;
@@ -132,6 +138,7 @@ pub async fn run(cli: SshCli) -> Result<()> {
             principal,
             command,
         } => {
+            crate::auth::ensure_session(&auth).await?;
             let mut api = ApiClient::from_auth(&auth)?;
             let resolved_id = resolve_ssh_service_id(&mut api, &service_id).await?;
             let service_slug = resolve_user_service_slug(&mut api, &service_id)
@@ -149,6 +156,7 @@ pub async fn run(cli: SshCli) -> Result<()> {
             service_id,
             principal,
         } => {
+            crate::auth::ensure_session(&auth).await?;
             let mut api = ApiClient::from_auth(&auth)?;
             let resolved_id = resolve_ssh_service_id(&mut api, &service_id).await?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -193,11 +193,11 @@ async fn run(cli: Cli) -> Result<()> {
         Commands::ResetPassword(args) => commands::auth_flows::run_reset_password(args).await,
 
         Commands::Whoami(auth) => {
-            let mut api = api::ApiClient::from_auth(&auth)?;
+            let mut api = api::ApiClient::from_auth_checked(&auth).await?;
             commands::whoami::run(&mut api, auth.output).await
         }
         Commands::Status(auth) => {
-            let mut api = api::ApiClient::from_auth(&auth)?;
+            let mut api = api::ApiClient::from_auth_checked(&auth).await?;
             commands::status::run(&mut api, auth.output).await
         }
         Commands::Doctor(args) => commands::doctor::run(args).await,

--- a/cli/src/node/agent.rs
+++ b/cli/src/node/agent.rs
@@ -834,7 +834,8 @@ pub async fn cmd_ssh_credentials(
             }
             let mut node_config = NodeConfig::load(&config_file)?;
             let backend = SecretBackend::from_config(&node_config, &config_dir)?;
-            let mut api = crate::api::ApiClient::from_auth(&auth)
+            let mut api = crate::api::ApiClient::from_auth_checked(&auth)
+                .await
                 .map_err(|error| super::error::Error::Config(error.to_string()))?;
             let resp: serde_json::Value = api
                 .get("/keys")

--- a/cli/src/wizard/mod.rs
+++ b/cli/src/wizard/mod.rs
@@ -355,6 +355,11 @@ pub async fn run_ai_key_wizard(
     prefill: WizardPrefill,
     no_wait: bool,
 ) -> Result<()> {
+    // Validate the session before opening any browser: a dead session prompts
+    // for re-login (or errors cleanly when headless) instead of launching the
+    // wizard only to 401 inside the SPA.
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let prefill_json = pairing::prefill_ai_key(&prefill);
         return pairing::run_no_wait_pairing(auth, pairing::PairingFlow::AiKey, prefill_json).await;
@@ -452,6 +457,8 @@ pub async fn run_node_register_token_wizard(
     prefill: NodeRegisterPrefill,
     no_wait: bool,
 ) -> Result<()> {
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let prefill_json = pairing::prefill_node_register(&prefill);
         return pairing::run_no_wait_pairing(
@@ -537,6 +544,8 @@ pub async fn run_api_key_create_wizard(
     prefill: ApiKeyCreatePrefill,
     no_wait: bool,
 ) -> Result<()> {
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let prefill_json = pairing::prefill_api_key_create(&prefill);
         return pairing::run_no_wait_pairing(
@@ -681,6 +690,10 @@ async fn run_rotation_wizard(
     resource_label: &'static str,
     rerun_command: &'static str,
 ) -> Result<()> {
+    // Covers all four rotation flows (api-key, node-token, SA secret,
+    // developer-app secret) since they funnel through here.
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let pairing_flow = rotation_pairing_flow(flow_kind)?;
         let prefill_json = pairing::prefill_rotate(&prefill);
@@ -838,6 +851,8 @@ pub async fn run_service_account_create_wizard(
     prefill: ServiceAccountCreatePrefill,
     no_wait: bool,
 ) -> Result<()> {
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let prefill_json = pairing::prefill_service_account_create(&prefill);
         return pairing::run_no_wait_pairing(
@@ -928,6 +943,8 @@ pub async fn run_developer_app_create_wizard(
     prefill: DeveloperAppCreatePrefill,
     no_wait: bool,
 ) -> Result<()> {
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let prefill_json = pairing::prefill_developer_app_create(&prefill);
         return pairing::run_no_wait_pairing(
@@ -1022,6 +1039,8 @@ pub async fn run_mfa_setup_wizard(
     prefill: MfaSetupPrefill,
     no_wait: bool,
 ) -> Result<()> {
+    crate::auth::ensure_session(auth).await?;
+
     if no_wait {
         let prefill_json = pairing::prefill_mfa_setup(&prefill);
         return pairing::run_no_wait_pairing(auth, pairing::PairingFlow::MfaSetup, prefill_json)

--- a/cli/src/wizard/server.rs
+++ b/cli/src/wizard/server.rs
@@ -1572,27 +1572,26 @@ async fn conditional_abandon_key(state: &ServerState, key_id: &str) {
 async fn try_refresh_access_token(state: &ServerState) -> Option<String> {
     let profile = state.proxy.profile.as_deref();
     let refresh_token = crate::auth::read_saved_refresh_token_for(profile)?;
-    let url = format!(
-        "{}/api/v1/auth/refresh",
-        state.proxy.base_url_root.trim_end_matches('/')
-    );
-    let resp = state
-        .upstream
-        .post(&url)
-        .json(&json!({ "refresh_token": refresh_token }))
-        .send()
-        .await
-        .ok()?;
-    if !resp.status().is_success() {
-        return None;
+    match crate::auth::exchange_refresh_token(
+        &state.upstream,
+        &state.proxy.base_url_root,
+        &refresh_token,
+    )
+    .await
+    {
+        crate::auth::RefreshExchange::Renewed {
+            access_token,
+            refresh_token,
+        } => {
+            crate::auth::save_tokens_for(profile, &access_token, Some(&refresh_token)).ok()?;
+            *state.access_token.lock().await = access_token.clone();
+            eprintln!("  [wizard] refreshed expired access token for profile {profile:?}");
+            Some(access_token)
+        }
+        crate::auth::RefreshExchange::Unauthorized | crate::auth::RefreshExchange::Network(_) => {
+            None
+        }
     }
-    let tokens: Value = resp.json().await.ok()?;
-    let new_access = tokens.get("access_token")?.as_str()?.to_string();
-    let new_refresh = tokens.get("refresh_token")?.as_str()?.to_string();
-    crate::auth::save_tokens_for(profile, &new_access, Some(&new_refresh)).ok()?;
-    *state.access_token.lock().await = new_access.clone();
-    eprintln!("  [wizard] refreshed expired access token for profile {profile:?}");
-    Some(new_access)
 }
 
 /// `POST /api/proxy/abandon-placeholder` — client-triggered cleanup of a


### PR DESCRIPTION
## Summary

Authenticated `nyxid` commands now validate the saved session **before** doing any user-visible work (opening a browser wizard, connecting an SSH socket, firing a proxy request). A dead/expired session prompts for re-login (interactive) or errors cleanly (headless) instead of dropping the user into a wizard/command that then 401s.

Closes #801.

## What changed

- **`auth::ensure_session(&AuthArgs)`** — skip when a token is supplied explicitly (`--access-token` / `NYXID_ACCESS_TOKEN`); local JWT `exp` check with 60s skew (zero network on the happy path); one silent `/auth/refresh` on expiry; on a dead session, **prompt-to-relogin when interactive** (then exit 0 asking the user to re-run) or a **clean error when headless** (never hangs CI/agents). No auto-login — a browser only opens after explicit consent.
- **`ApiClient::from_auth_checked`** wraps the gate + client build; wired into ~all session-authed command call sites, all 8 wizard entry points, and the SSH arms (gated before the raw WebSocket token is read).
- **Refresh consolidation** — one canonical `auth::exchange_refresh_token` now backs the preflight, `ApiClient`'s in-flight 401 retry, and the wizard server (removed three duplicate copies). `429`/`408` are treated as retryable, not session-dead.

Excluded by design: `mcp config` (local, no authed request), `channel-event push` (agent API-key auth), wizard/pairing internals, and the post-success display-name fetch. `ApiClient`'s in-flight 401-refresh stays as the backstop for mid-command expiry and server-side revocation.

## Scope

CLI only (`cli/`, 29 files). Backend unchanged.

## Testing

- `cargo test -p nyxid-cli` — 364 unit + 1 integration, all green. New `ensure_session` tests: explicit-token skip, valid-token no-op, no-token/expired headless errors, and an end-to-end silent-refresh test with a mock server.
- `cargo clippy -p nyxid-cli` and `cargo fmt` clean (pre-commit hook enforced).
- **CI green** on the rebased commit: CLI Test, Rust Clippy, Rust Format, CLI Wizard Bundle Freshness all pass.

## Review

Independently reviewed by a separate agent: verdict shipping-ready, no BLOCKER/HIGH. Verified base_url has no double-path bug, the refresh consolidation is behavior-preserving, SSH gating order is correct, and exclusions are right. Acted on the one MEDIUM finding (429 → retryable). Remaining LOW/NIT items (e.g. `process::exit(0)` skipping telemetry on the re-login path) are documented and judged acceptable.

## Merge readiness

Rebased onto latest `main` and re-verified: **0 commits behind**, single-commit clean diff, builds + tests + clippy green against current main, CI green. No conflicts. Ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
