### PR TITLE
feat(invite-code): enforce single redemption per identity + drawer copy actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs/CLI_AUDIT_GAPS.md
 docs/STREAMLINE_SERVICES_PROPOSAL.md
 .gstack/
 .context/
+.antigravitycli/

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -246,6 +246,9 @@ pub enum AppError {
 
     #[error("Invite code has been deactivated")]
     InviteCodeDeactivated,
+
+    #[error("Invite code has already been redeemed")]
+    InviteCodeAlreadyRedeemed,
 }
 
 impl AppError {
@@ -316,9 +319,10 @@ impl AppError {
             Self::OrgInviteInvalid(_) => StatusCode::BAD_REQUEST,
             Self::OrgInviteExpired => StatusCode::GONE,
             Self::OrgApprovalNoAdmin(_) => StatusCode::SERVICE_UNAVAILABLE,
-            Self::InviteCodeInvalid | Self::InviteCodeExhausted | Self::InviteCodeDeactivated => {
-                StatusCode::BAD_REQUEST
-            }
+            Self::InviteCodeInvalid
+            | Self::InviteCodeExhausted
+            | Self::InviteCodeDeactivated
+            | Self::InviteCodeAlreadyRedeemed => StatusCode::BAD_REQUEST,
             Self::Internal(_) | Self::DatabaseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -396,6 +400,7 @@ impl AppError {
             Self::InviteCodeInvalid => 8200,
             Self::InviteCodeExhausted => 8201,
             Self::InviteCodeDeactivated => 8202,
+            Self::InviteCodeAlreadyRedeemed => 8203,
         }
     }
 
@@ -505,6 +510,7 @@ impl AppError {
             Self::InviteCodeInvalid => "invite_code_invalid",
             Self::InviteCodeExhausted => "invite_code_exhausted",
             Self::InviteCodeDeactivated => "invite_code_deactivated",
+            Self::InviteCodeAlreadyRedeemed => "invite_code_already_redeemed",
         }
     }
 }
@@ -802,6 +808,10 @@ mod tests {
             AppError::InviteCodeDeactivated.status_code(),
             StatusCode::BAD_REQUEST
         );
