### PR TITLE
fix(ci): build frontend image from repo root so docs publish-gate finds docs/site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,14 @@ frontend/dist/
 keys/
 docs/
 !docs/AI_AGENT_PLAYBOOK.md
+# The public docs site (docs/site/**) is the build-time source for the
+# frontend image's docs pages: the vite `nyxid-docs-sync` plugin reads it
+# via ../docs/site and its publish-gate fails the build if absent. The
+# frontend image uses the repo root as its context (see publish-images.yml),
+# so re-include the docs tree here. Backend/node-agent images only COPY
+# docs/AI_AGENT_PLAYBOOK.md, so this does not change those images.
+!docs/site
+!docs/site/**
 k8s/
 node_modules/
 SERVICES_OVERHAUL_PLAN.md

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -68,7 +68,10 @@ jobs:
             context: .
             file: backend/Dockerfile
           - component: frontend
-            context: frontend
+            # Repo-root context (not frontend/): the frontend image needs the
+            # docs source at docs/site, read by the vite docs-sync publish-gate
+            # at build time, which lives outside frontend/. See frontend/Dockerfile.
+            context: .
             file: frontend/Dockerfile
           - component: node-agent
             context: .

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -137,8 +137,9 @@ Production Dockerfiles are provided for both backend and frontend with multi-sta
 # Build backend (context is the repo root for workspace Cargo.toml)
 docker build -f backend/Dockerfile -t nyxid-backend .
 
-# Build frontend
-docker build -f frontend/Dockerfile -t nyxid-frontend frontend/
+# Build frontend (context is the repo root so the build can read docs/site,
+# the source for the in-app docs pages)
+docker build -f frontend/Dockerfile -t nyxid-frontend .
 ```
 
 The **backend Dockerfile** (`backend/Dockerfile`) uses a two-stage build:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,22 @@
 # ── Stage 1: Build ────────────────────────────────────────────────────────────
+# NOTE: this image is built with the *repo root* as the Docker context
+# (see .github/workflows/publish-images.yml), not the frontend/ dir. The
+# frontend's vite `nyxid-docs-sync` plugin reads the public docs source at
+# `../docs/site` (repo root) during `vite build` and its publish-gate fails
+# the build if that tree is absent — so the docs must be present alongside
+# the frontend at build time, which a frontend/-only context cannot provide.
 FROM node:20-alpine AS builder
 
-WORKDIR /build
+WORKDIR /build/frontend
 
-COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
-COPY . .
+COPY frontend/ ./
+
+# Public docs site source. The docs-sync plugin resolves it relative to the
+# frontend dir (`../docs/site`), so it must land at /build/docs/site.
+COPY docs/ /build/docs/
 
 # Telemetry config (DSN, host, share-back flag) is fetched at runtime
 # from the backend's /api/v1/public/config endpoint — no build-time
@@ -19,10 +29,10 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 # Copy the built SPA
-COPY --from=builder /build/dist /usr/share/nginx/html
+COPY --from=builder /build/frontend/dist /usr/share/nginx/html
 
 # Copy the nginx config template (envsubst runs automatically via nginx entrypoint)
-COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY frontend/nginx.conf.template /etc/nginx/templates/default.conf.template
 
 ENV BACKEND_URL=http://backend:3001
 


### PR DESCRIPTION
## Problem

The **Publish Images** workflow's `Build frontend (linux/amd64)` and `(linux/arm64)` jobs have been failing since #814, so every push to `main` fails to publish a frontend image. The lint/test pipeline (`CI Gate`) is unaffected and green.

## Root cause

The failure is in the Docker image build's `npm run build`, not in any frontend code:

```
[plugin nyxid-docs-sync]
RolldownError: docs publish-gate lint failed:
  - manifest references a missing file: docs/site/ai/getting-started/what-is-ai-access.md
  ... (all 45 manifested pages)        ✓ 0 modules transformed.
```

The vite `nyxid-docs-sync` plugin (added in #814) reads the docs-site source from `../docs/site` (repo root) during `vite build`, and its publish-gate aborts the build when that tree is absent. But the frontend image was built with `context: frontend`, so `docs/site` sat outside the build context (and the root `.dockerignore` excluded `docs/` anyway) — the plugin found zero docs and reported all 45 manifested pages as missing.

This only affected the **Docker image** build. `CI Gate / Frontend` runs `npm ci && npm run build` on the full checkout (where `../docs/site` exists), so it stayed green and masked the issue.

## Fix

- **`.github/workflows/publish-images.yml`** — the frontend image now builds from the repo-root context (`context: .`), consistent with backend/node-agent.
- **`frontend/Dockerfile`** — stage the frontend at `/build/frontend` and `COPY docs/ /build/docs/` so the plugin's `../docs/site` resolves; updated the `dist`/nginx `COPY` paths for the new context.
- **`.dockerignore`** — re-include `docs/site` (it was swallowed by the blanket `docs/` exclude). Backend/node-agent images only `COPY docs/AI_AGENT_PLAYBOOK.md`, so they are unaffected.
- **`docs/DEPLOYMENT.md`** — manual `docker build` command updated to the repo-root context.

## Validation

Built the frontend image locally from the repo root (exactly as the fixed workflow does):

- Build succeeds: `✓ 3261 modules transformed` → `✓ built in 4.03s` (previously `✓ 0 modules transformed` + gate failure).
- Docs content ships into the image: `/usr/share/nginx/html/docs/{ai,cli,shared,web}` plus an 18 KB `search-index.json` and 4 KB `sitemap.xml`.

> `publish-images.yml` only runs on push-to-`main`, tags, or manual dispatch — not on PRs — so this PR's checks won't include the image build itself. The post-merge publish run (or a `workflow_dispatch`) is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
