### PR TITLE
fix: grant media.write on Twitter provider for media uploads

### DIFF
--- a/backend/src/services/provider_service.rs
+++ b/backend/src/services/provider_service.rs
@@ -37,6 +37,18 @@ const SEEDED_USER_CREDENTIAL_OAUTH_PROVIDER_SLUGS: &[&str] = &[
     "lark",
 ];
 
+/// Default OAuth scopes seeded for the Twitter / X provider. `media.write` is required so
+/// delegated clients can attach images/video via `POST /2/media/upload`; without it that
+/// endpoint returns 403 and the CLI pair wizard exposes no scope input to add it afterward.
+/// Kept as a constant so it is unit-testable and shared by the seed and the migration below.
+const TWITTER_DEFAULT_SCOPES: &[&str] = &[
+    "tweet.read",
+    "tweet.write",
+    "media.write",
+    "users.read",
+    "offline.access",
+];
+
 /// Seed default AI provider configurations at startup (idempotent).
 ///
 /// Checks for each provider by slug; if it does not exist, inserts it.
@@ -416,15 +428,14 @@ pub async fn seed_default_providers(
             authorization_url: Some("https://x.com/i/oauth2/authorize".to_string()),
             token_url: Some("https://api.x.com/2/oauth2/token".to_string()),
             revocation_url: Some("https://api.x.com/2/oauth2/revoke".to_string()),
-            // Write access is intentional: NyxID is a credential broker, so delegated
-            // clients commonly need to post on behalf of users. Admins can customise
-            // scopes per deployment.
-            default_scopes: Some(vec![
-                "tweet.read".to_string(),
-                "tweet.write".to_string(),
-                "users.read".to_string(),
-                "offline.access".to_string(),
-            ]),
+            // Write access is intentional: NyxID is a credential broker, so delegated clients
+            // commonly need to post on behalf of users (see TWITTER_DEFAULT_SCOPES).
+            default_scopes: Some(
+                TWITTER_DEFAULT_SCOPES
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
             client_id_encrypted: None,
             client_secret_encrypted: None,
             supports_pkce: true,
@@ -474,6 +485,26 @@ pub async fn seed_default_providers(
         tracing::info!(
             slug = "twitter",
             "Migrated existing Twitter provider to credential_mode=user, token_endpoint_auth_method=client_secret_basic"
+        );
+    }
+
+    // Migration: ensure the existing Twitter provider's default_scopes include `media.write`
+    // (see TWITTER_DEFAULT_SCOPES). The seed change alone never reaches an already-seeded
+    // provider, and the CLI pair wizard exposes no scope input to add it after connecting.
+    // `$ne` makes this a no-op once present; `$addToSet` appends without disturbing scopes.
+    let twitter_media_write_migration = collection
+        .update_one(
+            doc! { "slug": "twitter", "default_scopes": { "$ne": "media.write" } },
+            doc! {
+                "$addToSet": { "default_scopes": "media.write" },
+                "$set": { "updated_at": bson::DateTime::from_chrono(Utc::now()) },
+            },
+        )
+        .await?;
+    if twitter_media_write_migration.modified_count > 0 {
+        tracing::info!(
+            slug = "twitter",
+            "Migrated existing Twitter provider default_scopes to include media.write"
         );
     }
 
@@ -3773,7 +3804,7 @@ pub async fn delete_provider(db: &mongodb::Database, provider_id: &str) -> AppRe
 #[cfg(test)]
 mod tests {
     use super::{
-        ANTHROPIC_DEFAULT_HEADERS, DEFAULT_SERVICE_SEEDS, SeededHeader,
+        ANTHROPIC_DEFAULT_HEADERS, DEFAULT_SERVICE_SEEDS, SeededHeader, TWITTER_DEFAULT_SCOPES,
         normalize_telegram_bot_token, normalize_telegram_bot_username, reconcile_seeded_headers,
         seed_capability_override,
     };
@@ -3798,6 +3829,14 @@ mod tests {
 
         assert_eq!(seed.service_auth_method, Some("path"));
         assert_eq!(seed.service_auth_key_name, Some("bot"));
+    }
+
+    #[test]
+    fn twitter_seed_includes_media_write() {
+        assert!(
+            TWITTER_DEFAULT_SCOPES.contains(&"media.write"),
+            "Twitter default scopes must include media.write so delegated clients can POST /2/media/upload"
+        );
     }
 
     #[test]

--- a/backend/src/services/unified_key_service.rs
+++ b/backend/src/services/unified_key_service.rs
@@ -2060,9 +2060,10 @@ pub async fn get_key(
         None
     };
 
-    let cat_map: HashMap<&str, &DownstreamService> = catalog_ds
-        .as_ref()
-        .and_then(|ds| svc.catalog_service_id.as_deref().map(|id| (id, ds)))
+    let cat_map: HashMap<&str, &DownstreamService> = svc
+        .catalog_service_id
+        .as_deref()
+        .zip(catalog_ds.as_ref())
         .into_iter()
         .collect();
 

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -245,11 +245,7 @@ fn path_row() -> DoctorRow {
 fn install_version_row(current_exe: Option<&Path>) -> DoctorRow {
     let version = update_check::installed_release_tag();
     let status = current_exe
-        .and_then(|path| {
-            update::install_versions_root()
-                .ok()
-                .map(|root| (path, root))
-        })
+        .zip(update::install_versions_root().ok())
         .map(|(path, root)| {
             if path.starts_with(root) {
                 DoctorStatus::Pass

--- a/cli/src/commands/doctor.rs
+++ b/cli/src/commands/doctor.rs
@@ -244,16 +244,15 @@ fn path_row() -> DoctorRow {
 
 fn install_version_row(current_exe: Option<&Path>) -> DoctorRow {
     let version = update_check::installed_release_tag();
-    let status = current_exe
-        .zip(update::install_versions_root().ok())
-        .map(|(path, root)| {
-            if path.starts_with(root) {
-                DoctorStatus::Pass
-            } else {
-                DoctorStatus::Warn
-            }
-        })
-        .unwrap_or(DoctorStatus::Warn);
+    // Resolve the install root lazily so missing `current_exe` does not
+    // trigger extra env/path work.
+    let status = match current_exe {
+        Some(path) => match update::install_versions_root() {
+            Ok(root) if path.starts_with(&root) => DoctorStatus::Pass,
+            _ => DoctorStatus::Warn,
+        },
+        None => DoctorStatus::Warn,
+    };
 
     row("nyxid version", version, status)
 }


### PR DESCRIPTION
## Summary

- The Twitter / X provider's `default_scopes` omitted `media.write`, so delegated clients could post text but `POST /2/media/upload` returned **403 Forbidden** — and the CLI pair wizard exposes no scope input to add it after connecting.
- Seed `media.write` via a shared `TWITTER_DEFAULT_SCOPES` constant, and add an **idempotent migration** (mirroring the `credential_mode` migration just above) that `$addToSet`s `media.write` onto any already-seeded provider — the seed change alone never reaches an existing provider.
- Existing tokens are unaffected; a re-consent after deploy mints a token that includes `media.write`.

## Test plan

- `cargo fmt --all -- --check` — clean.
- Added unit test `twitter_seed_includes_media_write` asserting the scope constant contains `media.write` (`cargo test -p <backend>`).
- Idempotency: the migration's `default_scopes: { "$ne": "media.write" }` filter makes it a no-op once present (safe on every boot).
- Manual: after deploy, `GET /api/v1/catalog/api-twitter` shows `media.write` in `default_scopes`; re-connecting a Twitter service then makes `POST /2/media/upload` return a `media_id` (was 403).

## Notes

Follow-up to #915, which added `media.write` to the seed only (gated on `if !slug_exists`) and therefore did not update already-seeded production providers. This PR targets `dev` per CONTRIBUTING (supersedes #925, which was opened against `main` by mistake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also includes (CI unblock)

`dev`'s clippy gate is deny-level and currently red on two pre-existing manual Option-zips (`cli/src/commands/doctor.rs`, `backend/src/services/unified_key_service.rs`), which blocks every PR against `dev`. Replaced both with `Option::zip` (semantics + tuple order preserved) so this PR's CI Pipeline can pass. Happy to split these into a separate PR if preferred.
