### PR TITLE
test(backend): close #788 hot-path coverage gaps

### DIFF
--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -1988,16 +1988,11 @@ async fn execute_proxy_inner(
                         )),
                     );
 
-                    if let Some(ref agent_id) = auth_user.api_key_id
-                        && let Ok(val) = axum::http::HeaderValue::from_str(agent_id)
-                    {
-                        response.headers_mut().insert("x-nyxid-agent-id", val);
-                    }
-                    if let Some(ref conn_id) = target.connection_id
-                        && let Ok(val) = axum::http::HeaderValue::from_str(conn_id)
-                    {
-                        response.headers_mut().insert("x-nyxid-connection-id", val);
-                    }
+                    apply_agent_attribution_headers(
+                        &mut response,
+                        auth_user.api_key_id.as_deref(),
+                        target.connection_id.as_deref(),
+                    );
 
                     return Ok(response);
                 }
@@ -2184,16 +2179,11 @@ async fn execute_proxy_inner(
             })),
         );
 
-        if let Some(ref agent_id) = auth_user.api_key_id
-            && let Ok(val) = axum::http::HeaderValue::from_str(agent_id)
-        {
-            response.headers_mut().insert("x-nyxid-agent-id", val);
-        }
-        if let Some(ref conn_id) = target.connection_id
-            && let Ok(val) = axum::http::HeaderValue::from_str(conn_id)
-        {
-            response.headers_mut().insert("x-nyxid-connection-id", val);
-        }
+        apply_agent_attribution_headers(
+            &mut response,
+            auth_user.api_key_id.as_deref(),
+            target.connection_id.as_deref(),
+        );
 
         return Ok(response);
     }
@@ -2438,18 +2428,38 @@ async fn execute_proxy_inner(
         })),
     );
 