+        assert_eq!(
+            AppError::InviteCodeAlreadyRedeemed.status_code(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     #[test]
@@ -871,6 +881,7 @@ mod tests {
             AppError::InviteCodeInvalid.error_code(),
             AppError::InviteCodeExhausted.error_code(),
             AppError::InviteCodeDeactivated.error_code(),
+            AppError::InviteCodeAlreadyRedeemed.error_code(),
         ];
         let unique: std::collections::HashSet<u32> = codes.iter().copied().collect();
         assert_eq!(
@@ -1099,6 +1110,15 @@ mod tests {
         assert_eq!(
             format!("{}", AppError::InviteCodeDeactivated),
             "Invite code has been deactivated"
+        );
+        assert_eq!(
+            AppError::InviteCodeAlreadyRedeemed.error_key(),
+            "invite_code_already_redeemed"
+        );
+        assert_eq!(AppError::InviteCodeAlreadyRedeemed.error_code(), 8203);
+        assert_eq!(
+            format!("{}", AppError::InviteCodeAlreadyRedeemed),
+            "Invite code has already been redeemed"
         );
     }
 

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -366,7 +366,41 @@ pub async fn register(
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .ok_or_else(|| AppError::ValidationError("Invite code is required".to_string()))?;
-        Some(invite_code_service::reserve_invite_code(&state.db, raw_code).await?)
+        match invite_code_service::reserve_invite_code(&state.db, raw_code, &body.email).await {
+            Ok(id) => Some(id),
+            // Enumeration-safe: treat an already-redeemed code as if the
+            // email address simply doesn't exist yet. Return the same
+            // fake-success response used for duplicate-email registrations so
+            // callers cannot distinguish "code used" from "email unknown".
+            // Nothing was reserved, so there is nothing to release. We mirror
+            // the duplicate-email path's audit side-effect (and add a warn) so
+            // the two paths are indistinguishable AND the reuse attempt is
+            // still recorded for audit/monitoring.
+            Err(AppError::InviteCodeAlreadyRedeemed) => {
+                tracing::warn!("Registration attempt with an already-redeemed invite code");
+                let message = if state.config.auto_verify_email {
+                    "Registration processed. You can now sign in.".to_string()
+                } else {
+                    "Check your email for a verification link to complete registration.".to_string()
+                };
+                let fake_user_id = uuid::Uuid::new_v4().to_string();
+                audit_service::log_async(
+                    state.db.clone(),
+                    Some(fake_user_id.clone()),
+                    "register".to_string(),
+                    Some(serde_json::json!({ "email": body.email })),
+                    extract_ip(&headers, Some(peer)),
+                    extract_user_agent(&headers),
+                    None,
+                    None,
+                );
+                return Ok(Json(RegisterResponse {
+                    user_id: fake_user_id,
+                    message,
+                }));
+            }
+            Err(e) => return Err(e),
+        }
     } else {
         None
     };
@@ -384,7 +418,8 @@ pub async fn register(
     let result = match register_result {
         Ok(r) if r.actually_created => {
             if let Some(ref code_id) = invite_code_id {
-                invite_code_service::record_usage(&state.db, code_id, &r.user_id).await;
+                invite_code_service::record_usage(&state.db, code_id, &r.user_id, &body.email)
+                    .await;
             }
             r
         }

--- a/backend/src/handlers/social_auth.rs
+++ b/backend/src/handlers/social_auth.rs
@@ -395,17 +395,26 @@ pub async fn callback(
         .map(|c| c.into_owned())
         .filter(|c| !c.is_empty());
 
-    let (allow_new_users, reserved_invite_id) = if state.config.invite_code_required {
-        match invite_code.as_deref() {
-            Some(code) => match invite_code_service::reserve_invite_code(&state.db, code).await {
-                Ok(invite_id) => (true, Some(invite_id)),
-                Err(_) => (false, None),
-            },
-            None => (false, None),
-        }
-    } else {
-        (true, None)
-    };
+    let (allow_new_users, reserved_invite_id, already_redeemed) =
+        if state.config.invite_code_required {
+            match invite_code.as_deref() {
+                Some(code) => {
+                    match invite_code_service::reserve_invite_code(&state.db, code, &profile.email)
+                        .await
+                    {
+                        Ok(invite_id) => (true, Some(invite_id), false),
+                        // The email already consumed a slot. Set allow_new_users=false
+                        // so find_or_create_user rejects new signups, but existing
+                        // users still log in (find_or_create_user returns Ok for them).
+                        Err(AppError::InviteCodeAlreadyRedeemed) => (false, None, true),
+                        Err(_) => (false, None, false),
+                    }
+                }
+                None => (false, None, false),
+            }
+        } else {
+            (true, None, false)
+        };
 
     let create_outcome =
         social_auth_service::find_or_create_user(&state.db, &profile, allow_new_users)
@@ -424,6 +433,12 @@ pub async fn callback(
                     AppError::SocialAuthConflict => "social_auth_conflict",
                     AppError::SocialAuthNoEmail => "social_auth_no_email",
                     AppError::SocialAuthDeactivated => "social_auth_deactivated",
+                    // Surface invite_code_already_redeemed when registration was
+                    // blocked because this email already consumed a slot. Existing
+                    // users never reach this arm (find_or_create_user returns Ok for them).
+                    AppError::SocialAuthRegistrationClosed if already_redeemed => {
+                        "invite_code_already_redeemed"
+                    }
                     AppError::SocialAuthRegistrationClosed => "social_auth_registration_closed",
                     _ => "social_auth_exchange",
                 };
@@ -434,7 +449,7 @@ pub async fn callback(
 
     // Record invite code usage after successful user creation / lookup.
     if let Some(ref iid) = reserved_invite_id {
-        let _ = invite_code_service::record_usage(&state.db, iid, &user.id).await;
+        let _ = invite_code_service::record_usage(&state.db, iid, &user.id, &profile.email).await;
     }
 
     let ip = extract_ip(&headers, Some(peer));
@@ -803,17 +818,23 @@ pub async fn apple_callback(
         .map(|c| c.into_owned())
         .filter(|c| !c.is_empty());
 
-    let (allow_new_users, reserved_invite_id) = if state.config.invite_code_required {
-        match invite_code.as_deref() {
-            Some(code) => match invite_code_service::reserve_invite_code(&state.db, code).await {
-                Ok(invite_id) => (true, Some(invite_id)),
-                Err(_) => (false, None),
-            },
-            None => (false, None),
-        }
-    } else {
-        (true, None)
-    };
+    let (allow_new_users, reserved_invite_id, already_redeemed) =
+        if state.config.invite_code_required {
+            match invite_code.as_deref() {
+                Some(code) => {
+                    match invite_code_service::reserve_invite_code(&state.db, code, &profile.email)
+                        .await
+                    {
+                        Ok(invite_id) => (true, Some(invite_id), false),
+                        Err(AppError::InviteCodeAlreadyRedeemed) => (false, None, true),
+                        Err(_) => (false, None, false),
+                    }
+                }
+                None => (false, None, false),
+            }
+        } else {
+            (true, None, false)
+        };
 
     let create_outcome =
         social_auth_service::find_or_create_user(&state.db, &profile, allow_new_users)
@@ -831,6 +852,9 @@ pub async fn apple_callback(
                     AppError::SocialAuthConflict => "social_auth_conflict",
                     AppError::SocialAuthNoEmail => "social_auth_no_email",
                     AppError::SocialAuthDeactivated => "social_auth_deactivated",
+                    AppError::SocialAuthRegistrationClosed if already_redeemed => {
+                        "invite_code_already_redeemed"
+                    }
                     AppError::SocialAuthRegistrationClosed => "social_auth_registration_closed",
                     _ => "social_auth_exchange",
                 };
@@ -841,7 +865,7 @@ pub async fn apple_callback(
 
     // Record invite code usage after successful user creation / lookup.
     if let Some(ref iid) = reserved_invite_id {
-        let _ = invite_code_service::record_usage(&state.db, iid, &user.id).await;
+        let _ = invite_code_service::record_usage(&state.db, iid, &user.id, &profile.email).await;
     }
 
     let ip = extract_ip(&headers, Some(peer));

--- a/backend/src/models/invite_code.rs
+++ b/backend/src/models/invite_code.rs
@@ -9,6 +9,10 @@ pub struct InviteCodeUsage {
     pub user_id: String,
     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
     pub used_at: DateTime<Utc>,
+    /// Normalized (trimmed + lowercased) email of the registrant. Absent on
+    /// legacy usages recorded before per-identity enforcement was added.
+    #[serde(default)]
+    pub email: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/backend/src/services/invite_code_service.rs
+++ b/backend/src/services/invite_code_service.rs
@@ -82,6 +82,14 @@ pub fn normalize_code(input: &str) -> String {
     input.trim().to_uppercase()
 }
 
+/// Normalize an email to its canonical form for per-identity deduplication.
+///
+/// Trims surrounding whitespace and lowercases, matching the storage
+/// convention used everywhere else in the auth layer.
+pub fn normalize_email(input: &str) -> String {
+    input.trim().to_lowercase()
+}
+
 /// Return true if the given MongoDB error represents a unique-index violation.
 fn is_duplicate_key_error(e: &mongodb::error::Error) -> bool {
     matches!(
@@ -140,22 +148,34 @@ pub async fn create_invite_code(
 
 /// Atomically reserve one slot on an invite code.
 ///
-/// Returns `Ok(invite_code_id)` on success. On failure, returns one of three
+/// Returns `Ok(invite_code_id)` on success. On failure, returns one of four
 /// distinct errors so the registration UI can show an actionable message:
 ///   * `AppError::InviteCodeInvalid` — no code matches (never existed, or typo).
 ///   * `AppError::InviteCodeDeactivated` — the admin disabled this code.
+///   * `AppError::InviteCodeAlreadyRedeemed` — this email already consumed a slot.
 ///   * `AppError::InviteCodeExhausted` — the code has reached `max_uses`.
 ///
 /// Implementation: the atomic `find_one_and_update` runs first so the happy
-/// path is a single round-trip. Only when the update matched nothing do we
-/// fall back to a `find_one` diagnostic lookup to determine *why* it missed.
-/// This keeps the hot path fast while still giving the user a specific error.
+/// path is a single round-trip. The filter includes `"usages.email": {$ne:
+/// normalized_email}` so a second reservation for the same identity is
+/// rejected atomically. Missing/legacy `email` fields on existing usages are
+/// treated as not-equal by MongoDB's `$ne` semantics, so old records never
+/// block new redemptions (forward-only).
+///
+/// Only when the update matched nothing do we fall back to a `find_one`
+/// diagnostic lookup to determine *why* it missed. This keeps the hot path
+/// fast while still giving the user a specific error.
 ///
 /// This only touches `used_count`; the caller is responsible for recording
 /// the usage (via `record_usage`) once the downstream user creation succeeds,
 /// and releasing (via `release_reservation`) if it fails.
-pub async fn reserve_invite_code(db: &mongodb::Database, code: &str) -> AppResult<String> {
+pub async fn reserve_invite_code(
+    db: &mongodb::Database,
+    code: &str,
+    email: &str,
+) -> AppResult<String> {
     let normalized = normalize_code(code);
+    let normalized_email = normalize_email(email);
     let now = bson::DateTime::from_chrono(Utc::now());
 
     let options = FindOneAndUpdateOptions::builder()
@@ -170,6 +190,7 @@ pub async fn reserve_invite_code(db: &mongodb::Database, code: &str) -> AppResul
                 "code": &normalized,
                 "is_active": true,
                 "$expr": { "$lt": ["$used_count", "$max_uses"] },
+                "usages.email": { "$ne": &normalized_email },
             },
             doc! {
                 "$inc": { "used_count": 1 },
@@ -183,12 +204,22 @@ pub async fn reserve_invite_code(db: &mongodb::Database, code: &str) -> AppResul
         return Ok(invite.id);
     }
 
-    // Diagnose why the reservation failed. Order matters: deactivated takes
-    // precedence over exhausted, since an admin may have deactivated a code
-    // that also happens to be full. Both are more informative than "invalid".
+    // Diagnose why the reservation failed. Ordering is intentional:
+    //   1. Deactivated — admin-disabled takes precedence over everything.
+    //   2. AlreadyRedeemed — per-identity enforcement (email in usages).
+    //   3. Exhausted — all slots consumed.
+    //   4. Invalid — race window (see below) or code never existed.
     match collection.find_one(doc! { "code": &normalized }).await? {
         None => Err(AppError::InviteCodeInvalid),
         Some(invite) if !invite.is_active => Err(AppError::InviteCodeDeactivated),
+        Some(invite)
+            if invite
+                .usages
+                .iter()
+                .any(|u| u.email.as_deref() == Some(normalized_email.as_str())) =>
+        {
+            Err(AppError::InviteCodeAlreadyRedeemed)
+        }
         Some(invite) if invite.used_count >= invite.max_uses => Err(AppError::InviteCodeExhausted),
         // Race: the code became valid between the update miss and the
         // diagnostic read (e.g. `release_reservation` landed in between).
@@ -203,10 +234,19 @@ pub async fn reserve_invite_code(db: &mongodb::Database, code: &str) -> AppResul
 /// Best-effort append to the `usages` array. Failures are logged but do not
 /// propagate: the user has already been successfully created, and the atomic
 /// reservation still accurately reflects that one slot was consumed.
-pub async fn record_usage(db: &mongodb::Database, invite_code_id: &str, user_id: &str) {
+///
+/// `email` is normalized (trimmed + lowercased) before storage so the
+/// per-identity deduplication filter in `reserve_invite_code` finds it.
+pub async fn record_usage(
+    db: &mongodb::Database,
+    invite_code_id: &str,
+    user_id: &str,
+    email: &str,
+) {
     let usage = InviteCodeUsage {
         user_id: user_id.to_string(),
         used_at: Utc::now(),
+        email: Some(normalize_email(email)),
     };
     let usage_bson = match bson::to_bson(&usage) {
         Ok(b) => b,
@@ -497,5 +537,150 @@ mod tests {
         assert_eq!(normalize_code(&generated), generated);
         // Lowercase variant of the same code should normalize to the generated form.
         assert_eq!(normalize_code(&generated.to_lowercase()), generated);
+    }
+
+    #[test]
+    fn normalize_email_lowercases_and_trims() {
+        assert_eq!(normalize_email("Alice@Example.COM"), "alice@example.com");
+        assert_eq!(normalize_email("  user@domain.io  "), "user@domain.io");
+        assert_eq!(normalize_email("UPPER@CASE.NET"), "upper@case.net");
+        assert_eq!(normalize_email(""), "");
+        assert_eq!(normalize_email("   "), "");
+        // Internal case is lowered; surrounding whitespace stripped
+        assert_eq!(normalize_email(" Mixed.Case@X.Y "), "mixed.case@x.y");
+    }
+
+    #[test]
+    fn normalize_email_idempotent() {
+        let addr = "already@normalized.com";
+        assert_eq!(normalize_email(addr), addr);
+        assert_eq!(
+            normalize_email(&normalize_email("USER@HOST.ORG")),
+            "user@host.org"
+        );
+    }
+
+    // ── Integration tests (require local MongoDB) ─────────────────────────────
+    // These tests use `connect_test_database`. If no MongoDB is reachable they
+    // skip cleanly. Each test uses a unique DB name so tests are isolated.
+
+    #[tokio::test]
+    async fn reserve_rejects_already_redeemed_email() {
+        let Some(db) = crate::test_utils::connect_test_database("invite_already_redeemed").await
+        else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let code = create_invite_code(&db, "admin", 10, None).await.unwrap();
+
+        // First reservation for this email succeeds.
+        let id = reserve_invite_code(&db, &code.code, "alice@example.com")
+            .await
+            .unwrap();
+
+        // Record the usage so the email is persisted on the document.
+        record_usage(&db, &id, "user-1", "alice@example.com").await;
+
+        // Second reservation for the same email (case-insensitive) is rejected.
+        let err = reserve_invite_code(&db, &code.code, "Alice@Example.COM")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::errors::AppError::InviteCodeAlreadyRedeemed),
+            "expected InviteCodeAlreadyRedeemed, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reserve_allows_distinct_email_on_same_code() {
+        let Some(db) = crate::test_utils::connect_test_database("invite_distinct_email").await
+        else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let code = create_invite_code(&db, "admin", 10, None).await.unwrap();
+
+        let id1 = reserve_invite_code(&db, &code.code, "alice@example.com")
+            .await
+            .unwrap();
+        record_usage(&db, &id1, "user-1", "alice@example.com").await;
+
+        // Different email on the same code — should succeed.
+        let result = reserve_invite_code(&db, &code.code, "bob@example.com").await;
+        assert!(
+            result.is_ok(),
+            "distinct email must be allowed; got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reserve_legacy_usage_without_email_does_not_block() {
+        use crate::models::invite_code::InviteCodeUsage;
+
+        let Some(db) = crate::test_utils::connect_test_database("invite_legacy_no_email").await
+        else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let code = create_invite_code(&db, "admin", 10, None).await.unwrap();
+
+        // Manually push a legacy usage with no `email` field (simulates records
+        // written before per-identity enforcement).
+        let legacy_usage = InviteCodeUsage {
+            user_id: "legacy-user".to_string(),
+            used_at: chrono::Utc::now(),
+            email: None, // absent on old records
+        };
+        let usage_bson = bson::to_bson(&legacy_usage).unwrap();
+        db.collection::<InviteCode>(COLLECTION_NAME)
+            .update_one(
+                doc! { "_id": &code.id },
+                doc! {
+                    "$push": { "usages": usage_bson },
+                    "$inc": { "used_count": 1 },
+                },
+            )
+            .await
+            .unwrap();
+
+        // A new reservation for a real email must still succeed — legacy entry
+        // must not block it.
+        let result = reserve_invite_code(&db, &code.code, "newuser@example.com").await;
+        assert!(
+            result.is_ok(),
+            "legacy usage without email must not block new reservation; got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reserve_already_redeemed_ordering_vs_deactivated() {
+        // A deactivated code reports Deactivated even if the email is also in usages.
+        let Some(db) = crate::test_utils::connect_test_database("invite_order_deactivated").await
+        else {
+            eprintln!("skipping integration test: no local MongoDB available");
+            return;
+        };
+
+        let code = create_invite_code(&db, "admin", 10, None).await.unwrap();
+        // Record a usage for the email.
+        let id = reserve_invite_code(&db, &code.code, "eve@example.com")
+            .await
+            .unwrap();
+        record_usage(&db, &id, "user-eve", "eve@example.com").await;
+
+        // Now deactivate the code.
+        deactivate_invite_code(&db, &code.id).await.unwrap();
+
+        // Should report Deactivated, not AlreadyRedeemed.
+        let err = reserve_invite_code(&db, &code.code, "eve@example.com")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::errors::AppError::InviteCodeDeactivated),
+            "deactivated must take precedence over already-redeemed; got: {err:?}"
+        );
     }
 }

--- a/frontend/src/components/auth/auth-flow.test.tsx
+++ b/frontend/src/components/auth/auth-flow.test.tsx
@@ -165,6 +165,18 @@ describe("AuthFlow — login", () => {
     );
   });
 
+  it("maps invite_code_already_redeemed to the already-redeemed message", () => {
+    render(
+      <AuthFlow
+        initialPanel={0}
+        socialError="invite_code_already_redeemed"
+      />,
+    );
+    expect(screen.getByTestId("social-error")).toHaveTextContent(
+      "This invite code has already been redeemed with this account.",
+    );
+  });
+
   it("hides the email/password form when email auth is disabled", () => {
     config.value = {
       invite_code_required: true,

--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -61,6 +61,8 @@ const SOCIAL_ERROR_MESSAGES: Record<string, string> = {
   social_auth_failed: "Social sign-in failed. Please try again.",
   social_auth_exchange:
     "Social sign-in failed due to a temporary error. Please try again.",
+  invite_code_already_redeemed:
+    "This invite code has already been redeemed with this account.",
 };
 
 /** Trusted origins for return_to redirect validation (open-redirect prevention). */

--- a/frontend/src/pages/admin-invite-codes.tsx
+++ b/frontend/src/pages/admin-invite-codes.tsx
@@ -76,7 +76,7 @@ export function AdminInviteCodesPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [createdCode, setCreatedCode] = useState<InviteCode | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [, setCopiedLinkId] = useState<string | null>(null);
+  const [copiedLinkId, setCopiedLinkId] = useState<string | null>(null);
   const [deactivateTarget, setDeactivateTarget] = useState<InviteCode | null>(
     null,
   );
@@ -660,6 +660,52 @@ export function AdminInviteCodesPage() {
                 <SheetDescription>
                   Detailed usage and editable note for this invite code.
                 </SheetDescription>
+                <div className="flex items-center gap-2 pt-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      void handleCopyCode(selectedCode.code, selectedCode.id)
+                    }
+                  >
+                    {copiedId === selectedCode.id ? (
+                      <>
+                        <Check
+                          className="h-3 w-3 text-success"
+                          aria-hidden="true"
+                        />
+                        Copied
+                      </>
+                    ) : (
+                      <>
+                        <Copy className="h-3 w-3" aria-hidden="true" />
+                        Copy code
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      void handleCopyLink(selectedCode.code, selectedCode.id)
+                    }
+                  >
+                    {copiedLinkId === selectedCode.id ? (
+                      <>
+                        <Check
+                          className="h-3 w-3 text-success"
+                          aria-hidden="true"
+                        />
+                        Copied
+                      </>
+                    ) : (
+                      <>
+                        <Link2 className="h-3 w-3" aria-hidden="true" />
+                        Copy invite link
+                      </>
+                    )}
+                  </Button>
+                </div>
               </SheetHeader>
 
               <div className="grid grid-cols-2 gap-4 rounded-md border border-border bg-muted/20 p-4 text-sm">


### PR DESCRIPTION
## Summary

Closes #829, plus a small invite-code admin UX addition.

Two changes:

1. **Single redemption per identity (#829).** A given identity (normalized email) can now redeem a given invite code at most once. This closes the SSO double-redemption gap where an existing user could consume a second slot by signing in with a code their email had already redeemed.
2. **Invite-code drawer copy actions.** The admin invite-code detail drawer now has **Copy code** and **Copy invite link** buttons (with Copied feedback), reusing the existing copy helpers.

## Backend

- `models/invite_code`: each `InviteCodeUsage` now records the normalized email. `#[serde(default)]` → **forward-only**: legacy usages without an email field never block new redemptions.
- `invite_code_service`: `reserve_invite_code` takes the email and atomically rejects an email already present in `usages` via a `{ "usages.email": { $ne } }` filter. New `InviteCodeAlreadyRedeemed` diagnostic; ordering is **Deactivated → AlreadyRedeemed → Exhausted → Invalid**.
- `errors`: new `InviteCodeAlreadyRedeemed` (code **8203**, key `invite_code_already_redeemed`, 400).
- `handlers/auth` (email/password): passes the email through; an already-redeemed code returns the **enumeration-safe fake-success** — byte-identical body to a real success *and* to the existing duplicate-email path, with the matching `audit_service` side-effect — so it can't be used as an email oracle.
- `handlers/social_auth` (both Google/GitHub and Apple callbacks): pass `profile.email`. **Existing users still log in** (no second slot consumed); brand-new SSO signups presenting an already-redeemed code are rejected with `invite_code_already_redeemed`. `record_usage` only fires when a slot was actually reserved.

## Frontend

- `admin-invite-codes`: Copy code + Copy invite link in the drawer; fixed the previously-unused `copiedLinkId` feedback state.
- `auth-flow`: maps `invite_code_already_redeemed` to a friendly message.

## Testing

- Backend: `cargo build` green; 15 invite-code tests + 8 error tests pass — including DB-backed integration tests that ran against a live MongoDB (single-redemption rejection, distinct-email allow, legacy-no-email forward-only, Deactivated-over-AlreadyRedeemed ordering).
- Frontend: `npm run build` + `npm run lint` clean; `npm run test` green (1240 tests), including a new error-mapping test.

## Review

Implemented and self-reviewed by a delegated agent, independently reviewed by the Antigravity CLI (verdict: ship with minor fixes), then a final review here. The one finding — the already-redeemed path skipping the duplicate-email audit log — was applied (audit parity + records the reuse attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
