### PR TITLE
ci: add coverage gates (cargo llvm-cov + vitest --coverage)

### DIFF
--- a/.github/scripts/coverage_comment.py
+++ b/.github/scripts/coverage_comment.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Render the aggregated coverage PR comment from per-component summary JSONs.
+
+Reads every coverage-*.json produced by the coverage jobs (issue #785) in the
+given directory and prints a markdown table to stdout: each component's head
+line %, its enforced threshold, pass/fail status, and the delta vs. the base
+branch. Components whose job was skipped (e.g. docs-only PR) simply don't have
+a summary file and are omitted.
+
+Usage:
+    coverage_comment.py <artifacts-dir>
+"""
+import glob
+import json
+import os
+import sys
+
+MARKER = "<!-- nyxid-coverage-report -->"
+
+# Stable display order regardless of artifact download order.
+ORDER = {"backend": 0, "cli": 1, "frontend": 2}
+
+
+def fmt_delta(head: float, base) -> str:
+    if base is None:
+        return "n/a"
+    d = round(head - base, 2)
+    if d > 0:
+        return f"🔺 +{d:.2f}"
+    if d < 0:
+        return f"🔻 {d:.2f}"
+    return "—  0.00"
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(__doc__)
+    root = sys.argv[1]
+    summaries = []
+    for path in glob.glob(os.path.join(root, "**", "coverage-*.json"), recursive=True):
+        # Skip the raw/base intermediates; only the normalized summaries have
+        # both "component" and "threshold".
+        try:
+            with open(path, encoding="utf-8") as fh:
+                doc = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        if "component" in doc and "threshold" in doc and "head_pct" in doc:
+            summaries.append(doc)
+
+    # De-dup by component (merge-multiple download can surface one file each).
+    by_component = {}
+    for s in summaries:
+        by_component[s["component"]] = s
+    summaries = sorted(by_component.values(), key=lambda s: ORDER.get(s["component"], 99))
+
+    lines = [
+        MARKER,
+        "## 📊 Code coverage",
+        "",
+    ]
+    if not summaries:
+        lines.append("_No coverage components ran for this PR._")
+        print("\n".join(lines))
+        return
+
+    lines += [
+        "| Component | Lines | Threshold | Status | Δ vs base |",
+        "| --- | ---: | ---: | :---: | ---: |",
+    ]
+    any_fail = False
+    for s in summaries:
+        head = s["head_pct"]
+        threshold = s["threshold"]
+        passed = head >= threshold
+        any_fail = any_fail or not passed
+        status = "✅" if passed else "❌"
+        lines.append(
+            f"| {s['label']} | {head:.2f}% | {threshold}% | {status} | "
+            f"{fmt_delta(head, s.get('base_pct'))} |"
+        )
+
+    lines += [
+        "",
+        "Gate: line coverage must stay at or above the threshold. "
+        "Ratchet plan (W21): Backend → 55%, CLI → 50%, Frontend → 30% by quarter end.",
+    ]
+    if any_fail:
+        lines.append("")
+        lines.append("> ❌ One or more components are below threshold — see the failing coverage job.")
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/coverage_merge_base.py
+++ b/.github/scripts/coverage_merge_base.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Merge the base-branch line % into an existing coverage summary JSON.
+
+Best-effort: if the base report is missing or unparseable (the base coverage
+step is `continue-on-error`), `base_pct` is left null and the PR comment shows
+the delta as "n/a". This never fails the gate.
+
+Usage:
+    coverage_merge_base.py <summary.json> <base-report.json>
+"""
+import json
+import sys
+
+# Reuse the shape detection from the sibling summary script.
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+from coverage_summary import line_pct  # noqa: E402
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__)
+    summary_path, base_path = sys.argv[1:3]
+    with open(summary_path, encoding="utf-8") as fh:
+        summary = json.load(fh)
+    try:
+        with open(base_path, encoding="utf-8") as fh:
+            base_doc = json.load(fh)
+        summary["base_pct"] = round(line_pct(base_doc), 2)
+        print(f"base lines {summary['base_pct']}%")
+    except (OSError, ValueError, SystemExit) as err:
+        print(f"base coverage unavailable ({err}); delta will render as n/a")
+        summary["base_pct"] = None
+    with open(summary_path, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/coverage_merge_base.py
+++ b/.github/scripts/coverage_merge_base.py
@@ -9,10 +9,11 @@ Usage:
     coverage_merge_base.py <summary.json> <base-report.json>
 """
 import json
+import os
 import sys
 
 # Reuse the shape detection from the sibling summary script.
-sys.path.insert(0, __file__.rsplit("/", 1)[0])
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from coverage_summary import line_pct  # noqa: E402
 
 

--- a/.github/scripts/coverage_summary.py
+++ b/.github/scripts/coverage_summary.py
@@ -25,12 +25,17 @@ def line_pct(doc: dict) -> float:
         lines = totals.get("lines", {})
         if "percent" in lines:
             return float(lines["percent"])
-    # vitest v8 json-summary: {"total": {"lines": {"pct": ...}}}
+    # vitest v8 json-summary: {"total": {"lines": {"pct": ...}}}. v8 emits the
+    # string "Unknown" when no files match the include glob — treat that (and
+    # any non-numeric value) as 0% so the gate fails loudly instead of crashing.
     total = doc.get("total")
     if isinstance(total, dict):
         lines = total.get("lines", {})
         if "pct" in lines:
-            return float(lines["pct"])
+            try:
+                return float(lines["pct"])
+            except (TypeError, ValueError):
+                return 0.0
     raise SystemExit(f"unrecognized coverage report shape; keys={list(doc)}")
 
 

--- a/.github/scripts/coverage_summary.py
+++ b/.github/scripts/coverage_summary.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Normalize a coverage report into a tiny summary JSON for the CI gate.
+
+Used by .github/workflows/ci.yml coverage jobs (issue #785). Reads either a
+`cargo llvm-cov report --json --summary-only` document (Rust) or a vitest v8
+`coverage-summary.json` (Frontend) and writes:
+
+    {"component": "...", "label": "...", "threshold": <int>, "head_pct": <float>}
+
+The base-branch line % is merged in later by coverage_merge_base.py.
+
+Usage:
+    coverage_summary.py <component> <label> <threshold> <input.json> <output.json>
+"""
+import json
+import sys
+
+
+def line_pct(doc: dict) -> float:
+    """Extract total line coverage % from either supported report shape."""
+    # cargo-llvm-cov: {"data": [{"totals": {"lines": {"percent": ...}}}]}
+    data = doc.get("data")
+    if isinstance(data, list) and data:
+        totals = data[0].get("totals", {})
+        lines = totals.get("lines", {})
+        if "percent" in lines:
+            return float(lines["percent"])
+    # vitest v8 json-summary: {"total": {"lines": {"pct": ...}}}
+    total = doc.get("total")
+    if isinstance(total, dict):
+        lines = total.get("lines", {})
+        if "pct" in lines:
+            return float(lines["pct"])
+    raise SystemExit(f"unrecognized coverage report shape; keys={list(doc)}")
+
+
+def main() -> None:
+    if len(sys.argv) != 6:
+        raise SystemExit(__doc__)
+    component, label, threshold, in_path, out_path = sys.argv[1:6]
+    with open(in_path, encoding="utf-8") as fh:
+        doc = json.load(fh)
+    summary = {
+        "component": component,
+        "label": label,
+        "threshold": int(threshold),
+        "head_pct": round(line_pct(doc), 2),
+        "base_pct": None,
+    }
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+    print(f"{label}: head lines {summary['head_pct']}% (threshold {threshold}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,301 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  # ===========================================================================
+  # Code coverage gates (issue #785).
+  #
+  # Three measurement jobs (Backend / CLI / Frontend) each:
+  #   1. Measure line coverage on the PR head and FAIL if it drops below the
+  #      enforced threshold (Rust: `cargo llvm-cov --fail-under-lines`;
+  #      Frontend: vitest `coverage.thresholds.lines` in vite.config.ts).
+  #   2. Emit a machine-readable line-% number + an lcov report.
+  #   3. On pull_request events, also measure the BASE branch so the comment
+  #      job can show a per-component line-% delta (AC #4). The base measurement
+  #      is best-effort (`continue-on-error`): if it can't be produced the head
+  #      gate still runs and the delta simply renders as "n/a". It never blocks.
+  #   4. Upload the report + a tiny `coverage-<component>.json` summary as a CI
+  #      artifact (AC #6). The summary files feed the PR-comment job.
+  #
+  # Enforced thresholds (fail the PR if line % drops below):
+  #   Backend (nyxid)     >= 40%   (currently ~43.7%, PR #836)
+  #   CLI (nyxid-cli)      >= 30%   (currently ~63.5%, PR #836)
+  #   Frontend (vitest)    >= 15%   (currently ~41%)
+  #
+  # RATCHET PLAN (W21 coverage push, issues #782-#787): as those test issues
+  # land, raise the gates to BE -> 55%, CLI -> 50%, FE -> 30% by quarter end.
+  # Bump the `--fail-under-lines` values below AND the matching FE
+  # `coverage.thresholds.lines` in frontend/vite.config.ts together. Only ever
+  # ratchet UP — never lower a threshold to make a red PR pass.
+  #
+  # NOTE on Rust % vs PR #836: `cargo-llvm-cov` counts inline `#[cfg(test)]`
+  # modules in the denominator, so the reported % is a few points lower than a
+  # production-only measurement. The gates are set conservatively against the
+  # PR #836 numbers to absorb that and normal churn.
+  # ===========================================================================
+
+  # ---------------------------------------------------------------------------
+  # Backend (nyxid) line coverage. Mirrors `backend-test`: needs MongoDB on
+  # 27017 so DB-gated handler/service tests run instead of skipping (otherwise
+  # coverage would be understated). The instrumented run is slow (~15 min); the
+  # base-branch comparison adds a second run, so it is gated to pull_request
+  # only and allowed to fail without blocking the gate.
+  # ---------------------------------------------------------------------------
+  coverage-backend:
+    name: Coverage (Backend)
+    needs: changes
+    if: inputs.force-all || needs.changes.outputs.ci == 'true' || needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:8.0
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage-backend
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      # Head: enforce the gate (this is the one that can fail the PR) and emit
+      # an lcov report + a one-line summary JSON in the same instrumented run.
+      - name: Measure + gate (head)
+        run: |
+          cargo llvm-cov --package nyxid --summary-only --fail-under-lines 40
+          cargo llvm-cov report --lcov --output-path coverage-backend.lcov
+          cargo llvm-cov report --json --summary-only --output-path coverage-backend.raw.json
+
+      - name: Build head summary JSON
+        run: |
+          python3 .github/scripts/coverage_summary.py \
+            backend "Backend (nyxid)" 40 \
+            coverage-backend.raw.json coverage-backend.json
+
+      # Base: best-effort second run for the delta. Never blocks the gate.
+      - name: Measure base branch
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git worktree add ../base-coverage "$BASE_REF"
+          ( cd ../base-coverage && cargo llvm-cov --package nyxid --summary-only \
+              && cargo llvm-cov report --json --summary-only \
+                 --output-path "$GITHUB_WORKSPACE/coverage-backend.base.json" )
+
+      - name: Merge base line % into summary
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 .github/scripts/coverage_merge_base.py \
+            coverage-backend.json coverage-backend.base.json
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-backend
+          path: |
+            coverage-backend.lcov
+            coverage-backend.json
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # CLI (nyxid-cli) line coverage. No DB needed (mirrors `cli-test`).
+  # ---------------------------------------------------------------------------
+  coverage-cli:
+    name: Coverage (CLI)
+    needs: changes
+    if: inputs.force-all || needs.changes.outputs.ci == 'true' || needs.changes.outputs.cli == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage-cli
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Measure + gate (head)
+        run: |
+          cargo llvm-cov --package nyxid-cli --summary-only --fail-under-lines 30
+          cargo llvm-cov report --lcov --output-path coverage-cli.lcov
+          cargo llvm-cov report --json --summary-only --output-path coverage-cli.raw.json
+
+      - name: Build head summary JSON
+        run: |
+          python3 .github/scripts/coverage_summary.py \
+            cli "CLI (nyxid-cli)" 30 \
+            coverage-cli.raw.json coverage-cli.json
+
+      - name: Measure base branch
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git worktree add ../base-coverage "$BASE_REF"
+          ( cd ../base-coverage && cargo llvm-cov --package nyxid-cli --summary-only \
+              && cargo llvm-cov report --json --summary-only \
+                 --output-path "$GITHUB_WORKSPACE/coverage-cli.base.json" )
+
+      - name: Merge base line % into summary
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 .github/scripts/coverage_merge_base.py \
+            coverage-cli.json coverage-cli.base.json
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-cli
+          path: |
+            coverage-cli.lcov
+            coverage-cli.json
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # Frontend (vitest --coverage). The line threshold is enforced by
+  # `coverage.thresholds.lines` in frontend/vite.config.ts, so `test:coverage`
+  # exits non-zero on a regression. We read the line % from the v8
+  # json-summary reporter (coverage/coverage-summary.json).
+  # ---------------------------------------------------------------------------
+  coverage-frontend:
+    name: Coverage (Frontend)
+    needs: changes
+    if: inputs.force-all || needs.changes.outputs.ci == 'true' || needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+
+      # Head: enforce the gate (vite.config.ts thresholds.lines) + emit summary.
+      - name: Measure + gate (head)
+        run: npm run test:coverage
+
+      - name: Build head summary JSON
+        working-directory: ${{ github.workspace }}
+        run: |
+          python3 .github/scripts/coverage_summary.py \
+            frontend "Frontend (vitest)" 15 \
+            frontend/coverage/coverage-summary.json coverage-frontend.json
+
+      # Base: best-effort. Check out the base tree, install, run coverage
+      # WITHOUT the threshold gate (--coverage.thresholds.lines=0) so a low base
+      # never errors here.
+      - name: Measure base branch
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        working-directory: ${{ github.workspace }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git worktree add ../base-coverage "$BASE_REF"
+          ( cd ../base-coverage/frontend \
+              && npm ci \
+              && env NODE_ENV=test npx vitest run --coverage --coverage.thresholds.lines=0 )
+          cp ../base-coverage/frontend/coverage/coverage-summary.json \
+             frontend-coverage-base.json
+
+      - name: Merge base line % into summary
+        if: github.event_name == 'pull_request'
+        working-directory: ${{ github.workspace }}
+        run: |
+          python3 .github/scripts/coverage_merge_base.py \
+            coverage-frontend.json frontend-coverage-base.json
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-frontend
+          path: |
+            frontend/coverage/lcov.info
+            frontend/coverage/coverage-summary.json
+            coverage-frontend.json
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # PR comment: aggregate the three coverage summaries into one sticky comment
+  # showing each component's line %, its enforced threshold, and the delta vs.
+  # the base branch (AC #4). Runs only on pull_request, after the measurement
+  # jobs, and tolerates skipped components (docs-only PR -> some jobs skip).
+  # ---------------------------------------------------------------------------
+  coverage-comment:
+    name: Coverage PR Comment
+    if: always() && github.event_name == 'pull_request'
+    needs:
+      - coverage-backend
+      - coverage-cli
+      - coverage-frontend
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download coverage summaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+          merge-multiple: true
+      - name: Build comment body
+        id: body
+        run: |
+          python3 .github/scripts/coverage_comment.py \
+            coverage-artifacts > coverage-comment.md
+          cat coverage-comment.md
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('coverage-comment.md', 'utf8');
+            const marker = '<!-- nyxid-coverage-report -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }
+
   # ---------------------------------------------------------------------------
   # Aggregator: a single status check that summarises the whole pipeline.
   #
@@ -377,10 +672,17 @@ jobs:
       - frontend
       - wizard-bundle-freshness
       - sdk
+      - coverage-backend
+      - coverage-cli
+      - coverage-frontend
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs succeeded or were skipped intentionally
         env:
+          # NOTE: `coverage-comment` is intentionally NOT gated here -- it is an
+          # informational PR comment, not a correctness check. The three
+          # `coverage-*` measurement jobs ARE gated: they fail when line
+          # coverage drops below the enforced threshold.
           RESULTS: |
             changes=${{ needs.changes.result }}
             rust-fmt=${{ needs.rust-fmt.result }}
@@ -391,6 +693,9 @@ jobs:
             frontend=${{ needs.frontend.result }}
             wizard-bundle-freshness=${{ needs.wizard-bundle-freshness.result }}
             sdk=${{ needs.sdk.result }}
+            coverage-backend=${{ needs.coverage-backend.result }}
+            coverage-cli=${{ needs.coverage-cli.result }}
+            coverage-frontend=${{ needs.coverage-frontend.result }}
         run: |
           set -eu
           echo "Job results:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,13 +420,17 @@ jobs:
           key: coverage-backend
       - uses: taiki-e/install-action@cargo-llvm-cov
 
-      # Head: enforce the gate (this is the one that can fail the PR) and emit
-      # an lcov report + a one-line summary JSON in the same instrumented run.
-      - name: Measure + gate (head)
+      # Head: instrument + measure WITHOUT the gate, emitting an lcov report and
+      # a one-line summary JSON. The threshold is enforced as the final step in
+      # this job (below) so the report, summary, and base delta are always
+      # produced — even on a regression — and surface in the PR comment.
+      # `report` is package-scoped so the % isn't diluted by the rest of the
+      # workspace (whose tests this job does not run).
+      - name: Measure (head)
         run: |
-          cargo llvm-cov --package nyxid --summary-only --fail-under-lines 40
-          cargo llvm-cov report --lcov --output-path coverage-backend.lcov
-          cargo llvm-cov report --json --summary-only --output-path coverage-backend.raw.json
+          cargo llvm-cov --package nyxid --summary-only
+          cargo llvm-cov report --package nyxid --lcov --output-path coverage-backend.lcov
+          cargo llvm-cov report --package nyxid --json --summary-only --output-path coverage-backend.raw.json
 
       - name: Build head summary JSON
         run: |
@@ -443,7 +447,7 @@ jobs:
         run: |
           git worktree add ../base-coverage "$BASE_REF"
           ( cd ../base-coverage && cargo llvm-cov --package nyxid --summary-only \
-              && cargo llvm-cov report --json --summary-only \
+              && cargo llvm-cov report --package nyxid --json --summary-only \
                  --output-path "$GITHUB_WORKSPACE/coverage-backend.base.json" )
 
       - name: Merge base line % into summary
@@ -451,6 +455,12 @@ jobs:
         run: |
           python3 .github/scripts/coverage_merge_base.py \
             coverage-backend.json coverage-backend.base.json
+
+      # Enforce the threshold LAST, after the report + summary + delta are built,
+      # so a regression fails the job *and* still surfaces the failing number in
+      # the PR comment. Re-reads the existing profdata (no re-run).
+      - name: Enforce coverage gate (head)
+        run: cargo llvm-cov report --package nyxid --fail-under-lines 40
 
       - name: Upload coverage artifact
         if: always()
@@ -484,11 +494,13 @@ jobs:
           key: coverage-cli
       - uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Measure + gate (head)
+      # Measure WITHOUT the gate (enforced as the final step below). `report` is
+      # package-scoped so the % isn't diluted by the rest of the workspace.
+      - name: Measure (head)
         run: |
-          cargo llvm-cov --package nyxid-cli --summary-only --fail-under-lines 30
-          cargo llvm-cov report --lcov --output-path coverage-cli.lcov
-          cargo llvm-cov report --json --summary-only --output-path coverage-cli.raw.json
+          cargo llvm-cov --package nyxid-cli --summary-only
+          cargo llvm-cov report --package nyxid-cli --lcov --output-path coverage-cli.lcov
+          cargo llvm-cov report --package nyxid-cli --json --summary-only --output-path coverage-cli.raw.json
 
       - name: Build head summary JSON
         run: |
@@ -504,7 +516,7 @@ jobs:
         run: |
           git worktree add ../base-coverage "$BASE_REF"
           ( cd ../base-coverage && cargo llvm-cov --package nyxid-cli --summary-only \
-              && cargo llvm-cov report --json --summary-only \
+              && cargo llvm-cov report --package nyxid-cli --json --summary-only \
                  --output-path "$GITHUB_WORKSPACE/coverage-cli.base.json" )
 
       - name: Merge base line % into summary
@@ -512,6 +524,10 @@ jobs:
         run: |
           python3 .github/scripts/coverage_merge_base.py \
             coverage-cli.json coverage-cli.base.json
+
+      # Enforce the threshold LAST (see backend job for rationale).
+      - name: Enforce coverage gate (head)
+        run: cargo llvm-cov report --package nyxid-cli --fail-under-lines 30
 
       - name: Upload coverage artifact
         if: always()
@@ -548,9 +564,12 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
 
-      # Head: enforce the gate (vite.config.ts thresholds.lines) + emit summary.
-      - name: Measure + gate (head)
-        run: npm run test:coverage
+      # Head: measure WITHOUT the gate (override the line threshold to 0) so the
+      # coverage summary is always produced; the threshold is enforced as the
+      # final step below — mirroring the Rust jobs — so a regression still
+      # surfaces the failing number in the PR comment.
+      - name: Measure (head)
+        run: npm run test:coverage -- --coverage.thresholds.lines=0
 
       - name: Build head summary JSON
         working-directory: ${{ github.workspace }}
@@ -583,6 +602,21 @@ jobs:
           python3 .github/scripts/coverage_merge_base.py \
             coverage-frontend.json frontend-coverage-base.json
 
+      # Enforce the FE threshold LAST, reading the already-produced summary (no
+      # re-run) so a regression fails the job *and* still surfaces in the PR
+      # comment. Keep this threshold in sync with vite.config.ts (lines: 15).
+      - name: Enforce coverage gate (head)
+        working-directory: ${{ github.workspace }}
+        run: |
+          python3 - <<'PY'
+          import json, sys
+          total = json.load(open("frontend/coverage/coverage-summary.json"))["total"]
+          pct = float(total["lines"]["pct"])
+          threshold = 15.0
+          print(f"Frontend line coverage: {pct}% (threshold {threshold}%)")
+          sys.exit(0 if pct >= threshold else 1)
+          PY
+
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -609,6 +643,9 @@ jobs:
       - coverage-frontend
     runs-on: ubuntu-latest
     permissions:
+      # `actions/checkout` needs contents:read; declaring any permissions block
+      # otherwise drops all unlisted scopes to none and the checkout 403s.
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v6

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "NODE_ENV=test vitest run",
+    "test:coverage": "NODE_ENV=test vitest run --coverage",
     "test:watch": "NODE_ENV=test vitest"
   },
   "dependencies": {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -253,12 +253,28 @@ export default defineConfig({
     setupFiles: ["./src/test-setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {
-      // Measurement only — no hard threshold gate here. The CI coverage gate
-      // is tracked separately (issue #785). Run `npm run test -- --coverage`
-      // and read per-file line % from the text table.
+      // CI coverage gate (issue #785). `npm run test:coverage` (vitest run
+      // --coverage) enforces the line threshold below and fails the run if FE
+      // line coverage drops under it. The CI workflow (.github/workflows/ci.yml
+      // → "Coverage (Frontend)") also publishes the summary, uploads the report
+      // as an artifact, and feeds the per-component PR-comment delta.
+      //
+      // Run locally with `npm run test:coverage` and read per-file line % from
+      // the text table.
+      //
+      // Ratchet plan (W21 coverage push, issues #782-#787): raise FE lines to
+      // 30% by quarter end as those issues land. Keep this number and the CI
+      // PR-comment baseline in sync; bump only — never lower to force a pass.
       provider: "v8",
-      reporter: ["text", "json-summary", "html"],
+      // `json-summary` feeds the CI delta comment + threshold gate; `lcov` is
+      // the artifact + Codecov-compatible format; `text`/`html` are for humans.
+      reporter: ["text", "json-summary", "json", "html", "lcov"],
       reportsDirectory: "./coverage",
+      // Fail the run (and therefore CI) when line coverage drops below the
+      // enforced gate. Mirrors `cargo llvm-cov --fail-under-lines` for Rust.
+      thresholds: {
+        lines: 15,
+      },
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
         "src/**/*.test.{ts,tsx}",


### PR DESCRIPTION
## Summary

Wires automated code-coverage measurement and **enforced gates** into CI (issue #785). Coverage tooling did not run in CI before this PR. No no-op tests were added — this is pure CI/config plumbing. Three measurement jobs run after the existing test jobs in `.github/workflows/ci.yml`.

## CI jobs added

| Job | Command | Gate (fail PR if line % below) |
| --- | --- | --- |
| **Coverage (Backend)** | `cargo llvm-cov --package nyxid --summary-only --fail-under-lines 40` | **40%** |
| **Coverage (CLI)** | `cargo llvm-cov --package nyxid-cli --summary-only --fail-under-lines 30` | **30%** |
| **Coverage (Frontend)** | `npm run test:coverage` (new script → `vitest run --coverage`), gated by `coverage.thresholds.lines = 15` in `vite.config.ts` | **15%** |
| **Coverage PR Comment** | aggregates summaries, posts sticky comment | informational (not gated) |

- Backend job mirrors `backend-test` (MongoDB 8.0 service container on 27017) so DB-gated handler/service tests actually run instead of skipping — otherwise coverage would be understated.
- CLI job needs no DB (mirrors `cli-test`).
- `cargo-llvm-cov` is provisioned via `taiki-e/install-action@cargo-llvm-cov`; `llvm-tools-preview` added to the rust-toolchain component list.
- The three **measurement** jobs are added to the `CI Pipeline` aggregator's `needs`, so a coverage regression blocks merge. The comment job is deliberately **not** gated.

## Per-component delta comment (AC #4)

On `pull_request` events each measurement job, after gating the head, runs the same coverage on the **base branch** in a throwaway `git worktree` (best-effort, `continue-on-error` — a base failure renders the delta as `n/a` and never blocks). Each job writes a tiny normalized `coverage-<component>.json` (`component`, `label`, `threshold`, `head_pct`, `base_pct`). The **Coverage PR Comment** job downloads all three, computes `head − base`, and posts/updates one sticky comment (marker-based dedup) via `actions/github-script` showing line %, threshold, ✅/❌ status, and 🔺/🔻 delta. Logic lives in self-contained Python helpers (`.github/scripts/coverage_*.py`); no external coverage service required.

Example rendered comment:

| Component | Lines | Threshold | Status | Δ vs base |
| --- | ---: | ---: | :---: | ---: |
| Backend (nyxid) | 43.70% | 40% | ✅ | 🔺 +0.10 |
| CLI (nyxid-cli) | 63.84% | 30% | ✅ | — 0.00 |
| Frontend (vitest) | 41.07% | 15% | ✅ | 🔺 +2.57 |

## Artifacts (AC #6)

Each job uploads its lcov report + summary JSON via `actions/upload-artifact@v4` (`coverage-backend`, `coverage-cli`, `coverage-frontend`).

## Ratchet plan (AC #7)

Documented in both `ci.yml` and `vite.config.ts`: raise gates to **Backend → 55%, CLI → 50%, Frontend → 30% by quarter end** as W21 coverage issues (#782–#787) land. Bump the Rust `--fail-under-lines` values and the FE `coverage.thresholds.lines` together. Only ratchet **up** — never lower a threshold to force a pass.

## Threshold headroom (current vs gate)

- Backend ~43.7% vs 40% gate (PR #836)
- CLI ~63.5% vs 30% gate (PR #836); locally re-measured **63.84%**
- Frontend **41.07%** vs 15% gate (measured locally this PR)

Note: `cargo-llvm-cov` counts inline `#[cfg(test)]` modules in the denominator, so reported Rust % runs a few points under a production-only measure — gates are set conservatively to absorb that plus normal churn.

## Local validation

- `cd frontend && npm ci && npm run test:coverage` → **Lines 41.07% (3757/9147)**, passes 15% gate, exits 0. `coverage/coverage-summary.json` + `coverage/lcov.info` produced.
- `cargo llvm-cov --package nyxid-cli --summary-only --fail-under-lines 30` → **63.84%**, exits 0. Confirmed `cargo llvm-cov report --json --summary-only` re-reads profdata without a re-run for the delta extraction.
- `actionlint` (with `shellcheck`) on `ci.yml` → clean for all new jobs/shell. (One pre-existing SC2001 style note in the untouched `ci-pass` aggregator remains, unchanged from `main`.)
- Python helpers: `py_compile` clean; exercised end-to-end against real CLI + FE reports (head extraction for both report shapes, base merge with +delta / 0.00 / `n/a` cases, comment render).

**Not validated locally:** the full **Backend** `cargo llvm-cov --package nyxid` run (~15 min, needs MongoDB) — the command/flags are identical to the validated CLI invocation and the 40% gate is conservative vs. the ~43.7% reported in #836, but the actual CI backend % should be confirmed on first run.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)