### PR TITLE
fix(nginx): serve /docs via SPA fallback instead of redirecting to the docs dir

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -74,8 +74,14 @@ server {
         try_files $uri =404;
     }
 
-    # SPA fallback -- serve index.html for all non-file routes
+    # SPA fallback -- serve index.html for all non-file routes.
+    # Do NOT add `$uri/`: the build mirrors `docs/site/**` into `public/docs/`,
+    # so a real `/docs/` directory exists. With `$uri/`, a request to `/docs`
+    # matches that directory and nginx 301-redirects to `/docs/`, leaking the
+    # internal :8080 listen port into the Location URL and never reaching the
+    # SPA router. Real doc assets (`/docs/*.md`, `/docs/search-index.json`) are
+    # still served by the `$uri` match; client routes fall through to index.html.
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the production-only bug where clicking **Docs** from the landing page sent users to `https://nyx.chrono-ai.fun:8080/docs/` (internal port leaked into the URL) and a broken page.

**Root cause:** the Vite build mirrors `docs/site/**` into `frontend/public/docs/`, so a real `/docs/` directory ships in the frontend image. With `try_files $uri $uri/ /index.html`, a request to `/docs` matched that directory and nginx `301`-redirected to `/docs/` — leaking the internal `:8080` listen port into the `Location` URL and landing on a `403` (the directory has no `index.html`). The SPA router never ran. Local dev uses the Vite dev server (no nginx, no physical directory collision), so it never surfaced.

Dropping `$uri/` makes `/docs` fall through to `/index.html` so the SPA router renders it; real doc assets (`/docs/*.md`, `/docs/search-index.json`, images) still match via the bare `$uri`.

This re-applies the `try_files` fix from `a78b28cb` that was inadvertently reverted by `f89c992a` ("restore standard try_files directory matching").

## Verification

Tested against real nginx 1.31.1 with a docroot mimicking the build output (`index.html` + real `docs/` dir with assets):

| Path | Before (`$uri/`) | After (`$uri`) |
|---|---|---|
| `/docs` (route) | `301 → http://…:8080/docs/` → `403` | **`200` SPA** |
| `/docs/web/getting-started` (deep link) | `301 → …/` → `403` | **`200` SPA** |
| `/docs/search-index.json` | `200` | `200` |
| `/docs/web/getting-started.md` | `200` | `200` |
| `/docs/.../img/01.png` | `200` | `200` |
| `/` | `200` | `200` |

The `:8080` leak reproduces exactly with `$uri/` and no `absolute_redirect off`, which points to production running a frontend image built before the May 22 fixes.

## Deploy note

`nginx.conf.template` is baked into the frontend Docker image at build time — **the running container won't pick this up without a frontend image rebuild + redeploy.**

## Test plan

- [ ] Rebuild + redeploy the frontend image
- [ ] From the landing page, click **Docs** → lands on `/docs` (no `:8080`, no redirect), docs index renders
- [ ] Deep link e.g. `/docs/web/getting-started` loads directly
- [ ] In-docs search works (fetches `/docs/search-index.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)