### PR TITLE
Migrate existing Twitter provider default_scopes to include media.write (follow-up to #915)

### DIFF
--- a/backend/src/services/provider_service.rs
+++ b/backend/src/services/provider_service.rs
@@ -481,6 +481,27 @@ pub async fn seed_default_providers(
         );
     }
 
+    // Migration: ensure the existing Twitter provider's default_scopes include `media.write`,
+    // so delegated clients can attach images/video via `POST /2/media/upload` (without it that
+    // endpoint returns 403). The seed change alone never reaches an already-seeded provider, and
+    // the CLI pair wizard exposes no scope input to add it after the fact. The `$ne` filter makes
+    // this a no-op once present; `$addToSet` appends without disturbing existing scopes.
+    let twitter_media_write_migration = collection
+        .update_one(
+            doc! { "slug": "twitter", "default_scopes": { "$ne": "media.write" } },
+            doc! {
+                "$addToSet": { "default_scopes": "media.write" },
+                "$set": { "updated_at": bson::DateTime::from_chrono(Utc::now()) },
+            },
+        )
+        .await?;
+    if twitter_media_write_migration.modified_count > 0 {
+        tracing::info!(
+            slug = "twitter",
+            "Migrated existing Twitter provider default_scopes to include media.write"
+        );
+    }
+
     let social_user_mode_migration = collection
         .update_many(
             doc! {


### PR DESCRIPTION
## Follow-up to #915 — the seed change never reaches an already-seeded provider

#915 added `media.write` to the Twitter provider **seed**, but the seed is gated on `if !slug_exists!("twitter")`, so it only applies to a fresh database. On any deployment that already seeded the Twitter provider (i.e. production), `default_scopes` keeps the old set:

```
["tweet.read", "tweet.write", "users.read", "offline.access"]   // no media.write
```

Result: delegated clients can post text but `POST /2/media/upload` returns **403 Forbidden**, and there is no scope input in the CLI pair wizard to add `media.write` after connecting. Verified against the live catalog after #915 merged + 0.7.0 deployed — `default_scopes` still lacks `media.write`.

## Fix

Add an idempotent migration directly below the existing `credential_mode` Twitter migration, in the same style:

```rust
let twitter_media_write_migration = collection
    .update_one(
        doc! { "slug": "twitter", "default_scopes": { "$ne": "media.write" } },
        doc! {
            "$addToSet": { "default_scopes": "media.write" },
            "$set": { "updated_at": bson::DateTime::from_chrono(Utc::now()) },
        },
    )
    .await?;
```

- `$ne` filter → only matches an un-migrated provider, so it's a no-op once present (safe to run on every boot).
- `$addToSet` → appends `media.write` without disturbing existing scopes or order.
- Existing tokens are unaffected; a re-consent after deploy mints a token that includes `media.write`.

## Verify after deploy

```
GET /api/v1/catalog/api-twitter  → default_scopes contains "media.write"
re-connect a Twitter service, then POST /2/media/upload  → returns a media_id (was 403)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
