### PR TITLE
fix(oauth+proxy): surface actionable OAuth, device-code & aws_sigv4 errors (#694)

### DIFF
--- a/backend/src/handlers/user_tokens.rs
+++ b/backend/src/handlers/user_tokens.rs
@@ -452,10 +452,11 @@ async fn generic_oauth_callback_impl(
                         .target_user_id
                         .as_deref()
                         .unwrap_or(&oauth_state.user_id);
-                    match user_api_key_service::fail_pending_placeholders_for_provider(
+                    match user_api_key_service::fail_oauth_placeholders(
                         &state.db,
                         owner_id,
                         &oauth_state.provider_config_id,
+                        oauth_state.connection_id.as_deref(),
                         &msg,
                     )
                     .await
@@ -548,26 +549,26 @@ async fn generic_oauth_callback_impl(
             .target_user_id
             .as_deref()
             .unwrap_or(&oauth_state.user_id);
-        let failed_placeholders =
-            match user_api_key_service::fail_pending_placeholders_for_provider(
-                &state.db,
-                owner_id,
-                provider_id,
-                &message,
-            )
-            .await
-            {
-                Ok(count) => Some(count),
-                Err(error) => {
-                    tracing::warn!(
-                        user_id = %owner_id,
-                        provider_id = %provider_id,
-                        error = %error,
-                        "failed to mark OAuth placeholders as failed after session mismatch"
-                    );
-                    None
-                }
-            };
+        let failed_placeholders = match user_api_key_service::fail_oauth_placeholders(
+            &state.db,
+            owner_id,
+            provider_id,
+            oauth_state.connection_id.as_deref(),
+            &message,
+        )
+        .await
+        {
+            Ok(count) => Some(count),
+            Err(error) => {
+                tracing::warn!(
+                    user_id = %owner_id,
+                    provider_id = %provider_id,
+                    error = %error,
+                    "failed to mark OAuth placeholders as failed after session mismatch"
+                );
+                None
+            }
+        };
         audit_service::log_async(
             state.db.clone(),
             Some(oauth_state.user_id.clone()),
@@ -640,26 +641,26 @@ async fn generic_oauth_callback_impl(
             .await
             {
                 let user_msg = safe_error_message(&error);
-                let failed_placeholders =
-                    match user_api_key_service::fail_pending_placeholders_for_provider(
-                        &state.db,
-                        &outcome.user_id,
-                        provider_id,
-                        &user_msg,
-                    )
-                    .await
-                    {
-                        Ok(count) => Some(count),
-                        Err(e) => {
-                            tracing::warn!(
-                                user_id = %outcome.user_id,
-                                provider_id = %provider_id,
-                                error = %e,
-                                "failed to mark OAuth placeholders as failed after sync error"
-                            );
-                            None
-                        }
-                    };
+                let failed_placeholders = match user_api_key_service::fail_oauth_placeholders(
+                    &state.db,
+                    &outcome.user_id,
+                    provider_id,
+                    oauth_state.connection_id.as_deref(),
+                    &user_msg,
+                )
+                .await
+                {
+                    Ok(count) => Some(count),
+                    Err(e) => {
+                        tracing::warn!(
+                            user_id = %outcome.user_id,
+                            provider_id = %provider_id,
+                            error = %e,
+                            "failed to mark OAuth placeholders as failed after sync error"
+                        );
+                        None
+                    }
+                };
                 audit_service::log_async(
                     state.db.clone(),
                     Some(outcome.user_id.clone()),
@@ -693,26 +694,26 @@ async fn generic_oauth_callback_impl(
                 .as_deref()
                 .unwrap_or(&oauth_state.user_id);
             let user_msg = safe_error_message(&e);
-            let failed_placeholders =
-                match user_api_key_service::fail_pending_placeholders_for_provider(
-                    &state.db,
-                    owner_id,
-                    provider_id,
-                    &user_msg,
-                )
-                .await
-                {
-                    Ok(count) => Some(count),
-                    Err(error) => {
-                        tracing::warn!(
-                            user_id = %owner_id,
-                            provider_id = %provider_id,
-                            error = %error,
-                            "failed to mark OAuth placeholders as failed"
-                        );
-                        None
-                    }
-                };
+            let failed_placeholders = match user_api_key_service::fail_oauth_placeholders(
+                &state.db,
+                owner_id,
+                provider_id,
+                oauth_state.connection_id.as_deref(),
+                &user_msg,
+            )
+            .await
+            {
+                Ok(count) => Some(count),
+                Err(error) => {
+                    tracing::warn!(
+                        user_id = %owner_id,
+                        provider_id = %provider_id,
+                        error = %error,
+                        "failed to mark OAuth placeholders as failed"
+                    );
+                    None
+                }
+            };
             audit_service::log_async(
                 state.db.clone(),
                 Some(oauth_state.user_id.clone()),

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2296,13 +2296,19 @@ pub async fn forward_request(
                 ProxyBody::Buffered(None) => &[][..],
             };
             let creds = AwsCredentials::from_json(&target.credential).map_err(|e| {
-                AppError::Internal(format!(
-                    "aws_sigv4 credential is malformed: {e}. Expected JSON with access_key_id, secret_access_key, region, service."
-                ))
+                tracing::error!(error = %e, "aws_sigv4 credential malformed");
+                AppError::BadRequest(
+                    "The aws_sigv4 credential is malformed. Expected JSON with fields: access_key_id, secret_access_key, region, service.".to_string()
+                )
             })?;
             let signed_headers =
                 aws_sigv4::sign_request(method.as_str(), &url, &signed_input, body_bytes, &creds)
-                    .map_err(|e| AppError::Internal(format!("aws_sigv4 signing failed: {e}")))?;
+                    .map_err(|e| {
+                        tracing::error!(error = %e, "aws_sigv4 request signing failed");
+                        AppError::BadRequest(
+                            "Failed to sign the request for aws_sigv4. Verify the credential's region and service are correct.".to_string()
+                        )
+                    })?;
             for header in signed_headers {
                 request = request.header(&header.name, &header.value);
             }

--- a/backend/src/services/user_api_key_service.rs
+++ b/backend/src/services/user_api_key_service.rs
@@ -489,6 +489,68 @@ pub async fn fail_pending_placeholders_for_provider(
     Ok(result.modified_count)
 }
 
+/// Mark a single multi-connection OAuth placeholder (identified by its
+/// `connection_id`) as `failed` with an actionable message. Used by the
+/// OAuth callback failure arms for wizard / BYO-Custom-App flows, where the
+/// placeholder carries a non-null `connection_id` and is therefore skipped by
+/// the legacy `connection_id: null` fan-out in
+/// `fail_pending_placeholders_for_provider`.
+///
+/// Race-safe: only `pending_auth` rows are touched, so a callback that
+/// already activated the credential, or a row the user revoked, is never
+/// overwritten by a late provider-error callback.
+pub async fn fail_connection_placeholder(
+    db: &mongodb::Database,
+    connection_id: &str,
+    error_message: &str,
+) -> AppResult<u64> {
+    let message = normalize_error_message(error_message);
+    let result = db
+        .collection::<UserApiKey>(COLLECTION_NAME)
+        .update_one(
+            doc! {
+                "connection_id": connection_id,
+                "status": { "$in": ["pending_auth"] },
+                "credential_type": { "$ne": "node_managed" },
+            },
+            doc! {
+                "$set": {
+                    "status": "failed",
+                    "error_message": message,
+                    "credential_encrypted": bson::Bson::Null,
+                    "access_token_encrypted": bson::Bson::Null,
+                    "refresh_token_encrypted": bson::Bson::Null,
+                    "token_scopes": bson::Bson::Null,
+                    "expires_at": bson::Bson::Null,
+                    "updated_at": bson::DateTime::from_chrono(Utc::now()),
+                }
+            },
+        )
+        .await?;
+
+    Ok(result.modified_count)
+}
+
+/// Fail the OAuth placeholder(s) for a denied/failed callback, routing to the
+/// right strategy: multi-connection flows (non-null `connection_id`) fail
+/// their specific row; legacy flows fan out across `connection_id: null`
+/// placeholders for the provider.
+pub async fn fail_oauth_placeholders(
+    db: &mongodb::Database,
+    owner_id: &str,
+    provider_config_id: &str,
+    connection_id: Option<&str>,
+    error_message: &str,
+) -> AppResult<u64> {
+    match connection_id {
+        Some(conn_id) => fail_connection_placeholder(db, conn_id, error_message).await,
+        None => {
+            fail_pending_placeholders_for_provider(db, owner_id, provider_config_id, error_message)
+                .await
+        }
+    }
+}
+
 /// Lazy reconciliation of a single `pending_auth` OAuth placeholder. Called
 /// from the wizard's polling endpoint (`GET /api/v1/keys/{id}`) so each poll
 /// is a chance to converge the placeholder to a terminal status without
@@ -1079,9 +1141,10 @@ mod tests {
     use mongodb::bson::doc;
 
     use super::{
-        OAUTH_STATES, USER_PROVIDER_TOKENS, fail_pending_placeholders_for_provider,
-        has_server_credential, reconcile_pending_oauth_placeholder,
-        sync_provider_token_to_api_keys, write_oauth_tokens_to_key,
+        OAUTH_STATES, USER_PROVIDER_TOKENS, fail_connection_placeholder,
+        fail_pending_placeholders_for_provider, has_server_credential,
+        reconcile_pending_oauth_placeholder, sync_provider_token_to_api_keys,
+        write_oauth_tokens_to_key,
     };
     use crate::models::oauth_state::OAuthState;
     use crate::models::user_api_key::UserApiKey;
@@ -2302,6 +2365,116 @@ mod tests {
             "pending_auth",
             "multi-connection key must not be failed by a legacy denial"
         );
+    }
+
+    #[tokio::test]
+    async fn fail_connection_placeholder_marks_matching_placeholder_failed() {
+        let Some(db) = connect_test_database("user_api_key_fail_conn_marks_matching").await else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let provider_id = uuid::Uuid::new_v4().to_string();
+        let key_id = uuid::Uuid::new_v4().to_string();
+        let conn_id = uuid::Uuid::new_v4().to_string();
+
+        let mut key = provider_key(&key_id, &user_id, &provider_id, "pending_auth", "oauth2");
+        key.connection_id = Some(conn_id.clone());
+        key.credential_encrypted = Some(vec![1, 2]);
+        key.access_token_encrypted = Some(vec![3, 4]);
+        key.refresh_token_encrypted = Some(vec![5, 6]);
+        key.token_scopes = Some("scope1".to_string());
+        key.expires_at = Some(Utc::now());
+
+        db.collection::<UserApiKey>(super::COLLECTION_NAME)
+            .insert_one(key)
+            .await
+            .unwrap();
+
+        let modified = fail_connection_placeholder(&db, &conn_id, "test_error_message")
+            .await
+            .unwrap();
+
+        assert_eq!(modified, 1);
+
+        let updated = get_key(&db, &key_id).await;
+        assert_eq!(updated.status, "failed");
+        assert_eq!(
+            updated.error_message,
+            Some("test_error_message".to_string())
+        );
+        assert!(updated.credential_encrypted.is_none());
+        assert!(updated.access_token_encrypted.is_none());
+        assert!(updated.refresh_token_encrypted.is_none());
+        assert!(updated.token_scopes.is_none());
+        assert!(updated.expires_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn fail_connection_placeholder_isolation() {
+        let Some(db) = connect_test_database("user_api_key_fail_conn_isolation").await else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let provider_id = uuid::Uuid::new_v4().to_string();
+        let key_x_id = uuid::Uuid::new_v4().to_string();
+        let key_y_id = uuid::Uuid::new_v4().to_string();
+        let conn_x = uuid::Uuid::new_v4().to_string();
+        let conn_y = uuid::Uuid::new_v4().to_string();
+
+        let mut key_x = provider_key(&key_x_id, &user_id, &provider_id, "pending_auth", "oauth2");
+        key_x.connection_id = Some(conn_x.clone());
+
+        let mut key_y = provider_key(&key_y_id, &user_id, &provider_id, "pending_auth", "oauth2");
+        key_y.connection_id = Some(conn_y.clone());
+
+        db.collection::<UserApiKey>(super::COLLECTION_NAME)
+            .insert_many(vec![key_x, key_y])
+            .await
+            .unwrap();
+
+        let modified = fail_connection_placeholder(&db, &conn_x, "error_x")
+            .await
+            .unwrap();
+
+        assert_eq!(modified, 1);
+
+        assert_eq!(get_key(&db, &key_x_id).await.status, "failed");
+        assert_eq!(get_key(&db, &key_y_id).await.status, "pending_auth");
+    }
+
+    #[tokio::test]
+    async fn fail_connection_placeholder_race_safety() {
+        let Some(db) = connect_test_database("user_api_key_fail_conn_race").await else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let provider_id = uuid::Uuid::new_v4().to_string();
+        let key_id = uuid::Uuid::new_v4().to_string();
+        let conn_id = uuid::Uuid::new_v4().to_string();
+
+        let mut key = provider_key(&key_id, &user_id, &provider_id, "active", "oauth2");
+        key.connection_id = Some(conn_id.clone());
+
+        db.collection::<UserApiKey>(super::COLLECTION_NAME)
+            .insert_one(key)
+            .await
+            .unwrap();
+
+        let modified = fail_connection_placeholder(&db, &conn_id, "late_error")
+            .await
+            .unwrap();
+
+        assert_eq!(modified, 0);
+
+        let updated = get_key(&db, &key_id).await;
+        assert_eq!(updated.status, "active");
+        assert!(updated.error_message.is_none());
     }
 
     #[tokio::test]

--- a/backend/src/services/user_token_service.rs
+++ b/backend/src/services/user_token_service.rs
@@ -1092,58 +1092,63 @@ pub async fn poll_device_code(
     }
 
     if !status_code.is_success() {
-        // Parse RFC 8628 error response (used by both formats as fallback)
-        if let Ok(resp_data) = response.json::<serde_json::Value>().await
-            && let Some(error) = resp_data["error"].as_str()
-        {
-            match error {
-                "authorization_pending" => {
-                    return Ok(DeviceCodePollResult {
-                        status: "pending".to_string(),
-                        interval: oauth_state.poll_interval,
-                        effective_user_id: None,
-                    });
-                }
-                "slow_down" => {
-                    let new_interval = oauth_state.poll_interval.unwrap_or(5) + 5;
-                    db.collection::<OAuthState>(OAUTH_STATES)
-                        .update_one(
-                            doc! { "_id": state },
-                            doc! { "$set": { "poll_interval": new_interval } },
-                        )
-                        .await?;
-                    return Ok(DeviceCodePollResult {
-                        status: "slow_down".to_string(),
-                        interval: Some(new_interval),
-                        effective_user_id: None,
-                    });
-                }
-                "expired_token" => {
-                    db.collection::<OAuthState>(OAUTH_STATES)
-                        .delete_one(doc! { "_id": state })
-                        .await?;
-                    return Ok(DeviceCodePollResult {
-                        status: "expired".to_string(),
-                        interval: None,
-                        effective_user_id: None,
-                    });
-                }
-                "access_denied" => {
-                    db.collection::<OAuthState>(OAUTH_STATES)
-                        .delete_one(doc! { "_id": state })
-                        .await?;
-                    return Ok(DeviceCodePollResult {
-                        status: "denied".to_string(),
-                        interval: None,
-                        effective_user_id: None,
-                    });
-                }
-                _ => {}
+        let raw_body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "unknown".to_string());
+
+        match classify_device_poll_failure(status_code, &raw_body) {
+            Ok(DevicePollFlow::Pending) => {
+                return Ok(DeviceCodePollResult {
+                    status: "pending".to_string(),
+                    interval: oauth_state.poll_interval,
+                    effective_user_id: None,
+                });
+            }
+            Ok(DevicePollFlow::SlowDown) => {
+                let new_interval = oauth_state.poll_interval.unwrap_or(5) + 5;
+                db.collection::<OAuthState>(OAUTH_STATES)
+                    .update_one(
+                        doc! { "_id": state },
+                        doc! { "$set": { "poll_interval": new_interval } },
+                    )
+                    .await?;
+                return Ok(DeviceCodePollResult {
+                    status: "slow_down".to_string(),
+                    interval: Some(new_interval),
+                    effective_user_id: None,
+                });
+            }
+            Ok(DevicePollFlow::Expired) => {
+                db.collection::<OAuthState>(OAUTH_STATES)
+                    .delete_one(doc! { "_id": state })
+                    .await?;
+                return Ok(DeviceCodePollResult {
+                    status: "expired".to_string(),
+                    interval: None,
+                    effective_user_id: None,
+                });
+            }
+            Ok(DevicePollFlow::Denied) => {
+                db.collection::<OAuthState>(OAUTH_STATES)
+                    .delete_one(doc! { "_id": state })
+                    .await?;
+                return Ok(DeviceCodePollResult {
+                    status: "denied".to_string(),
+                    interval: None,
+                    effective_user_id: None,
+                });
+            }
+            Err(err) => {
+                tracing::error!(
+                    provider_id = %provider_id,
+                    status = %status_code,
+                    body = %raw_body,
+                    "Device code poll failed with provider error"
+                );
+                return Err(err);
             }
         }
-        return Err(AppError::Internal(format!(
-            "Device code poll returned unexpected status: {status_code}"
-        )));
     }
 
     // Success (2xx): parse response
@@ -1187,23 +1192,24 @@ pub async fn poll_device_code(
                     AppError::Internal(format!("Device code token exchange failed: {e}"))
                 })?;
 
-        if !token_response.status().is_success() {
-            let err_status = token_response.status();
-            let err_body = token_response.text().await.unwrap_or_default();
-            let truncated_err_body: String = err_body.chars().take(200).collect();
-            tracing::error!(
-                status = %err_status,
-                body = %truncated_err_body,
-                "Device code token exchange returned error"
-            );
-            return Err(AppError::Internal(format!(
-                "Device code token exchange failed with status {err_status}"
-            )));
-        }
+        let status = token_response.status();
+        let raw_body = token_response
+            .text()
+            .await
+            .unwrap_or_else(|_| "unknown".to_string());
 
-        let token_data: serde_json::Value = token_response.json().await.map_err(|e| {
-            AppError::Internal(format!("Failed to parse token exchange response: {e}"))
-        })?;
+        let token_data = match parse_token_exchange_response(status, &raw_body) {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::error!(
+                    provider_id = %provider_id,
+                    status = %status,
+                    body = %raw_body,
+                    "Device code token exchange returned error"
+                );
+                return Err(err);
+            }
+        };
 
         return store_device_code_tokens(
             db,
@@ -1862,6 +1868,49 @@ fn parse_token_exchange_response(
                 .to_string(),
         )),
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DevicePollFlow {
+    Pending,
+    SlowDown,
+    Expired,
+    Denied,
+}
+
+/// Classify a non-2xx device-code poll response body. Returns:
+/// - `Ok(DevicePollFlow)` for the four RFC 8628 flow-control states the
+///   caller maps to "pending"/"slow_down"/"expired"/"denied",
+/// - `Err(AppError::BadRequest)` for any other recognizable provider error
+///   (RFC 6749 / Lark envelope) or an opaque non-2xx. The error carries only
+///   the provider's own message or a generic-but-actionable hint — never the
+///   raw body.
+fn classify_device_poll_failure(
+    status: reqwest::StatusCode,
+    raw_body: &str,
+) -> AppResult<DevicePollFlow> {
+    let parsed: Option<serde_json::Value> = serde_json::from_str(raw_body).ok();
+
+    if let Some(ref value) = parsed {
+        if let Some(error) = value.get("error").and_then(serde_json::Value::as_str) {
+            match error {
+                "authorization_pending" => return Ok(DevicePollFlow::Pending),
+                "slow_down" => return Ok(DevicePollFlow::SlowDown),
+                "expired_token" => return Ok(DevicePollFlow::Expired),
+                "access_denied" => return Ok(DevicePollFlow::Denied),
+                _ => {}
+            }
+        }
+
+        if let Some(provider_err) = token_exchange_provider_error(value) {
+            return Err(provider_err);
+        }
+    }
+
+    Err(AppError::BadRequest(format!(
+        "Identity provider returned an error during device authorization (HTTP {}). Re-check the app credentials and try again.",
+        status.as_u16()
+    )))
 }
 
 /// Multi-connection OAuth refresh path: refresh an access token using the
@@ -2557,9 +2606,9 @@ pub async fn list_user_tokens(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_telegram_identity_metadata, build_telegram_identity_update_doc,
-        build_user_token_summary, ensure_additional_scopes_supported, merge_scopes,
-        normalize_telegram_bot_api_key, oauth_token_payload, params_to_json_body,
+        DevicePollFlow, build_telegram_identity_metadata, build_telegram_identity_update_doc,
+        build_user_token_summary, classify_device_poll_failure, ensure_additional_scopes_supported,
+        merge_scopes, normalize_telegram_bot_api_key, oauth_token_payload, params_to_json_body,
         parse_additional_scopes, parse_token_exchange_response, token_exchange_provider_error,
         uses_json_oauth_token_exchange,
     };
@@ -2793,6 +2842,62 @@ mod tests {
         let value = parse_token_exchange_response(reqwest::StatusCode::OK, body)
             .expect("valid token response parses");
         assert_eq!(value["access_token"], "abc");
+    }
+
+    #[test]
+    fn classify_device_poll_failure_handles_flow_control() {
+        let status = reqwest::StatusCode::BAD_REQUEST;
+
+        // Pending
+        let res =
+            classify_device_poll_failure(status, r#"{"error":"authorization_pending"}"#).unwrap();
+        assert_eq!(res, DevicePollFlow::Pending);
+
+        // Slow Down
+        let res = classify_device_poll_failure(status, r#"{"error":"slow_down"}"#).unwrap();
+        assert_eq!(res, DevicePollFlow::SlowDown);
+
+        // Expired
+        let res = classify_device_poll_failure(status, r#"{"error":"expired_token"}"#).unwrap();
+        assert_eq!(res, DevicePollFlow::Expired);
+
+        // Denied
+        let res = classify_device_poll_failure(status, r#"{"error":"access_denied"}"#).unwrap();
+        assert_eq!(res, DevicePollFlow::Denied);
+    }
+
+    #[test]
+    fn classify_device_poll_failure_surfaces_provider_error() {
+        let status = reqwest::StatusCode::BAD_REQUEST;
+
+        // Standard OAuth provider error (RFC 6749)
+        let body = r#"{"error":"invalid_client","error_description":"client secret mismatch"}"#;
+        let err = classify_device_poll_failure(status, body).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("invalid_client"));
+        assert!(msg.contains("client secret mismatch"));
+
+        // Lark-style non-zero code error envelope
+        let body = r#"{"code": 20029, "msg": "redirect_uri mismatch"}"#;
+        let err = classify_device_poll_failure(status, body).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("20029"));
+        assert!(msg.contains("redirect_uri mismatch"));
+    }
+
+    #[test]
+    fn classify_device_poll_failure_handles_opaque_failures_without_leak() {
+        let status = reqwest::StatusCode::INTERNAL_SERVER_ERROR;
+        let body = "<html><body>sensitive raw response stacktrace with secrets</body></html>";
+        let err = classify_device_poll_failure(status, body).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("500"));
+        assert!(!msg.contains("sensitive"));
+        assert!(!msg.contains("secrets"));
+        assert!(!msg.contains("stacktrace"));
     }
 
     #[test]

--- a/backend/src/services/user_token_service.rs
+++ b/backend/src/services/user_token_service.rs
@@ -1553,48 +1553,57 @@ pub async fn handle_oauth_callback(
         .await
         .map_err(|e| AppError::Internal(format!("OAuth token exchange failed: {e}")))?;
 
-    if !token_response.status().is_success() {
-        let status = token_response.status();
-        let body = token_response
-            .text()
-            .await
-            .unwrap_or_else(|_| "unknown".to_string());
-        tracing::error!(
-            provider_id = %provider_id,
-            status = %status,
-            body = %body,
-            "OAuth token exchange returned error"
-        );
-        return Err(AppError::Internal(format!(
-            "OAuth token exchange failed with status {status}"
-        )));
-    }
-
-    let token_data: serde_json::Value = token_response
-        .json()
+    let status = token_response.status();
+    // Read the body once as text so we can both (a) parse provider-shaped
+    // error envelopes that come back with HTTP 200 (Lark / Feishu return
+    // `{"code": <non-zero>, "msg": "..."}` with a 200 status) and (b) keep
+    // the full body for the server-side audit log without consuming the
+    // response twice.
+    let raw_body = token_response
+        .text()
         .await
-        .map_err(|e| AppError::Internal(format!("Failed to parse token response: {e}")))?;
+        .unwrap_or_else(|_| "unknown".to_string());
 
-    if token_data
-        .get("code")
-        .and_then(|value| value.as_i64())
-        .is_some_and(|code| code != 0)
-    {
-        tracing::error!(
-            provider_id = %provider_id,
-            response = %token_data,
-            "OAuth token exchange returned provider error"
-        );
-        return Err(AppError::Internal(
-            "OAuth token exchange failed".to_string(),
-        ));
-    }
+    let token_data = match parse_token_exchange_response(status, &raw_body) {
+        Ok(value) => value,
+        Err(err) => {
+            // Log the full status + raw body server-side; `err` only carries
+            // the provider's own returned error text (see
+            // `parse_token_exchange_response`), never internal/DB details.
+            tracing::error!(
+                provider_id = %provider_id,
+                status = %status,
+                body = %raw_body,
+                "OAuth token exchange returned error"
+            );
+            return Err(err);
+        }
+    };
 
     let token_payload = oauth_token_payload(&token_data);
 
-    let access_token = token_payload["access_token"]
-        .as_str()
-        .ok_or_else(|| AppError::Internal("Missing access_token in response".to_string()))?;
+    let access_token = match token_payload["access_token"].as_str() {
+        Some(token) => token,
+        None => {
+            tracing::error!(
+                provider_id = %provider_id,
+                status = %status,
+                body = %raw_body,
+                "OAuth token exchange response missing access_token"
+            );
+            // Surface any provider-returned error text rather than a generic
+            // internal error so the wizard shows something actionable.
+            return Err(
+                token_exchange_provider_error(&token_data).unwrap_or_else(|| {
+                    AppError::BadRequest(
+                        "Identity provider did not return an access token. \
+                     Re-check the app credentials and try connecting again."
+                            .to_string(),
+                    )
+                }),
+            );
+        }
+    };
 
     let refresh_token = token_payload["refresh_token"].as_str();
     let expires_in = token_payload["expires_in"].as_i64();
@@ -1757,6 +1766,102 @@ fn oauth_token_payload(token_data: &serde_json::Value) -> &serde_json::Value {
                 .is_some()
         })
         .unwrap_or(token_data)
+}
+
+/// Extract a user-surfaceable error from an OAuth token-exchange response
+/// body, if it carries one.
+///
+/// Two provider error shapes are recognized:
+///
+/// - **Lark / Feishu**: HTTP 200 with `{"code": <non-zero>, "msg": "..."}`.
+///   These providers do NOT use the OAuth-standard error envelope and do
+///   NOT signal failure via the HTTP status, so a generic parser that only
+///   inspects the status or looks for `access_token` would otherwise miss
+///   the real cause (issue #694).
+/// - **RFC 6749 §5.2**: `{"error": "...", "error_description": "..."}`.
+///
+/// Returns a [`AppError::BadRequest`] carrying ONLY the provider's own
+/// returned `code`/`msg`/`error` text. This is intentionally a surfaceable
+/// variant (not `Internal`/`DatabaseError`) so `safe_error_message` passes
+/// it through to the user. The raw body and HTTP status are logged by the
+/// caller for ops; they are never embedded in the returned error.
+fn token_exchange_provider_error(token_data: &serde_json::Value) -> Option<AppError> {
+    // Lark / Feishu envelope: non-zero integer `code` means failure.
+    if let Some(code) = token_data.get("code").and_then(serde_json::Value::as_i64)
+        && code != 0
+    {
+        let msg = token_data
+            .get("msg")
+            .and_then(serde_json::Value::as_str)
+            .filter(|m| !m.trim().is_empty())
+            .unwrap_or("unknown error");
+        return Some(AppError::BadRequest(format!(
+            "Identity provider rejected the authorization (code {code}): {msg}"
+        )));
+    }
+
+    // RFC 6749 §5.2 error envelope.
+    if let Some(error) = token_data
+        .get("error")
+        .and_then(serde_json::Value::as_str)
+        .filter(|e| !e.trim().is_empty())
+    {
+        let description = token_data
+            .get("error_description")
+            .and_then(serde_json::Value::as_str)
+            .filter(|d| !d.trim().is_empty());
+        let message = match description {
+            Some(desc) => format!("Identity provider rejected the authorization: {error} ({desc})"),
+            None => format!("Identity provider rejected the authorization: {error}"),
+        };
+        return Some(AppError::BadRequest(message));
+    }
+
+    None
+}
+
+/// Evaluate a raw OAuth token-exchange response body and return the parsed
+/// JSON value on success, or a user-surfaceable [`AppError`] on failure.
+///
+/// Failure handling never leaks internal/transport details to the returned
+/// error: only provider-returned error text (via
+/// [`token_exchange_provider_error`]) or a generic-but-actionable message is
+/// surfaced. The caller logs the full status + raw body for ops.
+fn parse_token_exchange_response(
+    status: reqwest::StatusCode,
+    raw_body: &str,
+) -> AppResult<serde_json::Value> {
+    let parsed: Option<serde_json::Value> = serde_json::from_str(raw_body).ok();
+
+    // A provider-shaped error can appear regardless of HTTP status (Lark
+    // returns it with 200). Prefer it whenever present so the user sees the
+    // provider's own message.
+    if let Some(ref value) = parsed
+        && let Some(provider_err) = token_exchange_provider_error(value)
+    {
+        return Err(provider_err);
+    }
+
+    if !status.is_success() {
+        // Non-2xx with no recognizable provider error envelope. Surface the
+        // status (RFC-style "the provider returned an error") without echoing
+        // the raw body, which may contain HTML or sensitive transport noise.
+        return Err(AppError::BadRequest(format!(
+            "Identity provider returned an error during token exchange (HTTP {}). \
+             Re-check the app credentials and try connecting again.",
+            status.as_u16()
+        )));
+    }
+
+    // 2xx: require a JSON object we can read tokens out of.
+    match parsed {
+        Some(value @ serde_json::Value::Object(_)) => Ok(value),
+        _ => Err(AppError::BadRequest(
+            "Identity provider returned an unreadable token response. \
+             Re-check the app credentials and try connecting again."
+                .to_string(),
+        )),
+    }
 }
 
 /// Multi-connection OAuth refresh path: refresh an access token using the
@@ -2455,9 +2560,11 @@ mod tests {
         build_telegram_identity_metadata, build_telegram_identity_update_doc,
         build_user_token_summary, ensure_additional_scopes_supported, merge_scopes,
         normalize_telegram_bot_api_key, oauth_token_payload, params_to_json_body,
-        parse_additional_scopes, uses_json_oauth_token_exchange,
+        parse_additional_scopes, parse_token_exchange_response, token_exchange_provider_error,
+        uses_json_oauth_token_exchange,
     };
     use crate::crypto::telegram::TelegramLoginData;
+    use crate::errors::AppError;
     use crate::models::provider_config::ProviderConfig;
     use crate::models::user_provider_token::UserProviderToken;
     use chrono::Utc;
@@ -2598,6 +2705,94 @@ mod tests {
         assert_eq!(payload["access_token"], "lark-access");
         assert_eq!(payload["refresh_token"], "lark-refresh");
         assert_eq!(payload["expires_in"], 7200);
+    }
+
+    /// Regression for issue #694: Lark / Feishu return HTTP 200 with a
+    /// non-zero `code` + `msg` instead of an OAuth error envelope. Before the
+    /// fix this surfaced as `AppError::Internal`, which `safe_error_message`
+    /// flattens to the generic "An internal error occurred" string, leaving
+    /// the wizard with no clue why the credential landed in `failed`. The
+    /// parsed error must now be a surfaceable variant carrying the provider's
+    /// own `code`/`msg`.
+    #[test]
+    fn lark_style_200_with_nonzero_code_surfaces_provider_message() {
+        // Lark sends HTTP 200 even on failure.
+        let body = r#"{"code": 99991663, "msg": "app ticket invalid"}"#;
+        let err = parse_token_exchange_response(reqwest::StatusCode::OK, body)
+            .expect_err("non-zero Lark code must be an error");
+
+        // Must NOT be Internal/DatabaseError, otherwise safe_error_message
+        // would hide it behind the generic string.
+        assert!(
+            matches!(err, AppError::BadRequest(_)),
+            "expected surfaceable BadRequest, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("99991663"), "missing provider code: {msg}");
+        assert!(
+            msg.contains("app ticket invalid"),
+            "missing provider msg: {msg}"
+        );
+    }
+
+    /// `safe_error_message` (in `handlers/user_tokens.rs`) only flattens
+    /// `Internal`/`DatabaseError`. Verify the Lark error is none of those, so
+    /// the actionable text reaches the user-facing redirect.
+    #[test]
+    fn lark_error_passes_through_safe_error_filter() {
+        let body = r#"{"code": 20029, "msg": "redirect_uri mismatch"}"#;
+        let err = parse_token_exchange_response(reqwest::StatusCode::OK, body)
+            .expect_err("non-zero Lark code must be an error");
+        // Mirror safe_error_message's filter: only Internal/DatabaseError are masked.
+        let masked = matches!(err, AppError::Internal(_) | AppError::DatabaseError(_));
+        assert!(!masked, "Lark error should not be masked as internal");
+        assert!(err.to_string().contains("redirect_uri mismatch"));
+    }
+
+    #[test]
+    fn missing_access_token_without_provider_error_is_actionable_bad_request() {
+        // 200 OK, valid JSON, but no access_token and no provider error code.
+        let body = r#"{"token_type": "bearer"}"#;
+        let value = parse_token_exchange_response(reqwest::StatusCode::OK, body)
+            .expect("body with no provider error parses as Ok value");
+        // Caller path: no access_token -> token_exchange_provider_error is None
+        // -> falls back to the generic-but-actionable BadRequest.
+        assert!(token_exchange_provider_error(&value).is_none());
+    }
+
+    #[test]
+    fn standard_oauth_error_envelope_surfaces_description() {
+        let body = r#"{"error": "invalid_grant", "error_description": "code expired"}"#;
+        let err = parse_token_exchange_response(reqwest::StatusCode::BAD_REQUEST, body)
+            .expect_err("OAuth error envelope must be an error");
+        assert!(matches!(err, AppError::BadRequest(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("invalid_grant"), "msg: {msg}");
+        assert!(msg.contains("code expired"), "msg: {msg}");
+    }
+
+    #[test]
+    fn non_success_without_envelope_does_not_leak_raw_body() {
+        // A 500 with an HTML/transport body and no recognizable envelope must
+        // NOT echo the raw body to the user.
+        let body = "<html><body>internal proxy stack trace: secret.db.host</body></html>";
+        let err = parse_token_exchange_response(reqwest::StatusCode::INTERNAL_SERVER_ERROR, body)
+            .expect_err("non-2xx without envelope must be an error");
+        assert!(matches!(err, AppError::BadRequest(_)));
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("secret.db.host") && !msg.contains("stack trace"),
+            "raw body must not leak into user message: {msg}"
+        );
+        assert!(msg.contains("500"), "status code should be surfaced: {msg}");
+    }
+
+    #[test]
+    fn successful_standard_response_parses_through() {
+        let body = r#"{"access_token": "abc", "token_type": "bearer", "expires_in": 3600}"#;
+        let value = parse_token_exchange_response(reqwest::StatusCode::OK, body)
+            .expect("valid token response parses");
+        assert_eq!(value["access_token"], "abc");
     }
 
     #[test]
@@ -2837,7 +3032,7 @@ mod tests {
     // refresh_user_api_key_in_place tests (multi-connection refresh path)
     // ───────────────────────────────────────────────────────────────────
 
-    use super::{AppError, Duration, PROVIDER_CONFIGS};
+    use super::{Duration, PROVIDER_CONFIGS};
     use crate::models::user_api_key::{COLLECTION_NAME as USER_API_KEYS, UserApiKey};
     use crate::test_utils::{connect_test_database, test_encryption_keys};
     use mongodb::bson::doc;


### PR DESCRIPTION
## Summary

Fixes #694 and closes the same error-flattening bug class across the OAuth/proxy surface. Provider-side and user-caused failures were mapped to `AppError::Internal`, which `safe_error_message` / `AppError::into_response` deliberately flatten to the generic **"An internal error occurred"** — hiding the real, actionable reason from the user and the CLI wizard.

Three commits, each a distinct slice:

### 1. Auth-code token exchange (`827d2c6c`) — the original #694 fix
Lark/Feishu return HTTP 200 with a non-zero `{code,msg}` envelope instead of an OAuth error. Added `token_exchange_provider_error()` + `parse_token_exchange_response()` that remap provider-side failures (Lark envelope, RFC 6749 `{error,error_description}`, non-2xx, missing/unreadable token) to `AppError::BadRequest` carrying only the provider's own message. Raw body + status stay in server-side tracing only.

### 2. Multi-connection wizard delivery (`908de770`)
The classification above was correct, but the callback handler only failed legacy (`connection_id: null`) placeholders, so the CLI wizard's multi-connection placeholder (non-null `connection_id`) was never updated and hung until the OAuthState TTL — surfacing a generic timeout instead of the actionable reason. Added `fail_connection_placeholder` + `fail_oauth_placeholders` dispatcher and routed all four callback failure arms through it (race-safe: only `pending_auth` rows are touched).

### 3. Device-code + aws_sigv4 (`306504ae`)
- **Device-code:** the second-step authorization_code exchange now reuses `parse_token_exchange_response`; a new pure, tested `classify_device_poll_failure` helper preserves the four RFC 8628 flow-control states (`authorization_pending`/`slow_down`/`expired_token`/`access_denied`) exactly while surfacing real provider errors as `BadRequest`.
- **aws_sigv4 (proxy):** malformed-credential and signing failures now return fixed, **leak-free** `BadRequest` messages (field names only — verified `AwsCredentials::from_json` serde errors can echo the raw credential); full detail goes to tracing.

> Note: the OAuth **token-refresh** path (originally listed as a related gap) was investigated and is **already handled** — the proxy swallows the `Internal` and falls back, and the refresh row already persists an actionable `error_message` + handles Lark 200+code. No change needed there.

## Review
Independently reviewed by Claude + agy (Antigravity CLI). agy surfaced the multi-connection delivery gap (commit 2) that the first commit alone missed; Claude verified each finding against source before acting.

## Test plan
- [x] `cargo test services::user_token_service` — 40 passed (incl. Lark/RFC6749/no-leak token-exchange + `classify_device_poll_failure` flow-control/provider-error/no-leak tests)
- [x] `cargo test services::user_api_key_service` — 33 passed (incl. `fail_connection_placeholder` marks-failed / isolation / race-safety)
- [x] `cargo test services::proxy_service` — 40 passed
- [x] `cargo clippy` clean, `cargo fmt` applied
- [ ] Manual: Lark OAuth via CLI wizard with bad Client Secret → wizard shows the provider's actionable reason, not the generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)