### PR TITLE
fix(frontend): enable Save Changes on admin services edit when toggles flip

### DIFF
--- a/frontend/src/pages/service-edit.tsx
+++ b/frontend/src/pages/service-edit.tsx
@@ -416,6 +416,7 @@ export function ServiceEditPage() {
                                 v
                                   ? [...current, app.id]
                                   : current.filter((id) => id !== app.id),
+                                { shouldDirty: true, shouldValidate: true },
                               );
                             }}
                           />
@@ -481,7 +482,10 @@ export function ServiceEditPage() {
                     id="edit-ssh-cert-auth"
                     checked={form.watch("certificate_auth_enabled") ?? false}
                     onCheckedChange={(checked) =>
-                      form.setValue("certificate_auth_enabled", checked)
+                      form.setValue("certificate_auth_enabled", checked, {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      })
                     }
                   />
                 </div>
@@ -628,19 +632,32 @@ export function ServiceEditPage() {
                           form.setValue(
                             "identity_propagation_mode",
                             v as UpdateServiceFormData["identity_propagation_mode"],
+                            { shouldDirty: true, shouldValidate: true },
                           )
                         }
                         onIncludeUserIdChange={(v) =>
-                          form.setValue("identity_include_user_id", v)
+                          form.setValue("identity_include_user_id", v, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
                         }
                         onIncludeEmailChange={(v) =>
-                          form.setValue("identity_include_email", v)
+                          form.setValue("identity_include_email", v, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
                         }
                         onIncludeNameChange={(v) =>
-                          form.setValue("identity_include_name", v)
+                          form.setValue("identity_include_name", v, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
                         }
                         onJwtAudienceChange={(v) =>
-                          form.setValue("identity_jwt_audience", v)
+                          form.setValue("identity_jwt_audience", v, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
                         }
                       />
                     </div>
@@ -907,7 +924,10 @@ export function ServiceEditPage() {
                                 id={`cap-${key}`}
                                 checked={form.watch(key) ?? false}
                                 onCheckedChange={(v) =>
-                                  form.setValue(key, v)
+                                  form.setValue(key, v, {
+                                    shouldDirty: true,
+                                    shouldValidate: true,
+                                  })
                                 }
                               />
                             </div>
@@ -941,7 +961,10 @@ export function ServiceEditPage() {
                             form.watch("forward_access_token") ?? false
                           }
                           onCheckedChange={(v) =>
-                            form.setValue("forward_access_token", v)
+                            form.setValue("forward_access_token", v, {
+                              shouldDirty: true,
+                              shouldValidate: true,
+                            })
                           }
                         />
                       </div>
@@ -975,7 +998,10 @@ export function ServiceEditPage() {
                             form.watch("inject_delegation_token") ?? false
                           }
                           onCheckedChange={(v) =>
-                            form.setValue("inject_delegation_token", v)
+                            form.setValue("inject_delegation_token", v, {
+                              shouldDirty: true,
+                              shouldValidate: true,
+                            })
                           }
                         />
                       </div>


### PR DESCRIPTION
## Summary

- Save Changes on `/services/:id/edit` was stuck disabled whenever the user only flipped switches, identity-propagation handlers, capability toggles, or developer-app checkboxes.
- Root cause: those controls called `form.setValue(name, value)` without options, and React Hook Form's `setValue` does not update `formState.isDirty` unless `{ shouldDirty: true }` is passed. The submit button's `disabled={!form.formState.isDirty}` then never released.
- Fix: pass `{ shouldDirty: true, shouldValidate: true }` to every affected `setValue` call in `frontend/src/pages/service-edit.tsx` (11 sites — developer-app checkboxes, SSH cert-auth switch, identity-propagation mode + 4 sub-fields, 7 capability switches, Forward Access Token, Inject Delegation Token).
- Plain `<FormField>` text inputs were already correct via `field.onChange`; this aligns the rest of the form with that behavior.

## Audit

Swept the whole frontend for the same pattern. No other form gated on `isDirty` repeats the bug:

- `pages/provider-edit.tsx`, `pages/org-detail.tsx`, `components/service-accounts/service-account-detail.tsx`, `pages/settings.tsx` (passwordForm), `pages/notification-settings.tsx`, `pages/channel-bot-detail.tsx` (EditVerificationCard) — all use `FormField`/`field.onChange` or `register`, no bare `setValue`.
- Bare `setValue` exists in a few create dialogs (`service-list.tsx`, `channel-bots.tsx`, `channel-bot-detail.tsx` AddRouteDialog, `api-key-create-dialog.tsx`) but those submits aren't gated by `isDirty`. The `api-key-create-dialog.tsx` and `provider-list.tsx` calls are intentional dependent-field resets and should not mark the form dirty.

## Test plan

- [ ] Open `/services/:id/edit` as admin
- [ ] Toggle any capability switch (e.g. Proxy Read) → Save Changes enables
- [ ] Toggle Forward Access Token → Save enables
- [ ] Toggle Inject Delegation Token → Save enables
- [ ] Change identity propagation mode → Save enables
- [ ] Toggle SSH cert-auth (for SSH services) → Save enables
- [ ] Select/deselect a developer app (private+admin only) → Save enables
- [ ] Save and confirm changes persist on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)