-    if let Some(ref agent_id) = auth_user.api_key_id
+    apply_agent_attribution_headers(
+        &mut response,
+        auth_user.api_key_id.as_deref(),
+        target.connection_id.as_deref(),
+    );
+
+    Ok(response)
+}
+
+/// Attach agent/connection attribution headers to a proxy response.
+///
+/// `X-NyxID-Agent-Id` is set only when the request authenticated via an API
+/// key (`AuthUser.api_key_id` is `Some`), letting callers confirm which agent
+/// identity NyxID attributed the request to. Session-token (browser) auth
+/// leaves `api_key_id` `None`, so the header is omitted. `X-NyxID-Connection-Id`
+/// is set when the resolved target carries a connection id. Values that cannot
+/// be encoded as header values are silently skipped.
+fn apply_agent_attribution_headers(
+    response: &mut Response,
+    api_key_id: Option<&str>,
+    connection_id: Option<&str>,
+) {
+    if let Some(agent_id) = api_key_id
         && let Ok(val) = axum::http::HeaderValue::from_str(agent_id)
     {
         response.headers_mut().insert("x-nyxid-agent-id", val);
     }
-    if let Some(ref conn_id) = target.connection_id
+    if let Some(conn_id) = connection_id
         && let Ok(val) = axum::http::HeaderValue::from_str(conn_id)
     {
         response.headers_mut().insert("x-nyxid-connection-id", val);
     }
-
-    Ok(response)
 }
 
 async fn read_proxy_request_body(
@@ -3762,9 +3772,10 @@ async fn bridge_websockets_via_node(
 mod tests {
     use super::{
         ALLOWED_FORWARD_HEADER_PREFIXES, ALLOWED_FORWARD_HEADERS, ALLOWED_WS_FORWARD_HEADERS,
-        WsPassthroughGuard, auth_kind_label, collect_forward_headers_with_prefixes,
-        compose_pre_resolved_node_ids, is_chat_completions_proxy_path, is_codex_transport_path,
-        is_ws_upgrade_request, should_enforce_runtime_approval, validate_range_header,
+        WsPassthroughGuard, apply_agent_attribution_headers, auth_kind_label,
+        collect_forward_headers_with_prefixes, compose_pre_resolved_node_ids,
+        is_chat_completions_proxy_path, is_codex_transport_path, is_ws_upgrade_request,
+        should_enforce_runtime_approval, validate_range_header,
     };
     use crate::mw::auth::AuthMethod;
     use crate::services::proxy_service::validate_requested_proxy_path;
@@ -3800,6 +3811,63 @@ mod tests {
             "service_account"
         );
         assert_eq!(auth_kind_label(&AuthMethod::Delegated), "delegated");
+    }
+
+    // ---- X-NyxID-Agent-Id attribution header tests (issue #788) ----
+
+    #[test]
+    fn agent_attribution_sets_agent_id_header_for_api_key_auth() {
+        // API-key-authed proxy request (api_key_id = Some) must surface the
+        // agent identity to the caller via X-NyxID-Agent-Id.
+        let mut response = Body::empty().into_response();
+        apply_agent_attribution_headers(&mut response, Some("ag-key-123"), None);
+
+        assert_eq!(
+            response
+                .headers()
+                .get("x-nyxid-agent-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("ag-key-123"),
+            "X-NyxID-Agent-Id must equal the authenticating API key id"
+        );
+        // No connection id was resolved, so that header stays absent.
+        assert!(!response.headers().contains_key("x-nyxid-connection-id"));
+    }
+
+    #[test]
+    fn agent_attribution_omits_agent_id_header_for_session_auth() {
+        // Session/browser auth leaves api_key_id = None; the header must be
+        // omitted entirely (callers rely on its absence to distinguish auth).
+        let mut response = Body::empty().into_response();
+        apply_agent_attribution_headers(&mut response, None, None);
+
+        assert!(
+            !response.headers().contains_key("x-nyxid-agent-id"),
+            "session-authed responses must not carry X-NyxID-Agent-Id"
+        );
+    }
+
+    #[test]
+    fn agent_attribution_sets_connection_id_header_independently() {
+        // Connection id is attached whenever the resolved target has one,
+        // independent of the agent-id header.
+        let mut response = Body::empty().into_response();
+        apply_agent_attribution_headers(&mut response, Some("ag-key-9"), Some("conn-42"));
+
+        assert_eq!(
+            response
+                .headers()
+                .get("x-nyxid-agent-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("ag-key-9")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("x-nyxid-connection-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("conn-42")
+        );
     }
 
     #[test]

--- a/backend/src/services/node_routing_service.rs
+++ b/backend/src/services/node_routing_service.rs
@@ -535,6 +535,37 @@ mod tests {
             .unwrap();
     }
 
+    /// Insert a node marked `Offline` in MongoDB. Routing filters on
+    /// `status: "online"`, so this node is dropped from candidate selection
+    /// even if a WS connection happens to be registered for it.
+    async fn insert_offline_node(db: &mongodb::Database, node_id: &str, owner_id: &str) {
+        let mut n = node(node_id, owner_id);
+        n.status = NodeStatus::Offline;
+        db.collection(NODES).insert_one(n).await.unwrap();
+    }
+
+    async fn insert_node_binding_with_priority(
+        db: &mongodb::Database,
+        node_id: &str,
+        owner_id: &str,
+        catalog_service_id: &str,
+        priority: i32,
+    ) {
+        db.collection(NODE_SERVICE_BINDINGS)
+            .insert_one(NodeServiceBinding {
+                id: uuid::Uuid::new_v4().to_string(),
+                node_id: node_id.to_string(),
+                user_id: owner_id.to_string(),
+                service_id: catalog_service_id.to_string(),
+                is_active: true,
+                priority,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+    }
+
     async fn insert_node_binding(
         db: &mongodb::Database,
         node_id: &str,
@@ -844,5 +875,78 @@ mod tests {
                 .unwrap();
 
         assert_eq!(node_ids, vec![node_id.to_string()]);
+    }
+
+    /// Node-OFFLINE failover (issue #788): when the highest-priority node
+    /// binding points at a node that is offline in MongoDB, routing must skip
+    /// it and promote the next online node, with any remaining online node
+    /// landing in `fallback_node_ids`. This proves the proxy's primary->
+    /// fallback failover path, not just the happy-path ordering.
+    #[tokio::test]
+    async fn resolve_node_route_fails_over_from_offline_node_to_online_fallback() {
+        let Some(db) = connect_test_database("node_route_offline_failover").await else {
+            eprintln!("skipping node routing integration test: no local MongoDB available");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let catalog_service_id = "catalog-failover";
+        let offline_node = "node-offline-primary";
+        let online_primary = "node-online-1";
+        let online_fallback = "node-online-2";
+
+        // The user seeds a personal user service (no explicit UserService.node_id)
+        // so routing comes entirely from priority-ordered bindings.
+        db.collection(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .unwrap();
+        insert_user_service(
+            &db,
+            &service_id,
+            &user_id,
+            "failoveros",
+            catalog_service_id,
+            None,
+        )
+        .await;
+
+        // Priority 0 (highest) is OFFLINE -> must be skipped.
+        insert_offline_node(&db, offline_node, &user_id).await;
+        insert_node_binding_with_priority(&db, offline_node, &user_id, catalog_service_id, 0).await;
+        // Priority 1 and 2 are online + WS-connected.
+        insert_node(&db, online_primary, &user_id).await;
+        insert_node_binding_with_priority(&db, online_primary, &user_id, catalog_service_id, 1)
+            .await;
+        insert_node(&db, online_fallback, &user_id).await;
+        insert_node_binding_with_priority(&db, online_fallback, &user_id, catalog_service_id, 2)
+            .await;
+
+        // WS connections exist for all three nodes (including the offline one),
+        // so the only thing dropping the offline node is its DB status.
+        let ws_manager = NodeWsManager::new(30, 100);
+        for nid in [offline_node, online_primary, online_fallback] {
+            let (tx, _rx) = tokio::sync::mpsc::channel(8);
+            ws_manager.register_connection(nid, tx);
+        }
+
+        let route = resolve_node_route(&db, &user_id, catalog_service_id, &ws_manager)
+            .await
+            .unwrap()
+            .expect("an online fallback node should be routable");
+
+        assert_eq!(
+            route.node_id, online_primary,
+            "offline highest-priority node must be skipped in favor of the next online node"
+        );
+        assert_eq!(
+            route.fallback_node_ids,
+            vec![online_fallback.to_string()],
+            "remaining online node must be available as a failover fallback"
+        );
+        assert!(
+            !route.fallback_node_ids.contains(&offline_node.to_string()),
+            "offline node must never appear in the routable set"
+        );
     }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2680,6 +2680,132 @@ mod tests {
         assert!(matches!(denied, AppError::OrgRoleInsufficient(_)));
     }
 
+    // ---- agent credential override resolution (issue #788) ----
+    //
+    // `resolve_agent_credential_override` is the proxy hot-path entry point
+    // for per-agent credential isolation. It has three branches:
+    //   1. No binding for (api_key_id, user_service_id) -> returns None, so the
+    //      proxy falls back to the service's own default credential.
+    //   2. A binding exists -> the bound UserApiKey is fetched, decrypted, and
+    //      its credential string is returned (the agent override).
+    //   3. (Covered elsewhere) inactive / missing override credential errors.
+    // This test exercises branches (1) and (2) end-to-end including the
+    // envelope decryption step, which `agent_binding_service`'s binding-level
+    // test does not reach.
+    #[tokio::test]
+    async fn resolve_agent_credential_override_falls_back_then_returns_override() {
+        let Some(db) = connect_test_database("proxy_agent_override").await else {
+            eprintln!("skipping agent override integration test: no local MongoDB available");
+            return;
+        };
+
+        use crate::models::api_key::{ApiKey, COLLECTION_NAME as API_KEYS};
+
+        let keys = test_encryption_keys();
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let api_key_id = uuid::Uuid::new_v4().to_string();
+        let user_service_id = uuid::Uuid::new_v4().to_string();
+        let endpoint_id = uuid::Uuid::new_v4().to_string();
+        let override_credential_id = uuid::Uuid::new_v4().to_string();
+        let override_secret = "sk-agent-override-secret";
+
+        // Seed the agent identity (ApiKey), the user service, and an external
+        // credential whose secret is envelope-encrypted with the test keys.
+        db.collection::<ApiKey>(API_KEYS)
+            .insert_one(ApiKey {
+                id: api_key_id.clone(),
+                user_id: user_id.clone(),
+                name: "coding-agent".to_string(),
+                key_prefix: "nyxid_ag".to_string(),
+                key_hash: "deadbeef".repeat(8),
+                scopes: "proxy".to_string(),
+                last_used_at: None,
+                expires_at: None,
+                is_active: true,
+                created_at: Utc::now(),
+                description: None,
+                allowed_service_ids: vec![],
+                allowed_node_ids: vec![],
+                allow_all_services: true,
+                allow_all_nodes: true,
+                rate_limit_per_second: None,
+                rate_limit_burst: None,
+                platform: Some("claude-code".to_string()),
+                callback_url: None,
+            })
+            .await
+            .unwrap();
+        db.collection::<crate::models::user_service::UserService>(USER_SERVICES)
+            .insert_one(test_user_service(
+                &user_service_id,
+                &user_id,
+                "svc-override",
+                &endpoint_id,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        let encrypted = keys.encrypt(override_secret.as_bytes()).await.unwrap();
+        db.collection::<UserApiKey>(USER_API_KEYS)
+            .insert_one(UserApiKey {
+                id: override_credential_id.clone(),
+                user_id: user_id.clone(),
+                label: "agent-specific-key".to_string(),
+                credential_type: "api_key".to_string(),
+                credential_encrypted: Some(encrypted),
+                access_token_encrypted: None,
+                refresh_token_encrypted: None,
+                token_scopes: None,
+                expires_at: None,
+                provider_config_id: None,
+                connection_id: None,
+                user_oauth_client_id_encrypted: None,
+                user_oauth_client_secret_encrypted: None,
+                status: "active".to_string(),
+                last_used_at: None,
+                error_message: None,
+                source: None,
+                source_id: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        // Branch 1: no binding -> None (proxy uses the service default).
+        let no_override =
+            resolve_agent_credential_override(&db, &keys, &user_id, &api_key_id, &user_service_id)
+                .await
+                .unwrap();
+        assert!(
+            no_override.is_none(),
+            "with no binding the agent must fall back to the service default credential"
+        );
+
+        // Branch 2: bind the agent to the override credential, then resolve
+        // must return the decrypted override secret.
+        agent_binding_service::create_binding(
+            &db,
+            &user_id,
+            &api_key_id,
+            &user_service_id,
+            &override_credential_id,
+        )
+        .await
+        .unwrap();
+
+        let override_value =
+            resolve_agent_credential_override(&db, &keys, &user_id, &api_key_id, &user_service_id)
+                .await
+                .unwrap();
+        assert_eq!(
+            override_value.as_deref(),
+            Some(override_secret),
+            "bound agent must receive the decrypted override credential, not the service default"
+        );
+    }
+
     // ---- credential_header_name tests (NyxID#356) ----
 
     #[test]


### PR DESCRIPTION
Closes the remaining hot-path test gaps for #788 that were not covered after PR #836 landed. No coverage padding — every added test asserts real behavior.

## Tests added (3 files)

**`backend/src/services/node_routing_service.rs`**
- `resolve_node_route_fails_over_from_offline_node_to_online_fallback` — seeds three priority-ordered node bindings where the highest-priority node is `NodeStatus::Offline` (but still WS-connected, so only its DB status drops it). Asserts routing skips the offline node, promotes the next online node to `route.node_id`, places the remaining online node in `route.fallback_node_ids`, and never includes the offline node. This is the explicit node-OFFLINE → fallback failover path; previously only happy-path ordering and the org-owner walk were covered.

**`backend/src/handlers/proxy.rs`**
- Refactor: extracted the `X-NyxID-Agent-Id` / `X-NyxID-Connection-Id` response-header insertion (duplicated verbatim at 3 proxy return sites) into `apply_agent_attribution_headers`, then made it testable.
- `agent_attribution_sets_agent_id_header_for_api_key_auth` — asserts the header is present and equals the api_key_id when auth is via API key.
- `agent_attribution_omits_agent_id_header_for_session_auth` — asserts the header is absent for session (browser) auth (`api_key_id = None`).
- `agent_attribution_sets_connection_id_header_independently` — asserts the connection-id header is attached independently of the agent-id header.

**`backend/src/services/proxy_service.rs`**
- `resolve_agent_credential_override_falls_back_then_returns_override` — exercises the proxy-facing `resolve_agent_credential_override` end-to-end including envelope decryption. Branch 1: no binding → `None` (proxy falls back to the service default credential). Branch 2: a real binding (created via `agent_binding_service::create_binding`) → the decrypted override secret is returned. This reaches the fetch+decrypt path that the binding-level test in `agent_binding_service` does not.

## Already satisfied by #836 / main (no tests added — no padding)

- `mw/rate_limit.rs` per-agent buckets (under/over limit, independent buckets per api_key_id, burst, cleanup) — already a full suite.
- `node_routing_service::build_node_route_returns_primary_and_fallbacks` and the org-owner-walk resolution tests — already present.
- `agent_binding_service` binding CRUD + `resolve_credential_override` binding-level lookup (None vs Some) — already present; the new proxy_service test covers the *decryption* layer above it rather than re-testing the lookup.
- `unified_key_service` (86 tests) and `user_service_service` (31 tests) auto-provision / slug+UUID / org-scoped resolution — already expanded by #836; no gaps found on read.

## Verification
- `cargo test --package nyxid` for all affected modules: green (node_routing 11, proxy handler 54, proxy_service 66, plus the 3 new header unit tests). MongoDB-backed integration tests actually executed (~10s each), not skipped.
- `cargo fmt --package nyxid --check`: clean.
- `cargo clippy --tests --package nyxid`: clean.

Coverage measurement deferred to the new CI coverage gate from PR #837 (#785) rather than running a slow local `cargo llvm-cov` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #788