### PR TITLE
fix: align landing page navbar items and fix docs routing port leak

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -2,6 +2,9 @@ server {
     listen 8080;
     server_name _;
 
+    # Disable absolute redirects to prevent internal port leaks in reverse proxy setups (e.g. :8080)
+    absolute_redirect off;
+
     root /usr/share/nginx/html;
     index index.html;
 
@@ -73,6 +76,6 @@ server {
 
     # SPA fallback -- serve index.html for all non-file routes
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 }

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -76,6 +76,6 @@ server {
 
     # SPA fallback -- serve index.html for all non-file routes
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/frontend/src/features/docs/docs-page.tsx
+++ b/frontend/src/features/docs/docs-page.tsx
@@ -57,7 +57,12 @@ export function DocsPage() {
   // derive cleanly from render without cascading setState.
   const [loaded, setLoaded] = useState<LoadedDoc | null>(null);
   const [toc, setToc] = useState<TocItem[]>([]);
-  const [activeId, setActiveId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(() => {
+    if (typeof window !== "undefined") {
+      return decodeURIComponent(window.location.hash.replace(/^#/, "")) || null;
+    }
+    return null;
+  });
   const contentRef = useRef<HTMLDivElement>(null);
   // Tracks the slug we've already handled an incoming `#hash` for, so the
   // load-time deep-link scroll fires exactly once per page.
@@ -81,6 +86,13 @@ export function DocsPage() {
       cancelled = true;
     };
   }, [slug, known]);
+
+  // Reset activeId when transitioning to a new page (adjust state during render to avoid cascading effects)
+  const [prevSlug, setPrevSlug] = useState<string>(slug);
+  if (slug !== prevSlug) {
+    setPrevSlug(slug);
+    setActiveId(decodeURIComponent(window.location.hash.replace(/^#/, "")) || null);
+  }
 
   // Unknown slugs are a 404 immediately; otherwise show the fetched doc once it
   // matches the current slug, and "loading" until it catches up.
@@ -158,18 +170,6 @@ export function DocsPage() {
         window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
       const next = atBottom ? (headings[headings.length - 1]?.id ?? null) : (current ?? headings[0]?.id ?? null);
       setActiveId(next);
-      // Mirror the section being read into the URL so it stays the shareable
-      // source of truth for the active heading. replaceState (not pushState)
-      // keeps the back button clean; an empty hash above the first section
-      // keeps a freshly-loaded URL untouched until the reader scrolls in.
-      const desiredHash = (atBottom || current) && next ? `#${next}` : "";
-      if (desiredHash !== window.location.hash) {
-        window.history.replaceState(
-          window.history.state,
-          "",
-          `${window.location.pathname}${window.location.search}${desiredHash}`,
-        );
-      }
     };
     recompute();
     const observer = new IntersectionObserver(recompute, {

--- a/frontend/src/features/landing/components/landing-navbar.tsx
+++ b/frontend/src/features/landing/components/landing-navbar.tsx
@@ -33,21 +33,21 @@ export function LandingNavbar() {
         <div className="flex items-center gap-3">
           <a
             href="/docs"
-            className="hidden text-sm font-medium text-gray-300 transition-colors hover:text-white sm:inline-block"
+            className="hidden text-sm font-medium text-gray-300 transition-colors hover:text-white sm:inline-flex sm:h-9 sm:items-center px-2"
           >
             {t("nav.docs")}
           </a>
-          <GitHubButton className="text-text-tertiary hover:text-foreground" />
+          <GitHubButton className="h-9 text-text-tertiary hover:text-foreground px-2" />
           <LanguageSwitcher />
           <a
             href={loginHref}
-            className="rounded-lg border border-white/[0.08] px-5 py-2 text-sm font-medium text-foreground transition-colors hover:border-white/[0.15] hover:bg-white/[0.03]"
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-white/[0.08] px-5 text-sm font-medium text-foreground transition-colors hover:border-white/[0.15] hover:bg-white/[0.03]"
           >
             {t("nav.login")}
           </a>
           <a
             href={registerHref}
-            className="hidden rounded-lg nyx-gradient-vivid px-5 py-2 text-sm font-medium text-white shadow-[0_0_12px_rgba(90,42,241,0.25)] transition-all hover:shadow-[0_0_18px_rgba(90,42,241,0.35)] hover:brightness-110 md:inline-block"
+            className="hidden md:inline-flex h-9 items-center justify-center rounded-lg nyx-gradient-vivid px-5 text-sm font-medium text-white shadow-[0_0_12px_rgba(90,42,241,0.25)] transition-all hover:shadow-[0_0_18px_rgba(90,42,241,0.35)] hover:brightness-110"
           >
             {t("nav.register")}
           </a>

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,33 @@
 import "@testing-library/jest-dom/vitest";
+
+// happy-dom 20.x ships a stub `localStorage` without the Storage API
+// methods (it expects a `--localstorage-file` path to enable full
+// persistence). We back it with a plain in-memory map so the tests
+// and state persist middleware have a real, working localStorage.
+const store = new Map<string, string>();
+const localStorageMock: Storage = {
+  get length() {
+    return store.size;
+  },
+  clear() {
+    store.clear();
+  },
+  getItem(key: string) {
+    return store.has(key) ? store.get(key)! : null;
+  },
+  key(index: number) {
+    return Array.from(store.keys())[index] ?? null;
+  },
+  removeItem(key: string) {
+    store.delete(key);
+  },
+  setItem(key: string, value: string) {
+    store.set(key, String(value));
+  },
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  configurable: true,
+  writable: true,
+});


### PR DESCRIPTION
## Summary

- **Resolved scroll-spy routing loop on documentation pages:** Removed history state manipulation (`replaceState`) on scroll, using local React state instead to track active TOC sections smoothly without triggering router re-renders.
- **Fixed docs routing and port leakage:** Added `absolute_redirect off;` to [nginx.conf.template](file:///Users/chronoai/Desktop/aelf-frontend-work/nyxid/frontend/nginx.conf.template) to disable absolute redirects. This prevents Nginx from redirecting folder-level requests (like `/docs`) to its internal container port (`:8080`) and preserves correct relative routing.
- **Aligned landing page navigation bar items:** Standardized flex alignment, padding, and height styles (`h-9` to match the language switcher) for the Docs link, GitHub button, and Login/Register buttons in [landing-navbar.tsx](file:///Users/chronoai/Desktop/aelf-frontend-work/nyxid/frontend/src/features/landing/components/landing-navbar.tsx) to resolve vertical misalignment.
- **Resolved local Vitest happy-dom compatibility:** Added a mock storage implementation for `localStorage` in [test-setup.ts](file:///Users/chronoai/Desktop/aelf-frontend-work/nyxid/frontend/src/test-setup.ts) to back the incomplete `happy-dom` 20.x stub with a standard in-memory storage structure, resolving pre-existing test suite failures.

## Test Plan

- [x] Existing tests pass (`cargo test`, `npm run test`)
- [ ] New tests added for new functionality
- [x] Manually tested the affected flows

## Checklist

- [x] Code follows the project's [architecture rules](CONTRIBUTING.md#architecture-rules)
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [ ] Documentation updated (if applicable)
