### PR TITLE
refactor(landing): align marketing pages with the app design system

### DIFF
--- a/frontend/src/components/layout/auth-layout.tsx
+++ b/frontend/src/components/layout/auth-layout.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { Link, Outlet } from "@tanstack/react-router";
 
+import { useLogoHref } from "@/hooks/use-logo-href";
+
 const AUTH_IMAGES = [
   "/auth-hero.png",
   "/auth-hero-2.png",
@@ -13,6 +15,7 @@ const FADE_MS = 1200;
 
 export function AuthLayout() {
   const [activeIndex, setActiveIndex] = useState(0);
+  const logoHref = useLogoHref();
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -34,7 +37,7 @@ export function AuthLayout() {
       >
         {/* Logo — top-left */}
         <div className="flex shrink-0 items-center px-10 pt-8">
-          <Link to="/login">
+          <Link to={logoHref}>
             <img
               src="/nyxid-coloured-logo.svg"
               alt="NyxID"

--- a/frontend/src/features/blog/components/blog-shell.tsx
+++ b/frontend/src/features/blog/components/blog-shell.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { PortalMarkLogo } from "@/components/shared/portal-mark-logo";
 import { LandingFooter } from "@/features/landing/components/landing-footer";
 import { useScroll } from "@/features/landing/hooks/use-scroll";
+import { useLogoHref } from "@/hooks/use-logo-href";
 import "@/features/landing/landing.css";
 
 // Visually matches LandingNavbar (border, glow, blur) but uses absolute hrefs
@@ -10,6 +11,7 @@ import "@/features/landing/landing.css";
 // non-existent local anchor.
 function BlogNavbar() {
   const [scrolled, setScrolled] = useState(false);
+  const logoHref = useLogoHref();
   useScroll((scrollY) => setScrolled(scrollY > 0));
 
   return (
@@ -21,7 +23,7 @@ function BlogNavbar() {
       }`}
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-        <a href="/" className="flex items-center gap-2">
+        <a href={logoHref} className="flex items-center gap-2">
           <PortalMarkLogo size={32} />
           <span className="font-serif text-xl text-white">NyxID</span>
         </a>

--- a/frontend/src/features/landing/components/app-carousel.tsx
+++ b/frontend/src/features/landing/components/app-carousel.tsx
@@ -9,18 +9,18 @@ function BrowserFrame({
   children: React.ReactNode;
 }) {
   return (
-    <div className="carousel-card w-[480px] shrink-0 overflow-hidden rounded-2xl border border-landing-border-subtle bg-landing-surface shadow-2xl shadow-primary/5">
-      <div className="flex items-center gap-2 border-b border-landing-border-subtle bg-landing-surface-raised px-4 py-2.5">
+    <div className="carousel-card w-[480px] shrink-0 overflow-hidden rounded-2xl border border-border/50 bg-card shadow-2xl shadow-primary/5">
+      <div className="flex items-center gap-2 border-b border-border/50 bg-muted px-4 py-2.5">
         <div className="flex gap-1.5">
           <div className="h-2.5 w-2.5 rounded-full bg-red-500/60" />
           <div className="h-2.5 w-2.5 rounded-full bg-yellow-500/60" />
           <div className="h-2.5 w-2.5 rounded-full bg-green-500/60" />
         </div>
-        <div className="mx-auto rounded-md bg-landing-surface px-3 py-0.5 font-mono text-xs text-gray-500">
+        <div className="mx-auto rounded-md bg-card px-3 py-0.5 font-mono text-xs text-text-tertiary">
           {url}
         </div>
       </div>
-      <div className="bg-landing-bg p-5">{children}</div>
+      <div className="bg-background p-5">{children}</div>
     </div>
   );
 }
@@ -35,15 +35,15 @@ function MobileFrame({
   children: React.ReactNode;
 }) {
   return (
-    <div className="carousel-card w-[380px] shrink-0 overflow-hidden rounded-2xl border border-landing-border-subtle bg-landing-surface shadow-2xl shadow-primary/5">
-      <div className="flex items-center justify-between border-b border-landing-border-subtle bg-landing-surface-raised px-4 py-2.5">
-        <div className="font-mono text-xs text-gray-500">{title}</div>
+    <div className="carousel-card w-[380px] shrink-0 overflow-hidden rounded-2xl border border-border/50 bg-card shadow-2xl shadow-primary/5">
+      <div className="flex items-center justify-between border-b border-border/50 bg-muted px-4 py-2.5">
+        <div className="font-mono text-xs text-text-tertiary">{title}</div>
         <div className="flex items-center gap-2">
           <div className="h-2 w-2 rounded-full bg-primary" />
-          <span className="font-mono text-xs text-gray-500">{badge}</span>
+          <span className="font-mono text-xs text-text-tertiary">{badge}</span>
         </div>
       </div>
-      <div className="bg-landing-bg p-5">{children}</div>
+      <div className="bg-background p-5">{children}</div>
     </div>
   );
 }
@@ -52,10 +52,10 @@ function DashboardCard() {
   return (
     <BrowserFrame url="app.nyxid.io/dashboard">
       <div className="mb-4 flex items-center justify-between">
-        <div className="font-serif text-base text-white">NyxID Dashboard</div>
+        <div className="text-base font-semibold text-foreground">NyxID Dashboard</div>
         <div className="flex items-center gap-2">
           <div className="h-2 w-2 rounded-full bg-success" />
-          <span className="font-mono text-xs text-gray-400">MFA Active</span>
+          <span className="font-mono text-xs text-muted-foreground">MFA Active</span>
         </div>
       </div>
       <div className="mb-4 grid grid-cols-4 gap-3">
@@ -67,9 +67,9 @@ function DashboardCard() {
         ].map((m) => (
           <div
             key={m.l}
-            className="rounded-lg border border-landing-border-subtle bg-landing-surface p-3"
+            className="rounded-lg border border-border/50 bg-card p-3"
           >
-            <div className="font-mono text-xs text-gray-500">{m.l}</div>
+            <div className="font-mono text-xs text-text-tertiary">{m.l}</div>
             <div className="mt-1 text-lg font-semibold text-nyx-secondary-400">
               {m.v}
             </div>
@@ -96,10 +96,10 @@ function ApprovalCard() {
   return (
     <MobileFrame title="NyxID Mobile" badge="Push Received">
       <div className="mb-3 rounded-lg border border-primary/20 bg-primary/5 p-3">
-        <div className="mb-0.5 font-mono text-xs text-primary">
+        <div className="mb-0.5 font-mono text-xs text-nyx-secondary-400">
           APPROVAL REQUEST
         </div>
-        <div className="font-semibold text-white">
+        <div className="font-semibold text-foreground">
           Production Database Access
         </div>
       </div>
@@ -113,8 +113,8 @@ function ApprovalCard() {
           ] as const
         ).map(([l, v]) => (
           <div key={l} className="flex justify-between">
-            <span className="font-mono text-xs text-gray-500">{l}</span>
-            <span className="font-mono text-xs text-white">{v}</span>
+            <span className="font-mono text-xs text-text-tertiary">{l}</span>
+            <span className="font-mono text-xs text-foreground">{v}</span>
           </div>
         ))}
       </div>
@@ -141,7 +141,7 @@ function AuditCard() {
   return (
     <BrowserFrame url="app.nyxid.io/audit">
       <div className="mb-3 flex items-center justify-between">
-        <div className="font-serif text-base text-white">Audit Trail</div>
+        <div className="text-base font-semibold text-foreground">Audit Trail</div>
         <span className="rounded bg-primary/10 px-2 py-0.5 font-mono text-xs text-nyx-secondary-400">
           Live
         </span>
@@ -150,17 +150,17 @@ function AuditCard() {
         {events.map((e, i) => (
           <div
             key={i}
-            className="flex items-center gap-3 rounded-lg border border-landing-border-subtle bg-landing-surface px-3 py-2"
+            className="flex items-center gap-3 rounded-lg border border-border/50 bg-card px-3 py-2"
           >
-            <span className="font-mono text-xs text-gray-500">{e.t}</span>
+            <span className="font-mono text-xs text-text-tertiary">{e.t}</span>
             <div className="min-w-0 flex-1">
-              <div className="truncate text-sm text-white">{e.a}</div>
-              <div className="truncate font-mono text-xs text-gray-400">
+              <div className="truncate text-sm text-foreground">{e.a}</div>
+              <div className="truncate font-mono text-xs text-muted-foreground">
                 {e.u}
               </div>
             </div>
             <span
-              className={`rounded-full px-2 py-0.5 font-mono text-xs ${e.s === "approved" ? "bg-success/10 text-success" : e.s === "pending" ? "bg-yellow-500/10 text-yellow-400" : "bg-destructive/10 text-destructive"}`}
+              className={`rounded-full px-2 py-0.5 font-mono text-xs ${e.s === "approved" ? "bg-success/10 text-success" : e.s === "pending" ? "bg-warning/10 text-warning" : "bg-destructive/10 text-destructive"}`}
             >
               {e.s}
             </span>
@@ -182,18 +182,18 @@ function ConnectionsCard() {
   ];
   return (
     <BrowserFrame url="app.nyxid.io/connections">
-      <div className="mb-3 font-serif text-base text-white">
+      <div className="mb-3 text-base font-semibold text-foreground">
         Connected Services
       </div>
       <div className="grid grid-cols-2 gap-2">
         {providers.map((p) => (
           <div
             key={p.n}
-            className="flex items-center justify-between rounded-lg border border-landing-border-subtle bg-landing-surface p-3"
+            className="flex items-center justify-between rounded-lg border border-border/50 bg-card p-3"
           >
             <div>
-              <div className="text-sm text-white">{p.n}</div>
-              <div className="font-mono text-xs text-gray-500">{p.t}</div>
+              <div className="text-sm text-foreground">{p.n}</div>
+              <div className="font-mono text-xs text-text-tertiary">{p.t}</div>
             </div>
             <span className="font-mono text-xs text-success">{p.s}</span>
           </div>
@@ -213,23 +213,23 @@ function LlmGatewayCard() {
   return (
     <BrowserFrame url="app.nyxid.io/gateway">
       <div className="mb-3 flex items-center justify-between">
-        <div className="font-serif text-base text-white">LLM Gateway</div>
+        <div className="text-base font-semibold text-foreground">LLM Gateway</div>
         <div className="flex items-center gap-2">
           <div className="h-2 w-2 rounded-full bg-success" />
-          <span className="font-mono text-xs text-gray-400">4 active</span>
+          <span className="font-mono text-xs text-muted-foreground">4 active</span>
         </div>
       </div>
       <div className="space-y-1.5">
         {models.map((m) => (
           <div
             key={m.p}
-            className="flex items-center gap-3 rounded-lg border border-landing-border-subtle bg-landing-surface px-3 py-2"
+            className="flex items-center gap-3 rounded-lg border border-border/50 bg-card px-3 py-2"
           >
             <div className="flex-1">
-              <div className="text-sm text-white">{m.p}</div>
-              <div className="font-mono text-xs text-gray-500">{m.m}</div>
+              <div className="text-sm text-foreground">{m.p}</div>
+              <div className="font-mono text-xs text-text-tertiary">{m.m}</div>
             </div>
-            <span className="font-mono text-xs text-gray-500">{m.ms}</span>
+            <span className="font-mono text-xs text-text-tertiary">{m.ms}</span>
             <span className="font-mono text-xs text-success">Ready</span>
           </div>
         ))}
@@ -262,7 +262,7 @@ function ApiKeysCard() {
   return (
     <BrowserFrame url="app.nyxid.io/keys">
       <div className="mb-3 flex items-center justify-between">
-        <div className="font-serif text-base text-white">API Keys</div>
+        <div className="text-base font-semibold text-foreground">API Keys</div>
         <span className="rounded-lg bg-primary/10 px-2.5 py-1 font-mono text-xs text-nyx-secondary-400">
           + Create
         </span>
@@ -271,13 +271,13 @@ function ApiKeysCard() {
         {keys.map((k) => (
           <div
             key={k.n}
-            className="rounded-lg border border-landing-border-subtle bg-landing-surface p-3"
+            className="rounded-lg border border-border/50 bg-card p-3"
           >
             <div className="mb-1 flex justify-between">
-              <span className="text-sm font-medium text-white">{k.n}</span>
-              <span className="font-mono text-xs text-gray-500">{k.u}</span>
+              <span className="text-sm font-medium text-foreground">{k.n}</span>
+              <span className="font-mono text-xs text-text-tertiary">{k.u}</span>
             </div>
-            <div className="mb-1.5 font-mono text-xs text-gray-400">
+            <div className="mb-1.5 font-mono text-xs text-muted-foreground">
               {k.k}
             </div>
             <div className="flex gap-1">
@@ -306,7 +306,7 @@ function RbacCard() {
   return (
     <BrowserFrame url="app.nyxid.io/roles">
       <div className="mb-3 flex items-center justify-between">
-        <div className="font-serif text-base text-white">
+        <div className="text-base font-semibold text-foreground">
           Roles & Permissions
         </div>
         <span className="rounded-lg bg-primary/10 px-2.5 py-1 font-mono text-xs text-nyx-secondary-400">
@@ -317,13 +317,13 @@ function RbacCard() {
         {roles.map((r) => (
           <div
             key={r.n}
-            className="rounded-lg border border-landing-border-subtle bg-landing-surface p-3"
+            className="rounded-lg border border-border/50 bg-card p-3"
           >
             <div className="mb-1.5 flex items-center gap-2">
-              <span className="font-mono text-sm font-medium text-white">
+              <span className="font-mono text-sm font-medium text-foreground">
                 {r.n}
               </span>
-              <span className="rounded bg-landing-surface-raised px-1.5 py-0.5 font-mono text-xs text-gray-500">
+              <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-text-tertiary">
                 {r.m}
               </span>
             </div>
@@ -367,22 +367,22 @@ function ActiveGrantsCard() {
   ];
   return (
     <MobileFrame title="NyxID Mobile" badge="3 active">
-      <div className="mb-3 font-serif text-base text-white">Active Grants</div>
+      <div className="mb-3 text-base font-semibold text-foreground">Active Grants</div>
       <div className="space-y-2">
         {grants.map((g) => (
           <div
             key={g.r}
-            className="rounded-lg border border-landing-border-subtle bg-landing-surface p-3"
+            className="rounded-lg border border-border/50 bg-card p-3"
           >
             <div className="mb-1 flex items-center justify-between">
-              <span className="text-sm font-medium text-white">{g.r}</span>
+              <span className="text-sm font-medium text-foreground">{g.r}</span>
               <span className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs text-nyx-secondary-400">
                 {g.t}
               </span>
             </div>
-            <div className="mb-2 font-mono text-xs text-gray-500">{g.u}</div>
+            <div className="mb-2 font-mono text-xs text-text-tertiary">{g.u}</div>
             <div className="flex items-center justify-between">
-              <span className="font-mono text-xs text-yellow-400">{g.e}</span>
+              <span className="font-mono text-xs text-warning">{g.e}</span>
               <button className="rounded bg-destructive/15 px-2.5 py-0.5 font-mono text-xs text-destructive">
                 Revoke
               </button>
@@ -427,10 +427,10 @@ export function AppCarousel() {
   return (
     <section className="py-24">
       <div className="mx-auto max-w-6xl px-6">
-        <h2 className="mb-4 text-center font-serif text-3xl text-white md:text-4xl">
+        <h2 className="mb-4 text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           {t("carousel.heading")}
         </h2>
-        <p className="mx-auto mb-12 max-w-xl text-center text-gray-300">
+        <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
           {t("carousel.subheading")}
         </p>
       </div>

--- a/frontend/src/features/landing/components/beta-access.tsx
+++ b/frontend/src/features/landing/components/beta-access.tsx
@@ -8,28 +8,28 @@ export function BetaAccess() {
   const { t } = useTranslation();
 
   return (
-    <section id="beta" className="px-6 py-24" ref={ref}>
+    <section id="beta" className="px-6 py-20" ref={ref}>
       <div
         className={`mx-auto max-w-lg ${
           inView ? "animate-fade-up" : "opacity-0"
         }`}
       >
-        <h2 className="mb-4 text-center font-serif text-3xl text-white md:text-4xl">
+        <h2 className="mb-4 text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           {t("beta.heading")}
         </h2>
-        <p className="mx-auto mb-2 max-w-md text-center text-gray-300">
+        <p className="mx-auto mb-2 max-w-md text-center text-muted-foreground">
           {t("beta.subheading")}
         </p>
-        <p className="mb-10 text-center font-mono text-sm text-primary">
+        <p className="mb-10 text-center text-sm font-medium text-nyx-secondary-400">
           {t("beta.socialProof")}
         </p>
 
-        <div className="rounded-2xl border border-landing-border-subtle bg-landing-surface p-8 text-center">
+        <div className="rounded-xl border border-border/50 bg-card p-6 text-center">
           <a
             href={DISCORD_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary py-3.5 font-semibold text-white transition-colors hover:bg-nyx-400"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg nyx-gradient-vivid py-3.5 font-medium text-white shadow-[0_2px_12px_rgba(90,42,241,0.25)] transition-all hover:shadow-[0_4px_20px_rgba(90,42,241,0.35)] hover:brightness-110"
           >
             <svg
               width="20"
@@ -42,7 +42,7 @@ export function BetaAccess() {
             </svg>
             {t("beta.discordCta")}
           </a>
-          <p className="mt-4 text-center text-xs text-gray-500">
+          <p className="mt-4 text-center text-xs text-text-tertiary">
             {t("beta.disclaimer")}
           </p>
         </div>

--- a/frontend/src/features/landing/components/features-section.tsx
+++ b/frontend/src/features/landing/components/features-section.tsx
@@ -70,12 +70,12 @@ export function FeaturesSection() {
   const { t } = useTranslation();
 
   return (
-    <section className="px-6 pt-8 pb-24" ref={ref}>
+    <section className="px-6 pt-8 pb-20" ref={ref}>
       <div className="mx-auto max-w-6xl">
-        <h2 className="mb-4 text-center font-serif text-3xl text-white md:text-4xl">
+        <h2 className="mb-4 text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           {t("features.heading")}
         </h2>
-        <p className="mx-auto mb-16 max-w-2xl text-center text-gray-300">
+        <p className="mx-auto mb-12 max-w-2xl text-center text-muted-foreground">
           {t("features.subheading")}
         </p>
 
@@ -83,18 +83,18 @@ export function FeaturesSection() {
           {featureKeys.map((key, i) => (
             <div
               key={key}
-              className={`group rounded-2xl border border-landing-border-subtle bg-landing-surface p-8 transition-colors hover:border-white/[0.15] ${
+              className={`group rounded-xl border border-border/50 bg-card p-6 transition-colors hover:border-white/[0.15] ${
                 inView ? "animate-fade-up" : "opacity-0"
               }`}
               style={{ animationDelay: `${i * 100}ms` }}
             >
-              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-nyx-secondary-400/10 text-nyx-secondary-400">
                 {icons[i]}
               </div>
-              <h3 className="mb-2 font-mono text-lg font-medium text-white">
+              <h3 className="mb-2 text-lg font-semibold text-foreground">
                 {t(`features.${key}.title`)}
               </h3>
-              <p className="leading-relaxed text-gray-300">
+              <p className="leading-relaxed text-muted-foreground">
                 {t(`features.${key}.description`)}
               </p>
             </div>

--- a/frontend/src/features/landing/components/hero.tsx
+++ b/frontend/src/features/landing/components/hero.tsx
@@ -90,29 +90,32 @@ export function Hero() {
         <img
           src="/nyxid-wordmark.svg"
           alt="NyxID"
-          className="mb-8 h-12 w-auto drop-shadow-[0_0_24px_rgba(90,42,241,0.45)] md:h-14"
+          className="mb-7 h-9 w-auto drop-shadow-[0_0_24px_rgba(90,42,241,0.45)] md:h-10"
         />
-        <h1 className="max-w-[700px] text-center font-serif text-[32px] leading-tight text-white md:text-5xl lg:text-6xl">
+        <h1
+          className="max-w-[640px] text-center text-[28px] font-bold leading-[1.1] tracking-tight text-foreground sm:text-4xl lg:text-5xl"
+          style={{ letterSpacing: "-0.03em" }}
+        >
           {t("hero.eyebrow")}
         </h1>
 
-        <p className="mt-6 max-w-2xl text-center text-lg leading-relaxed text-gray-300">
+        <p className="mt-5 max-w-xl text-center text-[15px] leading-relaxed text-muted-foreground sm:text-base">
           {t("hero.title")}
         </p>
 
-        <p className="mt-4 max-w-2xl text-center text-base leading-relaxed text-gray-400">
+        <p className="mt-3 max-w-xl text-center text-[13px] leading-relaxed text-muted-foreground/80 sm:text-sm">
           {t("hero.subtitle")}
         </p>
 
-        <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+        <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
           <a
             href={`/register${typeof window !== "undefined" ? window.location.search : ""}`}
-            className="inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-4 text-lg font-semibold text-white transition-all hover:bg-nyx-400 hover:shadow-lg hover:shadow-primary/25"
+            className="inline-flex items-center gap-2 rounded-lg nyx-gradient-vivid px-6 py-3 text-sm font-medium text-white shadow-[0_2px_12px_rgba(90,42,241,0.25)] transition-all hover:shadow-[0_4px_20px_rgba(90,42,241,0.35)] hover:brightness-110"
           >
             {t("hero.ctaRegister")}
             <svg
-              width="20"
-              height="20"
+              width="16"
+              height="16"
               viewBox="0 0 20 20"
               fill="none"
               aria-hidden="true"
@@ -128,13 +131,13 @@ export function Hero() {
           </a>
           <a
             href="#beta"
-            className="inline-flex items-center gap-2 rounded-xl border border-primary/40 px-8 py-4 text-lg font-semibold text-white transition-colors hover:bg-primary/10"
+            className="inline-flex items-center gap-2 rounded-lg border border-white/[0.08] px-6 py-3 text-sm font-medium text-foreground transition-colors hover:border-white/[0.15] hover:bg-white/[0.03]"
           >
             {t("hero.ctaEarlyAccess")}
           </a>
         </div>
 
-        <p className="mt-4 text-sm text-gray-500">{t("hero.ctaSubtext")}</p>
+        <p className="mt-4 text-[11px] text-text-tertiary">{t("hero.ctaSubtext")}</p>
       </div>
     </section>
   );

--- a/frontend/src/features/landing/components/how-it-works.tsx
+++ b/frontend/src/features/landing/components/how-it-works.tsx
@@ -60,26 +60,30 @@ export function HowItWorks() {
       if (!el) return;
       const threshold = (i + 0.5) / stepKeys.length;
       if (p >= threshold) {
-        el.classList.add("border-primary/60", "shadow-lg", "shadow-primary/20");
-        el.classList.remove("border-landing-border-subtle");
+        el.classList.add(
+          "border-nyx-secondary-400/50",
+          "shadow-lg",
+          "shadow-nyx-secondary-400/20",
+        );
+        el.classList.remove("border-border/50");
       } else {
         el.classList.remove(
-          "border-primary/60",
+          "border-nyx-secondary-400/50",
           "shadow-lg",
-          "shadow-primary/20",
+          "shadow-nyx-secondary-400/20",
         );
-        el.classList.add("border-landing-border-subtle");
+        el.classList.add("border-border/50");
       }
     });
   });
 
   return (
-    <section className="px-6 py-24">
+    <section className="px-6 py-20">
       <div className="mx-auto max-w-4xl" ref={sectionRef}>
-        <h2 className="mb-4 text-center font-serif text-3xl text-white md:text-4xl">
+        <h2 className="mb-4 text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           {t("howItWorks.heading")}
         </h2>
-        <p className="mx-auto mb-16 max-w-xl text-center text-gray-300">
+        <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
           {t("howItWorks.subheading")}
         </p>
 
@@ -87,14 +91,14 @@ export function HowItWorks() {
           {/* Track — positioned dynamically between first and last step centers */}
           <div
             ref={trackRef}
-            className="absolute left-[39px] w-[2px] bg-primary/10"
+            className="absolute left-[39px] w-[2px] bg-nyx-secondary-400/10"
             style={{ top: 0, height: 0 }}
           />
 
           {/* Fill */}
           <div
             ref={lineRef}
-            className="absolute left-[39px] w-[2px] bg-gradient-to-b from-primary via-nyx-300 to-primary"
+            className="absolute left-[39px] w-[2px] bg-gradient-to-b from-nyx-secondary-400 via-nyx-300 to-nyx-secondary-400"
             style={{ top: 0, height: 0, transition: "height 0.05s linear" }}
           />
 
@@ -106,9 +110,9 @@ export function HowItWorks() {
               top: "0%",
               opacity: 0,
               background:
-                "radial-gradient(circle, rgba(139,92,246,0.8) 0%, rgba(139,92,246,0.3) 50%, transparent 70%)",
+                "radial-gradient(circle, rgba(166,114,251,0.8) 0%, rgba(166,114,251,0.3) 50%, transparent 70%)",
               boxShadow:
-                "0 0 12px rgba(139,92,246,0.6), 0 0 30px rgba(139,92,246,0.3)",
+                "0 0 12px rgba(166,114,251,0.6), 0 0 30px rgba(166,114,251,0.3)",
               transition: "top 0.05s linear, opacity 0.3s ease",
             }}
           />
@@ -122,15 +126,15 @@ export function HowItWorks() {
                 ref={(el) => {
                   stepRefs.current[i] = el;
                 }}
-                className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl border border-landing-border-subtle bg-landing-surface font-mono text-2xl font-medium text-primary transition-all duration-500"
+                className="flex h-20 w-20 shrink-0 items-center justify-center rounded-xl border border-border/50 bg-card font-mono text-2xl font-medium text-nyx-secondary-400 transition-all duration-500"
               >
                 {stepNumbers[i]}
               </div>
               <div className="pt-2">
-                <h3 className="mb-2 text-lg font-semibold text-white">
+                <h3 className="mb-2 text-lg font-semibold text-foreground">
                   {t(`howItWorks.${key}.title`)}
                 </h3>
-                <p className="leading-relaxed text-gray-300">
+                <p className="leading-relaxed text-muted-foreground">
                   {t(`howItWorks.${key}.description`)}
                 </p>
               </div>

--- a/frontend/src/features/landing/components/install-skills.tsx
+++ b/frontend/src/features/landing/components/install-skills.tsx
@@ -19,27 +19,27 @@ export function InstallSkills() {
   };
 
   return (
-    <section className="border-y border-landing-border-subtle bg-landing-surface/40 px-6 py-20">
+    <section className="border-y border-border/60 bg-card/40 px-6 py-20">
       <div className="mx-auto max-w-3xl text-center">
-        <h2 className="font-serif text-3xl text-white md:text-4xl">
+        <h2 className="text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           {t("install.heading")}
         </h2>
-        <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-gray-400">
+        <p className="mx-auto mt-4 max-w-2xl text-base leading-relaxed text-muted-foreground">
           {t("install.subheading")}
         </p>
 
-        <div className="mt-10 flex flex-col items-stretch overflow-hidden rounded-xl border border-primary/30 bg-black/50 backdrop-blur-md sm:flex-row">
+        <div className="mt-10 flex flex-col items-stretch overflow-hidden rounded-xl border border-border bg-black/40 backdrop-blur-md sm:flex-row">
           <input
             readOnly
             value={INSTALL_COMMAND}
             onFocus={(e) => e.currentTarget.select()}
             aria-label={t("install.commandLabel")}
-            className="flex-1 truncate bg-transparent px-5 py-4 text-left font-mono text-sm text-gray-200 outline-none"
+            className="flex-1 truncate bg-transparent px-5 py-4 text-left font-mono text-sm text-muted-foreground outline-none"
           />
           <button
             type="button"
             onClick={handleCopy}
-            className="flex items-center justify-center gap-2 border-t border-primary/30 bg-primary/15 px-6 py-4 text-sm font-semibold text-white transition-colors hover:bg-primary/30 sm:border-l sm:border-t-0"
+            className="flex items-center justify-center gap-2 border-t border-border bg-nyx-secondary-400/10 px-6 py-4 text-sm font-medium text-nyx-secondary-400 transition-colors hover:bg-nyx-secondary-400/20 sm:border-l sm:border-t-0"
           >
             {copied ? (
               <>
@@ -91,7 +91,7 @@ export function InstallSkills() {
           </button>
         </div>
 
-        <p className="mt-5 text-sm text-gray-500">{t("install.helper")}</p>
+        <p className="mt-5 text-sm text-text-tertiary">{t("install.helper")}</p>
       </div>
     </section>
   );

--- a/frontend/src/features/landing/components/landing-footer.tsx
+++ b/frontend/src/features/landing/components/landing-footer.tsx
@@ -2,21 +2,21 @@ import { Link } from "@tanstack/react-router";
 
 export function LandingFooter() {
   return (
-    <footer className="border-t border-landing-border-subtle px-6 py-6">
+    <footer className="border-t border-border/60 px-6 py-6">
       <div className="mx-auto flex max-w-6xl flex-col items-center gap-3 sm:flex-row sm:justify-between">
-        <p className="font-mono text-xs text-gray-500">
+        <p className="text-xs text-text-tertiary">
           &copy; {new Date().getFullYear()} Chrono AI. All rights reserved.
         </p>
         <div className="flex items-center gap-4">
           <Link
             to="/terms"
-            className="font-mono text-xs text-gray-500 transition-colors hover:text-white"
+            className="text-xs text-text-tertiary transition-colors hover:text-foreground"
           >
             Terms of Use
           </Link>
           <Link
             to="/privacy"
-            className="font-mono text-xs text-gray-500 transition-colors hover:text-white"
+            className="text-xs text-text-tertiary transition-colors hover:text-foreground"
           >
             Privacy
           </Link>
@@ -24,7 +24,7 @@ export function LandingFooter() {
             href="https://discord.gg/QMvcs8UQBW"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 transition-colors hover:text-white"
+            className="text-text-tertiary transition-colors hover:text-foreground"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-label="Discord">
               <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z" />
@@ -34,7 +34,7 @@ export function LandingFooter() {
             href="https://github.com/ChronoAIProject/NyxID"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 transition-colors hover:text-white"
+            className="text-text-tertiary transition-colors hover:text-foreground"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-label="GitHub">
               <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />

--- a/frontend/src/features/landing/components/landing-navbar.tsx
+++ b/frontend/src/features/landing/components/landing-navbar.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LanguageSwitcher } from "./language-switcher";
 import { useScroll } from "../hooks/use-scroll";
+import { useAuthStore } from "@/stores/auth-store";
 
 export function LandingNavbar() {
   const [scrolled, setScrolled] = useState(false);
   const { t } = useTranslation();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   useScroll((scrollY) => setScrolled(scrollY > 0));
 
@@ -16,14 +18,14 @@ export function LandingNavbar() {
 
   return (
     <nav
-      className={`fixed top-0 left-0 right-0 z-50 border-b backdrop-blur-md transition-all duration-500 ${
+      className={`fixed top-0 left-0 right-0 z-50 border-b backdrop-blur-md transition-colors duration-300 ${
         scrolled
-          ? "border-primary/20 bg-landing-bg/80 navbar-glow"
-          : "border-landing-border-subtle bg-landing-bg/80"
+          ? "border-border/60 bg-landing-bg/80"
+          : "border-transparent bg-landing-bg/60"
       }`}
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-        <a href="#" className="flex items-center">
+        <a href={isAuthenticated ? "/dashboard" : "#"} className="flex items-center">
           <img src="/nyxid-wordmark.svg" alt="NyxID" className="h-8 w-auto" />
         </a>
 
@@ -31,13 +33,13 @@ export function LandingNavbar() {
           <LanguageSwitcher />
           <a
             href={loginHref}
-            className="rounded-lg border border-primary/40 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/10"
+            className="rounded-lg border border-white/[0.08] px-5 py-2 text-sm font-medium text-foreground transition-colors hover:border-white/[0.15] hover:bg-white/[0.03]"
           >
             {t("nav.login")}
           </a>
           <a
             href={registerHref}
-            className="hidden rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-nyx-400 md:inline-block"
+            className="hidden rounded-lg nyx-gradient-vivid px-5 py-2 text-sm font-medium text-white shadow-[0_0_12px_rgba(90,42,241,0.25)] transition-all hover:shadow-[0_0_18px_rgba(90,42,241,0.35)] hover:brightness-110 md:inline-block"
           >
             {t("nav.register")}
           </a>

--- a/frontend/src/features/landing/components/language-switcher.tsx
+++ b/frontend/src/features/landing/components/language-switcher.tsx
@@ -44,7 +44,7 @@ export function LanguageSwitcher() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
-        className="flex h-9 items-center gap-1 rounded-full bg-landing-surface-raised/60 px-2.5 font-mono text-xs text-gray-400 transition-colors hover:text-white"
+        className="flex h-9 items-center gap-1 rounded-full bg-white/[0.04] px-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
         aria-label="Change language"
       >
         <svg
@@ -61,19 +61,19 @@ export function LanguageSwitcher() {
           <path d="M2 12h20" />
           <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
         </svg>
-        <span className="text-gray-300">{current?.label ?? "EN"}</span>
+        <span className="text-foreground">{current?.label ?? "EN"}</span>
       </button>
 
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1.5 min-w-[80px] overflow-hidden rounded-xl border border-landing-border-subtle bg-landing-surface shadow-xl shadow-black/40">
+        <div className="absolute left-0 top-full z-50 mt-1.5 min-w-[80px] overflow-hidden rounded-xl border border-border/50 bg-card shadow-xl shadow-black/40">
           {languages.map((lang) => (
             <button
               key={lang.code}
               onClick={() => select(lang.code)}
-              className={`flex w-full items-center px-4 py-2 font-mono text-xs transition-colors ${
+              className={`flex w-full items-center px-4 py-2 text-xs transition-colors ${
                 i18n.language === lang.code
-                  ? "text-primary"
-                  : "text-gray-400 hover:bg-landing-surface-raised hover:text-white"
+                  ? "text-nyx-secondary-400"
+                  : "text-muted-foreground hover:bg-white/[0.06] hover:text-foreground"
               }`}
             >
               {lang.label}

--- a/frontend/src/features/landing/components/scroll-fab.tsx
+++ b/frontend/src/features/landing/components/scroll-fab.tsx
@@ -29,7 +29,7 @@ export function ScrollFab() {
   return (
     <button
       onClick={scrollToTop}
-      className={`fixed z-50 flex items-center justify-center rounded-full border bg-landing-surface/90 backdrop-blur-sm transition-all duration-500 ${
+      className={`fixed z-50 flex items-center justify-center rounded-full border bg-card/90 backdrop-blur-sm transition-all duration-500 ${
         progress > 0.95
           ? "border-primary/50 fab-glow-full"
           : "border-primary/30 shadow-lg shadow-primary/20"
@@ -62,7 +62,7 @@ export function ScrollFab() {
           cx="22"
           cy="22"
           r="15"
-          fill="#8B5CF6"
+          fill="#A672FB"
           opacity={0.5}
           mask="url(#fab-moon-mask)"
         />
@@ -73,7 +73,7 @@ export function ScrollFab() {
         height={22}
         viewBox="0 0 20 22"
         fill="none"
-        stroke="#DDD6FE"
+        stroke="#E4D2FD"
         strokeWidth={2}
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/frontend/src/features/landing/components/who-its-for.tsx
+++ b/frontend/src/features/landing/components/who-its-for.tsx
@@ -54,12 +54,12 @@ export function WhoItsFor() {
   const { t } = useTranslation();
 
   return (
-    <section className="px-6 py-24" ref={ref}>
+    <section className="px-6 py-20" ref={ref}>
       <div className="mx-auto max-w-6xl">
-        <h2 className="mb-4 text-center font-serif text-3xl text-white md:text-4xl">
+        <h2 className="mb-4 text-center text-3xl font-bold tracking-tight text-foreground md:text-4xl">
           {t("whoItsFor.heading")}
         </h2>
-        <p className="mx-auto mb-16 max-w-xl text-center text-gray-300">
+        <p className="mx-auto mb-12 max-w-xl text-center text-muted-foreground">
           {t("whoItsFor.subheading")}
         </p>
 
@@ -67,18 +67,18 @@ export function WhoItsFor() {
           {segmentKeys.map((key, i) => (
             <div
               key={key}
-              className={`rounded-2xl border border-landing-border-subtle bg-landing-surface p-8 transition-colors hover:border-white/[0.15] ${
+              className={`rounded-xl border border-border/50 bg-card p-6 transition-colors hover:border-white/[0.15] ${
                 inView ? "animate-fade-up" : "opacity-0"
               }`}
               style={{ animationDelay: `${i * 120}ms` }}
             >
-              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-nyx-secondary-400/10 text-nyx-secondary-400">
                 {icons[i]}
               </div>
-              <h3 className="mb-2 font-mono text-lg font-medium text-white">
+              <h3 className="mb-2 text-lg font-semibold text-foreground">
                 {t(`whoItsFor.${key}.title`)}
               </h3>
-              <p className="leading-relaxed text-gray-300">
+              <p className="leading-relaxed text-muted-foreground">
                 {t(`whoItsFor.${key}.description`)}
               </p>
             </div>

--- a/frontend/src/features/landing/components/why-nyx.tsx
+++ b/frontend/src/features/landing/components/why-nyx.tsx
@@ -145,7 +145,7 @@ export function WhyNyx() {
               top: "10%",
               left: "5%",
               background:
-                "radial-gradient(circle, rgba(139,92,246,0.14) 0%, rgba(139,92,246,0.04) 45%, transparent 70%)",
+                "radial-gradient(circle, rgba(166,114,251,0.14) 0%, rgba(166,114,251,0.04) 45%, transparent 70%)",
               filter: "blur(20px)",
             }}
           />
@@ -191,16 +191,16 @@ export function WhyNyx() {
           className={`relative mx-auto max-w-3xl ${inView ? "animate-fade-up" : "opacity-0"}`}
           style={{ zIndex: 10 }}
         >
-          <div className="rounded-2xl border border-landing-border-subtle bg-landing-surface/90 p-10 backdrop-blur-sm md:p-14">
-            <p className="mb-6 font-mono text-xs uppercase tracking-widest text-primary">
+          <div className="rounded-xl border border-border/50 bg-card/90 p-8 backdrop-blur-sm md:p-12">
+            <p className="mb-6 text-xs font-medium uppercase tracking-widest text-nyx-secondary-400">
               {t("whyNyx.label")}
             </p>
 
-            <blockquote className="mb-8 font-serif text-2xl leading-relaxed text-white md:text-3xl">
+            <blockquote className="mb-8 text-2xl font-semibold leading-relaxed tracking-tight text-foreground md:text-3xl">
               {t("whyNyx.quote")}
             </blockquote>
 
-            <div className="space-y-4 leading-relaxed text-gray-300">
+            <div className="space-y-4 leading-relaxed text-muted-foreground">
               <p>{t("whyNyx.para1")}</p>
               <p>{t("whyNyx.para2")}</p>
               <p className="font-medium text-nyx-100">

--- a/frontend/src/features/landing/landing.css
+++ b/frontend/src/features/landing/landing.css
@@ -64,7 +64,8 @@ html {
   will-change: auto;
 }
 
-/* Navbar purple glow — animated wave light (brand primary #5A2AF1) */
+/* Navbar purple glow — consumed by the blog shell (features/blog/components/blog-shell.tsx).
+   The landing navbar no longer uses this (it has a quiet static border); kept for the blog. */
 @keyframes navbar-wave {
   0% {
     background-position: -100% 0;
@@ -156,47 +157,11 @@ html {
   animation: fab-glow-pulse 3s ease-in-out infinite;
 }
 
-/* Star twinkle */
-@keyframes star-twinkle {
-  0%,
-  100% {
-    opacity: 0.2;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-
-.animate-star-twinkle {
-  animation: star-twinkle 3s ease-in-out infinite;
-}
-
-/* Scroll indicator bounce */
-@keyframes scroll-down {
-  0% {
-    transform: translateY(-100%);
-    opacity: 0;
-  }
-  30% {
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(100%);
-    opacity: 0;
-  }
-}
-
-.animate-scroll-down {
-  animation: scroll-down 1.5s ease-in-out infinite;
-}
-
-/* Reduced motion support for parallax */
+/* Reduced motion: pause looping decorative landing animations */
 @media (prefers-reduced-motion: reduce) {
-  .animate-star-twinkle {
-    animation: none;
-    opacity: 0.5;
-  }
-  .animate-scroll-down {
+  .animate-scroll,
+  .glow-pulse,
+  .fab-glow-full {
     animation: none;
   }
 }

--- a/frontend/src/hooks/use-logo-href.ts
+++ b/frontend/src/hooks/use-logo-href.ts
@@ -1,0 +1,10 @@
+import { useAuthStore } from "@/stores/auth-store";
+
+/**
+ * Where the NyxID logo should navigate: the dashboard when the user is signed
+ * in, otherwise the public landing page. Used by every clickable logo so the
+ * behavior stays consistent across the app, auth, blog, and legal pages.
+ */
+export function useLogoHref(): "/" | "/dashboard" {
+  return useAuthStore((s) => s.isAuthenticated) ? "/dashboard" : "/";
+}

--- a/frontend/src/pages/_legal-document-page.tsx
+++ b/frontend/src/pages/_legal-document-page.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
+
+import { useLogoHref } from "@/hooks/use-logo-href";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -31,6 +33,7 @@ function stripFrontMatter(md: string): { content: string; effectiveDate: string 
 }
 
 export function LegalDocumentPage({ title, mdPath, docKey }: Props) {
+  const logoHref = useLogoHref();
   const [content, setContent] = useState<string>("");
   const [effectiveDate, setEffectiveDate] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -69,7 +72,7 @@ export function LegalDocumentPage({ title, mdPath, docKey }: Props) {
     >
       <div className="w-full max-w-[680px] space-y-8">
         <div className="flex flex-col items-center gap-4">
-          <Link to="/" className="flex items-center transition-opacity hover:opacity-80">
+          <Link to={logoHref} className="flex items-center transition-opacity hover:opacity-80">
             <img src="/nyxid-wordmark.svg" alt="NyxID" className="h-8 w-auto" />
           </Link>
           <h1 className="text-2xl font-bold text-foreground">{title}</h1>

--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 
+import { useLogoHref } from "@/hooks/use-logo-href";
+
 // ── Last updated date (update on each revision) ──
 const EFFECTIVE_DATE = "2026-02-25";
 
@@ -22,6 +24,8 @@ function Section({
 }
 
 export function PrivacyPage() {
+  const logoHref = useLogoHref();
+
   return (
     <div
       className="flex min-h-dvh flex-col items-center bg-background px-4 py-8"
@@ -34,7 +38,7 @@ export function PrivacyPage() {
         {/* ── Header ── */}
         <div className="flex flex-col items-center gap-4">
           <Link
-            to="/"
+            to={logoHref}
             className="flex items-center transition-opacity hover:opacity-80"
           >
             <img src="/nyxid-wordmark.svg" alt="NyxID" className="h-8 w-auto" />


### PR DESCRIPTION
## What & why

The marketing landing page (and the shared blog / legal / auth chrome) had drifted from the logged-in app: an unstyled serif heading, raw Tailwind grays, a parallel `landing-*` token set, flat CTAs, and off-palette glows. This re-skins those surfaces to the **live app's design tokens + Mona Sans** so the whole product reads as one design language.

> Note on source of truth: where `DESIGN.md`'s literal values (`#9775fa`, Space Grotesk/Playfair) conflict with the implemented app (`app.css`: `#5A2AF1`/`#A672FB`, Mona Sans), this follows the **live app**. `DESIGN.md` is intentionally left unchanged — its stale concrete values are a known, separate cleanup.

## Design coherence
- Replace raw grays / parallel `landing-*` tokens with app tokens (`text-foreground` · `text-muted-foreground` · `text-text-tertiary` · `bg-card` · `border-border/50` · `nyx-secondary-400` · `nyx-gradient-vivid`).
- Headings move off the unstyled serif fallback to **Mona Sans**.
- Primary CTAs use `nyx-gradient-vivid`; secondary buttons are neutral ghosts.
- Recolor off-palette `#8B5CF6` glows (moon, scroll progress, FAB) to brand purple.
- Tighten the **hero** toward the app's compact type scale; unify the how-it-works progress rail to the accent ramp.
- Tame the landing navbar's pulsing glow to a quiet static border, and **restore the `.navbar-glow` CSS the blog navbar still imports** (regression caught in review).

## Logo navigation
- New `useLogoHref()` hook → the NyxID logo links to **`/` when signed out** and **`/dashboard` when signed in**, applied across auth, landing, blog, and legal pages. The landing's own navbar keeps `#` (scroll-to-top) when signed out since you're already there. The dashboard top-bar logo was already correct (authenticated-only).

## Verification
- `tsc` + `vite build` ✅ · ESLint ✅ (0 errors; pre-existing warnings only) · pre-commit hook passed.
- Browser-verified logged-out logo destinations across `/login`, `/`, `/blog`, `/privacy`, `/terms`.
- Reviewed by two independent agents (correctness + design): both **P1s found and fixed** (the blog `.navbar-glow` regression and a low-contrast carousel accent); design verdict 8/10 "land it."

## Not in this PR
- The page-wide density rollout beyond the hero (section headings + 10px overlines) — deferred.
- Independent `codex review` couldn't run (local codex CLI's `llm.aelf.dev` key is expired); the agent reviews stand in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)