### PR TITLE
feat(auth): RFC 8628 device-code login for headless CLIs (#971)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,22 @@ Generic async task relay that lets any NyxID user/agent call a browser-driven LL
 
 Key files: `models/oracle_{pool,task,session,worker}.rs`, `services/oracle_{pool,task,session}_service.rs`, `handlers/oracle_{pools,tasks,worker}.rs`, `cli/src/commands/oracle.rs`, `integrations/oracle/nyxid_oracle.user.js`.
 
+### 12. Auth Device-Code Login
+
+First-party RFC 8628-style login for headless CLI environments. `nyxid login --device` starts an unauthenticated browser-assisted login, displays a short `user_code`, and lets an already logged-in human approve the code in the web UI so the waiting CLI receives normal first-party access and refresh tokens without collecting a password in the terminal.
+
+- **Storage**: `auth_device_codes` collection. It stores HMACs of both the opaque `device_code` and display `user_code`, a `pending` / `approved` / `denied` / `expired` / `delivered` status state machine, sanitized client context, encrypted delivery tokens, and timestamps. Raw codes and token plaintext are never persisted.
+- **Worker token**: N/A. This is not a worker-pool flow; the CLI receives an opaque `device_code` secret with the `nyx_adc_` prefix and polls with that value until the human approves or the code expires.
+- **Routes**:
+  - `POST /api/v1/auth/device/request` -- public router, no auth; mints `device_code`, `user_code`, and verification URLs.
+  - `POST /api/v1/auth/device/poll` -- public router, no auth; polls by opaque `device_code` and returns the one-time token pair when approved.
+  - `POST /api/v1/auth/device/approve` -- human-only router, JWT-authenticated session user; rejects API keys, service accounts, and delegated tokens before handler execution.
+  - `POST /api/v1/auth/device/preview` -- human-only router, JWT-authenticated session user; returns anti-phishing context for a `user_code` without changing state.
+- **Error codes**: auth-device login uses the existing 11200-11207 block in the node/proxy conventions section above; do not duplicate that table elsewhere.
+- **Atomic delivery**: polling uses a MongoDB `find_one_and_update(...).return_document(Before)` claim from `approved` to `delivered`. The returned pre-update document contains the encrypted delivery tokens for exactly one poller; concurrent or later pollers see `delivered` and receive `AuthDeviceCodeAlreadyDelivered` (11205).
+- **Rate limiters**: `auth_device_request_limiter`, `auth_device_poll_limiter`, `auth_device_approve_limiter`, `auth_device_approve_per_user_limiter`, and `auth_device_preview_limiter`.
+- **CLI**: `nyxid login --device` forces device-code login. Plain `nyxid login` auto-falls back to device-code login when browser launch is unavailable unless `NYXID_LOGIN_NO_DEVICE_FALLBACK=1` is set.
+
 ## File Structure
 
 ```
@@ -302,6 +318,10 @@ sdk/                     # OAuth SDK monorepo (TypeScript, @nyxids/* npm namespa
 
 All API routes under `/api/v1`:
 - `/auth` -- register, login, logout, refresh, verify-email, forgot/reset-password
+- `/auth/device/request` -- public auth device-code login start; mints `device_code`, `user_code`, and verification URLs
+- `/auth/device/poll` -- public auth device-code login poll; exchanges an approved opaque `device_code` for a token pair
+- `/auth/device/approve` -- human-only auth device-code approval; JWT-authenticated user approves a `user_code`
+- `/auth/device/preview` -- human-only auth device-code anti-phishing lookup for a `user_code`
 - `/users` -- get/update current user
 - `/auth/mfa` -- setup, confirm, verify (login), disable (nested under `/auth` in `backend/src/routes.rs`; `setup` is idempotent against unverified factors per NyxID#506)
 - `/api-keys` -- CRUD + rotate. `ApiKey` model has scope fields: `allowed_service_ids`, `allowed_node_ids`, `allow_all_services`, `allow_all_nodes` (absorbed from deleted AgentGroup model). Also has agent isolation fields: `rate_limit_per_second`, `rate_limit_burst`, `platform`
@@ -506,6 +526,7 @@ source "$HOME/.cargo/env" 2>/dev/null  # Ensure cargo is available
 cargo build -p nyxid-cli                # Build CLI binary
 cargo install --path cli                # Install CLI as `nyxid`
 nyxid --help                            # Verify installation
+nyxid login --device                    # Headless browser-assisted login; set NYXID_LOGIN_NO_DEVICE_FALLBACK=1 to disable automatic fallback from plain `nyxid login`
 # End users install prebuilt release binaries; cargo install is for dev.
 
 # Backend (from project root)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,11 +262,13 @@ First-party RFC 8628-style login for headless CLI environments. `nyxid login --d
   - `POST /api/v1/auth/device/request` -- public router, no auth; mints `device_code`, `user_code`, and verification URLs.
   - `POST /api/v1/auth/device/poll` -- public router, no auth; polls by opaque `device_code` and returns the one-time token pair when approved.
   - `POST /api/v1/auth/device/approve` -- human-only router, JWT-authenticated session user; rejects API keys, service accounts, and delegated tokens before handler execution.
-  - `POST /api/v1/auth/device/preview` -- human-only router, JWT-authenticated session user; returns anti-phishing context for a `user_code` without changing state.
+  - `POST /api/v1/auth/device/preview` -- public router, no auth; returns non-sensitive anti-phishing context (`client_label`, `client_user_agent`, timestamps, status) for a `user_code` without changing state. All fields are device-supplied at `/request` time so there is nothing to leak. The verification page itself gates entry on JWT auth and only calls this endpoint after the user has signed in (matching GitHub's terminal -> URL -> login -> code flow); the endpoint stays public as defense-in-depth simplification and to leave room for future surfaces (e.g. anonymous preview before login) without backend changes. Rate-limited per IP by `auth_device_preview_limiter`.
 - **Error codes**: auth-device login uses the existing 11200-11207 block in the node/proxy conventions section above; do not duplicate that table elsewhere.
 - **Atomic delivery**: polling uses a MongoDB `find_one_and_update(...).return_document(Before)` claim from `approved` to `delivered`. The returned pre-update document contains the encrypted delivery tokens for exactly one poller; concurrent or later pollers see `delivered` and receive `AuthDeviceCodeAlreadyDelivered` (11205).
 - **Rate limiters**: `auth_device_request_limiter`, `auth_device_poll_limiter`, `auth_device_approve_limiter`, `auth_device_approve_per_user_limiter`, and `auth_device_preview_limiter`.
-- **CLI**: `nyxid login --device` forces device-code login. Plain `nyxid login` auto-falls back to device-code login when browser launch is unavailable unless `NYXID_LOGIN_NO_DEVICE_FALLBACK=1` is set.
+- **CLI output**: prints `user_code` plus the bare `verification_uri` (never `verification_uri_complete`, which would put the code in the URL and defeat manual-entry anti-phishing). On stdin+stderr TTYs, prompts `Open in your browser? [Y/n]` and `crate::browser::open_browser`s the URL on Enter; falls through with a "paste it manually" hint if the open fails. Non-TTY (CI / piped) skips the prompt and starts polling immediately.
+- **CLI dispatch**: `nyxid login --device` forces device-code login. Plain `nyxid login` auto-falls back to device-code login when browser launch is unavailable unless `NYXID_LOGIN_NO_DEVICE_FALLBACK=1` is set.
+- **Verification page UX** (`/login/device`): auth-gated at entry — unauthenticated visitors are redirected to `/login?return_to=/login/device` (matches GH's terminal → URL → login → code → terminal order). Empty code input on arrival; the `?user_code=` query param is stripped by the router's `validateSearch` and ignored. Two explicit clicks: **Continue** calls `/preview` (anti-phishing block renders), then **Approve** calls `/approve`. No API call fires on typing, focus, mount, or reconnect. Both buttons throttled to ≥ 750 ms between clicks and disabled while their mutation is pending. The input is also disabled during pending preview/approve.
 - **Out of scope**: Mobile approval (deep-link from `/login/device` to the existing approval app) is out of scope for v1; tracked in a follow-up issue if needed.
 
 ## File Structure
@@ -322,7 +324,7 @@ All API routes under `/api/v1`:
 - `/auth/device/request` -- public auth device-code login start; mints `device_code`, `user_code`, and verification URLs
 - `/auth/device/poll` -- public auth device-code login poll; exchanges an approved opaque `device_code` for a token pair
 - `/auth/device/approve` -- human-only auth device-code approval; JWT-authenticated user approves a `user_code`
-- `/auth/device/preview` -- human-only auth device-code anti-phishing lookup for a `user_code`
+- `/auth/device/preview` -- public auth device-code anti-phishing lookup for a `user_code` (no auth, rate-limited per IP)
 - `/users` -- get/update current user
 - `/auth/mfa` -- setup, confirm, verify (login), disable (nested under `/auth` in `backend/src/routes.rs`; `setup` is idempotent against unverified factors per NyxID#506)
 - `/api-keys` -- CRUD + rotate. `ApiKey` model has scope fields: `allowed_service_ids`, `allowed_node_ids`, `allow_all_services`, `allow_all_nodes` (absorbed from deleted AgentGroup model). Also has agent isolation fields: `rate_limit_per_second`, `rate_limit_burst`, `platform`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,7 @@ First-party RFC 8628-style login for headless CLI environments. `nyxid login --d
 - **Atomic delivery**: polling uses a MongoDB `find_one_and_update(...).return_document(Before)` claim from `approved` to `delivered`. The returned pre-update document contains the encrypted delivery tokens for exactly one poller; concurrent or later pollers see `delivered` and receive `AuthDeviceCodeAlreadyDelivered` (11205).
 - **Rate limiters**: `auth_device_request_limiter`, `auth_device_poll_limiter`, `auth_device_approve_limiter`, `auth_device_approve_per_user_limiter`, and `auth_device_preview_limiter`.
 - **CLI**: `nyxid login --device` forces device-code login. Plain `nyxid login` auto-falls back to device-code login when browser launch is unavailable unless `NYXID_LOGIN_NO_DEVICE_FALLBACK=1` is set.
+- **Out of scope**: Mobile approval (deep-link from `/login/device` to the existing approval app) is out of scope for v1; tracked in a follow-up issue if needed.
 
 ## File Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,15 @@ Add new entries here when introducing additional vendored URN types.
   - 9506 `DeviceCodeRateLimited`
   - 9507 `DeviceCodeLocked`
   - 9508 `DeviceCodeSlowDown`
+- Error codes 11200-11207 are reserved for auth-device login:
+  - 11200 `AuthDeviceCodeNotFound`
+  - 11201 `AuthDeviceCodeExpired`
+  - 11202 `AuthDeviceCodePending`
+  - 11203 `AuthDeviceCodeSlowDown`
+  - 11204 `AuthDeviceCodeDenied`
+  - 11205 `AuthDeviceCodeAlreadyDelivered`
+  - 11206 `AuthDeviceCodeRateLimited`
+  - 11207 `AuthDeviceUserCodeInvalid`
 - `NodeStatus` is an enum (`Online`/`Offline`/`Draining`) -- not a bare string
 - WS writer channels are bounded (capacity: 256); `try_send` treats full buffers as node offline (H4)
 - WebSocket auth-frame injection rules live on `DownstreamService.ws_frame_injections` and `UserService.ws_frame_injections`; they are additive and separate from HTTP `auth_method` injection. `WsFrameDirection` is the trigger direction, so a `downstream` rule matches frames from the service and injects the configured response back toward that service. Direct and node-routed WS paths emit metadata-only `ws_frame_auth_injected` audit events; never log injected payloads or credentials.

--- a/backend/src/crypto/hmac_keys.rs
+++ b/backend/src/crypto/hmac_keys.rs
@@ -1,0 +1,58 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use zeroize::Zeroizing;
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub fn derive_hmac_key(
+    label: &str,
+    encryption_key: Option<&[u8]>,
+    jwt_private_pem: &[u8],
+) -> Zeroizing<[u8; 32]> {
+    if let Some(master) = encryption_key {
+        let label = format!("nyxid:{label}-code-hmac-v1");
+        return hmac_key(master, label.as_bytes());
+    }
+
+    if !jwt_private_pem.is_empty() {
+        let label = format!("nyxid:{label}-code-hmac-v1:jwt");
+        return hmac_key(jwt_private_pem, label.as_bytes());
+    }
+
+    panic!("HMAC key has no source: encryption key and JWT private key are both missing");
+}
+
+fn hmac_key(secret: &[u8], info: &[u8]) -> Zeroizing<[u8; 32]> {
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC-SHA256 accepts any key length");
+    mac.update(info);
+    let digest = mac.finalize().into_bytes();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    Zeroizing::new(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_hmac_key_domain_separates_labels() {
+        let encryption_key = [0x42_u8; 32];
+        let jwt_private_pem = [0x99_u8; 512];
+
+        let cli = derive_hmac_key("cli-pairing", Some(&encryption_key), &jwt_private_pem);
+        let auth = derive_hmac_key("auth-device", Some(&encryption_key), &jwt_private_pem);
+
+        assert_ne!(cli.as_slice(), auth.as_slice());
+    }
+
+    #[test]
+    fn derive_hmac_key_falls_back_to_jwt_pem() {
+        let jwt_private_pem = [0x99_u8; 512];
+
+        let a = derive_hmac_key("auth-device", None, &jwt_private_pem);
+        let b = derive_hmac_key("auth-device", None, &jwt_private_pem);
+
+        assert_eq!(a.as_slice(), b.as_slice());
+    }
+}

--- a/backend/src/crypto/mod.rs
+++ b/backend/src/crypto/mod.rs
@@ -2,6 +2,7 @@ pub mod aes;
 pub mod apple_client_secret;
 pub mod device_code;
 pub mod dpop;
+pub mod hmac_keys;
 pub mod jwks;
 pub mod jwt;
 pub mod key_provider;

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -9,6 +9,7 @@ use mongodb::{Client, Database, IndexModel};
 
 use crate::config::AppConfig;
 use crate::models::anonymous_endpoint_usage::COLLECTION_NAME as ANONYMOUS_ENDPOINT_USAGE;
+use crate::models::auth_device_code::{AuthDeviceCode, COLLECTION_NAME as AUTH_DEVICE_CODES};
 use crate::models::device_code::COLLECTION_NAME as DEVICE_CODES;
 use crate::models::device_onboard_credential::COLLECTION_NAME as DEVICE_ONBOARD_CREDENTIALS;
 use crate::models::downstream_service::{
@@ -915,6 +916,42 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
         )
         .await?;
     device_codes
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "expires_at": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .expire_after(Duration::from_secs(0))
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+
+    // ── auth_device_codes ──
+    let auth_device_codes = db.collection::<AuthDeviceCode>(AUTH_DEVICE_CODES);
+    auth_device_codes
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "device_code_hmac": 1 })
+                .options(IndexOptions::builder().unique(true).build())
+                .build(),
+        )
+        .await?;
+    auth_device_codes
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "user_code_hmac": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .unique(true)
+                        .partial_filter_expression(doc! { "status": "pending" })
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    auth_device_codes
         .create_index(
             IndexModel::builder()
                 .keys(doc! { "expires_at": 1 })

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -236,6 +236,30 @@ pub enum AppError {
     #[error("Device code poll interval must slow down")]
     DeviceCodeSlowDown,
 
+    #[error("Auth device code not found")]
+    AuthDeviceCodeNotFound,
+
+    #[error("Auth device code expired")]
+    AuthDeviceCodeExpired,
+
+    #[error("Authorization pending")]
+    AuthDeviceCodePending,
+
+    #[error("Auth device code poll interval must slow down")]
+    AuthDeviceCodeSlowDown,
+
+    #[error("Auth device code denied")]
+    AuthDeviceCodeDenied,
+
+    #[error("Auth device code already delivered")]
+    AuthDeviceCodeAlreadyDelivered,
+
+    #[error("Auth device code rate limited")]
+    AuthDeviceCodeRateLimited,
+
+    #[error("Auth device user code invalid")]
+    AuthDeviceUserCodeInvalid,
+
     #[error("Channel bot not found: {0}")]
     ChannelBotNotFound(String),
 
@@ -400,6 +424,14 @@ impl AppError {
             Self::DeviceCodeRateLimited => StatusCode::TOO_MANY_REQUESTS,
             Self::DeviceCodeLocked => StatusCode::TOO_MANY_REQUESTS,
             Self::DeviceCodeSlowDown => StatusCode::TOO_MANY_REQUESTS,
+            Self::AuthDeviceCodeNotFound => StatusCode::NOT_FOUND,
+            Self::AuthDeviceCodeExpired => StatusCode::GONE,
+            Self::AuthDeviceCodePending => StatusCode::BAD_REQUEST,
+            Self::AuthDeviceCodeSlowDown => StatusCode::TOO_MANY_REQUESTS,
+            Self::AuthDeviceCodeDenied => StatusCode::FORBIDDEN,
+            Self::AuthDeviceCodeAlreadyDelivered => StatusCode::GONE,
+            Self::AuthDeviceCodeRateLimited => StatusCode::TOO_MANY_REQUESTS,
+            Self::AuthDeviceUserCodeInvalid => StatusCode::BAD_REQUEST,
             Self::ChannelBotNotFound(_) => StatusCode::NOT_FOUND,
             Self::ChannelBotInactive(_) => StatusCode::BAD_REQUEST,
             Self::ChannelBotLimitReached(_) => StatusCode::TOO_MANY_REQUESTS,
@@ -508,6 +540,14 @@ impl AppError {
             Self::DeviceCodeRateLimited => 9506,
             Self::DeviceCodeLocked => 9507,
             Self::DeviceCodeSlowDown => 9508,
+            Self::AuthDeviceCodeNotFound => 11200,
+            Self::AuthDeviceCodeExpired => 11201,
+            Self::AuthDeviceCodePending => 11202,
+            Self::AuthDeviceCodeSlowDown => 11203,
+            Self::AuthDeviceCodeDenied => 11204,
+            Self::AuthDeviceCodeAlreadyDelivered => 11205,
+            Self::AuthDeviceCodeRateLimited => 11206,
+            Self::AuthDeviceUserCodeInvalid => 11207,
             Self::ChannelBotNotFound(_) => 10000,
             Self::ChannelBotInactive(_) => 10001,
             Self::ChannelBotLimitReached(_) => 10002,
@@ -648,6 +688,14 @@ impl AppError {
             Self::DeviceCodeRateLimited => "device_code_rate_limited",
             Self::DeviceCodeLocked => "device_code_locked",
             Self::DeviceCodeSlowDown => "device_code_slow_down",
+            Self::AuthDeviceCodeNotFound => "auth_device_code_not_found",
+            Self::AuthDeviceCodeExpired => "auth_device_expired_token",
+            Self::AuthDeviceCodePending => "auth_device_authorization_pending",
+            Self::AuthDeviceCodeSlowDown => "auth_device_slow_down",
+            Self::AuthDeviceCodeDenied => "auth_device_access_denied",
+            Self::AuthDeviceCodeAlreadyDelivered => "auth_device_already_delivered",
+            Self::AuthDeviceCodeRateLimited => "auth_device_rate_limited",
+            Self::AuthDeviceUserCodeInvalid => "auth_device_user_code_invalid",
             Self::ChannelBotNotFound(_) => "channel_bot_not_found",
             Self::ChannelBotInactive(_) => "channel_bot_inactive",
             Self::ChannelBotLimitReached(_) => "channel_bot_limit_reached",
@@ -1091,6 +1139,14 @@ mod tests {
             AppError::DeviceCodeRateLimited.error_code(),
             AppError::DeviceCodeLocked.error_code(),
             AppError::DeviceCodeSlowDown.error_code(),
+            AppError::AuthDeviceCodeNotFound.error_code(),
+            AppError::AuthDeviceCodeExpired.error_code(),
+            AppError::AuthDeviceCodePending.error_code(),
+            AppError::AuthDeviceCodeSlowDown.error_code(),
+            AppError::AuthDeviceCodeDenied.error_code(),
+            AppError::AuthDeviceCodeAlreadyDelivered.error_code(),
+            AppError::AuthDeviceCodeRateLimited.error_code(),
+            AppError::AuthDeviceUserCodeInvalid.error_code(),
             AppError::ChannelBotNotFound("".into()).error_code(),
             AppError::ChannelBotInactive("".into()).error_code(),
             AppError::ChannelBotLimitReached("".into()).error_code(),
@@ -1477,6 +1533,66 @@ mod tests {
             AppError::OracleExtractDisabled("".into()).error_key(),
             "oracle_extract_disabled"
         );
+    }
+
+    #[test]
+    fn auth_device_error_contract() {
+        let cases = vec![
+            (
+                AppError::AuthDeviceCodeNotFound,
+                11200,
+                "auth_device_code_not_found",
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                AppError::AuthDeviceCodeExpired,
+                11201,
+                "auth_device_expired_token",
+                StatusCode::GONE,
+            ),
+            (
+                AppError::AuthDeviceCodePending,
+                11202,
+                "auth_device_authorization_pending",
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                AppError::AuthDeviceCodeSlowDown,
+                11203,
+                "auth_device_slow_down",
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (
+                AppError::AuthDeviceCodeDenied,
+                11204,
+                "auth_device_access_denied",
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                AppError::AuthDeviceCodeAlreadyDelivered,
+                11205,
+                "auth_device_already_delivered",
+                StatusCode::GONE,
+            ),
+            (
+                AppError::AuthDeviceCodeRateLimited,
+                11206,
+                "auth_device_rate_limited",
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (
+                AppError::AuthDeviceUserCodeInvalid,
+                11207,
+                "auth_device_user_code_invalid",
+                StatusCode::BAD_REQUEST,
+            ),
+        ];
+
+        for (error, expected_code, expected_key, expected_status) in cases {
+            assert_eq!(error.error_code(), expected_code);
+            assert_eq!(error.error_key(), expected_key);
+            assert_eq!(error.into_response().status(), expected_status);
+        }
     }
 
     #[tokio::test]

--- a/backend/src/handlers/auth_device.rs
+++ b/backend/src/handlers/auth_device.rs
@@ -1,0 +1,786 @@
+use std::net::{IpAddr, SocketAddr};
+
+use axum::{
+    Json,
+    extract::{ConnectInfo, State},
+    http::{HeaderMap, header},
+};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use utoipa::ToSchema;
+
+use crate::AppState;
+use crate::errors::{AppError, AppResult};
+use crate::mw::auth::AuthUser;
+use crate::services::auth_device_service::{
+    self, ApproveInput, InitiateInput, PollClaim, PreviewOutput,
+};
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AuthDeviceRequestBody {
+    #[serde(default)]
+    pub client_label: Option<String>,
+    #[serde(default)]
+    pub client_user_agent: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthDeviceRequestResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: String,
+    pub expires_in: i64,
+    pub interval: u32,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AuthDevicePollBody {
+    pub device_code: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthDevicePollResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub token_type: &'static str,
+    pub expires_in: i64,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AuthDeviceApproveBody {
+    pub user_code: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AuthDevicePreviewBody {
+    pub user_code: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthDevicePreviewResponse {
+    pub client_label: Option<String>,
+    pub client_user_agent: Option<String>,
+    pub initiated_at: String,
+    pub expires_at: String,
+    pub status: String,
+}
+
+#[tracing::instrument(skip_all, fields(client_ip_hash, route = "request"))]
+pub async fn request_auth_device(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<AuthDeviceRequestBody>,
+) -> AppResult<Json<AuthDeviceRequestResponse>> {
+    let client_ip = resolve_client_ip(&headers, addr, &state)?;
+    let client_ip_hash = client_ip_hash(&state, client_ip);
+    tracing::Span::current().record("client_ip_hash", client_ip_hash.as_str());
+
+    if !state.auth_device_request_limiter.check(client_ip) {
+        rate_limit_hit("request", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    let initiated = auth_device_service::initiate(
+        &state.db,
+        state.auth_device_hmac_key.as_slice(),
+        InitiateInput {
+            client_label: body.client_label,
+            client_user_agent: body.client_user_agent,
+            client_ip: Some(client_ip.to_string()),
+        },
+    )
+    .await?;
+
+    let (verification_uri, verification_uri_complete) =
+        build_verification_uris(&state.config.frontend_url, &initiated.user_code)?;
+
+    tracing::info!(
+        client_ip_hash = %client_ip_hash,
+        status_code = 200_u16,
+        "auth_device.handler.request"
+    );
+
+    Ok(Json(AuthDeviceRequestResponse {
+        device_code: initiated.device_code,
+        user_code: initiated.user_code,
+        verification_uri,
+        verification_uri_complete,
+        expires_in: initiated.expires_in,
+        interval: initiated.interval,
+    }))
+}
+
+#[tracing::instrument(skip_all, fields(client_ip_hash, route = "poll"))]
+pub async fn poll_auth_device(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<AuthDevicePollBody>,
+) -> AppResult<Json<AuthDevicePollResponse>> {
+    let client_ip = resolve_client_ip(&headers, addr, &state)?;
+    let client_ip_hash = client_ip_hash(&state, client_ip);
+    tracing::Span::current().record("client_ip_hash", client_ip_hash.as_str());
+
+    if !state.auth_device_poll_limiter.check(client_ip) {
+        rate_limit_hit("poll", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    let claim = auth_device_service::poll_and_claim(
+        &state.db,
+        state.auth_device_hmac_key.as_slice(),
+        &body.device_code,
+    )
+    .await?;
+
+    match claim {
+        PollClaim::Pending => {
+            trace_poll_error(&client_ip_hash, "pending");
+            Err(AppError::AuthDeviceCodePending)
+        }
+        PollClaim::SlowDown => {
+            trace_poll_error(&client_ip_hash, "slow_down");
+            Err(AppError::AuthDeviceCodeSlowDown)
+        }
+        PollClaim::Denied => {
+            trace_poll_error(&client_ip_hash, "denied");
+            Err(AppError::AuthDeviceCodeDenied)
+        }
+        PollClaim::Expired => {
+            trace_poll_error(&client_ip_hash, "expired");
+            Err(AppError::AuthDeviceCodeExpired)
+        }
+        PollClaim::AlreadyDelivered => {
+            trace_poll_error(&client_ip_hash, "already_delivered");
+            Err(AppError::AuthDeviceCodeAlreadyDelivered)
+        }
+        PollClaim::Ready {
+            encrypted_access,
+            encrypted_refresh,
+            expires_in,
+        } => {
+            let (access_token, refresh_token) = auth_device_service::decrypt_tokens(
+                &state.encryption_keys,
+                &encrypted_access,
+                &encrypted_refresh,
+            )
+            .await?;
+
+            tracing::info!(
+                client_ip_hash = %client_ip_hash,
+                outcome = "delivered",
+                "auth_device.handler.poll"
+            );
+
+            Ok(Json(AuthDevicePollResponse {
+                access_token,
+                refresh_token,
+                token_type: "Bearer",
+                expires_in,
+            }))
+        }
+    }
+}
+
+#[tracing::instrument(skip_all, fields(client_ip_hash, route = "approve"))]
+pub async fn approve_auth_device(
+    State(state): State<AppState>,
+    user: AuthUser,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<AuthDeviceApproveBody>,
+) -> AppResult<Json<serde_json::Value>> {
+    let client_ip = resolve_client_ip(&headers, addr, &state)?;
+    let client_ip_hash = client_ip_hash(&state, client_ip);
+    tracing::Span::current().record("client_ip_hash", client_ip_hash.as_str());
+
+    if !state.auth_device_approve_limiter.check(client_ip) {
+        rate_limit_hit("approve", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    let user_key = format!("user:{}", user.user_id);
+    if !state.auth_device_approve_per_user_limiter.check(&user_key) {
+        rate_limit_hit("approve", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    auth_device_service::approve(
+        &state.db,
+        &state.config,
+        &state.jwt_keys,
+        &state.encryption_keys,
+        state.auth_device_hmac_key.as_slice(),
+        ApproveInput {
+            user_id: user.user_id.to_string(),
+            user_code: body.user_code,
+            approver_ip: Some(client_ip.to_string()),
+            approver_user_agent: user_agent(&headers),
+        },
+    )
+    .await?;
+
+    tracing::info!(
+        client_ip_hash = %client_ip_hash,
+        user_id = %user.user_id,
+        audit_logged = true,
+        "auth_device.handler.approve"
+    );
+
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+#[tracing::instrument(skip_all, fields(client_ip_hash, route = "preview"))]
+pub async fn preview_auth_device(
+    State(state): State<AppState>,
+    user: AuthUser,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<AuthDevicePreviewBody>,
+) -> AppResult<Json<AuthDevicePreviewResponse>> {
+    let client_ip = resolve_client_ip(&headers, addr, &state)?;
+    let client_ip_hash = client_ip_hash(&state, client_ip);
+    tracing::Span::current().record("client_ip_hash", client_ip_hash.as_str());
+
+    if !state.auth_device_preview_limiter.check(client_ip) {
+        rate_limit_hit("preview", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    let preview = auth_device_service::preview(
+        &state.db,
+        state.auth_device_hmac_key.as_slice(),
+        &body.user_code,
+    )
+    .await?;
+
+    tracing::info!(
+        client_ip_hash = %client_ip_hash,
+        user_id = %user.user_id,
+        status_code = 200_u16,
+        "auth_device.handler.preview"
+    );
+
+    Ok(Json(preview_response(preview)))
+}
+
+fn resolve_client_ip(headers: &HeaderMap, addr: SocketAddr, state: &AppState) -> AppResult<IpAddr> {
+    crate::mw::rate_limit::resolve_client_ip_for_rate_limit(
+        headers,
+        Some(addr),
+        &state.config.trusted_proxy_ips,
+    )
+    .or_else(|| Some(addr.ip()))
+    .ok_or_else(|| AppError::Internal("unable to resolve client IP".to_string()))
+}
+
+fn client_ip_hash(state: &AppState, ip: IpAddr) -> String {
+    hmac_hex(
+        state.auth_device_hmac_key.as_slice(),
+        ip.to_string().as_bytes(),
+    )
+}
+
+fn hmac_hex(hmac_key: &[u8], payload: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(hmac_key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(payload);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn build_verification_uris(frontend_url: &str, user_code: &str) -> AppResult<(String, String)> {
+    let base = frontend_url.trim().trim_end_matches('/');
+    if base.is_empty() {
+        tracing::error!("FRONTEND_URL is empty; cannot build auth-device verification URI");
+        return Err(AppError::Internal(
+            "auth-device verification URI is not configured".to_string(),
+        ));
+    }
+
+    let verification_uri = format!("{base}/login/device");
+    let mut parsed = url::Url::parse(&verification_uri).map_err(|error| {
+        tracing::error!(%error, "FRONTEND_URL is invalid; cannot build auth-device verification URI");
+        AppError::Internal("auth-device verification URI is invalid".to_string())
+    })?;
+    parsed.query_pairs_mut().append_pair("user_code", user_code);
+
+    Ok((verification_uri, parsed.to_string()))
+}
+
+fn user_agent(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(header::USER_AGENT)
+        .and_then(|value| value.to_str().ok())
+        .map(String::from)
+}
+
+fn preview_response(preview: PreviewOutput) -> AuthDevicePreviewResponse {
+    AuthDevicePreviewResponse {
+        client_label: preview.client_label,
+        client_user_agent: preview.client_user_agent,
+        initiated_at: preview
+            .initiated_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        expires_at: preview
+            .expires_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        status: serde_json::to_value(preview.status)
+            .ok()
+            .and_then(|value| value.as_str().map(String::from))
+            .unwrap_or_else(|| "pending".to_string()),
+    }
+}
+
+fn rate_limit_hit(route: &str, client_ip_hash: &str) {
+    tracing::warn!(route, client_ip_hash, "auth_device.rate_limit_hit");
+}
+
+fn trace_poll_error(client_ip_hash: &str, outcome: &str) {
+    tracing::info!(client_ip_hash, outcome, "auth_device.handler.poll");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use mongodb::bson::doc;
+    use reqwest::Client;
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+    use uuid::Uuid;
+
+    use crate::models::audit_log::{AuditLog, COLLECTION_NAME as AUDIT_LOG};
+    use crate::models::user::{COLLECTION_NAME as USERS, UserType};
+    use crate::services::auth_device_service::InitiateInput;
+    use crate::test_utils::{connect_test_database, test_app_config, test_app_state, test_user};
+
+    struct TestServer {
+        base_url: String,
+        client: Client,
+    }
+
+    async fn spawn_test_server(state: AppState) -> TestServer {
+        let (_, private) = crate::routes::build_router(
+            state.config.proxy_max_body_size,
+            state.config.public_proxy_max_body_size,
+        );
+        let app = private.with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("test server");
+        });
+
+        TestServer {
+            base_url: format!("http://{addr}"),
+            client: Client::new(),
+        }
+    }
+
+    async fn setup_state(prefix: &str) -> Option<AppState> {
+        let db = connect_test_database(prefix).await?;
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        Some(test_app_state(db))
+    }
+
+    async fn insert_user(state: &AppState, user_id: &str) {
+        state
+            .db
+            .collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(user_id, UserType::Person))
+            .await
+            .expect("insert user");
+    }
+
+    fn access_token(state: &AppState, user_id: &str) -> String {
+        let user_id = Uuid::parse_str(user_id).expect("valid user id");
+        crate::crypto::jwt::generate_access_token(
+            &state.jwt_keys,
+            &state.config,
+            &user_id,
+            "",
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("sign access token")
+    }
+
+    async fn post_json(
+        server: &TestServer,
+        path: &str,
+        token: Option<&str>,
+        body: Value,
+    ) -> (StatusCode, Value) {
+        let mut request = server
+            .client
+            .post(format!("{}{}", server.base_url, path))
+            .json(&body);
+        if let Some(token) = token {
+            request = request.bearer_auth(token);
+        }
+        let response = request.send().await.expect("send request");
+        let status = response.status();
+        let text = response.text().await.expect("response text");
+        let json = if text.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_str(&text).expect("json response")
+        };
+        (status, json)
+    }
+
+    async fn post_request(
+        server: &TestServer,
+        path: &str,
+        headers: &[(&str, &str)],
+        body: Value,
+    ) -> (StatusCode, Value) {
+        let mut request = server
+            .client
+            .post(format!("{}{}", server.base_url, path))
+            .json(&body);
+        for (name, value) in headers {
+            request = request.header(*name, *value);
+        }
+        let response = request.send().await.expect("send request");
+        let status = response.status();
+        let json = response.json::<Value>().await.expect("json response");
+        (status, json)
+    }
+
+    async fn create_api_key(state: &AppState, user_id: &str) -> String {
+        crate::services::key_service::create_api_key(
+            &state.db,
+            user_id,
+            "codex-test",
+            "read write proxy",
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+            Some(true),
+            None,
+            None,
+            Some("codex"),
+            None,
+        )
+        .await
+        .expect("create api key")
+        .full_key
+    }
+
+    fn assert_error(json: &Value, error: &str, code: u64) {
+        assert_eq!(json["error"], error);
+        assert_eq!(json["error_code"], code);
+    }
+
+    #[tokio::test]
+    async fn auth_device_full_happy_path_returns_valid_jwt_pair() {
+        let Some(state) = setup_state("auth_device_http_happy").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let token = access_token(&state, &user_id);
+        let server = spawn_test_server(state.clone()).await;
+
+        let (status, request_json) = post_json(
+            &server,
+            "/api/v1/auth/device/request",
+            None,
+            serde_json::json!({
+                "client_label": "wsl-calvin",
+                "client_user_agent": "nyxid-cli/0.8.0"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            request_json["verification_uri"],
+            "http://localhost:3000/login/device"
+        );
+        assert_eq!(
+            request_json["verification_uri_complete"],
+            format!(
+                "http://localhost:3000/login/device?user_code={}",
+                request_json["user_code"].as_str().unwrap()
+            )
+        );
+        assert_eq!(request_json["expires_in"], 600);
+        assert_eq!(request_json["interval"], 5);
+
+        let (status, approve_json) = post_json(
+            &server,
+            "/api/v1/auth/device/approve",
+            Some(&token),
+            serde_json::json!({ "user_code": request_json["user_code"].as_str().unwrap() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(approve_json, serde_json::json!({ "ok": true }));
+
+        let (status, poll_json) = post_json(
+            &server,
+            "/api/v1/auth/device/poll",
+            None,
+            serde_json::json!({ "device_code": request_json["device_code"].as_str().unwrap() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(poll_json["token_type"], "Bearer");
+
+        let access_claims = crate::crypto::jwt::verify_token(
+            &state.jwt_keys,
+            &state.config,
+            poll_json["access_token"].as_str().unwrap(),
+        )
+        .expect("valid access token");
+        assert_eq!(access_claims.sub, user_id);
+        assert_eq!(access_claims.aud, state.config.base_url);
+
+        let refresh_claims = crate::crypto::jwt::verify_token(
+            &state.jwt_keys,
+            &state.config,
+            poll_json["refresh_token"].as_str().unwrap(),
+        )
+        .expect("valid refresh token");
+        assert_eq!(refresh_claims.sub, access_claims.sub);
+    }
+
+    #[tokio::test]
+    async fn auth_device_approve_rejects_api_key_auth() {
+        let Some(state) = setup_state("auth_device_api_key_approve").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let api_key = create_api_key(&state, &user_id).await;
+        let server = spawn_test_server(state).await;
+
+        let (status, _) = post_json(
+            &server,
+            "/api/v1/auth/device/approve",
+            Some(&api_key),
+            serde_json::json!({ "user_code": "ABCD-EFGH" }),
+        )
+        .await;
+        assert_ne!(status, StatusCode::OK);
+        assert!(matches!(
+            status,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ));
+    }
+
+    #[tokio::test]
+    async fn auth_device_preview_rejects_api_key_auth() {
+        let Some(state) = setup_state("auth_device_api_key_preview").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let api_key = create_api_key(&state, &user_id).await;
+        let server = spawn_test_server(state).await;
+
+        let (status, _) = post_json(
+            &server,
+            "/api/v1/auth/device/preview",
+            Some(&api_key),
+            serde_json::json!({ "user_code": "ABCD-EFGH" }),
+        )
+        .await;
+        assert_ne!(status, StatusCode::OK);
+        assert!(matches!(
+            status,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ));
+    }
+
+    #[tokio::test]
+    async fn auth_device_poll_unknown_device_code_returns_11200() {
+        let Some(state) = setup_state("auth_device_poll_unknown").await else {
+            return;
+        };
+        let server = spawn_test_server(state).await;
+        let (status, json) = post_json(
+            &server,
+            "/api/v1/auth/device/poll",
+            None,
+            serde_json::json!({ "device_code": "nyx_adc_unknown" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_error(&json, "auth_device_code_not_found", 11200);
+    }
+
+    #[tokio::test]
+    async fn auth_device_two_concurrent_polls_only_deliver_once() {
+        let Some(state) = setup_state("auth_device_concurrent_poll").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let initiated = auth_device_service::initiate(
+            &state.db,
+            state.auth_device_hmac_key.as_slice(),
+            InitiateInput {
+                client_label: None,
+                client_user_agent: None,
+                client_ip: Some("127.0.0.1".to_string()),
+            },
+        )
+        .await
+        .expect("initiate");
+        auth_device_service::approve(
+            &state.db,
+            &state.config,
+            &state.jwt_keys,
+            &state.encryption_keys,
+            state.auth_device_hmac_key.as_slice(),
+            ApproveInput {
+                user_id,
+                user_code: initiated.user_code,
+                approver_ip: Some("127.0.0.1".to_string()),
+                approver_user_agent: Some("nyxid-cli/0.8.0".to_string()),
+            },
+        )
+        .await
+        .expect("approve");
+        let server = spawn_test_server(state).await;
+
+        let body = serde_json::json!({ "device_code": initiated.device_code });
+        let first = post_json(&server, "/api/v1/auth/device/poll", None, body.clone());
+        let second = post_json(&server, "/api/v1/auth/device/poll", None, body);
+        let (a, b) = tokio::join!(first, second);
+        let mut statuses = [a.0, b.0];
+        statuses.sort();
+        assert_eq!(statuses, [StatusCode::OK, StatusCode::GONE]);
+        let gone = if a.0 == StatusCode::GONE { a.1 } else { b.1 };
+        assert_error(&gone, "auth_device_already_delivered", 11205);
+    }
+
+    #[tokio::test]
+    async fn auth_device_request_rate_limit_sixth_request_returns_11206() {
+        let Some(state) = setup_state("auth_device_rate_limit").await else {
+            return;
+        };
+        let server = spawn_test_server(state).await;
+        let mut last = (StatusCode::OK, Value::Null);
+        for _ in 0..6 {
+            last = post_json(
+                &server,
+                "/api/v1/auth/device/request",
+                None,
+                serde_json::json!({}),
+            )
+            .await;
+        }
+
+        assert_eq!(last.0, StatusCode::TOO_MANY_REQUESTS);
+        assert_error(&last.1, "auth_device_rate_limited", 11206);
+    }
+
+    #[tokio::test]
+    async fn auth_device_untrusted_forwarded_for_cannot_bypass_request_rate_limit() {
+        let Some(state) = setup_state("auth_device_spoof_xff").await else {
+            return;
+        };
+        let server = spawn_test_server(state).await;
+        let mut last = (StatusCode::OK, Value::Null);
+        for i in 0..6 {
+            let spoofed = format!("198.51.100.{i}");
+            last = post_request(
+                &server,
+                "/api/v1/auth/device/request",
+                &[("x-forwarded-for", spoofed.as_str())],
+                serde_json::json!({}),
+            )
+            .await;
+        }
+
+        assert_eq!(last.0, StatusCode::TOO_MANY_REQUESTS);
+        assert_error(&last.1, "auth_device_rate_limited", 11206);
+    }
+
+    #[tokio::test]
+    async fn auth_device_approve_emits_audit_log() {
+        let Some(state) = setup_state("auth_device_audit").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let token = access_token(&state, &user_id);
+        let server = spawn_test_server(state.clone()).await;
+
+        let (_, request_json) = post_json(
+            &server,
+            "/api/v1/auth/device/request",
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        let (status, _) = post_json(
+            &server,
+            "/api/v1/auth/device/approve",
+            Some(&token),
+            serde_json::json!({ "user_code": request_json["user_code"].as_str().unwrap() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        for _ in 0..20 {
+            if let Some(log) = state
+                .db
+                .collection::<AuditLog>(AUDIT_LOG)
+                .find_one(doc! { "event_type": "auth_device_code_approved", "user_id": &user_id })
+                .await
+                .expect("query audit log")
+            {
+                assert!(log.api_key_id.is_none());
+                assert_eq!(log.user_id.as_deref(), Some(user_id.as_str()));
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!("expected auth_device_code_approved audit log");
+    }
+
+    #[tokio::test]
+    async fn auth_device_request_with_empty_frontend_url_returns_500() {
+        let Some(db) = connect_test_database("auth_device_empty_frontend").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let mut config = test_app_config();
+        config.frontend_url = String::new();
+        let state = crate::test_utils::test_app_state_with_config(db, config);
+        let server = spawn_test_server(state).await;
+
+        let (status, json) = post_json(
+            &server,
+            "/api/v1/auth/device/request",
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(json["error"], "internal_error");
+    }
+}

--- a/backend/src/handlers/auth_device.rs
+++ b/backend/src/handlers/auth_device.rs
@@ -238,7 +238,6 @@ pub async fn approve_auth_device(
 #[tracing::instrument(skip_all, fields(client_ip_hash, route = "preview"))]
 pub async fn preview_auth_device(
     State(state): State<AppState>,
-    user: AuthUser,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<AuthDevicePreviewBody>,
@@ -261,7 +260,6 @@ pub async fn preview_auth_device(
 
     tracing::info!(
         client_ip_hash = %client_ip_hash,
-        user_id = %user.user_id,
         status_code = 200_u16,
         "auth_device.handler.preview"
     );
@@ -603,28 +601,41 @@ mod tests {
         ));
     }
 
+    // Covers the public mount of /auth/device/preview: an anonymous caller must
+    // succeed and receive the sanitized anti-phishing payload (client_label,
+    // UA, timestamps, status). Approve stays human-only — see the test above.
     #[tokio::test]
-    async fn auth_device_preview_rejects_api_key_auth() {
-        let Some(state) = setup_state("auth_device_api_key_preview").await else {
+    async fn auth_device_preview_accepts_anonymous_caller() {
+        let Some(state) = setup_state("auth_device_preview_anon").await else {
             return;
         };
-        let user_id = Uuid::new_v4().to_string();
-        insert_user(&state, &user_id).await;
-        let api_key = create_api_key(&state, &user_id).await;
+        let initiated = auth_device_service::initiate(
+            &state.db,
+            state.auth_device_hmac_key.as_slice(),
+            InitiateInput {
+                client_label: Some("kitchen-rpi".to_string()),
+                client_user_agent: Some("nyxid-cli/0.7.1".to_string()),
+                client_ip: Some("127.0.0.1".to_string()),
+            },
+        )
+        .await
+        .expect("initiate");
         let server = spawn_test_server(state).await;
 
-        let (status, _) = post_json(
+        let (status, json) = post_json(
             &server,
             "/api/v1/auth/device/preview",
-            Some(&api_key),
-            serde_json::json!({ "user_code": "ABCD-EFGH" }),
+            None,
+            serde_json::json!({ "user_code": initiated.user_code }),
         )
         .await;
-        assert_ne!(status, StatusCode::OK);
-        assert!(matches!(
-            status,
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
-        ));
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["client_label"], "kitchen-rpi");
+        assert_eq!(json["client_user_agent"], "nyxid-cli/0.7.1");
+        assert_eq!(json["status"], "pending");
+        assert!(json["initiated_at"].is_string());
+        assert!(json["expires_at"].is_string());
     }
 
     #[tokio::test]
@@ -975,7 +986,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn e2e_api_key_auth_rejected_on_approve_and_preview() {
+    async fn e2e_api_key_auth_rejected_on_approve() {
         let Some(state) = setup_state("auth_device_e2e_api_key_reject").await else {
             return;
         };
@@ -996,21 +1007,6 @@ mod tests {
             approve_status,
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
         ));
-
-        let (preview_status, preview_json) = post_json(
-            &server,
-            "/api/v1/auth/device/preview",
-            Some(&api_key),
-            serde_json::json!({ "user_code": "ABCD-EFGH" }),
-        )
-        .await;
-        assert_ne!(preview_status, StatusCode::OK);
-        assert!(matches!(
-            preview_status,
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
-        ));
-
         assert_ne!(approve_json, serde_json::json!({ "ok": true }));
-        assert_ne!(preview_json["status"], "pending");
     }
 }

--- a/backend/src/handlers/auth_device.rs
+++ b/backend/src/handlers/auth_device.rs
@@ -463,6 +463,22 @@ mod tests {
         (status, json)
     }
 
+    async fn get_json(server: &TestServer, path: &str, token: Option<&str>) -> (StatusCode, Value) {
+        let mut request = server.client.get(format!("{}{}", server.base_url, path));
+        if let Some(token) = token {
+            request = request.bearer_auth(token);
+        }
+        let response = request.send().await.expect("send request");
+        let status = response.status();
+        let text = response.text().await.expect("response text");
+        let json = if text.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_str(&text).expect("json response")
+        };
+        (status, json)
+    }
+
     async fn create_api_key(state: &AppState, user_id: &str) -> String {
         crate::services::key_service::create_api_key(
             &state.db,
@@ -782,5 +798,219 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(json["error"], "internal_error");
+    }
+
+    #[tokio::test]
+    async fn e2e_full_happy_path_request_approve_poll_refresh() {
+        let Some(state) = setup_state("auth_device_e2e_happy").await else {
+            return;
+        };
+        crate::services::role_service::seed_system_roles(&state.db)
+            .await
+            .expect("seed roles");
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let approving_jwt = access_token(&state, &user_id);
+        let server = spawn_test_server(state.clone()).await;
+
+        let (status, request_json) = post_json(
+            &server,
+            "/api/v1/auth/device/request",
+            None,
+            serde_json::json!({
+                "client_label": "wsl-calvin",
+                "client_user_agent": "nyxid-cli/0.8.0"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            request_json["device_code"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("nyx_adc_"))
+        );
+        assert!(
+            request_json["user_code"]
+                .as_str()
+                .is_some_and(|value| value.len() == 9 && value.contains('-'))
+        );
+
+        let (status, approve_json) = post_json(
+            &server,
+            "/api/v1/auth/device/approve",
+            Some(&approving_jwt),
+            serde_json::json!({ "user_code": request_json["user_code"].as_str().unwrap() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(approve_json, serde_json::json!({ "ok": true }));
+
+        let (status, poll_json) = post_json(
+            &server,
+            "/api/v1/auth/device/poll",
+            None,
+            serde_json::json!({ "device_code": request_json["device_code"].as_str().unwrap() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            poll_json["access_token"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty())
+        );
+        assert!(
+            poll_json["refresh_token"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty())
+        );
+        assert_eq!(poll_json["token_type"], "Bearer");
+        assert_eq!(poll_json["expires_in"], 900);
+
+        let access_token = poll_json["access_token"].as_str().unwrap();
+        let (status, me_json) = get_json(&server, "/api/v1/users/me", Some(access_token)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(me_json["id"], user_id);
+        assert_eq!(me_json["email"], format!("{user_id}@example.com"));
+        assert_eq!(me_json["display_name"], "Test User");
+
+        let refresh_token = poll_json["refresh_token"].as_str().unwrap();
+        let (status, refresh_json) = post_json(
+            &server,
+            "/api/v1/auth/refresh",
+            None,
+            serde_json::json!({ "refresh_token": refresh_token }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            refresh_json["access_token"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty() && value != access_token)
+        );
+        assert!(
+            refresh_json["refresh_token"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty() && value != refresh_token)
+        );
+        assert_eq!(refresh_json["expires_in"], 900);
+
+        let (status, refreshed_me_json) = get_json(
+            &server,
+            "/api/v1/users/me",
+            Some(refresh_json["access_token"].as_str().unwrap()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(refreshed_me_json["id"], user_id);
+    }
+
+    #[tokio::test]
+    async fn e2e_concurrent_poll_after_approve_only_one_winner() {
+        let Some(state) = setup_state("auth_device_e2e_concurrent_poll").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let approving_jwt = access_token(&state, &user_id);
+        let server = spawn_test_server(state).await;
+
+        let (status, request_json) = post_json(
+            &server,
+            "/api/v1/auth/device/request",
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, _) = post_json(
+            &server,
+            "/api/v1/auth/device/approve",
+            Some(&approving_jwt),
+            serde_json::json!({ "user_code": request_json["user_code"].as_str().unwrap() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let body =
+            serde_json::json!({ "device_code": request_json["device_code"].as_str().unwrap() });
+        let first = post_json(&server, "/api/v1/auth/device/poll", None, body.clone());
+        let second = post_json(&server, "/api/v1/auth/device/poll", None, body);
+        let (first, second) = tokio::join!(first, second);
+
+        let ok_count = [first.0, second.0]
+            .into_iter()
+            .filter(|status| *status == StatusCode::OK)
+            .count();
+        let already_delivered = [first, second]
+            .into_iter()
+            .filter(|(status, json)| {
+                *status == StatusCode::GONE && json["error_code"].as_u64() == Some(11205)
+            })
+            .count();
+        assert_eq!(ok_count, 1);
+        assert_eq!(already_delivered, 1);
+    }
+
+    #[tokio::test]
+    async fn e2e_spoofed_xff_does_not_bypass_request_rate_limit() {
+        let Some(state) = setup_state("auth_device_e2e_spoof_xff").await else {
+            return;
+        };
+        let server = spawn_test_server(state).await;
+        let mut last = (StatusCode::OK, Value::Null);
+        for i in 0..6 {
+            let spoofed = format!("198.51.100.{i}");
+            last = post_request(
+                &server,
+                "/api/v1/auth/device/request",
+                &[("x-forwarded-for", spoofed.as_str())],
+                serde_json::json!({}),
+            )
+            .await;
+        }
+
+        assert_eq!(last.0, StatusCode::TOO_MANY_REQUESTS);
+        assert_error(&last.1, "auth_device_rate_limited", 11206);
+    }
+
+    #[tokio::test]
+    async fn e2e_api_key_auth_rejected_on_approve_and_preview() {
+        let Some(state) = setup_state("auth_device_e2e_api_key_reject").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let api_key = create_api_key(&state, &user_id).await;
+        let server = spawn_test_server(state).await;
+
+        let (approve_status, approve_json) = post_json(
+            &server,
+            "/api/v1/auth/device/approve",
+            Some(&api_key),
+            serde_json::json!({ "user_code": "ABCD-EFGH" }),
+        )
+        .await;
+        assert_ne!(approve_status, StatusCode::OK);
+        assert!(matches!(
+            approve_status,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ));
+
+        let (preview_status, preview_json) = post_json(
+            &server,
+            "/api/v1/auth/device/preview",
+            Some(&api_key),
+            serde_json::json!({ "user_code": "ABCD-EFGH" }),
+        )
+        .await;
+        assert_ne!(preview_status, StatusCode::OK);
+        assert!(matches!(
+            preview_status,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ));
+
+        assert_ne!(approve_json, serde_json::json!({ "ok": true }));
+        assert_ne!(preview_json["status"], "pending");
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -11,6 +11,7 @@ pub mod agent_bindings;
 pub mod api_keys;
 pub mod approvals;
 pub mod auth;
+pub mod auth_device;
 pub mod broker_bindings;
 pub mod catalog;
 pub mod channel_bots;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -51,6 +51,7 @@ fn install_rustls_crypto_provider() {
 use crate::db::DbHandle;
 use config::AppConfig;
 use crypto::aes::EncryptionKeys;
+use crypto::hmac_keys::derive_hmac_key;
 use crypto::jwks::JwksCache;
 use crypto::jwt::JwtKeys;
 use crypto::key_provider::KeyProvider;
@@ -114,6 +115,9 @@ pub struct AppState {
     /// (or `CLI_PAIRING_HMAC_KEY` when set); see
     /// `derive_cli_pairing_hmac_key` in `main.rs`.
     pub cli_pairing_hmac_key: std::sync::Arc<zeroize::Zeroizing<[u8; 32]>>,
+    /// Server-side HMAC key used to derive auth-device login code hashes.
+    /// Domain-separated from CLI pairing with the `auth-device` label.
+    pub auth_device_hmac_key: std::sync::Arc<zeroize::Zeroizing<[u8; 32]>>,
     /// Per-channel rate limiter keyed by conversation_id, for the HTTP Event
     /// Gateway (NyxID#221). Distinct from `per_agent_limiter`.
     pub per_channel_event_limiter: mw::rate_limit::SharedPerChannelEventLimiter,
@@ -457,6 +461,10 @@ async fn main() {
         config.encryption_key.as_deref(),
         Some(&jwt_private_key_pem),
     ));
+    let auth_device_hmac_key = Arc::new(derive_auth_device_hmac_key(
+        config.encryption_key.as_deref(),
+        Some(&jwt_private_key_pem),
+    ));
     // JWT private key bytes carry no secret beyond what's
     // already in JwtKeys; drop them immediately after derivation.
     drop(jwt_private_key_pem);
@@ -490,6 +498,7 @@ async fn main() {
             60,
         ),
         cli_pairing_hmac_key,
+        auth_device_hmac_key,
         per_channel_event_limiter,
         per_message_edit_limiter,
         event_dedup_cache,
@@ -913,10 +922,6 @@ fn derive_cli_pairing_hmac_key(
     encryption_key: Option<&str>,
     jwt_private_key_pem: Option<&[u8]>,
 ) -> zeroize::Zeroizing<[u8; 32]> {
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
-    type HmacSha256 = Hmac<Sha256>;
-
     // 1. Explicit env override takes precedence. A set-but-empty
     //    value is treated as unset (dotenv / docker-compose often
     //    emit empty strings for unused vars).
@@ -942,18 +947,13 @@ fn derive_cli_pairing_hmac_key(
     //    and is the natural shared-secret in single-region
     //    deployments. Domain-separate the output so we can't
     //    accidentally collide with any future HMAC use.
-    if let Some(hex_key) = encryption_key
-        && let Ok(master) = hex::decode(hex_key.trim())
-        && master.len() == 32
-    {
-        let mut mac =
-            HmacSha256::new_from_slice(&master).expect("HMAC-SHA256 accepts any key length");
-        mac.update(b"nyxid:cli-pairing-code-hmac-v1");
-        let digest = mac.finalize().into_bytes();
-        let mut out = [0u8; 32];
-        out.copy_from_slice(&digest);
+    if let Some(master) = decode_hmac_seed(encryption_key) {
         tracing::info!("cli-pairing HMAC key derived from ENCRYPTION_KEY");
-        return zeroize::Zeroizing::new(out);
+        return derive_hmac_key(
+            "cli-pairing",
+            Some(&master),
+            jwt_private_key_pem.unwrap_or_default(),
+        );
     }
 
     // 3. Universal JWT-private-key fallback. Lets KMS
@@ -967,18 +967,13 @@ fn derive_cli_pairing_hmac_key(
     if let Some(pem) = jwt_private_key_pem
         && !pem.is_empty()
     {
-        let mut mac = HmacSha256::new_from_slice(pem).expect("HMAC-SHA256 accepts any key length");
-        mac.update(b"nyxid:cli-pairing-code-hmac-v1:jwt");
-        let digest = mac.finalize().into_bytes();
-        let mut out = [0u8; 32];
-        out.copy_from_slice(&digest);
         tracing::info!(
             "cli-pairing HMAC key derived from JWT private key \
              (neither CLI_PAIRING_HMAC_KEY nor ENCRYPTION_KEY is \
              set). Set CLI_PAIRING_HMAC_KEY explicitly if you need \
              to rotate it independently of the JWT signing key."
         );
-        return zeroize::Zeroizing::new(out);
+        return derive_hmac_key("cli-pairing", None, pem);
     }
 
     // 4. Defensive stop. Unreachable in practice because the JWT
@@ -992,6 +987,39 @@ fn derive_cli_pairing_hmac_key(
          Set CLI_PAIRING_HMAC_KEY to a 64-hex-char value \
          (`openssl rand -hex 32`) — see docs/ENV.md."
     );
+}
+
+fn derive_auth_device_hmac_key(
+    encryption_key: Option<&str>,
+    jwt_private_key_pem: Option<&[u8]>,
+) -> zeroize::Zeroizing<[u8; 32]> {
+    let jwt_private_key_pem = jwt_private_key_pem.unwrap_or_default();
+    if let Some(master) = decode_hmac_seed(encryption_key) {
+        tracing::info!("auth-device HMAC key derived from ENCRYPTION_KEY");
+        return derive_hmac_key("auth-device", Some(&master), jwt_private_key_pem);
+    }
+
+    if !jwt_private_key_pem.is_empty() {
+        tracing::info!("auth-device HMAC key derived from JWT private key");
+        return derive_hmac_key("auth-device", None, jwt_private_key_pem);
+    }
+
+    panic!(
+        "auth-device HMAC key has no source: ENCRYPTION_KEY and the JWT private key \
+         are both missing."
+    );
+}
+
+fn decode_hmac_seed(encryption_key: Option<&str>) -> Option<zeroize::Zeroizing<Vec<u8>>> {
+    let hex_key = encryption_key?;
+    let Ok(master) = hex::decode(hex_key.trim()) else {
+        return None;
+    };
+    if master.len() == 32 {
+        Some(zeroize::Zeroizing::new(master))
+    } else {
+        None
+    }
 }
 
 /// Run the --promote-admin CLI command, then return.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -94,6 +94,16 @@ pub struct AppState {
     pub device_code_pubkey_limiter: mw::rate_limit::SharedPerPubkeyRateLimiter,
     /// Per-IP limiter for `/api/v1/devices/code/*`.
     pub device_code_ip_limiter: mw::rate_limit::SharedPerIpRateLimiter,
+    /// Per-IP limiter for `POST /api/v1/auth/device/request` (5/min).
+    pub auth_device_request_limiter: mw::rate_limit::SharedPerIpRateLimiter,
+    /// Per-IP limiter for `POST /api/v1/auth/device/poll` (60/min).
+    pub auth_device_poll_limiter: mw::rate_limit::SharedPerIpRateLimiter,
+    /// Per-IP limiter for `POST /api/v1/auth/device/approve` (10/min).
+    pub auth_device_approve_limiter: mw::rate_limit::SharedPerIpRateLimiter,
+    /// Per-user limiter for `POST /api/v1/auth/device/approve` (10/5min).
+    pub auth_device_approve_per_user_limiter: mw::rate_limit::SharedPerKeyRateLimiter,
+    /// Per-IP limiter for `POST /api/v1/auth/device/preview` (30/min).
+    pub auth_device_preview_limiter: mw::rate_limit::SharedPerIpRateLimiter,
     /// Per-IP rate limiter for `POST /cli-pairings/claim`. Tighter than
     /// the global rate limiter (5 attempts per 60s per IP) so brute
     /// forcing the 8-char pairing code is infeasible even from a
@@ -486,6 +496,11 @@ async fn main() {
         per_agent_limiter: Arc::new(mw::rate_limit::PerAgentRateLimiter::new()),
         device_code_pubkey_limiter: mw::rate_limit::create_per_pubkey_rate_limiter(),
         device_code_ip_limiter: mw::rate_limit::create_per_ip_rate_limiter(5, 60),
+        auth_device_request_limiter: mw::rate_limit::create_per_ip_rate_limiter(5, 60),
+        auth_device_poll_limiter: mw::rate_limit::create_per_ip_rate_limiter(60, 60),
+        auth_device_approve_limiter: mw::rate_limit::create_per_ip_rate_limiter(10, 60),
+        auth_device_approve_per_user_limiter: mw::rate_limit::create_per_key_rate_limiter(10, 300),
+        auth_device_preview_limiter: mw::rate_limit::create_per_ip_rate_limiter(30, 60),
         // 5 claim attempts per 60 seconds per IP; window-based, not token
         // bucket, because we want a hard cap on guesses per unit time.
         cli_pairing_claim_limiter: mw::rate_limit::create_per_ip_rate_limiter(5, 60),
@@ -590,6 +605,47 @@ async fn main() {
         loop {
             interval.tick().await;
             cleanup_device_code_ip_limiter.cleanup();
+        }
+    });
+    let cleanup_auth_device_request_limiter = state.auth_device_request_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            cleanup_auth_device_request_limiter.cleanup();
+        }
+    });
+    let cleanup_auth_device_poll_limiter = state.auth_device_poll_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            cleanup_auth_device_poll_limiter.cleanup();
+        }
+    });
+    let cleanup_auth_device_approve_limiter = state.auth_device_approve_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            cleanup_auth_device_approve_limiter.cleanup();
+        }
+    });
+    let cleanup_auth_device_approve_per_user_limiter =
+        state.auth_device_approve_per_user_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            cleanup_auth_device_approve_per_user_limiter.cleanup();
+        }
+    });
+    let cleanup_auth_device_preview_limiter = state.auth_device_preview_limiter.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            cleanup_auth_device_preview_limiter.cleanup();
         }
     });
 

--- a/backend/src/models/auth_device_code.rs
+++ b/backend/src/models/auth_device_code.rs
@@ -1,0 +1,241 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use super::bson_datetime;
+use crate::redaction::RedactedLen;
+
+pub const COLLECTION_NAME: &str = "auth_device_codes";
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthDeviceCodeStatus {
+    Pending,
+    Approved,
+    Denied,
+    Expired,
+    Delivered,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AuthDeviceCode {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub device_code_hmac: String,
+    pub user_code_hmac: String,
+    pub status: AuthDeviceCodeStatus,
+    pub poll_interval_secs: u32,
+    pub slow_down_increments: u32,
+    pub client_label: Option<String>,
+    pub client_user_agent: Option<String>,
+    pub client_ip_hmac: Option<String>,
+    #[serde(default, with = "bson_datetime::optional")]
+    pub last_polled_at: Option<DateTime<Utc>>,
+    pub approved_user_id: Option<String>,
+    pub approved_session_id: Option<String>,
+    pub approver_ip_hmac: Option<String>,
+    #[serde(default, with = "crate::models::bson_bytes::optional")]
+    pub delivery_access_token_encrypted: Option<Vec<u8>>,
+    #[serde(default, with = "crate::models::bson_bytes::optional")]
+    pub delivery_refresh_token_encrypted: Option<Vec<u8>>,
+    pub delivery_access_token_expires_in: Option<i64>,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default, with = "bson_datetime::optional")]
+    pub approved_at: Option<DateTime<Utc>>,
+    #[serde(default, with = "bson_datetime::optional")]
+    pub delivered_at: Option<DateTime<Utc>>,
+    #[serde(default, with = "bson_datetime::optional")]
+    pub denied_at: Option<DateTime<Utc>>,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub expires_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for AuthDeviceCodeStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pending => f.write_str("Pending"),
+            Self::Approved => f.write_str("Approved"),
+            Self::Denied => f.write_str("Denied"),
+            Self::Expired => f.write_str("Expired"),
+            Self::Delivered => f.write_str("Delivered"),
+        }
+    }
+}
+
+impl fmt::Debug for AuthDeviceCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthDeviceCode")
+            .field("id", &self.id)
+            .field(
+                "device_code_hmac",
+                &RedactedLen(self.device_code_hmac.len()),
+            )
+            .field("user_code_hmac", &RedactedLen(self.user_code_hmac.len()))
+            .field("status", &self.status)
+            .field("poll_interval_secs", &self.poll_interval_secs)
+            .field("slow_down_increments", &self.slow_down_increments)
+            .field("client_label", &self.client_label)
+            .field("client_user_agent", &self.client_user_agent)
+            .field(
+                "client_ip_hmac",
+                &self
+                    .client_ip_hmac
+                    .as_ref()
+                    .map(|hash| RedactedLen(hash.len())),
+            )
+            .field("last_polled_at", &self.last_polled_at)
+            .field("approved_user_id", &self.approved_user_id)
+            .field("approved_session_id", &self.approved_session_id)
+            .field(
+                "approver_ip_hmac",
+                &self
+                    .approver_ip_hmac
+                    .as_ref()
+                    .map(|hash| RedactedLen(hash.len())),
+            )
+            .field(
+                "delivery_access_token_encrypted",
+                &self
+                    .delivery_access_token_encrypted
+                    .as_ref()
+                    .map(|bytes| RedactedLen(bytes.len())),
+            )
+            .field(
+                "delivery_refresh_token_encrypted",
+                &self
+                    .delivery_refresh_token_encrypted
+                    .as_ref()
+                    .map(|bytes| RedactedLen(bytes.len())),
+            )
+            .field(
+                "delivery_access_token_expires_in",
+                &self.delivery_access_token_expires_in,
+            )
+            .field("created_at", &self.created_at)
+            .field("approved_at", &self.approved_at)
+            .field("delivered_at", &self.delivered_at)
+            .field("denied_at", &self.denied_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_auth_device_code() -> AuthDeviceCode {
+        let now = Utc::now();
+        AuthDeviceCode {
+            id: uuid::Uuid::new_v4().to_string(),
+            device_code_hmac: "abc123ff".repeat(8),
+            user_code_hmac: "def456aa".repeat(8),
+            status: AuthDeviceCodeStatus::Pending,
+            poll_interval_secs: 5,
+            slow_down_increments: 0,
+            client_label: Some("wsl-calvin".to_string()),
+            client_user_agent: Some("nyxid-cli/0.8.0".to_string()),
+            client_ip_hmac: Some("11112222".repeat(8)),
+            last_polled_at: Some(now + chrono::Duration::seconds(5)),
+            approved_user_id: Some(uuid::Uuid::new_v4().to_string()),
+            approved_session_id: Some(uuid::Uuid::new_v4().to_string()),
+            approver_ip_hmac: Some("33334444".repeat(8)),
+            delivery_access_token_encrypted: Some(vec![0xab, 0xcd, 0xef]),
+            delivery_refresh_token_encrypted: Some(vec![0x12, 0x34, 0x56]),
+            delivery_access_token_expires_in: Some(900),
+            created_at: now,
+            approved_at: Some(now + chrono::Duration::seconds(10)),
+            delivered_at: Some(now + chrono::Duration::seconds(20)),
+            denied_at: None,
+            expires_at: now + chrono::Duration::minutes(10),
+        }
+    }
+
+    #[test]
+    fn collection_name() {
+        assert_eq!(COLLECTION_NAME, "auth_device_codes");
+    }
+
+    #[test]
+    fn status_serializes_as_lowercase() {
+        let value = serde_json::to_value(AuthDeviceCodeStatus::Pending).expect("serialize status");
+        assert_eq!(value, serde_json::json!("pending"));
+    }
+
+    #[test]
+    fn bson_roundtrip_preserves_struct_identity() {
+        let row = make_auth_device_code();
+        let doc = bson::to_document(&row).expect("serialize");
+        let restored: AuthDeviceCode = bson::from_document(doc).expect("deserialize");
+
+        assert_eq!(row.id, restored.id);
+        assert_eq!(row.device_code_hmac, restored.device_code_hmac);
+        assert_eq!(row.user_code_hmac, restored.user_code_hmac);
+        assert_eq!(row.status, restored.status);
+        assert_eq!(row.poll_interval_secs, restored.poll_interval_secs);
+        assert_eq!(row.slow_down_increments, restored.slow_down_increments);
+        assert_eq!(row.client_label, restored.client_label);
+        assert_eq!(row.client_user_agent, restored.client_user_agent);
+        assert_eq!(row.client_ip_hmac, restored.client_ip_hmac);
+        assert_eq!(row.approved_user_id, restored.approved_user_id);
+        assert_eq!(row.approved_session_id, restored.approved_session_id);
+        assert_eq!(row.approver_ip_hmac, restored.approver_ip_hmac);
+        assert_eq!(
+            row.delivery_access_token_encrypted,
+            restored.delivery_access_token_encrypted
+        );
+        assert_eq!(
+            row.delivery_refresh_token_encrypted,
+            restored.delivery_refresh_token_encrypted
+        );
+        assert_eq!(
+            row.delivery_access_token_expires_in,
+            restored.delivery_access_token_expires_in
+        );
+        assert_eq!(
+            row.created_at.timestamp_millis(),
+            restored.created_at.timestamp_millis()
+        );
+        assert_eq!(
+            row.last_polled_at.unwrap().timestamp_millis(),
+            restored.last_polled_at.unwrap().timestamp_millis()
+        );
+        assert_eq!(
+            row.approved_at.unwrap().timestamp_millis(),
+            restored.approved_at.unwrap().timestamp_millis()
+        );
+        assert_eq!(
+            row.delivered_at.unwrap().timestamp_millis(),
+            restored.delivered_at.unwrap().timestamp_millis()
+        );
+        assert_eq!(row.denied_at, restored.denied_at);
+        assert_eq!(
+            row.expires_at.timestamp_millis(),
+            restored.expires_at.timestamp_millis()
+        );
+    }
+
+    #[test]
+    fn debug_redacts_hashes_and_ciphertext_but_prints_safe_fields() {
+        let row = make_auth_device_code();
+        let debug = format!("{row:?}");
+
+        for secret in [
+            row.device_code_hmac.as_str(),
+            row.user_code_hmac.as_str(),
+            row.client_ip_hmac.as_deref().unwrap(),
+            row.approver_ip_hmac.as_deref().unwrap(),
+            "abcdef",
+            "123456",
+        ] {
+            assert!(!debug.contains(secret), "{secret} leaked in {debug}");
+        }
+
+        assert!(debug.contains("Pending"));
+        assert!(debug.contains("created_at"));
+        assert!(debug.contains("expires_at"));
+        assert!(debug.contains("wsl-calvin"));
+        assert!(debug.contains("nyxid-cli/0.8.0"));
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod api_key;
 pub mod approval_grant;
 pub mod approval_request;
 pub mod audit_log;
+pub mod auth_device_code;
 pub mod authorization_code;
 pub mod bson_bytes;
 pub mod bson_datetime;

--- a/backend/src/mw/auth.rs
+++ b/backend/src/mw/auth.rs
@@ -818,6 +818,38 @@ pub async fn reject_service_account_tokens(
     Ok(next.run(request).await)
 }
 
+/// Middleware that rejects API-key credentials from human-only endpoints.
+pub async fn reject_api_key_tokens(
+    request: axum::http::Request<axum::body::Body>,
+    next: Next,
+) -> Result<impl IntoResponse, AppError> {
+    if is_api_key_request(&request) {
+        return Err(AppError::Forbidden(
+            "API keys cannot access this endpoint".to_string(),
+        ));
+    }
+    Ok(next.run(request).await)
+}
+
+fn is_api_key_request(request: &axum::http::Request<axum::body::Body>) -> bool {
+    if request.headers().get("x-api-key").is_some() {
+        return true;
+    }
+
+    request
+        .headers()
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(|token| {
+            token.starts_with("nyx_")
+                || token.starts_with("nyxid_")
+                || token.starts_with("nyxid_ag_")
+                || token.starts_with("nyxid_sk_")
+        })
+        .unwrap_or(false)
+}
+
 /// Check if the request bears a service account token.
 fn is_service_account_request(request: &axum::http::Request<axum::body::Body>) -> bool {
     // Check Authorization header

--- a/backend/src/mw/rate_limit.rs
+++ b/backend/src/mw/rate_limit.rs
@@ -80,6 +80,52 @@ impl PerIpRateLimiter {
 /// Shared per-IP rate limiter type for use as an Extension.
 pub type SharedPerIpRateLimiter = Arc<PerIpRateLimiter>;
 
+/// Per-string-key limiter for cases where the security principal is not an IP
+/// address, e.g. human user IDs. Uses the same fixed-window semantics as
+/// `PerIpRateLimiter`.
+#[derive(Clone)]
+pub struct PerKeyRateLimiter {
+    state: Arc<Mutex<HashMap<String, (u32, Instant)>>>,
+    max_requests: u32,
+    window_secs: u64,
+}
+
+impl PerKeyRateLimiter {
+    pub fn new(max_requests: u32, window_secs: u64) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            max_requests,
+            window_secs,
+        }
+    }
+
+    pub fn check(&self, key: &str) -> bool {
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = state.entry(key.to_string()).or_insert((0, now));
+
+        if now.duration_since(entry.1).as_secs() >= self.window_secs {
+            entry.0 = 0;
+            entry.1 = now;
+        }
+
+        if entry.0 >= self.max_requests {
+            return false;
+        }
+
+        entry.0 += 1;
+        true
+    }
+
+    pub fn cleanup(&self) {
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.retain(|_, (_, start)| now.duration_since(*start).as_secs() < self.window_secs * 2);
+    }
+}
+
+pub type SharedPerKeyRateLimiter = Arc<PerKeyRateLimiter>;
+
 /// Per-agent rate limiter keyed by API key ID.
 /// Each agent gets its own token bucket keyed by API key ID.
 /// `rate_limit_per_second` controls refill rate and `burst` controls capacity.
@@ -372,6 +418,11 @@ pub fn create_rate_limiter(per_second: u64, burst: u32) -> SharedRateLimiter {
 /// Create a per-IP rate limiter.
 pub fn create_per_ip_rate_limiter(max_requests: u32, window_secs: u64) -> SharedPerIpRateLimiter {
     Arc::new(PerIpRateLimiter::new(max_requests, window_secs))
+}
+
+/// Create a per-string-key rate limiter.
+pub fn create_per_key_rate_limiter(max_requests: u32, window_secs: u64) -> SharedPerKeyRateLimiter {
+    Arc::new(PerKeyRateLimiter::new(max_requests, window_secs))
 }
 
 /// Create a per-pubkey limiter for device authorization endpoints.

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -854,7 +854,8 @@ pub fn build_router(
         .route("/poll", post(handlers::devices::poll_device_code));
     let auth_device_public_routes = Router::new()
         .route("/request", post(handlers::auth_device::request_auth_device))
-        .route("/poll", post(handlers::auth_device::poll_auth_device));
+        .route("/poll", post(handlers::auth_device::poll_auth_device))
+        .route("/preview", post(handlers::auth_device::preview_auth_device));
     let device_onboard_public_routes =
         Router::new().route("/redeem", post(handlers::devices::redeem_onboard_device));
 
@@ -961,10 +962,6 @@ pub fn build_router(
         .route(
             "/auth/device/approve",
             post(handlers::auth_device::approve_auth_device),
-        )
-        .route(
-            "/auth/device/preview",
-            post(handlers::auth_device::preview_auth_device),
         )
         .route("/devices/onboard", post(handlers::devices::onboard_device))
         .route(

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -9,7 +9,9 @@ use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::AppState;
 use crate::handlers;
-use crate::mw::auth::{reject_delegated_tokens, reject_service_account_tokens};
+use crate::mw::auth::{
+    reject_api_key_tokens, reject_delegated_tokens, reject_service_account_tokens,
+};
 
 /// Per RFC 9207 / OAuth 2.0 for Browser-Based Apps, the token endpoint,
 /// userinfo endpoint, and discovery documents MUST be accessible from any
@@ -850,6 +852,9 @@ pub fn build_router(
     let device_code_public_routes = Router::new()
         .route("/request", post(handlers::devices::request_device_code))
         .route("/poll", post(handlers::devices::poll_device_code));
+    let auth_device_public_routes = Router::new()
+        .route("/request", post(handlers::auth_device::request_auth_device))
+        .route("/poll", post(handlers::auth_device::poll_auth_device));
     let device_onboard_public_routes =
         Router::new().route("/redeem", post(handlers::devices::redeem_onboard_device));
 
@@ -858,6 +863,7 @@ pub fn build_router(
             "/runtime-config",
             get(handlers::runtime_config::get_runtime_config),
         )
+        .nest("/auth/device", auth_device_public_routes)
         .nest("/devices/code", device_code_public_routes)
         .nest("/devices/onboard", device_onboard_public_routes);
 
@@ -952,6 +958,14 @@ pub fn build_router(
             "/devices/code/approve",
             post(handlers::devices::approve_device_code),
         )
+        .route(
+            "/auth/device/approve",
+            post(handlers::auth_device::approve_auth_device),
+        )
+        .route(
+            "/auth/device/preview",
+            post(handlers::auth_device::preview_auth_device),
+        )
         .route("/devices/onboard", post(handlers::devices::onboard_device))
         .route(
             "/devices/onboard/{bootstrap_id}",
@@ -1003,6 +1017,7 @@ pub fn build_router(
         )
         .route("/public/config", get(handlers::health::public_config))
         .layer(middleware::from_fn(reject_delegated_tokens))
+        .layer(middleware::from_fn(reject_api_key_tokens))
         .layer(middleware::from_fn(reject_service_account_tokens));
 
     let api_v1 = api_v1_public

--- a/backend/src/services/auth_device_service.rs
+++ b/backend/src/services/auth_device_service.rs
@@ -1,0 +1,778 @@
+#![allow(dead_code)]
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Duration, Utc};
+use hmac::{Hmac, Mac};
+use mongodb::{
+    Collection, Database,
+    bson::{self, doc},
+    options::ReturnDocument,
+};
+use rand::{Rng, RngCore, rngs::OsRng};
+use uuid::Uuid;
+
+use crate::errors::{AppError, AppResult};
+use crate::models::auth_device_code::{
+    AuthDeviceCode, AuthDeviceCodeStatus, COLLECTION_NAME as AUTH_DEVICE_CODES,
+};
+
+type HmacSha256 = Hmac<sha2::Sha256>;
+
+const AUTH_DEVICE_CODE_PREFIX: &str = "nyx_adc_";
+const AUTH_DEVICE_EXPIRES_IN_SECS: i64 = 10 * 60;
+const AUTH_DEVICE_POLL_INTERVAL_SECS: u32 = 5;
+const AUTH_DEVICE_SLOW_DOWN_INCREMENT_SECS: i64 = 5;
+const AUTH_DEVICE_USER_CODE_LEN: usize = 8;
+const AUTH_DEVICE_USER_CODE_WRITE_RETRIES: usize = 5;
+const AUTH_DEVICE_USER_CODE_ALPHABET: &[u8] = b"123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InitiateInput {
+    pub client_label: Option<String>,
+    pub client_user_agent: Option<String>,
+    pub client_ip: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InitiateOutput {
+    pub device_code: String,
+    pub user_code: String,
+    pub expires_in: i64,
+    pub interval: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PollClaim {
+    Pending,
+    SlowDown,
+    Denied,
+    Expired,
+    AlreadyDelivered,
+    Ready {
+        encrypted_access: Vec<u8>,
+        encrypted_refresh: Vec<u8>,
+        expires_in: i64,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreviewOutput {
+    pub client_label: Option<String>,
+    pub client_user_agent: Option<String>,
+    pub initiated_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub status: AuthDeviceCodeStatus,
+}
+
+#[tracing::instrument(
+    name = "auth_device.initiate",
+    skip_all,
+    fields(row_id, client_label_len)
+)]
+pub async fn initiate(
+    db: &Database,
+    hmac_key: &[u8],
+    input: InitiateInput,
+) -> AppResult<InitiateOutput> {
+    let client_label = sanitize_optional(input.client_label, 64);
+    let client_user_agent = sanitize_optional(input.client_user_agent, 256);
+    tracing::Span::current().record(
+        "client_label_len",
+        client_label.as_ref().map(|label| label.len()).unwrap_or(0),
+    );
+
+    initiate_with_user_code_generator(
+        db,
+        hmac_key,
+        client_label,
+        client_user_agent,
+        input.client_ip,
+        generate_user_code,
+    )
+    .await
+}
+
+async fn initiate_with_user_code_generator<F>(
+    db: &Database,
+    hmac_key: &[u8],
+    client_label: Option<String>,
+    client_user_agent: Option<String>,
+    client_ip: Option<String>,
+    mut user_code_generator: F,
+) -> AppResult<InitiateOutput>
+where
+    F: FnMut() -> String,
+{
+    for attempt in 0..=AUTH_DEVICE_USER_CODE_WRITE_RETRIES {
+        let now = Utc::now();
+        let device_code = generate_device_code();
+        let user_code_normalized = user_code_generator();
+        let user_code = format_user_code(&user_code_normalized);
+
+        let row = AuthDeviceCode {
+            id: Uuid::new_v4().to_string(),
+            device_code_hmac: hmac_hex(hmac_key, device_code.as_bytes()),
+            user_code_hmac: hmac_hex(hmac_key, user_code_normalized.as_bytes()),
+            status: AuthDeviceCodeStatus::Pending,
+            poll_interval_secs: AUTH_DEVICE_POLL_INTERVAL_SECS,
+            slow_down_increments: 0,
+            client_label: client_label.clone(),
+            client_user_agent: client_user_agent.clone(),
+            client_ip_hmac: client_ip
+                .as_deref()
+                .map(|client_ip| hmac_hex(hmac_key, client_ip.as_bytes())),
+            last_polled_at: None,
+            approved_user_id: None,
+            approved_session_id: None,
+            approver_ip_hmac: None,
+            delivery_access_token_encrypted: None,
+            delivery_refresh_token_encrypted: None,
+            delivery_access_token_expires_in: None,
+            created_at: now,
+            approved_at: None,
+            delivered_at: None,
+            denied_at: None,
+            expires_at: now + Duration::seconds(AUTH_DEVICE_EXPIRES_IN_SECS),
+        };
+
+        match collection(db).insert_one(&row).await {
+            Ok(_) => {
+                tracing::Span::current().record("row_id", row.id.as_str());
+                tracing::info!(row_id = %row.id, "auth_device.initiate");
+                return Ok(InitiateOutput {
+                    device_code,
+                    user_code,
+                    expires_in: AUTH_DEVICE_EXPIRES_IN_SECS,
+                    interval: AUTH_DEVICE_POLL_INTERVAL_SECS,
+                });
+            }
+            Err(error)
+                if is_duplicate_key_error(&error)
+                    && attempt < AUTH_DEVICE_USER_CODE_WRITE_RETRIES =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Err(AppError::Internal(
+        "auth-device user_code collision retry limit exceeded".to_string(),
+    ))
+}
+
+#[tracing::instrument(name = "auth_device.poll.outcome", skip_all, fields(row_id, outcome))]
+pub async fn poll_and_claim(
+    db: &Database,
+    hmac_key: &[u8],
+    device_code: &str,
+) -> AppResult<PollClaim> {
+    let collection = collection(db);
+    let now = Utc::now();
+    let device_code_hmac = hmac_hex(hmac_key, device_code.as_bytes());
+    let row = collection
+        .find_one(doc! { "device_code_hmac": device_code_hmac })
+        .await?
+        .ok_or(AppError::AuthDeviceCodeNotFound)?;
+
+    tracing::Span::current().record("row_id", row.id.as_str());
+
+    if row.expires_at < now {
+        mark_expired(&collection, &row.id, now).await?;
+        record_poll_outcome(&row.id, "expired");
+        return Ok(PollClaim::Expired);
+    }
+
+    if row.status == AuthDeviceCodeStatus::Pending && should_slow_down(&row, now) {
+        collection
+            .update_one(
+                doc! { "_id": &row.id },
+                doc! {
+                    "$inc": { "slow_down_increments": 1_i64 },
+                    "$set": { "last_polled_at": bson::DateTime::from_chrono(now) },
+                },
+            )
+            .await?;
+        record_poll_outcome(&row.id, "slow_down");
+        return Ok(PollClaim::SlowDown);
+    }
+
+    collection
+        .update_one(
+            doc! { "_id": &row.id },
+            doc! { "$set": { "last_polled_at": bson::DateTime::from_chrono(now) } },
+        )
+        .await?;
+
+    let outcome = match row.status {
+        AuthDeviceCodeStatus::Pending => PollClaim::Pending,
+        AuthDeviceCodeStatus::Denied => PollClaim::Denied,
+        AuthDeviceCodeStatus::Expired => PollClaim::Expired,
+        AuthDeviceCodeStatus::Delivered => PollClaim::AlreadyDelivered,
+        AuthDeviceCodeStatus::Approved => deliver_approved_claim(&collection, &row, now).await?,
+    };
+
+    record_poll_outcome(&row.id, poll_claim_outcome(&outcome));
+    Ok(outcome)
+}
+
+#[tracing::instrument(name = "auth_device.preview", skip_all, fields(row_id))]
+pub async fn preview(db: &Database, hmac_key: &[u8], user_code: &str) -> AppResult<PreviewOutput> {
+    let normalized = normalize_user_code(user_code)?;
+    let user_code_hmac = hmac_hex(hmac_key, normalized.as_bytes());
+    let row = collection(db)
+        .find_one(doc! { "user_code_hmac": user_code_hmac })
+        .await?
+        .ok_or(AppError::AuthDeviceUserCodeInvalid)?;
+
+    tracing::Span::current().record("row_id", row.id.as_str());
+
+    Ok(PreviewOutput {
+        client_label: row.client_label,
+        client_user_agent: row.client_user_agent,
+        initiated_at: row.created_at,
+        expires_at: row.expires_at,
+        status: row.status,
+    })
+}
+
+pub fn normalize_user_code(raw: &str) -> Result<String, AppError> {
+    let mut normalized = String::with_capacity(AUTH_DEVICE_USER_CODE_LEN);
+    for ch in raw.chars() {
+        let ch = match ch {
+            '-' | ' ' | '\t' => continue,
+            ch => ch.to_ascii_uppercase(),
+        };
+        let ch = match ch {
+            'I' | 'L' => '1',
+            'O' => '0',
+            'U' => 'V',
+            ch => ch,
+        };
+        if !is_valid_normalized_user_code_char(ch) {
+            return Err(AppError::AuthDeviceUserCodeInvalid);
+        }
+        normalized.push(ch);
+    }
+
+    if normalized.len() == AUTH_DEVICE_USER_CODE_LEN {
+        Ok(normalized)
+    } else {
+        Err(AppError::AuthDeviceUserCodeInvalid)
+    }
+}
+
+pub fn format_user_code(normalized: &str) -> String {
+    if normalized.len() <= 4 {
+        return normalized.to_string();
+    }
+    format!("{}-{}", &normalized[..4], &normalized[4..])
+}
+
+fn collection(db: &Database) -> Collection<AuthDeviceCode> {
+    db.collection::<AuthDeviceCode>(AUTH_DEVICE_CODES)
+}
+
+fn generate_device_code() -> String {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    format!("{AUTH_DEVICE_CODE_PREFIX}{}", URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn generate_user_code() -> String {
+    let mut rng = OsRng;
+    (0..AUTH_DEVICE_USER_CODE_LEN)
+        .map(|_| {
+            let idx = rng.gen_range(0..AUTH_DEVICE_USER_CODE_ALPHABET.len());
+            AUTH_DEVICE_USER_CODE_ALPHABET[idx] as char
+        })
+        .collect()
+}
+
+fn hmac_hex(hmac_key: &[u8], payload: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(hmac_key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(payload);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn sanitize_optional(value: Option<String>, max_len: usize) -> Option<String> {
+    let value = value?;
+    let sanitized: String = value
+        .trim()
+        .chars()
+        .filter(|ch| !ch.is_control())
+        .take(max_len)
+        .collect();
+    if sanitized.is_empty() {
+        None
+    } else {
+        Some(sanitized)
+    }
+}
+
+fn should_slow_down(row: &AuthDeviceCode, now: DateTime<Utc>) -> bool {
+    let Some(last_polled_at) = row.last_polled_at else {
+        return false;
+    };
+    let interval_secs = row.poll_interval_secs as i64
+        + (row.slow_down_increments as i64 * AUTH_DEVICE_SLOW_DOWN_INCREMENT_SECS);
+    now - last_polled_at < Duration::seconds(interval_secs)
+}
+
+async fn mark_expired(
+    collection: &Collection<AuthDeviceCode>,
+    row_id: &str,
+    now: DateTime<Utc>,
+) -> AppResult<()> {
+    let expired_status = bson::to_bson(&AuthDeviceCodeStatus::Expired)
+        .map_err(|e| AppError::Internal(format!("serialize auth device status: {e}")))?;
+    collection
+        .update_one(
+            doc! { "_id": row_id, "status": { "$ne": "delivered" } },
+            doc! {
+                "$set": {
+                    "status": expired_status,
+                    "last_polled_at": bson::DateTime::from_chrono(now),
+                }
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+async fn claim_approved_delivery(
+    collection: &Collection<AuthDeviceCode>,
+    row_id: &str,
+    now: DateTime<Utc>,
+) -> AppResult<Option<AuthDeviceCode>> {
+    let delivered_status = bson::to_bson(&AuthDeviceCodeStatus::Delivered)
+        .map_err(|e| AppError::Internal(format!("serialize auth device status: {e}")))?;
+
+    let claimed = collection
+        .find_one_and_update(
+            doc! { "_id": row_id, "status": "approved" },
+            doc! {
+                "$set": {
+                    "status": delivered_status,
+                    "delivered_at": bson::DateTime::from_chrono(now),
+                    "last_polled_at": bson::DateTime::from_chrono(now),
+                },
+                "$unset": {
+                    "delivery_access_token_encrypted": "",
+                    "delivery_refresh_token_encrypted": "",
+                },
+            },
+        )
+        .return_document(ReturnDocument::Before)
+        .await?;
+
+    Ok(claimed)
+}
+
+#[tracing::instrument(name = "auth_device.deliver", skip_all, fields(row_id = %row.id, latency_ms = (now - row.created_at).num_milliseconds()))]
+async fn deliver_approved_claim(
+    collection: &Collection<AuthDeviceCode>,
+    row: &AuthDeviceCode,
+    now: DateTime<Utc>,
+) -> AppResult<PollClaim> {
+    match claim_approved_delivery(collection, &row.id, now).await? {
+        Some(claimed) => {
+            let encrypted_access = claimed.delivery_access_token_encrypted.ok_or_else(|| {
+                AppError::Internal(
+                    "approved auth-device row missing encrypted access token".to_string(),
+                )
+            })?;
+            let encrypted_refresh = claimed.delivery_refresh_token_encrypted.ok_or_else(|| {
+                AppError::Internal(
+                    "approved auth-device row missing encrypted refresh token".to_string(),
+                )
+            })?;
+            let expires_in = claimed.delivery_access_token_expires_in.ok_or_else(|| {
+                AppError::Internal(
+                    "approved auth-device row missing access token expiry".to_string(),
+                )
+            })?;
+            tracing::info!("auth_device.deliver");
+            Ok(PollClaim::Ready {
+                encrypted_access,
+                encrypted_refresh,
+                expires_in,
+            })
+        }
+        None => Ok(PollClaim::AlreadyDelivered),
+    }
+}
+
+fn record_poll_outcome(row_id: &str, outcome: &str) {
+    tracing::Span::current().record("outcome", outcome);
+    tracing::info!(row_id = %row_id, outcome, "auth_device.poll.outcome");
+}
+
+fn poll_claim_outcome(outcome: &PollClaim) -> &'static str {
+    match outcome {
+        PollClaim::Pending => "pending",
+        PollClaim::SlowDown => "slow_down",
+        PollClaim::Denied => "denied",
+        PollClaim::Expired => "expired",
+        PollClaim::AlreadyDelivered => "already_delivered",
+        PollClaim::Ready { .. } => "delivered",
+    }
+}
+
+fn is_valid_normalized_user_code_char(ch: char) -> bool {
+    matches!(ch, '0'..='9' | 'A'..='Z') && !matches!(ch, 'I' | 'L' | 'U')
+}
+
+fn is_duplicate_key_error(error: &mongodb::error::Error) -> bool {
+    matches!(
+        error.kind.as_ref(),
+        mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(write_error))
+            if write_error.code == 11000
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::hmac_keys::derive_hmac_key;
+    use crate::test_utils::connect_test_database;
+
+    const TEST_HMAC_KEY: &[u8] = b"auth-device-test-hmac-key-32-bytes";
+
+    #[test]
+    fn normalize_user_code_accepts_roundtrip_vectors() {
+        for (raw, expected) in [
+            ("abcd1234", "ABCD1234"),
+            ("AbCd-1234", "ABCD1234"),
+            ("ab cd\t12-34", "ABCD1234"),
+            ("iLoU2345", "110V2345"),
+            ("zzzzzzzz", "ZZZZZZZZ"),
+        ] {
+            assert_eq!(normalize_user_code(raw).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn normalize_user_code_rejects_invalid_inputs() {
+        for raw in ["", "ABC1234", "ABCDE12345", "ABC_DEF1", "ABC\nDEF1"] {
+            assert!(matches!(
+                normalize_user_code(raw),
+                Err(AppError::AuthDeviceUserCodeInvalid)
+            ));
+        }
+    }
+
+    #[test]
+    fn format_user_code_adds_midpoint_dash() {
+        assert_eq!(format_user_code("ABCDEFGH"), "ABCD-EFGH");
+    }
+
+    #[test]
+    fn auth_device_hmac_label_is_domain_separated() {
+        let encryption_key = [0x42_u8; 32];
+        let jwt_private_pem = [0x99_u8; 512];
+        let cli = derive_hmac_key("cli-pairing", Some(&encryption_key), &jwt_private_pem);
+        let auth = derive_hmac_key("auth-device", Some(&encryption_key), &jwt_private_pem);
+
+        assert_ne!(cli.as_slice(), auth.as_slice());
+    }
+
+    #[tokio::test]
+    async fn initiate_persists_sanitized_pending_row() {
+        let Some(db) = connect_test_database("auth_device_initiate").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+
+        let output = initiate(
+            &db,
+            TEST_HMAC_KEY,
+            InitiateInput {
+                client_label: Some("  label\u{0000}with-control  ".to_string()),
+                client_user_agent: Some(format!("  {}  ", "a".repeat(300))),
+                client_ip: Some("203.0.113.10".to_string()),
+            },
+        )
+        .await
+        .expect("initiate");
+
+        assert!(output.device_code.starts_with(AUTH_DEVICE_CODE_PREFIX));
+        assert_eq!(output.user_code.len(), 9);
+        assert_eq!(output.expires_in, AUTH_DEVICE_EXPIRES_IN_SECS);
+        assert_eq!(output.interval, AUTH_DEVICE_POLL_INTERVAL_SECS);
+
+        let row = collection(&db)
+            .find_one(doc! {
+                "device_code_hmac": hmac_hex(TEST_HMAC_KEY, output.device_code.as_bytes())
+            })
+            .await
+            .expect("query")
+            .expect("row exists");
+
+        assert_eq!(row.status, AuthDeviceCodeStatus::Pending);
+        assert_eq!(row.client_label.as_deref(), Some("labelwith-control"));
+        assert_eq!(row.client_user_agent.as_ref().unwrap().len(), 256);
+        assert_eq!(
+            row.client_ip_hmac.as_deref(),
+            Some(hmac_hex(TEST_HMAC_KEY, b"203.0.113.10").as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_returns_safe_display_fields() {
+        let Some(db) = connect_test_database("auth_device_preview").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let output = initiate_with_user_code_generator(
+            &db,
+            TEST_HMAC_KEY,
+            Some("workstation".to_string()),
+            Some("nyxid-cli/0.8.0".to_string()),
+            None,
+            || "ABCD1234".to_string(),
+        )
+        .await
+        .expect("initiate");
+
+        let preview = preview(&db, TEST_HMAC_KEY, &output.user_code)
+            .await
+            .expect("preview");
+
+        assert_eq!(preview.client_label.as_deref(), Some("workstation"));
+        assert_eq!(
+            preview.client_user_agent.as_deref(),
+            Some("nyxid-cli/0.8.0")
+        );
+        assert_eq!(preview.status, AuthDeviceCodeStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn slow_down_repoll_increments_counter() {
+        let Some(db) = connect_test_database("auth_device_slow_down").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let output = initiate(&db, TEST_HMAC_KEY, empty_input())
+            .await
+            .expect("initiate");
+
+        assert_eq!(
+            poll_and_claim(&db, TEST_HMAC_KEY, &output.device_code)
+                .await
+                .expect("first poll"),
+            PollClaim::Pending
+        );
+        assert_eq!(
+            poll_and_claim(&db, TEST_HMAC_KEY, &output.device_code)
+                .await
+                .expect("second poll"),
+            PollClaim::SlowDown
+        );
+
+        let row = collection(&db)
+            .find_one(doc! {
+                "device_code_hmac": hmac_hex(TEST_HMAC_KEY, output.device_code.as_bytes())
+            })
+            .await
+            .expect("query")
+            .expect("row exists");
+        assert_eq!(row.slow_down_increments, 1);
+    }
+
+    #[tokio::test]
+    async fn expired_poll_marks_expired() {
+        let Some(db) = connect_test_database("auth_device_expired").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() - Duration::seconds(1),
+        )
+        .await;
+
+        assert_eq!(
+            poll_and_claim(&db, TEST_HMAC_KEY, "device-code")
+                .await
+                .expect("poll"),
+            PollClaim::Expired
+        );
+        let updated = collection(&db)
+            .find_one(doc! { "_id": &row.id })
+            .await
+            .expect("query")
+            .expect("row exists");
+        assert_eq!(updated.status, AuthDeviceCodeStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn concurrent_approved_claim_has_exactly_one_ready_winner() {
+        let Some(db) = connect_test_database("auth_device_concurrent_claim").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        seed_row(
+            &db,
+            AuthDeviceCodeStatus::Approved,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let (left, right) = tokio::join!(
+            poll_and_claim(&db, TEST_HMAC_KEY, "device-code"),
+            poll_and_claim(&db, TEST_HMAC_KEY, "device-code")
+        );
+        let outcomes = [left.expect("left poll"), right.expect("right poll")];
+
+        let ready_count = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, PollClaim::Ready { .. }))
+            .count();
+        let already_delivered_count = outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, PollClaim::AlreadyDelivered))
+            .count();
+
+        assert_eq!(ready_count, 1, "{outcomes:?}");
+        assert_eq!(already_delivered_count, 1, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn successful_claim_removes_ciphertext_fields_from_db() {
+        let Some(db) = connect_test_database("auth_device_claim_unsets_ciphertext").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Approved,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let claim = poll_and_claim(&db, TEST_HMAC_KEY, "device-code")
+            .await
+            .expect("poll");
+        assert_eq!(
+            claim,
+            PollClaim::Ready {
+                encrypted_access: b"encrypted-access".to_vec(),
+                encrypted_refresh: b"encrypted-refresh".to_vec(),
+                expires_in: 900,
+            }
+        );
+
+        let raw = db
+            .collection::<bson::Document>(AUTH_DEVICE_CODES)
+            .find_one(doc! { "_id": row.id })
+            .await
+            .expect("query")
+            .expect("row exists");
+        assert!(!raw.contains_key("delivery_access_token_encrypted"));
+        assert!(!raw.contains_key("delivery_refresh_token_encrypted"));
+        assert!(raw.contains_key("delivery_access_token_expires_in"));
+    }
+
+    #[test]
+    fn auth_device_debug_redaction_still_hides_hashes_and_ciphertext() {
+        let row = make_debug_row();
+        let debug = format!("{row:?}");
+
+        for secret in [
+            row.device_code_hmac.as_str(),
+            row.user_code_hmac.as_str(),
+            row.client_ip_hmac.as_deref().unwrap(),
+            row.approver_ip_hmac.as_deref().unwrap(),
+            "abcdef",
+            "123456",
+        ] {
+            assert!(!debug.contains(secret), "{secret} leaked in {debug}");
+        }
+
+        assert!(debug.contains("Pending"));
+        assert!(debug.contains("created_at"));
+        assert!(debug.contains("expires_at"));
+    }
+
+    async fn seed_row(
+        db: &Database,
+        status: AuthDeviceCodeStatus,
+        expires_at: DateTime<Utc>,
+    ) -> AuthDeviceCode {
+        let now = Utc::now();
+        let row = AuthDeviceCode {
+            id: Uuid::new_v4().to_string(),
+            device_code_hmac: hmac_hex(TEST_HMAC_KEY, b"device-code"),
+            user_code_hmac: hmac_hex(TEST_HMAC_KEY, b"ABCD1234"),
+            status,
+            poll_interval_secs: AUTH_DEVICE_POLL_INTERVAL_SECS,
+            slow_down_increments: 0,
+            client_label: None,
+            client_user_agent: None,
+            client_ip_hmac: None,
+            last_polled_at: None,
+            approved_user_id: None,
+            approved_session_id: None,
+            approver_ip_hmac: None,
+            delivery_access_token_encrypted: Some(b"encrypted-access".to_vec()),
+            delivery_refresh_token_encrypted: Some(b"encrypted-refresh".to_vec()),
+            delivery_access_token_expires_in: Some(900),
+            created_at: now,
+            approved_at: None,
+            delivered_at: None,
+            denied_at: None,
+            expires_at,
+        };
+        collection(db).insert_one(&row).await.expect("seed row");
+        row
+    }
+
+    fn empty_input() -> InitiateInput {
+        InitiateInput {
+            client_label: None,
+            client_user_agent: None,
+            client_ip: None,
+        }
+    }
+
+    fn make_debug_row() -> AuthDeviceCode {
+        let now = Utc::now();
+        AuthDeviceCode {
+            id: Uuid::new_v4().to_string(),
+            device_code_hmac: "abc123ff".repeat(8),
+            user_code_hmac: "def456aa".repeat(8),
+            status: AuthDeviceCodeStatus::Pending,
+            poll_interval_secs: 5,
+            slow_down_increments: 0,
+            client_label: Some("wsl-calvin".to_string()),
+            client_user_agent: Some("nyxid-cli/0.8.0".to_string()),
+            client_ip_hmac: Some("11112222".repeat(8)),
+            last_polled_at: Some(now),
+            approved_user_id: Some(Uuid::new_v4().to_string()),
+            approved_session_id: Some(Uuid::new_v4().to_string()),
+            approver_ip_hmac: Some("33334444".repeat(8)),
+            delivery_access_token_encrypted: Some(vec![0xab, 0xcd, 0xef]),
+            delivery_refresh_token_encrypted: Some(vec![0x12, 0x34, 0x56]),
+            delivery_access_token_expires_in: Some(900),
+            created_at: now,
+            approved_at: Some(now),
+            delivered_at: Some(now),
+            denied_at: None,
+            expires_at: now + Duration::minutes(10),
+        }
+    }
+}

--- a/backend/src/services/auth_device_service.rs
+++ b/backend/src/services/auth_device_service.rs
@@ -1025,6 +1025,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn approve_loser_of_concurrent_race_leaves_no_usable_session() {
+        // Two approvers race the same pending row. Exactly one wins the atomic
+        // update; the loser either short-circuits before minting (sees a
+        // non-pending row) or mints and then hits `updated.is_none()` and must
+        // revoke its just-minted session. Either way the invariant that must
+        // hold is: no usable (non-revoked) session exists beyond the winner's,
+        // and that session is the one recorded on the approved row.
+        let Some(db) = connect_test_database("auth_device_approve_race_rollback").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let config = test_app_config();
+        let jwt_keys = cached_test_jwt_keys();
+        let encryption_keys = test_encryption_keys();
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let approve_input = || ApproveInput {
+            user_id: user_id.clone(),
+            user_code: "ABCD-1234".to_string(),
+            approver_ip: None,
+            approver_user_agent: None,
+        };
+        let (left, right) = tokio::join!(
+            approve(
+                &db,
+                &config,
+                &jwt_keys,
+                &encryption_keys,
+                TEST_HMAC_KEY,
+                approve_input(),
+            ),
+            approve(
+                &db,
+                &config,
+                &jwt_keys,
+                &encryption_keys,
+                TEST_HMAC_KEY,
+                approve_input(),
+            )
+        );
+
+        let ok_count = [&left, &right].iter().filter(|r| r.is_ok()).count();
+        let already_delivered_count = [&left, &right]
+            .iter()
+            .filter(|r| matches!(r, Err(AppError::AuthDeviceCodeAlreadyDelivered)))
+            .count();
+        assert_eq!(ok_count, 1, "left={left:?} right={right:?}");
+        assert_eq!(already_delivered_count, 1, "left={left:?} right={right:?}");
+
+        let approved = row_by_id(&db, &row.id).await;
+        assert_eq!(approved.status, AuthDeviceCodeStatus::Approved);
+        let winner_session = approved
+            .approved_session_id
+            .clone()
+            .expect("approved session id");
+
+        // No orphaned usable session: exactly one non-revoked session, and it is
+        // the winner's. Any session the loser minted before the failed update
+        // must have been revoked by the rollback path.
+        let live_sessions = db
+            .collection::<bson::Document>(SESSIONS)
+            .count_documents(doc! { "revoked": false })
+            .await
+            .expect("live session count");
+        assert_eq!(live_sessions, 1, "exactly one usable session must survive");
+        let winner_revoked = db
+            .collection::<crate::models::session::Session>(SESSIONS)
+            .find_one(doc! { "_id": &winner_session })
+            .await
+            .expect("winner session query")
+            .expect("winner session row")
+            .revoked;
+        assert!(!winner_revoked, "the delivered session must remain usable");
+    }
+
+    #[tokio::test]
     async fn decrypt_tokens_roundtrips_encrypted_jwt_bytes() {
         let encryption_keys = test_encryption_keys();
         let access = "eyJ.access.jwt";

--- a/backend/src/services/auth_device_service.rs
+++ b/backend/src/services/auth_device_service.rs
@@ -5,16 +5,20 @@ use chrono::{DateTime, Duration, Utc};
 use hmac::{Hmac, Mac};
 use mongodb::{
     Collection, Database,
-    bson::{self, doc},
+    bson::{self, Binary, Bson, doc, spec::BinarySubtype},
     options::ReturnDocument,
 };
 use rand::{Rng, RngCore, rngs::OsRng};
 use uuid::Uuid;
+use zeroize::Zeroizing;
 
+use crate::config::AppConfig;
+use crate::crypto::{aes::EncryptionKeys, jwt::JwtKeys};
 use crate::errors::{AppError, AppResult};
 use crate::models::auth_device_code::{
     AuthDeviceCode, AuthDeviceCodeStatus, COLLECTION_NAME as AUTH_DEVICE_CODES,
 };
+use crate::services::{audit_service, token_service};
 
 type HmacSha256 = Hmac<sha2::Sha256>;
 
@@ -62,6 +66,14 @@ pub struct PreviewOutput {
     pub initiated_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub status: AuthDeviceCodeStatus,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApproveInput {
+    pub user_id: String,
+    pub user_code: String,
+    pub approver_ip: Option<String>,
+    pub approver_user_agent: Option<String>,
 }
 
 #[tracing::instrument(
@@ -236,6 +248,161 @@ pub async fn preview(db: &Database, hmac_key: &[u8], user_code: &str) -> AppResu
     })
 }
 
+#[tracing::instrument(
+    name = "auth_device.approve",
+    skip_all,
+    fields(row_id, user_id = %input.user_id, session_id)
+)]
+pub async fn approve(
+    db: &Database,
+    config: &AppConfig,
+    jwt_keys: &JwtKeys,
+    encryption_keys: &EncryptionKeys,
+    hmac_key: &[u8],
+    input: ApproveInput,
+) -> AppResult<()> {
+    let started_at = std::time::Instant::now();
+    let normalized = normalize_user_code(&input.user_code)?;
+    let user_code_hmac = hmac_hex(hmac_key, normalized.as_bytes());
+    let collection = collection(db);
+    let now = Utc::now();
+
+    let row = collection
+        .find_one(doc! { "user_code_hmac": user_code_hmac })
+        .await?
+        .ok_or(AppError::AuthDeviceUserCodeInvalid)?;
+
+    tracing::Span::current().record("row_id", row.id.as_str());
+
+    if row.expires_at < now {
+        return Err(AppError::AuthDeviceCodeExpired);
+    }
+
+    if row.status != AuthDeviceCodeStatus::Pending {
+        return Err(non_pending_approve_error(row.status));
+    }
+
+    let user_agent = approve_session_user_agent(input.approver_user_agent.as_deref());
+    let tokens = token_service::create_session_and_issue_tokens(
+        db,
+        config,
+        jwt_keys,
+        &input.user_id,
+        input.approver_ip.as_deref(),
+        Some(user_agent.as_str()),
+    )
+    .await?;
+    tracing::Span::current().record("session_id", tokens.session_id.as_str());
+    let session_id = tokens.session_id.clone();
+
+    let access_plaintext = Zeroizing::new(tokens.access_token.into_bytes());
+    let refresh_plaintext = Zeroizing::new(tokens.refresh_token.into_bytes());
+    let encrypted_access = match encryption_keys.encrypt(access_plaintext.as_slice()).await {
+        Ok(encrypted) => encrypted,
+        Err(error) => {
+            cleanup_issued_session(db, &session_id).await;
+            return Err(error);
+        }
+    };
+    let encrypted_refresh = match encryption_keys.encrypt(refresh_plaintext.as_slice()).await {
+        Ok(encrypted) => encrypted,
+        Err(error) => {
+            cleanup_issued_session(db, &session_id).await;
+            return Err(error);
+        }
+    };
+
+    let approved_status = bson::to_bson(&AuthDeviceCodeStatus::Approved)
+        .map_err(|e| AppError::Internal(format!("serialize auth device status: {e}")))?;
+    let approved_at = Utc::now();
+    let delivery_expires_at = approved_at + Duration::seconds(60);
+    let approver_ip_hmac = input
+        .approver_ip
+        .as_deref()
+        .map(|ip| hmac_hex(hmac_key, ip.as_bytes()));
+
+    let mut set_doc = doc! {
+        "status": approved_status,
+        "approved_user_id": &input.user_id,
+        "approved_session_id": &tokens.session_id,
+        "approved_at": bson::DateTime::from_chrono(approved_at),
+        "delivery_access_token_encrypted": Bson::Binary(Binary {
+            subtype: BinarySubtype::Generic,
+            bytes: encrypted_access,
+        }),
+        "delivery_refresh_token_encrypted": Bson::Binary(Binary {
+            subtype: BinarySubtype::Generic,
+            bytes: encrypted_refresh,
+        }),
+        "delivery_access_token_expires_in": tokens.access_expires_in,
+        "expires_at": bson::DateTime::from_chrono(delivery_expires_at),
+    };
+    match approver_ip_hmac {
+        Some(ip_hmac) => {
+            set_doc.insert("approver_ip_hmac", ip_hmac);
+        }
+        None => {
+            set_doc.insert("approver_ip_hmac", Bson::Null);
+        }
+    }
+
+    let updated = collection
+        .find_one_and_update(
+            doc! { "_id": &row.id, "status": "pending" },
+            doc! { "$set": set_doc },
+        )
+        .return_document(ReturnDocument::After)
+        .await?;
+
+    if updated.is_none() {
+        cleanup_issued_session(db, &session_id).await;
+        return Err(AppError::AuthDeviceCodeAlreadyDelivered);
+    }
+
+    audit_service::log_async(
+        db.clone(),
+        Some(input.user_id.clone()),
+        "auth_device_code_approved".to_string(),
+        Some(serde_json::json!({
+            "session_id": session_id,
+            "user_code_redacted": redact_user_code(&normalized),
+        })),
+        input.approver_ip.clone(),
+        input.approver_user_agent.clone(),
+        None,
+        None,
+    );
+
+    tracing::info!(
+        row_id = %row.id,
+        user_id = %input.user_id,
+        session_id = %session_id,
+        latency_ms = started_at.elapsed().as_millis() as u64,
+        audit_logged = true,
+        "auth_device.approve"
+    );
+
+    Ok(())
+}
+
+pub async fn decrypt_tokens(
+    encryption_keys: &EncryptionKeys,
+    encrypted_access: &[u8],
+    encrypted_refresh: &[u8],
+) -> AppResult<(String, String)> {
+    let access_plaintext = Zeroizing::new(encryption_keys.decrypt(encrypted_access).await?);
+    let refresh_plaintext = Zeroizing::new(encryption_keys.decrypt(encrypted_refresh).await?);
+
+    let access_token = String::from_utf8(access_plaintext.to_vec()).map_err(|_| {
+        AppError::Internal("auth-device delivery access token is not valid UTF-8".to_string())
+    })?;
+    let refresh_token = String::from_utf8(refresh_plaintext.to_vec()).map_err(|_| {
+        AppError::Internal("auth-device delivery refresh token is not valid UTF-8".to_string())
+    })?;
+
+    Ok((access_token, refresh_token))
+}
+
 pub fn normalize_user_code(raw: &str) -> Result<String, AppError> {
     let mut normalized = String::with_capacity(AUTH_DEVICE_USER_CODE_LEN);
     for ch in raw.chars() {
@@ -308,6 +475,48 @@ fn sanitize_optional(value: Option<String>, max_len: usize) -> Option<String> {
     } else {
         Some(sanitized)
     }
+}
+
+fn approve_session_user_agent(approver_user_agent: Option<&str>) -> String {
+    match approver_user_agent {
+        Some(user_agent) if user_agent.starts_with("nyxid-cli/") => user_agent.to_string(),
+        _ => "nyxid-cli (device-code)".to_string(),
+    }
+}
+
+async fn cleanup_issued_session(db: &Database, session_id: &str) {
+    if let Err(error) = token_service::revoke_session(db, session_id, None).await {
+        tracing::error!(
+            session_id = %session_id,
+            error = %error,
+            "failed to revoke auth-device session after approve failure"
+        );
+    }
+}
+
+fn non_pending_approve_error(status: AuthDeviceCodeStatus) -> AppError {
+    match status {
+        AuthDeviceCodeStatus::Pending => AppError::AuthDeviceCodePending,
+        AuthDeviceCodeStatus::Denied => AppError::AuthDeviceCodeDenied,
+        AuthDeviceCodeStatus::Expired => AppError::AuthDeviceCodeExpired,
+        AuthDeviceCodeStatus::Approved | AuthDeviceCodeStatus::Delivered => {
+            AppError::AuthDeviceCodeAlreadyDelivered
+        }
+    }
+}
+
+fn redact_user_code(normalized: &str) -> String {
+    let chars: Vec<char> = normalized.chars().collect();
+    if chars.len() <= 4 {
+        return "*".repeat(chars.len());
+    }
+    format!(
+        "{}{}****{}{}",
+        chars[0],
+        chars[1],
+        chars[chars.len() - 2],
+        chars[chars.len() - 1]
+    )
 }
 
 fn should_slow_down(row: &AuthDeviceCode, now: DateTime<Utc>) -> bool {
@@ -435,7 +644,13 @@ fn is_duplicate_key_error(error: &mongodb::error::Error) -> bool {
 mod tests {
     use super::*;
     use crate::crypto::hmac_keys::derive_hmac_key;
-    use crate::test_utils::connect_test_database;
+    use crate::models::audit_log::{AuditLog, COLLECTION_NAME as AUDIT_LOG};
+    use crate::models::session::COLLECTION_NAME as SESSIONS;
+    use crate::models::user::{COLLECTION_NAME as USERS, UserType};
+    use crate::test_utils::{
+        cached_test_jwt_keys, connect_test_database, test_app_config, test_encryption_keys,
+        test_user,
+    };
 
     const TEST_HMAC_KEY: &[u8] = b"auth-device-test-hmac-key-32-bytes";
 
@@ -465,6 +680,11 @@ mod tests {
     #[test]
     fn format_user_code_adds_midpoint_dash() {
         assert_eq!(format_user_code("ABCDEFGH"), "ABCD-EFGH");
+    }
+
+    #[test]
+    fn redact_user_code_keeps_only_edges() {
+        assert_eq!(redact_user_code("ABCDEFGH"), "AB****GH");
     }
 
     #[test]
@@ -549,6 +769,276 @@ mod tests {
             Some("nyxid-cli/0.8.0")
         );
         assert_eq!(preview.status, AuthDeviceCodeStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn approve_pending_row_encrypts_tokens_shortens_expiry_and_audits() {
+        let Some(db) = connect_test_database("auth_device_approve_happy").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let config = test_app_config();
+        let jwt_keys = cached_test_jwt_keys();
+        let encryption_keys = test_encryption_keys();
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+
+        let output = initiate_with_user_code_generator(
+            &db,
+            TEST_HMAC_KEY,
+            Some("workstation".to_string()),
+            Some("nyxid-cli/0.8.0".to_string()),
+            None,
+            || "ABCDEFGH".to_string(),
+        )
+        .await
+        .expect("initiate");
+        let original = row_by_user_code(&db, "ABCDEFGH").await;
+        let audit_written =
+            audit_service::notify_on_audit_write_for_user("auth_device_code_approved", &user_id);
+
+        approve(
+            &db,
+            &config,
+            &jwt_keys,
+            &encryption_keys,
+            TEST_HMAC_KEY,
+            ApproveInput {
+                user_id: user_id.clone(),
+                user_code: output.user_code,
+                approver_ip: Some("203.0.113.77".to_string()),
+                approver_user_agent: Some("nyxid-cli/0.8.0".to_string()),
+            },
+        )
+        .await
+        .expect("approve");
+
+        let updated = row_by_id(&db, &original.id).await;
+        assert_eq!(updated.status, AuthDeviceCodeStatus::Approved);
+        assert_eq!(updated.approved_user_id.as_deref(), Some(user_id.as_str()));
+        assert!(updated.approved_session_id.is_some());
+        assert!(updated.approved_at.is_some());
+        assert_eq!(
+            updated.approver_ip_hmac.as_deref(),
+            Some(hmac_hex(TEST_HMAC_KEY, b"203.0.113.77").as_str())
+        );
+        assert!(updated.delivery_access_token_encrypted.is_some());
+        assert!(updated.delivery_refresh_token_encrypted.is_some());
+        assert_eq!(
+            updated.delivery_access_token_expires_in,
+            Some(config.jwt_access_ttl_secs)
+        );
+        assert!(updated.expires_at < original.expires_at);
+        assert!(updated.expires_at <= Utc::now() + Duration::seconds(70));
+
+        let (access, refresh) = decrypt_tokens(
+            &encryption_keys,
+            updated.delivery_access_token_encrypted.as_deref().unwrap(),
+            updated.delivery_refresh_token_encrypted.as_deref().unwrap(),
+        )
+        .await
+        .expect("decrypt");
+        assert_eq!(
+            crate::crypto::jwt::verify_token(&jwt_keys, &config, &access)
+                .expect("access token")
+                .sub,
+            user_id
+        );
+        assert_eq!(
+            crate::crypto::jwt::verify_token(&jwt_keys, &config, &refresh)
+                .expect("refresh token")
+                .sub,
+            user_id
+        );
+
+        let audit_id = tokio::time::timeout(Duration::seconds(2).to_std().unwrap(), audit_written)
+            .await
+            .expect("audit write timed out")
+            .expect("audit watcher");
+        let audit = db
+            .collection::<AuditLog>(AUDIT_LOG)
+            .find_one(doc! { "_id": audit_id })
+            .await
+            .expect("audit query")
+            .expect("audit row");
+        assert_eq!(audit.event_type, "auth_device_code_approved");
+        assert_eq!(audit.user_id.as_deref(), Some(user_id.as_str()));
+        assert!(audit.api_key_id.is_none());
+        assert!(audit.api_key_name.is_none());
+        assert_eq!(
+            audit
+                .event_data
+                .as_ref()
+                .and_then(|data| data.get("user_code_redacted"))
+                .and_then(serde_json::Value::as_str),
+            Some("AB****GH")
+        );
+        assert_eq!(
+            audit
+                .event_data
+                .as_ref()
+                .and_then(|data| data.get("session_id"))
+                .and_then(serde_json::Value::as_str),
+            updated.approved_session_id.as_deref()
+        );
+    }
+
+    #[tokio::test]
+    async fn approve_wrong_user_code_returns_invalid_without_mutation() {
+        let Some(db) = connect_test_database("auth_device_approve_wrong_code").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let config = test_app_config();
+        let jwt_keys = cached_test_jwt_keys();
+        let encryption_keys = test_encryption_keys();
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let result = approve(
+            &db,
+            &config,
+            &jwt_keys,
+            &encryption_keys,
+            TEST_HMAC_KEY,
+            ApproveInput {
+                user_id,
+                user_code: "WXYZ-9999".to_string(),
+                approver_ip: None,
+                approver_user_agent: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AppError::AuthDeviceUserCodeInvalid)));
+        let unchanged = row_by_id(&db, &row.id).await;
+        assert_eq!(unchanged.status, AuthDeviceCodeStatus::Pending);
+        assert!(unchanged.approved_user_id.is_none());
+        assert!(unchanged.approved_session_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn approve_already_approved_row_rejects_before_token_mint() {
+        let Some(db) = connect_test_database("auth_device_approve_already_approved").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let config = test_app_config();
+        let jwt_keys = cached_test_jwt_keys();
+        let encryption_keys = test_encryption_keys();
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+        seed_row(
+            &db,
+            AuthDeviceCodeStatus::Approved,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let result = approve(
+            &db,
+            &config,
+            &jwt_keys,
+            &encryption_keys,
+            TEST_HMAC_KEY,
+            ApproveInput {
+                user_id,
+                user_code: "ABCD-1234".to_string(),
+                approver_ip: None,
+                approver_user_agent: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(AppError::AuthDeviceCodeAlreadyDelivered)
+        ));
+        assert_eq!(
+            db.collection::<bson::Document>(SESSIONS)
+                .count_documents(doc! {})
+                .await
+                .expect("session count"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn approve_expired_row_returns_expired_before_token_mint() {
+        let Some(db) = connect_test_database("auth_device_approve_expired").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let config = test_app_config();
+        let jwt_keys = cached_test_jwt_keys();
+        let encryption_keys = test_encryption_keys();
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() - Duration::seconds(1),
+        )
+        .await;
+
+        let result = approve(
+            &db,
+            &config,
+            &jwt_keys,
+            &encryption_keys,
+            TEST_HMAC_KEY,
+            ApproveInput {
+                user_id,
+                user_code: "ABCD-1234".to_string(),
+                approver_ip: None,
+                approver_user_agent: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AppError::AuthDeviceCodeExpired)));
+        assert_eq!(
+            row_by_id(&db, &row.id).await.status,
+            AuthDeviceCodeStatus::Pending
+        );
+        assert_eq!(
+            db.collection::<bson::Document>(SESSIONS)
+                .count_documents(doc! {})
+                .await
+                .expect("session count"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn decrypt_tokens_roundtrips_encrypted_jwt_bytes() {
+        let encryption_keys = test_encryption_keys();
+        let access = "eyJ.access.jwt";
+        let refresh = "eyJ.refresh.jwt";
+        let encrypted_access = encryption_keys.encrypt(access.as_bytes()).await.unwrap();
+        let encrypted_refresh = encryption_keys.encrypt(refresh.as_bytes()).await.unwrap();
+
+        let (decrypted_access, decrypted_refresh) =
+            decrypt_tokens(&encryption_keys, &encrypted_access, &encrypted_refresh)
+                .await
+                .unwrap();
+
+        assert_eq!(decrypted_access, access);
+        assert_eq!(decrypted_refresh, refresh);
     }
 
     #[tokio::test]
@@ -739,6 +1229,31 @@ mod tests {
         };
         collection(db).insert_one(&row).await.expect("seed row");
         row
+    }
+
+    async fn seed_user(db: &Database, user_id: &str) {
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(user_id, UserType::Person))
+            .await
+            .expect("seed user");
+    }
+
+    async fn row_by_user_code(db: &Database, normalized_user_code: &str) -> AuthDeviceCode {
+        collection(db)
+            .find_one(doc! {
+                "user_code_hmac": hmac_hex(TEST_HMAC_KEY, normalized_user_code.as_bytes())
+            })
+            .await
+            .expect("query by user code")
+            .expect("row exists")
+    }
+
+    async fn row_by_id(db: &Database, row_id: &str) -> AuthDeviceCode {
+        collection(db)
+            .find_one(doc! { "_id": row_id })
+            .await
+            .expect("query by id")
+            .expect("row exists")
     }
 
     fn empty_input() -> InitiateInput {

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod api_docs_service;
 pub mod approval_policy;
 pub mod approval_service;
 pub mod audit_service;
+pub mod auth_device_service;
 pub mod auth_service;
 pub mod cae_webhook_service;
 pub mod catalog_service;

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -379,6 +379,13 @@ pub(crate) fn test_app_state_with_config(db: mongodb::Database, config: AppConfi
         per_agent_limiter: Arc::new(crate::mw::rate_limit::PerAgentRateLimiter::new()),
         device_code_pubkey_limiter: crate::mw::rate_limit::create_per_pubkey_rate_limiter(),
         device_code_ip_limiter: crate::mw::rate_limit::create_per_ip_rate_limiter(5, 60),
+        auth_device_request_limiter: crate::mw::rate_limit::create_per_ip_rate_limiter(5, 60),
+        auth_device_poll_limiter: crate::mw::rate_limit::create_per_ip_rate_limiter(60, 60),
+        auth_device_approve_limiter: crate::mw::rate_limit::create_per_ip_rate_limiter(10, 60),
+        auth_device_approve_per_user_limiter: crate::mw::rate_limit::create_per_key_rate_limiter(
+            10, 300,
+        ),
+        auth_device_preview_limiter: crate::mw::rate_limit::create_per_ip_rate_limiter(30, 60),
         public_proxy_limiter: crate::mw::rate_limit::create_per_ip_rate_limiter(
             config.public_proxy_rate_limit_per_minute,
             60,

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -394,6 +394,9 @@ pub(crate) fn test_app_state_with_config(db: mongodb::Database, config: AppConfi
         // Tests don't exercise pairing-code HMAC verification; a
         // zero-filled key is deterministic and never touches prod data.
         cli_pairing_hmac_key: Arc::new(zeroize::Zeroizing::new([0u8; 32])),
+        // Tests don't exercise auth-device HMAC verification through AppState yet;
+        // service-level tests pass their own explicit HMAC key.
+        auth_device_hmac_key: Arc::new(zeroize::Zeroizing::new([1u8; 32])),
         per_channel_event_limiter: Arc::new(crate::mw::rate_limit::PerChannelEventLimiter::new(
             config.channel_event_rate_limit_per_second,
             config.channel_event_rate_limit_burst,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1,10 +1,58 @@
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 /// User-Agent string sent on all CLI HTTP requests.
 pub const CLI_USER_AGENT: &str = concat!("nyxid-cli/", env!("CARGO_PKG_VERSION"));
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthDeviceRequestBody {
+    pub client_label: Option<String>,
+    pub client_user_agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AuthDeviceRequestResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthDevicePollBody {
+    pub device_code: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AuthDevicePollResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub token_type: String,
+    pub expires_in: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ErrorEnvelope {
+    pub error: String,
+    pub error_code: i64,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthDeviceRequestOutcome {
+    Created(AuthDeviceRequestResponse),
+    NotSupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthDevicePollOutcome {
+    Delivered(AuthDevicePollResponse),
+    Error(ErrorEnvelope),
+}
 
 pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
     // Attach `X-NyxID-Client: cli` + `X-NyxID-Client-Version` ONLY when
@@ -69,6 +117,71 @@ pub fn build_cli_http_client(profile: Option<&str>) -> Result<Client> {
     }
 
     builder.build().context("Failed to build HTTP client")
+}
+
+pub async fn auth_device_request(
+    base_url: &str,
+    body: &AuthDeviceRequestBody,
+    profile: Option<&str>,
+) -> Result<AuthDeviceRequestOutcome> {
+    let base = format!("{}/api/v1", base_url.trim_end_matches('/'));
+    let url = format!("{base}/auth/device/request");
+    let client = build_cli_http_client(profile)?;
+
+    let resp = client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .context("POST /auth/device/request failed")?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(AuthDeviceRequestOutcome::NotSupported);
+    }
+
+    if resp.status().is_success() {
+        let body = resp
+            .json::<AuthDeviceRequestResponse>()
+            .await
+            .context("Failed to parse response from /auth/device/request")?;
+        return Ok(AuthDeviceRequestOutcome::Created(body));
+    }
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    bail!("/auth/device/request failed (HTTP {status}): {body}");
+}
+
+pub async fn auth_device_poll(
+    base_url: &str,
+    body: &AuthDevicePollBody,
+    profile: Option<&str>,
+) -> Result<AuthDevicePollOutcome> {
+    let base = format!("{}/api/v1", base_url.trim_end_matches('/'));
+    let url = format!("{base}/auth/device/poll");
+    let client = build_cli_http_client(profile)?;
+
+    let resp = client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .context("POST /auth/device/poll failed")?;
+
+    if resp.status().is_success() {
+        let body = resp
+            .json::<AuthDevicePollResponse>()
+            .await
+            .context("Failed to parse response from /auth/device/poll")?;
+        return Ok(AuthDevicePollOutcome::Delivered(body));
+    }
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    match serde_json::from_str::<ErrorEnvelope>(&body) {
+        Ok(error) => Ok(AuthDevicePollOutcome::Error(error)),
+        Err(_) => bail!("/auth/device/poll failed (HTTP {status}): {body}"),
+    }
 }
 
 pub struct ApiClient {

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -1,6 +1,8 @@
-use std::io::Write;
+use std::future::Future;
+use std::io::{IsTerminal, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
+use std::pin::Pin;
 
 use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine;
@@ -8,7 +10,10 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{Duration, Utc};
 use serde::Deserialize;
 
-use crate::api::{CLI_USER_AGENT, build_cli_http_client};
+use crate::api::{
+    AuthDevicePollBody, AuthDevicePollOutcome, AuthDeviceRequestBody, AuthDeviceRequestOutcome,
+    CLI_USER_AGENT, build_cli_http_client,
+};
 use crate::cli::{AuthArgs, LoginArgs};
 
 /// Default NyxID base URL used when prompting for re-login on a session that
@@ -33,6 +38,13 @@ const REFRESH_TOKEN_FILE_NAME: &str = "refresh_token";
 const BASE_URL_FILE_NAME: &str = "base_url";
 const USER_ID_FILE_NAME: &str = "user_id";
 const CALLBACK_TIMEOUT_SECS: u64 = 120;
+
+const AUTH_DEVICE_CODE_EXPIRED: i64 = 11201;
+const AUTH_DEVICE_CODE_PENDING: i64 = 11202;
+const AUTH_DEVICE_CODE_SLOW_DOWN: i64 = 11203;
+const AUTH_DEVICE_CODE_DENIED: i64 = 11204;
+const AUTH_DEVICE_CODE_ALREADY_DELIVERED: i64 = 11205;
+const AUTH_DEVICE_CODE_RATE_LIMITED: i64 = 11206;
 
 /// Extract the `sub` claim (NyxID user UUID) from a JWT access token.
 /// Decodes the payload section only; does not verify the signature, since
@@ -501,6 +513,7 @@ async fn handle_dead_session(auth: &AuthArgs, reason: DeadSessionReason) -> Resu
     run_login(LoginArgs {
         base_url,
         password: false,
+        device: false,
         email: None,
         profile: auth.profile.clone(),
     })
@@ -517,11 +530,101 @@ async fn handle_dead_session(auth: &AuthArgs, reason: DeadSessionReason) -> Resu
 // ---- Login ----
 
 pub async fn run_login(args: LoginArgs) -> Result<()> {
+    let strategies = RealLoginStrategies;
+    run_login_with_strategies(args, &strategies).await
+}
+
+trait LoginStrategies {
+    fn run_password_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        email: Option<&'a str>,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    fn run_device_code_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    fn run_browser_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), BrowserLoginError>> + Send + 'a>>;
+}
+
+struct RealLoginStrategies;
+
+impl LoginStrategies for RealLoginStrategies {
+    fn run_password_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        email: Option<&'a str>,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(run_password_login(base_url, email, profile))
+    }
+
+    fn run_device_code_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(run_device_code_login(base_url, profile))
+    }
+
+    fn run_browser_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), BrowserLoginError>> + Send + 'a>> {
+        Box::pin(run_browser_login(base_url, profile))
+    }
+}
+
+async fn run_login_with_strategies(
+    args: LoginArgs,
+    strategies: &impl LoginStrategies,
+) -> Result<()> {
     let profile = args.profile.as_deref();
     if args.password {
-        return run_password_login(&args.base_url, args.email.as_deref(), profile).await;
+        return strategies
+            .run_password_login(&args.base_url, args.email.as_deref(), profile)
+            .await;
     }
-    run_browser_login(&args.base_url, profile).await
+    if args.device {
+        return strategies
+            .run_device_code_login(&args.base_url, profile)
+            .await;
+    }
+
+    if std::env::var_os("NYXID_LOGIN_NO_DEVICE_FALLBACK").is_none() {
+        if is_ci_environment() {
+            bail!(
+                "Detected CI environment (CI / GITHUB_ACTIONS / BUILDKITE / CIRCLECI / \
+                 JENKINS_URL / GITLAB_CI set). Use `nyxid api-key create` and \
+                 `NYXID_API_KEY` instead of interactive login."
+            );
+        }
+        if !crate::wizard::is_wizard_eligible() && stderr_is_tty() {
+            return strategies
+                .run_device_code_login(&args.base_url, profile)
+                .await;
+        }
+    }
+
+    match strategies.run_browser_login(&args.base_url, profile).await {
+        Ok(()) => Ok(()),
+        Err(BrowserLoginError::CannotOpenBrowser(_)) => {
+            eprintln!("Couldn't open a browser. Falling back to device-code login.");
+            strategies
+                .run_device_code_login(&args.base_url, profile)
+                .await
+        }
+        Err(e) => Err(e.into()),
+    }
 }
 
 // ---- Logout ----
@@ -555,17 +658,62 @@ pub async fn run_logout(base_url: &str, profile: Option<&str>) -> Result<()> {
 
 // ---- Browser login (ported from login_cli.rs) ----
 
-async fn run_browser_login(base_url: &str, profile: Option<&str>) -> Result<()> {
+#[derive(Debug)]
+pub enum BrowserLoginError {
+    CannotOpenBrowser(std::io::Error),
+    CallbackTimedOut,
+    CallbackIo(anyhow::Error),
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for BrowserLoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CannotOpenBrowser(e) => write!(f, "couldn't open browser: {e}"),
+            Self::CallbackTimedOut => {
+                write!(
+                    f,
+                    "Login timed out after {CALLBACK_TIMEOUT_SECS}s. Please try again."
+                )
+            }
+            Self::CallbackIo(e) => write!(f, "{e}"),
+            Self::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for BrowserLoginError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CannotOpenBrowser(e) => Some(e),
+            Self::CallbackTimedOut => None,
+            Self::CallbackIo(e) | Self::Other(e) => e.source(),
+        }
+    }
+}
+
+async fn run_browser_login(
+    base_url: &str,
+    profile: Option<&str>,
+) -> std::result::Result<(), BrowserLoginError> {
     let base_url = base_url.trim_end_matches('/');
 
-    let frontend_url = fetch_frontend_url(base_url, profile).await?;
+    let frontend_url = fetch_frontend_url(base_url, profile)
+        .await
+        .map_err(BrowserLoginError::Other)?;
 
-    let listener =
-        TcpListener::bind("127.0.0.1:0").context("Failed to bind local callback server")?;
-    let port = listener.local_addr()?.port();
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .context("Failed to bind local callback server")
+        .map_err(BrowserLoginError::CallbackIo)?;
+    let port = listener
+        .local_addr()
+        .context("Failed to read local callback server address")
+        .map_err(BrowserLoginError::CallbackIo)?
+        .port();
 
     let state = generate_state();
-    let auth_url = build_cli_auth_url(&frontend_url, port, &state)?;
+    let auth_url =
+        build_cli_auth_url(&frontend_url, port, &state).map_err(BrowserLoginError::Other)?;
 
     eprintln!("Opening browser to log in...");
     eprintln!();
@@ -576,15 +724,19 @@ async fn run_browser_login(base_url: &str, profile: Option<&str>) -> Result<()> 
     eprintln!("(e.g. \"invite code required\" for new social sign-ups).");
     eprintln!();
 
-    let _ = crate::browser::open_browser(&auth_url);
+    if let Err(e) = crate::browser::open_browser(&auth_url) {
+        drop(listener);
+        return Err(BrowserLoginError::CannotOpenBrowser(e));
+    }
 
     let callback = wait_for_callback(listener, &state).await?;
     save_tokens_for(
         profile,
         &callback.access_token,
         callback.refresh_token.as_deref(),
-    )?;
-    save_base_url_for(profile, base_url)?;
+    )
+    .map_err(BrowserLoginError::Other)?;
+    save_base_url_for(profile, base_url).map_err(BrowserLoginError::Other)?;
 
     // Telemetry: identify the now-authenticated user. `save_tokens_for`
     // above derived + persisted `user_id` from the JWT; we read it
@@ -597,7 +749,8 @@ async fn run_browser_login(base_url: &str, profile: Option<&str>) -> Result<()> 
     }
 
     eprintln!("Logged in successfully.");
-    eprintln!("Token saved to {}", token_file_path_for(profile)?.display());
+    let token_path = token_file_path_for(profile).map_err(BrowserLoginError::Other)?;
+    eprintln!("Token saved to {}", token_path.display());
 
     Ok(())
 }
@@ -607,12 +760,17 @@ struct CallbackTokens {
     refresh_token: Option<String>,
 }
 
-async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<CallbackTokens> {
+async fn wait_for_callback(
+    listener: TcpListener,
+    expected_state: &str,
+) -> std::result::Result<CallbackTokens, BrowserLoginError> {
     listener
         .set_nonblocking(true)
-        .context("Failed to set listener to non-blocking")?;
-    let listener =
-        tokio::net::TcpListener::from_std(listener).context("Failed to create async listener")?;
+        .context("Failed to set listener to non-blocking")
+        .map_err(BrowserLoginError::CallbackIo)?;
+    let listener = tokio::net::TcpListener::from_std(listener)
+        .context("Failed to create async listener")
+        .map_err(BrowserLoginError::CallbackIo)?;
 
     let timeout = tokio::time::sleep(std::time::Duration::from_secs(CALLBACK_TIMEOUT_SECS));
     tokio::pin!(timeout);
@@ -620,10 +778,13 @@ async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Resul
     loop {
         tokio::select! {
             accept = listener.accept() => {
-                let (mut stream, _) = accept.context("Failed to accept connection")?;
+                let (mut stream, _) = accept
+                    .context("Failed to accept connection")
+                    .map_err(BrowserLoginError::CallbackIo)?;
                 let mut buf = vec![0u8; 8192];
                 let n = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await
-                    .context("Failed to read request")?;
+                    .context("Failed to read request")
+                    .map_err(BrowserLoginError::CallbackIo)?;
                 let request = String::from_utf8_lossy(&buf[..n]);
 
                 if let Some(tokens) = parse_callback_request(&request, expected_state) {
@@ -639,7 +800,7 @@ async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Resul
                 let _ = tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes()).await;
             }
             () = &mut timeout => {
-                bail!("Login timed out after {CALLBACK_TIMEOUT_SECS}s. Please try again.");
+                return Err(BrowserLoginError::CallbackTimedOut);
             }
         }
     }
@@ -737,6 +898,235 @@ pub async fn fetch_frontend_url(base_url: &str, profile: Option<&str>) -> Result
     Ok(config.frontend_url.trim_end_matches('/').to_string())
 }
 
+// ---- Device-code login ----
+
+trait AuthDeviceApi {
+    fn request<'a>(
+        &'a self,
+        base_url: &'a str,
+        body: &'a AuthDeviceRequestBody,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthDeviceRequestOutcome>> + Send + 'a>>;
+
+    fn poll<'a>(
+        &'a self,
+        base_url: &'a str,
+        body: &'a AuthDevicePollBody,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthDevicePollOutcome>> + Send + 'a>>;
+}
+
+struct RealAuthDeviceApi;
+
+impl AuthDeviceApi for RealAuthDeviceApi {
+    fn request<'a>(
+        &'a self,
+        base_url: &'a str,
+        body: &'a AuthDeviceRequestBody,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthDeviceRequestOutcome>> + Send + 'a>> {
+        Box::pin(crate::api::auth_device_request(base_url, body, profile))
+    }
+
+    fn poll<'a>(
+        &'a self,
+        base_url: &'a str,
+        body: &'a AuthDevicePollBody,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthDevicePollOutcome>> + Send + 'a>> {
+        Box::pin(crate::api::auth_device_poll(base_url, body, profile))
+    }
+}
+
+trait LoginSleeper {
+    fn sleep<'a>(&'a self, seconds: u64) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}
+
+struct TokioLoginSleeper;
+
+impl LoginSleeper for TokioLoginSleeper {
+    fn sleep<'a>(&'a self, seconds: u64) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(tokio::time::sleep(std::time::Duration::from_secs(seconds)))
+    }
+}
+
+trait DeviceBrowserFallback {
+    fn run_browser_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), BrowserLoginError>> + Send + 'a>>;
+}
+
+struct RealDeviceBrowserFallback;
+
+impl DeviceBrowserFallback for RealDeviceBrowserFallback {
+    fn run_browser_login<'a>(
+        &'a self,
+        base_url: &'a str,
+        profile: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = std::result::Result<(), BrowserLoginError>> + Send + 'a>> {
+        Box::pin(run_browser_login(base_url, profile))
+    }
+}
+
+async fn run_device_code_login(base_url: &str, profile: Option<&str>) -> Result<()> {
+    let api = RealAuthDeviceApi;
+    let sleeper = TokioLoginSleeper;
+    let browser = RealDeviceBrowserFallback;
+    run_device_code_login_with_api(base_url, profile, &api, &sleeper, &browser).await
+}
+
+async fn run_device_code_login_with_api(
+    base_url: &str,
+    profile: Option<&str>,
+    api: &impl AuthDeviceApi,
+    sleeper: &impl LoginSleeper,
+    browser: &impl DeviceBrowserFallback,
+) -> Result<()> {
+    let base_url = base_url.trim_end_matches('/');
+    let request = AuthDeviceRequestBody {
+        client_label: client_label(),
+        client_user_agent: Some(CLI_USER_AGENT.to_string()),
+    };
+
+    let challenge = match api.request(base_url, &request, profile).await? {
+        AuthDeviceRequestOutcome::Created(challenge) => challenge,
+        AuthDeviceRequestOutcome::NotSupported => {
+            eprintln!(
+                "This NyxID backend doesn't support device-code login. Falling back to browser login."
+            );
+            return browser
+                .run_browser_login(base_url, profile)
+                .await
+                .map_err(Into::into);
+        }
+    };
+
+    eprintln!("! First copy your one-time code: {}", challenge.user_code);
+    eprintln!();
+    eprintln!("Then open: {}", challenge.verification_uri_complete);
+    eprintln!(
+        "  or visit {} and enter the code above.",
+        challenge.verification_uri
+    );
+
+    poll_device_code_login(
+        base_url,
+        profile,
+        api,
+        sleeper,
+        challenge.device_code,
+        challenge.interval,
+    )
+    .await
+}
+
+async fn poll_device_code_login(
+    base_url: &str,
+    profile: Option<&str>,
+    api: &impl AuthDeviceApi,
+    sleeper: &impl LoginSleeper,
+    device_code: String,
+    initial_interval: u64,
+) -> Result<()> {
+    let mut interval = initial_interval.max(1);
+
+    loop {
+        sleeper.sleep(interval).await;
+        let body = AuthDevicePollBody {
+            device_code: device_code.clone(),
+        };
+
+        match api.poll(base_url, &body, profile).await? {
+            AuthDevicePollOutcome::Delivered(tokens) => {
+                save_tokens_for(profile, &tokens.access_token, Some(&tokens.refresh_token))?;
+                save_base_url_for(profile, base_url)?;
+
+                if let Some(user_id) = read_saved_user_id_for(profile)
+                    && let Some(mut client) = crate::telemetry::TelemetryClient::init(profile)
+                {
+                    client.identify(&user_id).await;
+                }
+
+                eprintln!("Signed in.");
+                return Ok(());
+            }
+            AuthDevicePollOutcome::Error(error) => {
+                interval = handle_device_poll_error(error.error_code, &error.message, interval)?;
+            }
+        }
+    }
+}
+
+fn handle_device_poll_error(error_code: i64, message: &str, interval: u64) -> Result<u64> {
+    match error_code {
+        AUTH_DEVICE_CODE_PENDING => Ok(interval),
+        AUTH_DEVICE_CODE_SLOW_DOWN => Ok(interval + 5),
+        AUTH_DEVICE_CODE_EXPIRED => bail!("Login timed out - run `nyxid login --device` again."),
+        AUTH_DEVICE_CODE_DENIED => bail!("Login denied."),
+        AUTH_DEVICE_CODE_ALREADY_DELIVERED => {
+            bail!("This code was already used. Run `nyxid login --device` again.")
+        }
+        AUTH_DEVICE_CODE_RATE_LIMITED => bail!("Too many attempts. Try again in a few minutes."),
+        _ => bail!("{message}"),
+    }
+}
+
+fn client_label() -> Option<String> {
+    hostname_from_env()
+        .or_else(hostname_from_command)
+        .map(|s| sanitize_client_label(&s))
+        .filter(|s| !s.is_empty())
+}
+
+fn hostname_from_env() -> Option<String> {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            std::env::var("COMPUTERNAME")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+        })
+}
+
+fn hostname_from_command() -> Option<String> {
+    let output = std::process::Command::new("hostname").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+}
+
+fn sanitize_client_label(value: &str) -> String {
+    value
+        .trim()
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(64)
+        .collect()
+}
+
+pub(crate) fn is_ci_environment() -> bool {
+    [
+        "CI",
+        "GITHUB_ACTIONS",
+        "BUILDKITE",
+        "CIRCLECI",
+        "JENKINS_URL",
+        "GITLAB_CI",
+    ]
+    .iter()
+    .any(|key| std::env::var_os(key).is_some())
+}
+
+fn stderr_is_tty() -> bool {
+    std::io::stderr().is_terminal()
+}
+
 // ---- Password login (ported from login_cli.rs) ----
 
 #[derive(Deserialize)]
@@ -819,11 +1209,23 @@ async fn run_password_login(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_cli_auth_url, callback_success_html, jwt_sub_from_token, parse_callback_request,
-        refresh_token_file_path_for, token_dir_for_profile, token_file_path_for,
-        validate_profile_name,
+        AUTH_DEVICE_CODE_ALREADY_DELIVERED, AUTH_DEVICE_CODE_DENIED, AUTH_DEVICE_CODE_EXPIRED,
+        AUTH_DEVICE_CODE_PENDING, AUTH_DEVICE_CODE_RATE_LIMITED, AUTH_DEVICE_CODE_SLOW_DOWN,
+        AuthDeviceApi, BrowserLoginError, DeviceBrowserFallback, LoginSleeper, LoginStrategies,
+        build_cli_auth_url, callback_success_html, handle_device_poll_error, is_ci_environment,
+        jwt_sub_from_token, parse_callback_request, poll_device_code_login,
+        refresh_token_file_path_for, run_login_with_strategies, token_dir_for_profile,
+        token_file_path_for, validate_profile_name,
     };
-    use crate::api::CLI_USER_AGENT;
+    use crate::api::{
+        AuthDevicePollBody, AuthDevicePollOutcome, AuthDevicePollResponse, AuthDeviceRequestBody,
+        AuthDeviceRequestOutcome, CLI_USER_AGENT, ErrorEnvelope,
+    };
+    use anyhow::{Result, bail};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     // ---- Profile validation ----
 
@@ -954,6 +1356,85 @@ mod tests {
             params.get("client_ua").map(|v| v.as_ref()),
             Some(CLI_USER_AGENT)
         );
+    }
+
+    #[test]
+    fn device_poll_error_mapping_matches_contract() {
+        assert_eq!(
+            handle_device_poll_error(AUTH_DEVICE_CODE_PENDING, "pending", 5).expect("pending"),
+            5
+        );
+        assert_eq!(
+            handle_device_poll_error(AUTH_DEVICE_CODE_SLOW_DOWN, "slow", 5).expect("slow"),
+            10
+        );
+
+        let expired = handle_device_poll_error(AUTH_DEVICE_CODE_EXPIRED, "expired", 5).unwrap_err();
+        assert!(
+            expired.to_string().contains("Login timed out"),
+            "unexpected: {expired}"
+        );
+        let denied = handle_device_poll_error(AUTH_DEVICE_CODE_DENIED, "denied", 5).unwrap_err();
+        assert_eq!(denied.to_string(), "Login denied.");
+        let used =
+            handle_device_poll_error(AUTH_DEVICE_CODE_ALREADY_DELIVERED, "used", 5).unwrap_err();
+        assert!(
+            used.to_string().contains("already used"),
+            "unexpected: {used}"
+        );
+        let limited =
+            handle_device_poll_error(AUTH_DEVICE_CODE_RATE_LIMITED, "limited", 5).unwrap_err();
+        assert!(
+            limited.to_string().contains("Too many attempts"),
+            "unexpected: {limited}"
+        );
+        let not_found =
+            handle_device_poll_error(11200, "device code not found from server", 5).unwrap_err();
+        assert_eq!(not_found.to_string(), "device code not found from server");
+        let invalid =
+            handle_device_poll_error(11207, "user code invalid from server", 5).unwrap_err();
+        assert_eq!(invalid.to_string(), "user code invalid from server");
+        let unknown = handle_device_poll_error(11999, "server message", 5).unwrap_err();
+        assert_eq!(unknown.to_string(), "server message");
+    }
+
+    #[test]
+    fn is_ci_environment_detects_standard_ci_vars() {
+        let _guard = crate::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let keys = [
+            "CI",
+            "GITHUB_ACTIONS",
+            "BUILDKITE",
+            "CIRCLECI",
+            "JENKINS_URL",
+            "GITLAB_CI",
+        ];
+        let previous: Vec<_> = keys
+            .iter()
+            .map(|key| (*key, std::env::var_os(key)))
+            .collect();
+        unsafe {
+            for key in keys {
+                std::env::remove_var(key);
+            }
+        }
+        assert!(!is_ci_environment());
+
+        unsafe {
+            std::env::set_var("CI", "1");
+        }
+        assert!(is_ci_environment());
+
+        unsafe {
+            for (key, value) in previous {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
     }
 
     // ---- JWT sub extraction ----
@@ -1286,5 +1767,324 @@ mod tests {
             "unexpected message: {msg}"
         );
         assert!(msg.contains("nyxid login"), "should point at login: {msg}");
+    }
+
+    #[derive(Clone)]
+    struct MockDeviceApi {
+        request: AuthDeviceRequestOutcome,
+        polls: Arc<Mutex<Vec<AuthDevicePollOutcome>>>,
+    }
+
+    impl MockDeviceApi {
+        fn with_polls(polls: Vec<AuthDevicePollOutcome>) -> Self {
+            Self {
+                request: AuthDeviceRequestOutcome::Created(crate::api::AuthDeviceRequestResponse {
+                    device_code: "nyx_adc_test".to_string(),
+                    user_code: "ADCB-EFGH".to_string(),
+                    verification_uri: "https://nyx.example/login/device".to_string(),
+                    verification_uri_complete:
+                        "https://nyx.example/login/device?user_code=ADCB-EFGH".to_string(),
+                    expires_in: 600,
+                    interval: 5,
+                }),
+                polls: Arc::new(Mutex::new(polls)),
+            }
+        }
+    }
+
+    impl AuthDeviceApi for MockDeviceApi {
+        fn request<'a>(
+            &'a self,
+            _base_url: &'a str,
+            _body: &'a AuthDeviceRequestBody,
+            _profile: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = Result<AuthDeviceRequestOutcome>> + Send + 'a>> {
+            let outcome = self.request.clone();
+            Box::pin(async move { Ok(outcome) })
+        }
+
+        fn poll<'a>(
+            &'a self,
+            _base_url: &'a str,
+            _body: &'a AuthDevicePollBody,
+            _profile: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = Result<AuthDevicePollOutcome>> + Send + 'a>> {
+            let polls = self.polls.clone();
+            Box::pin(async move {
+                let mut polls = polls.lock().unwrap_or_else(|e| e.into_inner());
+                if polls.is_empty() {
+                    bail!("unexpected extra poll")
+                }
+                Ok(polls.remove(0))
+            })
+        }
+    }
+
+    struct RecordingSleeper {
+        intervals: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl RecordingSleeper {
+        fn new() -> Self {
+            Self {
+                intervals: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn intervals(&self) -> Vec<u64> {
+            self.intervals
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        }
+    }
+
+    impl LoginSleeper for RecordingSleeper {
+        fn sleep<'a>(&'a self, seconds: u64) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            let intervals = self.intervals.clone();
+            Box::pin(async move {
+                intervals
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(seconds);
+            })
+        }
+    }
+
+    fn poll_error(code: i64) -> AuthDevicePollOutcome {
+        AuthDevicePollOutcome::Error(ErrorEnvelope {
+            error: "contract_error".to_string(),
+            error_code: code,
+            message: format!("message for {code}"),
+        })
+    }
+
+    fn delivered_tokens() -> AuthDevicePollOutcome {
+        AuthDevicePollOutcome::Delivered(AuthDevicePollResponse {
+            access_token: build_jwt(&serde_json::json!({
+                "sub": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+                "exp": 9999999999i64,
+            })),
+            refresh_token: "refresh-token".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: 900,
+        })
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn device_poll_loop_handles_pending_slow_down_then_success_and_profile_storage() {
+        let _home = PreflightHome::set();
+        let api = MockDeviceApi::with_polls(vec![
+            poll_error(AUTH_DEVICE_CODE_PENDING),
+            poll_error(AUTH_DEVICE_CODE_SLOW_DOWN),
+            delivered_tokens(),
+        ]);
+        let sleeper = RecordingSleeper::new();
+
+        poll_device_code_login(
+            "https://nyx-api.example",
+            Some("alt"),
+            &api,
+            &sleeper,
+            "nyx_adc_test".to_string(),
+            5,
+        )
+        .await
+        .expect("device login");
+
+        assert_eq!(sleeper.intervals(), vec![5, 5, 10]);
+        assert!(
+            super::token_file_path_for(Some("alt"))
+                .expect("token path")
+                .to_string_lossy()
+                .contains(".nyxid/profiles/alt/access_token")
+        );
+        assert!(super::read_saved_token_for(Some("alt")).is_some());
+        assert_eq!(
+            super::read_saved_refresh_token_for(Some("alt")).as_deref(),
+            Some("refresh-token")
+        );
+        assert_eq!(
+            super::read_saved_base_url_for(Some("alt")).as_deref(),
+            Some("https://nyx-api.example")
+        );
+    }
+
+    struct MockDeviceBrowser {
+        calls: AtomicUsize,
+    }
+
+    impl MockDeviceBrowser {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl DeviceBrowserFallback for MockDeviceBrowser {
+        fn run_browser_login<'a>(
+            &'a self,
+            _base_url: &'a str,
+            _profile: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = std::result::Result<(), BrowserLoginError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn device_request_404_falls_back_to_browser_flow() {
+        let api = MockDeviceApi {
+            request: AuthDeviceRequestOutcome::NotSupported,
+            polls: Arc::new(Mutex::new(Vec::new())),
+        };
+        let sleeper = RecordingSleeper::new();
+        let browser = MockDeviceBrowser::new();
+
+        super::run_device_code_login_with_api(
+            "https://nyx-api.example",
+            None,
+            &api,
+            &sleeper,
+            &browser,
+        )
+        .await
+        .expect("browser fallback");
+
+        assert_eq!(browser.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(sleeper.intervals(), Vec::<u64>::new());
+    }
+
+    #[derive(Default)]
+    struct MockLoginStrategies {
+        browser_result: Mutex<Option<std::result::Result<(), BrowserLoginError>>>,
+        password_calls: AtomicUsize,
+        device_calls: AtomicUsize,
+        browser_calls: AtomicUsize,
+    }
+
+    impl LoginStrategies for MockLoginStrategies {
+        fn run_password_login<'a>(
+            &'a self,
+            _base_url: &'a str,
+            _email: Option<&'a str>,
+            _profile: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+            Box::pin(async move {
+                self.password_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+
+        fn run_device_code_login<'a>(
+            &'a self,
+            _base_url: &'a str,
+            _profile: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+            Box::pin(async move {
+                self.device_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+
+        fn run_browser_login<'a>(
+            &'a self,
+            _base_url: &'a str,
+            _profile: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = std::result::Result<(), BrowserLoginError>> + Send + 'a>>
+        {
+            Box::pin(async move {
+                self.browser_calls.fetch_add(1, Ordering::SeqCst);
+                self.browser_result
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .take()
+                    .unwrap_or(Ok(()))
+            })
+        }
+    }
+
+    fn login_args() -> crate::cli::LoginArgs {
+        crate::cli::LoginArgs {
+            base_url: "https://nyx-api.example".to_string(),
+            password: false,
+            device: false,
+            email: None,
+            profile: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn browser_open_failure_falls_back_to_device_flow() {
+        let strategies = MockLoginStrategies {
+            browser_result: Mutex::new(Some(Err(BrowserLoginError::CannotOpenBrowser(
+                std::io::Error::new(std::io::ErrorKind::NotFound, "browser"),
+            )))),
+            ..Default::default()
+        };
+
+        run_login_with_strategies(login_args(), &strategies)
+            .await
+            .expect("fallback succeeds");
+
+        assert_eq!(strategies.browser_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(strategies.device_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn explicit_device_flag_skips_browser_flow() {
+        let strategies = MockLoginStrategies::default();
+        let mut args = login_args();
+        args.device = true;
+
+        run_login_with_strategies(args, &strategies)
+            .await
+            .expect("device login");
+
+        assert_eq!(strategies.browser_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(strategies.device_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn ci_short_circuit_fires_before_network_or_browser() {
+        let _guard = crate::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev_ci = std::env::var_os("CI");
+        let prev_disable = std::env::var_os("NYXID_LOGIN_NO_DEVICE_FALLBACK");
+        unsafe {
+            std::env::set_var("CI", "1");
+            std::env::remove_var("NYXID_LOGIN_NO_DEVICE_FALLBACK");
+        }
+
+        let strategies = MockLoginStrategies::default();
+        let err = run_login_with_strategies(login_args(), &strategies)
+            .await
+            .expect_err("CI should fail");
+        let msg = err.to_string();
+        assert!(msg.contains("Detected CI environment"), "unexpected: {msg}");
+        assert!(
+            msg.contains("nyxid api-key create"),
+            "missing api-key hint: {msg}"
+        );
+        assert_eq!(strategies.browser_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(strategies.device_calls.load(Ordering::SeqCst), 0);
+
+        unsafe {
+            match prev_ci {
+                Some(value) => std::env::set_var("CI", value),
+                None => std::env::remove_var("CI"),
+            }
+            match prev_disable {
+                Some(value) => std::env::set_var("NYXID_LOGIN_NO_DEVICE_FALLBACK", value),
+                None => std::env::remove_var("NYXID_LOGIN_NO_DEVICE_FALLBACK"),
+            }
+        }
     }
 }

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -1005,11 +1005,26 @@ async fn run_device_code_login_with_api(
 
     eprintln!("! First copy your one-time code: {}", challenge.user_code);
     eprintln!();
-    eprintln!("Then open: {}", challenge.verification_uri_complete);
     eprintln!(
-        "  or visit {} and enter the code above.",
+        "Then open {} and enter the code above.",
         challenge.verification_uri
     );
+
+    let interactive = std::io::IsTerminal::is_terminal(&std::io::stdin())
+        && std::io::IsTerminal::is_terminal(&std::io::stderr());
+    if interactive {
+        eprint!("\nOpen in your browser? [Y/n] ");
+        std::io::stderr().flush().ok();
+        let mut answer = String::new();
+        if std::io::stdin().read_line(&mut answer).is_ok() {
+            let a = answer.trim().to_ascii_lowercase();
+            if a.is_empty() || a == "y" || a == "yes" {
+                if let Err(e) = crate::browser::open_browser(&challenge.verification_uri) {
+                    eprintln!("Could not open browser: {e}. Paste the URL above manually.");
+                }
+            }
+        }
+    }
 
     poll_device_code_login(
         base_url,

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -2051,10 +2051,7 @@ mod tests {
             "GITLAB_CI",
             "NYXID_LOGIN_NO_DEVICE_FALLBACK",
         ];
-        let prev: Vec<_> = ci_keys
-            .iter()
-            .map(|k| (*k, std::env::var_os(k)))
-            .collect();
+        let prev: Vec<_> = ci_keys.iter().map(|k| (*k, std::env::var_os(k))).collect();
         unsafe {
             for k in &ci_keys {
                 std::env::remove_var(k);

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -1018,10 +1018,10 @@ async fn run_device_code_login_with_api(
         let mut answer = String::new();
         if std::io::stdin().read_line(&mut answer).is_ok() {
             let a = answer.trim().to_ascii_lowercase();
-            if a.is_empty() || a == "y" || a == "yes" {
-                if let Err(e) = crate::browser::open_browser(&challenge.verification_uri) {
-                    eprintln!("Could not open browser: {e}. Paste the URL above manually.");
-                }
+            if (a.is_empty() || a == "y" || a == "yes")
+                && let Err(e) = crate::browser::open_browser(&challenge.verification_uri)
+            {
+                eprintln!("Could not open browser: {e}. Paste the URL above manually.");
             }
         }
     }
@@ -2035,7 +2035,32 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn browser_open_failure_falls_back_to_device_flow() {
+        // Must clear CI env vars so the dispatcher reaches the browser branch
+        // — on GitHub Actions runners CI=true is preset.
+        let _guard = crate::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let ci_keys = [
+            "CI",
+            "GITHUB_ACTIONS",
+            "BUILDKITE",
+            "CIRCLECI",
+            "JENKINS_URL",
+            "GITLAB_CI",
+            "NYXID_LOGIN_NO_DEVICE_FALLBACK",
+        ];
+        let prev: Vec<_> = ci_keys
+            .iter()
+            .map(|k| (*k, std::env::var_os(k)))
+            .collect();
+        unsafe {
+            for k in &ci_keys {
+                std::env::remove_var(k);
+            }
+        }
+
         let strategies = MockLoginStrategies {
             browser_result: Mutex::new(Some(Err(BrowserLoginError::CannotOpenBrowser(
                 std::io::Error::new(std::io::ErrorKind::NotFound, "browser"),
@@ -2043,10 +2068,18 @@ mod tests {
             ..Default::default()
         };
 
-        run_login_with_strategies(login_args(), &strategies)
-            .await
-            .expect("fallback succeeds");
+        let result = run_login_with_strategies(login_args(), &strategies).await;
 
+        unsafe {
+            for (k, v) in &prev {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+
+        result.expect("fallback succeeds");
         assert_eq!(strategies.browser_calls.load(Ordering::SeqCst), 1);
         assert_eq!(strategies.device_calls.load(Ordering::SeqCst), 1);
     }

--- a/cli/src/browser.rs
+++ b/cli/src/browser.rs
@@ -14,6 +14,8 @@
 
 use std::process::Command;
 
+pub type BrowserError = std::io::Error;
+
 /// True when running inside Windows Subsystem for Linux (WSL 1 or 2).
 ///
 /// Checks the interop env vars first — `WSL_INTEROP` / `WSL_DISTRO_NAME`
@@ -38,7 +40,7 @@ pub fn is_wsl() -> bool {
 /// Native platforms go straight through `open::that`. Under WSL we use
 /// [`open_browser_wsl`] so the URL actually reaches a Windows browser
 /// instead of silently failing on a missing `wslview`.
-pub fn open_browser(url: &str) -> std::io::Result<()> {
+pub fn open_browser(url: &str) -> Result<(), BrowserError> {
     if is_wsl() {
         open_browser_wsl(url)
     } else {
@@ -48,7 +50,7 @@ pub fn open_browser(url: &str) -> std::io::Result<()> {
 
 /// WSL bridge: try each Windows-side opener until one launches the URL,
 /// then fall back to the `open` crate's generic UNIX chain.
-fn open_browser_wsl(url: &str) -> std::io::Result<()> {
+fn open_browser_wsl(url: &str) -> Result<(), BrowserError> {
     let mut last_err: Option<std::io::Error> = None;
     for mut cmd in wsl_open_commands(url) {
         match cmd.status() {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -446,6 +446,9 @@ pub struct LoginArgs {
     /// Use email/password login instead of opening the browser
     #[arg(long)]
     pub password: bool,
+    /// Use RFC 8628 device-code login instead of opening the browser
+    #[arg(long, conflicts_with = "password")]
+    pub device: bool,
     /// Email address (only used with --password)
     #[arg(long)]
     pub email: Option<String>,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -315,4 +315,13 @@ mod tests {
         let info = Cli::parse_from(["nyxid", "info"]);
         assert!(extract_profile(&info.command).is_none());
     }
+
+    #[test]
+    fn login_device_and_password_conflict() {
+        let err = match Cli::try_parse_from(["nyxid", "login", "--password", "--device"]) {
+            Ok(_) => panic!("--device and --password must conflict"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 }

--- a/cli/src/skill_self_heal.rs
+++ b/cli/src/skill_self_heal.rs
@@ -271,6 +271,7 @@ mod tests {
             crate::cli::LoginArgs {
                 base_url: String::new(),
                 password: false,
+                device: false,
                 email: None,
                 profile: None
             }
@@ -282,6 +283,7 @@ mod tests {
         assert!(!should_run(&Commands::Login(crate::cli::LoginArgs {
             base_url: String::new(),
             password: false,
+            device: false,
             email: None,
             profile: None
         })));

--- a/docs/AI_AGENT_PLAYBOOK.md
+++ b/docs/AI_AGENT_PLAYBOOK.md
@@ -104,8 +104,15 @@ nyxid --help
 # --base-url is saved to ~/.nyxid/base_url -- all subsequent commands use it automatically
 nyxid login --base-url http://localhost:3001
 
-# Or use password login (for headless/AI-agent environments)
-nyxid login --base-url http://localhost:3001 --password --password-env NYXID_PASSWORD
+# Headless / SSH / no $DISPLAY -- bare `nyxid login` auto-falls-back to
+# device-code, or force it explicitly:
+nyxid login --base-url http://localhost:3001 --device
+
+# For unattended CI / agent runtimes, skip interactive login entirely and
+# issue a scoped API key instead. `nyxid login` will short-circuit and tell
+# you to do this when it detects CI / GITHUB_ACTIONS / BUILDKITE / etc.
+nyxid api-key create --name my-agent --platform claude-code
+export NYXID_API_KEY=nyxid_ag_...
 
 # Check connection (no --base-url needed after login)
 nyxid status
@@ -1103,6 +1110,11 @@ Users add services and manage credentials from the AI Services page: http://loca
 ## 10b. Device-Code Grant (headless device provisioning)
 
 **Goal:** Provision a fresh headless device, such as an ESP32 camera, with NyxID credentials after a human approves the code shown by the device.
+
+> Three distinct "device-code" features exist in NyxID — pick the right one:
+> 1. **Provider device-code OAuth** (section 10) — connect a user's downstream OAuth provider credential.
+> 2. **Auth device-code login** (`nyxid login --device`, endpoints under `/api/v1/auth/device/*`) — RFC 8628 flow that lets the CLI authenticate a user on a headless box (WSL / SSH / no `$DISPLAY`).
+> 3. **Device-code grant** (this section, endpoints under `/api/v1/devices/code/*`) — provision a headless IoT device with its own scoped NyxID API key, node id, and one-time refresh token.
 
 This is not the provider device-code OAuth flow above. Provider device-code connects a user's downstream OAuth provider credential. Device-code grant gives the device its own NyxID API key, node id, and one-time refresh token.
 

--- a/docs/AI_AGENT_PLAYBOOK.md
+++ b/docs/AI_AGENT_PLAYBOOK.md
@@ -99,23 +99,39 @@ nyxid --help
 
 **First-time setup:**
 
+> **Who runs what?** There are two identities in this section:
+>
+> 1. **You, the human.** You authenticate **once** with `nyxid login`, which writes your session to `~/.nyxid/`. Browser SSO on desktop, device-code on headless boxes — either way you complete the flow in a signed-in browser.
+> 2. **Your agent.** A separate identity, represented by a scoped API key (`nyxid_ag_…`) you mint **from your authenticated session**. The agent reads it from `NYXID_API_KEY` and uses it for every proxy call.
+>
+> **Agents must never run `nyxid login` themselves.** Device-code requires a human to approve a code in a browser; an autonomous agent has nothing to "approve" on its own. If an agent attempts `nyxid login` in CI it short-circuits with an api-key hint; in an interactive shell it would block forever. The correct agent action is to read the pre-issued `NYXID_API_KEY` from its environment.
+
+Step 1 — **you** authenticate:
+
 ```bash
-# Login via browser SSO (opens browser, stores token at ~/.nyxid/access_token)
-# --base-url is saved to ~/.nyxid/base_url -- all subsequent commands use it automatically
+# Desktop with a browser (opens browser, stores token at ~/.nyxid/access_token).
+# --base-url is saved to ~/.nyxid/base_url, so subsequent commands don't need it.
 nyxid login --base-url http://localhost:3001
 
-# Headless / SSH / no $DISPLAY -- bare `nyxid login` auto-falls-back to
-# device-code, or force it explicitly:
+# Headless / SSH / no $DISPLAY: bare `nyxid login` auto-falls-back to
+# device-code, or force it explicitly. The CLI prints a one-time code +
+# verification URL; you approve in any signed-in browser (phone, laptop).
 nyxid login --base-url http://localhost:3001 --device
 
-# For unattended CI / agent runtimes, skip interactive login entirely and
-# issue a scoped API key instead. `nyxid login` will short-circuit and tell
-# you to do this when it detects CI / GITHUB_ACTIONS / BUILDKITE / etc.
-nyxid api-key create --name my-agent --platform claude-code
-export NYXID_API_KEY=nyxid_ag_...
-
-# Check connection (no --base-url needed after login)
+# Sanity check the session.
 nyxid status
+```
+
+Step 2 — **you** mint a key for the agent and hand it over:
+
+```bash
+# Issue a scoped key (rate-limited and audit-attributed under this agent's name).
+nyxid api-key create --name my-agent --platform claude-code
+# -> prints `nyxid_ag_…` ONCE. Copy it now; it cannot be retrieved later.
+
+# Put it in the agent's environment. The agent uses NYXID_API_KEY for
+# every NyxID call. It should not have access to ~/.nyxid/ files.
+export NYXID_API_KEY=nyxid_ag_...
 ```
 
 > **Note:** After `nyxid login --base-url <URL>`, the URL is persisted at `~/.nyxid/base_url`. You do not need to pass `--base-url` on subsequent commands.

--- a/docs/AI_SERVICES_ARCHITECTURE.md
+++ b/docs/AI_SERVICES_ARCHITECTURE.md
@@ -216,7 +216,7 @@ graph LR
 ```mermaid
 graph TB
     subgraph "nyxid CLI (user operations)"
-        LOGIN["nyxid login<br/>Browser SSO"]
+        LOGIN["nyxid login<br/>Browser SSO / --device / --password"]
         CATALOG["nyxid catalog list/show<br/>Browse services"]
         SERVICE["nyxid service add/list/show/delete<br/>Manage AI services"]
         APIKEY["nyxid api-key create/list/rotate/delete<br/>Manage API keys with scope"]

--- a/docs/SSH_TUNNELING.md
+++ b/docs/SSH_TUNNELING.md
@@ -53,11 +53,13 @@ nyxid login --base-url https://auth.example.com
 
 The CLI starts a temporary localhost server, opens the browser to `/cli-auth`, and waits for the redirect callback with the access token. The token is saved to `~/.nyxid/access_token` with `0600` permissions.
 
-For headless environments (CI, Docker), use `--password` to enter email and password directly:
+For headless interactive environments (SSH, Docker shell, WSL with no `$DISPLAY`), the bare `nyxid login` auto-falls back to the device-code flow, or you can force it:
 
 ```bash
-nyxid login --base-url https://auth.example.com --password
+nyxid login --base-url https://auth.example.com --device
 ```
+
+The CLI prints a one-time code and a URL — open the URL on any signed-in browser (phone, another machine), type the code, approve, and the CLI completes. For unattended CI/CD use an API key (Option B below) instead — `nyxid login` short-circuits in CI environments with a hint to do exactly that. `--password` is still available for legacy scripted setups where neither device-code nor an API key fits.
 
 ### Option B: API Key
 

--- a/docs/site/ai/getting-started/connect-your-agent.md
+++ b/docs/site/ai/getting-started/connect-your-agent.md
@@ -41,11 +41,15 @@ nyxid login --base-url https://nyx-api.chrono-ai.fun
 nyxid login --base-url http://localhost:3001
 ```
 
-For headless or CI environments, use password login with an environment variable:
+For headless environments (SSH, container, WSL with no `$DISPLAY`), `nyxid login` auto-falls back to the **device-code flow**. You can also force it explicitly:
 
 ```bash
-nyxid login --base-url https://nyx-api.chrono-ai.fun --password --password-env NYXID_PASSWORD
+nyxid login --device --base-url https://nyx-api.chrono-ai.fun
 ```
+
+The CLI prints a one-time code and a URL; open the URL on any signed-in browser (phone, another machine), paste the code, approve, and the CLI completes.
+
+For non-interactive CI use a pre-issued API key (`nyxid api-key create --platform <agent>`) instead of an interactive login — `nyxid login` short-circuits in CI environments with a hint to do exactly that.
 
 Confirm the session is working:
 

--- a/docs/site/ai/getting-started/connect-your-agent.md
+++ b/docs/site/ai/getting-started/connect-your-agent.md
@@ -9,6 +9,16 @@ This page gets an AI agent connected to NyxID. By the end you will have the `nyx
 If this is your first time ever adding a service, consider completing the Web UI flow first so you have at least one working connection before wiring up MCP. See the web console at `https://nyx.chrono-ai.fun`.
 :::
 
+:::warning Two identities, never confuse them
+
+There are two NyxID identities involved here, and only the human can move between them:
+
+- **You** — the human running these steps. You authenticate **once** via `nyxid login` (browser or device-code). Your session is what authorizes everything else; the CLI saves it to `~/.nyxid/`.
+- **The agent** — a separate, scoped identity (`nyxid_ag_…` API key) that **you mint for the agent** with `nyxid api-key create`. The agent reads it from `NYXID_API_KEY` in its environment and uses it for proxy requests.
+
+**Agents must never run `nyxid login`.** Device-code login requires a human to approve a code in a signed-in browser — there is nothing for an autonomous agent to "approve" on its own end. If your agent tries `nyxid login`, it will block on the approval step (interactive TTYs) or short-circuit with an api-key hint (CI / GITHUB_ACTIONS / BUILDKITE / etc.). Either way the correct action for the agent is to read its pre-issued API key from `NYXID_API_KEY` — which you set for it below.
+:::
+
 ## Install the CLI
 
 The `nyxid` CLI is a Rust binary. Install the Rust toolchain if you don't have it:
@@ -29,9 +39,9 @@ nyxid --help    # verify
 End users install prebuilt release binaries from the releases page. `cargo install` is the development path; both produce the same binary.
 :::
 
-## Authenticate
+## Authenticate (you, the human)
 
-Log in once. The `--base-url` is saved to `~/.nyxid/base_url`; all subsequent commands pick it up automatically.
+Log in once. The `--base-url` is saved to `~/.nyxid/base_url`; all subsequent commands pick it up automatically. This is **your** session, not the agent's.
 
 ```bash
 # Hosted deployment
@@ -57,9 +67,9 @@ Confirm the session is working:
 nyxid status
 ```
 
-## Create an Agent Key
+## Create an Agent Key (for the agent to use)
 
-An Agent Key is a scoped NyxID API key your agent uses to authenticate. It carries its own rate limit and service scope, keeping agent traffic separated in the audit log.
+This is the second identity — a scoped NyxID API key the agent reads from `NYXID_API_KEY`. You mint it from your authenticated session above. It carries its own rate limit, service scope, and audit attribution so the agent's traffic is fully separated from yours.
 
 ```bash
 nyxid api-key create --name "my-agent" --platform claude-code --scopes "proxy"

--- a/docs/site/cli/getting-started/authenticate.md
+++ b/docs/site/cli/getting-started/authenticate.md
@@ -16,6 +16,16 @@ nyxid login --base-url <BASE_URL>
 - **Hosted:** `https://nyx-api.chrono-ai.fun`
 - **Self-host:** `http://localhost:3001` (the API runs on 3001; the web console is on 3000)
 
+### Headless / SSH / no browser
+
+If `nyxid login` can't open a browser (SSH session, container, WSL without `$DISPLAY`), it auto-falls back to the **device-code flow**: the CLI prints a one-time code + a URL, you open the URL on any signed-in browser (phone, laptop), type the code, approve, and the CLI completes. You can also force the flow explicitly:
+
+```bash
+nyxid login --device --base-url <BASE_URL>
+```
+
+Set `NYXID_LOGIN_NO_DEVICE_FALLBACK=1` to opt out of the auto-fallback (you'll get the old "hang on browser callback" behavior instead). For non-interactive CI use, generate an API key with `nyxid api-key create` and authenticate via the `nyxid_ag_…` token — `nyxid login` itself short-circuits with an api-key hint when it detects `CI` / `GITHUB_ACTIONS` / `BUILDKITE` / `CIRCLECI` / `JENKINS_URL` / `GITLAB_CI`.
+
 ## Check your session
 
 ```bash

--- a/docs/site/cli/reference/others.md
+++ b/docs/site/cli/reference/others.md
@@ -48,7 +48,9 @@ nyxid ai-setup status                        # show which tools have skills inst
 Bootstrap and tear down the locally stored session. Day-to-day login lives in [Authenticate](/docs/cli/getting-started/authenticate).
 
 ```bash
-nyxid login --base-url <BASE_URL>        # browser sign-in (add --password for email/password)
+nyxid login --base-url <BASE_URL>        # browser sign-in; auto-falls back to device-code when headless
+nyxid login --device --base-url <BASE_URL>  # force RFC 8628 device-code flow (no local browser needed)
+nyxid login --password --email <addr>    # email + password (only if EMAIL_AUTH_ENABLED)
 nyxid logout                             # clear the stored session
 nyxid register --base-url <URL> --email <addr> --invite-code <CODE>
 nyxid verify-email --token <TOKEN>       # confirm a new account

--- a/frontend/src/hooks/use-auth-device.test.tsx
+++ b/frontend/src/hooks/use-auth-device.test.tsx
@@ -1,0 +1,143 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useApproveAuthDevice,
+  usePreviewAuthDevice,
+} from "./use-auth-device";
+
+const { mockPost } = vi.hoisted(() => ({ mockPost: vi.fn() }));
+
+vi.mock("@/lib/api-client", () => ({
+  api: { post: mockPost },
+}));
+
+function wrapper({ children }: PropsWithChildren) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("usePreviewAuthDevice", () => {
+  it("is idle on mount and only fires when mutateAsync is called", async () => {
+    const { result } = renderHook(() => usePreviewAuthDevice(), { wrapper });
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("posts the user_code to /auth/device/preview and parses the response", async () => {
+    mockPost.mockResolvedValue({
+      client_label: "kitchen-rpi",
+      client_user_agent: "nyxid-cli/0.7.1",
+      initiated_at: "2026-06-18T10:00:00Z",
+      expires_at: "2026-06-18T10:10:00Z",
+      status: "pending",
+    });
+    const { result } = renderHook(() => usePreviewAuthDevice(), { wrapper });
+
+    const response = await result.current.mutateAsync("ABCDEFGH");
+
+    expect(mockPost).toHaveBeenCalledWith("/auth/device/preview", {
+      user_code: "ABCDEFGH",
+    });
+    expect(response.status).toBe("pending");
+    expect(response.client_label).toBe("kitchen-rpi");
+  });
+
+  it("rejects responses that don't match the preview schema", async () => {
+    mockPost.mockResolvedValue({
+      client_label: "ok",
+      client_user_agent: "ok",
+      initiated_at: "not-a-datetime",
+      expires_at: "2026-06-18T10:10:00Z",
+      status: "pending",
+    });
+    const { result } = renderHook(() => usePreviewAuthDevice(), { wrapper });
+
+    await expect(result.current.mutateAsync("ABCDEFGH")).rejects.toThrow();
+  });
+
+  it("rejects status values outside the documented enum", async () => {
+    mockPost.mockResolvedValue({
+      client_label: null,
+      client_user_agent: null,
+      initiated_at: "2026-06-18T10:00:00Z",
+      expires_at: "2026-06-18T10:10:00Z",
+      status: "weird-state",
+    });
+    const { result } = renderHook(() => usePreviewAuthDevice(), { wrapper });
+
+    await expect(result.current.mutateAsync("ABCDEFGH")).rejects.toThrow();
+  });
+
+  it("can be re-fired with reset() between calls", async () => {
+    mockPost
+      .mockResolvedValueOnce({
+        client_label: "device-1",
+        client_user_agent: null,
+        initiated_at: "2026-06-18T10:00:00Z",
+        expires_at: "2026-06-18T10:10:00Z",
+        status: "pending",
+      })
+      .mockResolvedValueOnce({
+        client_label: "device-2",
+        client_user_agent: null,
+        initiated_at: "2026-06-18T10:05:00Z",
+        expires_at: "2026-06-18T10:15:00Z",
+        status: "pending",
+      });
+    const { result } = renderHook(() => usePreviewAuthDevice(), { wrapper });
+
+    await result.current.mutateAsync("AAAA1111");
+    await waitFor(() => {
+      expect(result.current.data?.client_label).toBe("device-1");
+    });
+
+    result.current.reset();
+    await waitFor(() => {
+      expect(result.current.data).toBeUndefined();
+    });
+
+    await result.current.mutateAsync("BBBB2222");
+    await waitFor(() => {
+      expect(result.current.data?.client_label).toBe("device-2");
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useApproveAuthDevice", () => {
+  it("is idle on mount and only fires when mutateAsync is called", () => {
+    const { result } = renderHook(() => useApproveAuthDevice(), { wrapper });
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("normalizes the user_code (strips dashes, uppercases) before posting", async () => {
+    mockPost.mockResolvedValue({ ok: true });
+    const { result } = renderHook(() => useApproveAuthDevice(), { wrapper });
+
+    await result.current.mutateAsync("abcd-efgh");
+
+    expect(mockPost).toHaveBeenCalledWith("/auth/device/approve", {
+      user_code: "ABCDEFGH",
+    });
+  });
+
+  it("rejects responses that aren't { ok: true }", async () => {
+    mockPost.mockResolvedValue({ ok: false });
+    const { result } = renderHook(() => useApproveAuthDevice(), { wrapper });
+
+    await expect(result.current.mutateAsync("ABCDEFGH")).rejects.toThrow();
+  });
+});

--- a/frontend/src/hooks/use-auth-device.ts
+++ b/frontend/src/hooks/use-auth-device.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import {
+  approveBodySchema,
+  approveResponseSchema,
+  previewResponseSchema,
+  type ApproveAuthDeviceResponse,
+  type PreviewAuthDeviceResponse,
+} from "@/schemas/auth-device";
+
+export function usePreviewAuthDevice(userCode: string | null) {
+  return useQuery({
+    queryKey: ["auth-device-preview", userCode],
+    queryFn: async (): Promise<PreviewAuthDeviceResponse | null> => {
+      if (!userCode) return null;
+      const response = await api.post<PreviewAuthDeviceResponse>(
+        "/auth/device/preview",
+        { user_code: userCode },
+      );
+      return previewResponseSchema.parse(response);
+    },
+    enabled: !!userCode,
+    retry: false,
+  });
+}
+
+export function useApproveAuthDevice() {
+  return useMutation({
+    mutationFn: async (
+      userCode: string,
+    ): Promise<ApproveAuthDeviceResponse> => {
+      const body = approveBodySchema.parse({ user_code: userCode });
+      const response = await api.post<ApproveAuthDeviceResponse>(
+        "/auth/device/approve",
+        body,
+      );
+      return approveResponseSchema.parse(response);
+    },
+  });
+}

--- a/frontend/src/hooks/use-auth-device.ts
+++ b/frontend/src/hooks/use-auth-device.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import {
   approveBodySchema,
@@ -8,19 +8,17 @@ import {
   type PreviewAuthDeviceResponse,
 } from "@/schemas/auth-device";
 
-export function usePreviewAuthDevice(userCode: string | null) {
-  return useQuery({
-    queryKey: ["auth-device-preview", userCode],
-    queryFn: async (): Promise<PreviewAuthDeviceResponse | null> => {
-      if (!userCode) return null;
+export function usePreviewAuthDevice() {
+  return useMutation({
+    mutationFn: async (
+      userCode: string,
+    ): Promise<PreviewAuthDeviceResponse> => {
       const response = await api.post<PreviewAuthDeviceResponse>(
         "/auth/device/preview",
         { user_code: userCode },
       );
       return previewResponseSchema.parse(response);
     },
-    enabled: !!userCode,
-    retry: false,
   });
 }
 

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -1456,6 +1456,19 @@ const MOCK_HANDLERS: MockHandler[] = [
 
   // Public config
   (p) => p === "/public/config" ? MOCK_PUBLIC_CONFIG : undefined,
+
+  // Auth device-code login (issue #971 T5 frozen contract)
+  (p) =>
+    p === "/auth/device/preview"
+      ? {
+          client_label: "wsl-calvin",
+          client_user_agent: "nyxid-cli/0.8.0",
+          initiated_at: "2026-06-18T11:32:14Z",
+          expires_at: "2026-06-18T11:42:14Z",
+          status: "pending",
+        }
+      : undefined,
+  (p) => (p === "/auth/device/approve" ? { ok: true } : undefined),
 ];
 
 let _mockLatched: boolean | null = null;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -21,7 +21,8 @@ sessionStorage.removeItem("nyxid_chunk_reload");
 // visitors so `CliPairPage` can redirect to `/login` with a
 // `return_to` carrying `?code=...` intact. Routing to bare
 // `/login` from here would drop the query string and strand the
-// pairing.
+// pairing. `/login/device` follows the same pattern for CLI
+// device-code login and preserves `?user_code=...`.
 function isPublicPath(path: string): boolean {
   return (
     path === "/" ||
@@ -37,7 +38,8 @@ function isPublicPath(path: string): boolean {
     path.startsWith("/error") ||
     path.startsWith("/oauth-consent") ||
     path === "/cli-auth" ||
-    path === "/cli/pair"
+    path === "/cli/pair" ||
+    path === "/login/device"
   );
 }
 

--- a/frontend/src/pages/lazy.ts
+++ b/frontend/src/pages/lazy.ts
@@ -18,6 +18,11 @@ export const CliAuthPage = lazy(() =>
 export const CliPairPage = lazy(() =>
   import("@/pages/cli-pair").then((m) => ({ default: m.CliPairPage })),
 );
+export const LoginDevicePage = lazy(() =>
+  import("@/pages/login-device").then((m) => ({
+    default: m.LoginDevicePage,
+  })),
+);
 export const DashboardPage = lazy(() =>
   import("@/pages/dashboard").then((m) => ({ default: m.DashboardPage })),
 );

--- a/frontend/src/pages/login-device.tsx
+++ b/frontend/src/pages/login-device.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -28,37 +28,57 @@ import {
 import { useAuthStore } from "@/stores/auth-store";
 
 const VALID_CODE_LENGTH = 9;
+const CLICK_THROTTLE_MS = 750;
 
 export function LoginDevicePage() {
   const navigate = useNavigate();
-  const search = useSearch({ strict: false }) as { user_code?: string };
   const { isAuthenticated, isLoading } = useAuthStore();
-  const initialCode =
-    typeof search.user_code === "string"
-      ? formatAuthDeviceUserCodeInput(search.user_code)
-      : "";
-  const [userCode, setUserCode] = useState(initialCode);
+  const [userCode, setUserCode] = useState("");
   const [approved, setApproved] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const lastClickAtRef = useRef(0);
   const normalizedCode = useMemo(() => {
     const parsed = userCodeSchema.safeParse(userCode);
     return parsed.success ? parsed.data : null;
   }, [userCode]);
-  const preview = usePreviewAuthDevice(normalizedCode);
+  const preview = usePreviewAuthDevice();
   const approve = useApproveAuthDevice();
+  const step: "enter-code" | "review" | "approved" = approved
+    ? "approved"
+    : preview.data
+      ? "review"
+      : "enter-code";
 
   useEffect(() => {
     if (isLoading || isAuthenticated) return;
-    const next = `/login/device?user_code=${encodeURIComponent(userCode)}`;
-    void navigate({ to: "/login", search: { return_to: next } });
-  }, [isAuthenticated, isLoading, navigate, userCode]);
+    void navigate({ to: "/login", search: { return_to: "/login/device" } });
+  }, [isAuthenticated, isLoading, navigate]);
+
+  function withinCooldown(): boolean {
+    const now = Date.now();
+    if (now - lastClickAtRef.current < CLICK_THROTTLE_MS) return true;
+    lastClickAtRef.current = now;
+    return false;
+  }
+
+  function resetToEnterCode() {
+    preview.reset();
+    approve.reset();
+    setSubmitError(null);
+  }
+
+  async function handleContinue() {
+    if (!normalizedCode || preview.isPending || withinCooldown()) return;
+    setSubmitError(null);
+    try {
+      await preview.mutateAsync(normalizedCode);
+    } catch (error) {
+      setSubmitError(friendlyAuthDeviceErrorMessage(error));
+    }
+  }
 
   async function handleApprove() {
-    if (!normalizedCode) {
-      setSubmitError("Enter the 8-character code from your terminal.");
-      return;
-    }
-
+    if (!normalizedCode || approve.isPending || withinCooldown()) return;
     setSubmitError(null);
     try {
       await approve.mutateAsync(normalizedCode);
@@ -123,9 +143,13 @@ export function LoginDevicePage() {
                 maxLength={VALID_CODE_LENGTH}
                 placeholder="ABCD-EFGH"
                 value={userCode}
+                disabled={
+                  step === "review" || preview.isPending || approve.isPending
+                }
                 onChange={(event) => {
                   setSubmitError(null);
                   setApproved(false);
+                  resetToEnterCode();
                   setUserCode(
                     formatAuthDeviceUserCodeInput(event.target.value),
                   );
@@ -134,26 +158,26 @@ export function LoginDevicePage() {
             </div>
 
             {submitError ? <ErrorBanner message={submitError} /> : null}
-            {!normalizedCode && userCode.length > 0 ? (
+            {!normalizedCode && userCode.replace("-", "").length === 8 ? (
               <ErrorBanner message="Enter an 8-character code using A-H, J-K, M-N, P-T, and V-Z." />
             ) : null}
             {preview.isError ? (
               <ErrorBanner
                 message={friendlyAuthDeviceErrorMessage(preview.error)}
-                onRetry={() => void preview.refetch()}
               />
             ) : null}
 
             <WarningBanner />
 
-            <PreviewPanel
-              isLoading={preview.isFetching}
-              clientLabel={preview.data?.client_label ?? null}
-              clientUserAgent={preview.data?.client_user_agent ?? null}
-              initiatedAt={preview.data?.initiated_at ?? null}
-              expiresAt={preview.data?.expires_at ?? null}
-              status={preview.data?.status ?? null}
-            />
+            {step === "review" && preview.data ? (
+              <PreviewPanel
+                clientLabel={preview.data.client_label}
+                clientUserAgent={preview.data.client_user_agent}
+                initiatedAt={preview.data.initiated_at}
+                expiresAt={preview.data.expires_at}
+                status={preview.data.status}
+              />
+            ) : null}
 
             <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
               <Button
@@ -163,18 +187,33 @@ export function LoginDevicePage() {
               >
                 Cancel
               </Button>
-              <Button
-                type="button"
-                variant="primary"
-                disabled={!normalizedCode || preview.isError}
-                isLoading={approve.isPending}
-                onClick={() => void handleApprove()}
-              >
-                <ButtonIcon variant="primary">
-                  <ShieldCheck />
-                </ButtonIcon>
-                Sign in to a CLI on that device
-              </Button>
+              {step === "enter-code" ? (
+                <Button
+                  type="button"
+                  variant="primary"
+                  disabled={!normalizedCode || preview.isPending}
+                  isLoading={preview.isPending}
+                  onClick={() => void handleContinue()}
+                >
+                  <ButtonIcon variant="primary">
+                    <ShieldCheck />
+                  </ButtonIcon>
+                  Continue
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="primary"
+                  disabled={approve.isPending}
+                  isLoading={approve.isPending}
+                  onClick={() => void handleApprove()}
+                >
+                  <ButtonIcon variant="primary">
+                    <ShieldCheck />
+                  </ButtonIcon>
+                  Approve
+                </Button>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -206,36 +245,18 @@ function WarningBanner() {
 }
 
 function PreviewPanel({
-  isLoading,
   clientLabel,
   clientUserAgent,
   initiatedAt,
   expiresAt,
   status,
 }: {
-  readonly isLoading: boolean;
   readonly clientLabel: string | null;
   readonly clientUserAgent: string | null;
   readonly initiatedAt: string | null;
   readonly expiresAt: string | null;
-  readonly status: string | null;
+  readonly status: string;
 }) {
-  if (isLoading) {
-    return (
-      <div className="rounded-xl border border-border/50 bg-white/[0.02] p-4">
-        <Skeleton className="h-20 w-full" />
-      </div>
-    );
-  }
-
-  if (!status) {
-    return (
-      <div className="rounded-xl border border-border/50 bg-white/[0.02] px-4 py-3 text-[12px] text-muted-foreground">
-        Enter the code from your terminal to preview the login request.
-      </div>
-    );
-  }
-
   return (
     <div className="rounded-xl border border-border/50 bg-white/[0.02]">
       <div className="border-b border-border/50 px-4 py-2.5">

--- a/frontend/src/pages/login-device.tsx
+++ b/frontend/src/pages/login-device.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ShieldCheck,
+  Terminal,
+} from "lucide-react";
+import { ErrorBanner } from "@/components/shared/error-banner";
+import { Button, ButtonIcon } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useApproveAuthDevice,
+  usePreviewAuthDevice,
+} from "@/hooks/use-auth-device";
+import {
+  formatAuthDeviceUserCodeInput,
+  friendlyAuthDeviceErrorMessage,
+  userCodeSchema,
+} from "@/schemas/auth-device";
+import { useAuthStore } from "@/stores/auth-store";
+
+const VALID_CODE_LENGTH = 9;
+
+export function LoginDevicePage() {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { user_code?: string };
+  const { isAuthenticated, isLoading } = useAuthStore();
+  const initialCode =
+    typeof search.user_code === "string"
+      ? formatAuthDeviceUserCodeInput(search.user_code)
+      : "";
+  const [userCode, setUserCode] = useState(initialCode);
+  const [approved, setApproved] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const normalizedCode = useMemo(() => {
+    const parsed = userCodeSchema.safeParse(userCode);
+    return parsed.success ? parsed.data : null;
+  }, [userCode]);
+  const preview = usePreviewAuthDevice(normalizedCode);
+  const approve = useApproveAuthDevice();
+
+  useEffect(() => {
+    if (isLoading || isAuthenticated) return;
+    const next = `/login/device?user_code=${encodeURIComponent(userCode)}`;
+    void navigate({ to: "/login", search: { return_to: next } });
+  }, [isAuthenticated, isLoading, navigate, userCode]);
+
+  async function handleApprove() {
+    if (!normalizedCode) {
+      setSubmitError("Enter the 8-character code from your terminal.");
+      return;
+    }
+
+    setSubmitError(null);
+    try {
+      await approve.mutateAsync(normalizedCode);
+      setApproved(true);
+    } catch (error) {
+      setSubmitError(friendlyAuthDeviceErrorMessage(error));
+    }
+  }
+
+  if (isLoading || !isAuthenticated) {
+    return (
+      <LoginDeviceShell>
+        <Card className="border-border/50">
+          <CardContent className="p-4">
+            <Skeleton className="h-52 w-full" />
+          </CardContent>
+        </Card>
+      </LoginDeviceShell>
+    );
+  }
+
+  return (
+    <LoginDeviceShell>
+      <header className="flex flex-col gap-2 text-center">
+        <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl border border-nyx-500/30 bg-nyx-500/10">
+          <Terminal className="h-4 w-4 text-nyx-secondary-400" />
+        </div>
+        <div className="space-y-1">
+          <h1 className="text-[22px] font-bold leading-tight tracking-tight text-foreground sm:text-[28px]">
+            Sign in to NyxID CLI on another device
+          </h1>
+          <p className="mx-auto max-w-md text-[12px] text-muted-foreground">
+            Confirm the one-time code shown by{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+              nyxid login --device
+            </code>
+            .
+          </p>
+        </div>
+      </header>
+
+      {approved ? (
+        <SuccessPanel />
+      ) : (
+        <Card className="border-border/50">
+          <CardHeader>
+            <CardTitle>Device login request</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="space-y-2">
+              <label
+                className="text-[10px] font-medium uppercase tracking-[1.5px] text-text-tertiary"
+                htmlFor="auth-device-code"
+              >
+                User code
+              </label>
+              <Input
+                id="auth-device-code"
+                autoComplete="one-time-code"
+                className="h-14 text-center font-mono text-[22px] tracking-[0.16em]"
+                inputMode="text"
+                maxLength={VALID_CODE_LENGTH}
+                placeholder="ABCD-EFGH"
+                value={userCode}
+                onChange={(event) => {
+                  setSubmitError(null);
+                  setApproved(false);
+                  setUserCode(
+                    formatAuthDeviceUserCodeInput(event.target.value),
+                  );
+                }}
+              />
+            </div>
+
+            {submitError ? <ErrorBanner message={submitError} /> : null}
+            {!normalizedCode && userCode.length > 0 ? (
+              <ErrorBanner message="Enter an 8-character code using A-H, J-K, M-N, P-T, and V-Z." />
+            ) : null}
+            {preview.isError ? (
+              <ErrorBanner
+                message={friendlyAuthDeviceErrorMessage(preview.error)}
+                onRetry={() => void preview.refetch()}
+              />
+            ) : null}
+
+            <WarningBanner />
+
+            <PreviewPanel
+              isLoading={preview.isFetching}
+              clientLabel={preview.data?.client_label ?? null}
+              clientUserAgent={preview.data?.client_user_agent ?? null}
+              initiatedAt={preview.data?.initiated_at ?? null}
+              expiresAt={preview.data?.expires_at ?? null}
+              status={preview.data?.status ?? null}
+            />
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void navigate({ to: "/dashboard" })}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                disabled={!normalizedCode || preview.isError}
+                isLoading={approve.isPending}
+                onClick={() => void handleApprove()}
+              >
+                <ButtonIcon variant="primary">
+                  <ShieldCheck />
+                </ButtonIcon>
+                Sign in to a CLI on that device
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </LoginDeviceShell>
+  );
+}
+
+function LoginDeviceShell({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <main className="flex min-h-dvh items-start justify-center bg-background px-4 py-8 text-foreground sm:items-center sm:py-10">
+      <div className="flex w-full max-w-xl flex-col gap-5">{children}</div>
+    </main>
+  );
+}
+
+function WarningBanner() {
+  return (
+    <div className="flex gap-3 rounded-xl border border-warning/20 bg-warning/[0.04] px-4 py-3">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-warning/10">
+        <AlertTriangle className="h-4 w-4 text-warning" />
+      </div>
+      <p className="text-[12px] leading-relaxed text-warning">
+        Only enter a code you generated yourself. If someone sent you this
+        code, cancel and start a fresh login from your own terminal.
+      </p>
+    </div>
+  );
+}
+
+function PreviewPanel({
+  isLoading,
+  clientLabel,
+  clientUserAgent,
+  initiatedAt,
+  expiresAt,
+  status,
+}: {
+  readonly isLoading: boolean;
+  readonly clientLabel: string | null;
+  readonly clientUserAgent: string | null;
+  readonly initiatedAt: string | null;
+  readonly expiresAt: string | null;
+  readonly status: string | null;
+}) {
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-border/50 bg-white/[0.02] p-4">
+        <Skeleton className="h-20 w-full" />
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className="rounded-xl border border-border/50 bg-white/[0.02] px-4 py-3 text-[12px] text-muted-foreground">
+        Enter the code from your terminal to preview the login request.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-white/[0.02]">
+      <div className="border-b border-border/50 px-4 py-2.5">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[13px] font-semibold text-foreground">
+            Request details
+          </p>
+          <span className="rounded-md border border-warning/30 bg-warning/10 px-2 py-0.5 text-[10px] font-medium capitalize text-warning">
+            {status}
+          </span>
+        </div>
+      </div>
+      <div className="divide-y divide-border/30">
+        <PreviewRow label="Client" value={clientLabel ?? "Unknown device"} />
+        <PreviewRow
+          label="User agent"
+          value={clientUserAgent ?? "Not provided"}
+          mono
+        />
+        <PreviewRow
+          label="Started"
+          value={initiatedAt ? formatStartedAt(initiatedAt) : "Unknown"}
+        />
+        <PreviewRow
+          label="Expires"
+          value={expiresAt ? formatAbsoluteTime(expiresAt) : "Unknown"}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PreviewRow({
+  label,
+  value,
+  mono = false,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly mono?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-2.5 text-[12px]">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span
+        className={
+          mono
+            ? "min-w-0 break-words text-right font-mono text-[11px] text-foreground"
+            : "min-w-0 break-words text-right font-medium text-foreground"
+        }
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function SuccessPanel() {
+  return (
+    <Card className="border-success/25 bg-success/[0.03]">
+      <CardContent className="flex flex-col items-center gap-4 p-5 text-center">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-success/30 bg-success/10">
+          <CheckCircle2 className="h-5 w-5 text-success" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-[15px] font-semibold text-foreground">
+            Signed in
+          </h2>
+          <p className="text-[12px] text-muted-foreground">
+            Return to your terminal. The CLI should finish automatically.
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link to="/settings" search={{ tab: "sessions" }}>
+            Manage sessions
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatRelativeAge(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return "just now";
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds} seconds`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours} hour${hours === 1 ? "" : "s"}`;
+}
+
+function formatStartedAt(value: string): string {
+  const relativeAge = formatRelativeAge(value);
+  return relativeAge === "just now" ? relativeAge : `${relativeAge} ago`;
+}
+
+function formatAbsoluteTime(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return "Unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(timestamp);
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -60,6 +60,7 @@ import {
   AdminInviteCodesPage,
   CliAuthPage,
   CliPairPage,
+  LoginDevicePage,
   SshTerminalPage,
   KeysPage,
   KeyDetailPage,
@@ -224,6 +225,19 @@ const cliPairRoute = createRoute({
   path: "/cli/pair",
   getParentRoute: () => rootRoute,
   component: CliPairPage,
+});
+
+const loginDeviceRoute = createRoute({
+  path: "/login/device",
+  getParentRoute: () => rootRoute,
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { readonly user_code?: string } => ({
+    ...(typeof search.user_code === "string"
+      ? { user_code: search.user_code }
+      : {}),
+  }),
+  component: LoginDevicePage,
 });
 
 const sshTerminalRoute = createRoute({
@@ -730,6 +744,7 @@ const routeTree = rootRoute.addChildren([
   docsDetailRoute,
   cliAuthRoute,
   cliPairRoute,
+  loginDeviceRoute,
   sshTerminalRoute,
   designSystemRoute,
   dashboardLayout.addChildren([

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -230,13 +230,7 @@ const cliPairRoute = createRoute({
 const loginDeviceRoute = createRoute({
   path: "/login/device",
   getParentRoute: () => rootRoute,
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { readonly user_code?: string } => ({
-    ...(typeof search.user_code === "string"
-      ? { user_code: search.user_code }
-      : {}),
-  }),
+  validateSearch: (): Record<string, never> => ({}),
   component: LoginDevicePage,
 });
 

--- a/frontend/src/schemas/auth-device.test.ts
+++ b/frontend/src/schemas/auth-device.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  approveBodySchema,
+  errorEnvelopeSchema,
+  formatAuthDeviceUserCodeInput,
+  friendlyAuthDeviceErrorMessage,
+  userCodeSchema,
+} from "./auth-device";
+
+describe("userCodeSchema", () => {
+  it("normalizes case and separators", () => {
+    expect(userCodeSchema.parse("abcd-efgh")).toBe("ABCDEFGH");
+    expect(userCodeSchema.parse("abcd efgh")).toBe("ABCDEFGH");
+    expect(userCodeSchema.parse("abCD\tefGH")).toBe("ABCDEFGH");
+  });
+
+  it("rejects 7-character and 9-character inputs", () => {
+    expect(userCodeSchema.safeParse("ABCDEFG").success).toBe(false);
+    expect(userCodeSchema.safeParse("ABCDEFGHI").success).toBe(false);
+  });
+
+  it("rejects ambiguous I, L, O, and U inputs", () => {
+    for (const char of ["I", "L", "O", "U"]) {
+      expect(userCodeSchema.safeParse(`ABCD-EFG${char}`).success).toBe(false);
+    }
+  });
+});
+
+describe("approveBodySchema", () => {
+  it("normalizes the request payload", () => {
+    expect(approveBodySchema.parse({ user_code: "abcd-efgh" })).toEqual({
+      user_code: "ABCDEFGH",
+    });
+  });
+});
+
+describe("formatAuthDeviceUserCodeInput", () => {
+  it("keeps an editable XXXX-XXXX shape while typing", () => {
+    expect(formatAuthDeviceUserCodeInput("ab")).toBe("AB");
+    expect(formatAuthDeviceUserCodeInput("abcde")).toBe("ABCD-E");
+    expect(formatAuthDeviceUserCodeInput("abcd-efgh-zz")).toBe("ABCD-EFGH");
+  });
+});
+
+describe("errorEnvelopeSchema", () => {
+  it("accepts the documented error envelope shape", () => {
+    expect(
+      errorEnvelopeSchema.parse({
+        error: "auth_device_authorization_pending",
+        error_code: 11202,
+        message: "Authorization pending.",
+      }),
+    ).toEqual({
+      error: "auth_device_authorization_pending",
+      error_code: 11202,
+      message: "Authorization pending.",
+    });
+  });
+});
+
+describe("friendlyAuthDeviceErrorMessage", () => {
+  it("maps auth-device error codes to friendly messages", () => {
+    expect(
+      friendlyAuthDeviceErrorMessage({
+        errorCode: 11200,
+        errorResponse: {
+          error: "auth_device_code_not_found",
+          error_code: 11200,
+          message: "Not found.",
+        },
+      }),
+    ).toBe("That code is no longer valid. Run `nyxid login --device` again.");
+
+    expect(
+      friendlyAuthDeviceErrorMessage({
+        errorResponse: {
+          error: "auth_device_expired_token",
+          error_code: 11201,
+          message: "Expired.",
+        },
+      }),
+    ).toBe("This code has expired.");
+
+    expect(
+      friendlyAuthDeviceErrorMessage({
+        errorCode: 11205,
+      }),
+    ).toBe("This code was already used.");
+
+    expect(
+      friendlyAuthDeviceErrorMessage({
+        errorCode: 11206,
+      }),
+    ).toBe("Too many attempts. Try again in a few minutes.");
+
+    expect(
+      friendlyAuthDeviceErrorMessage({
+        errorCode: 11207,
+      }),
+    ).toBe("That code is no longer valid. Run `nyxid login --device` again.");
+  });
+});

--- a/frontend/src/schemas/auth-device.ts
+++ b/frontend/src/schemas/auth-device.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const AUTH_DEVICE_ERROR_MESSAGES: Record<number, string> = {
+  11200: "That code is no longer valid. Run `nyxid login --device` again.",
+  11201: "This code has expired.",
+  11205: "This code was already used.",
+  11206: "Too many attempts. Try again in a few minutes.",
+  11207: "That code is no longer valid. Run `nyxid login --device` again.",
+};
+
+export const userCodeSchema = z
+  .string()
+  .transform((value) => value.replace(/[-\s]/g, "").toUpperCase())
+  .pipe(z.string().regex(/^[0-9A-HJKMNP-TV-Z]{8}$/, "Invalid code"));
+
+export const approveBodySchema = z.object({
+  user_code: userCodeSchema,
+});
+
+export const approveResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
+export const previewResponseSchema = z.object({
+  client_label: z.string().nullable(),
+  client_user_agent: z.string().nullable(),
+  initiated_at: z.string().datetime(),
+  expires_at: z.string().datetime(),
+  status: z.enum(["pending", "approved", "denied", "expired", "delivered"]),
+});
+
+export const errorEnvelopeSchema = z.object({
+  error: z.string(),
+  error_code: z.number(),
+  message: z.string(),
+});
+
+export type ApproveAuthDeviceBody = z.output<typeof approveBodySchema>;
+export type ApproveAuthDeviceResponse = z.infer<typeof approveResponseSchema>;
+export type PreviewAuthDeviceResponse = z.infer<typeof previewResponseSchema>;
+export type AuthDeviceErrorEnvelope = z.infer<typeof errorEnvelopeSchema>;
+
+export function formatAuthDeviceUserCodeInput(value: string): string {
+  const compact = value
+    .replace(/[-\s]/g, "")
+    .toUpperCase()
+    .replace(/[^0-9A-Z]/g, "")
+    .slice(0, 8);
+
+  return compact.length > 4
+    ? `${compact.slice(0, 4)}-${compact.slice(4)}`
+    : compact;
+}
+
+export function friendlyAuthDeviceErrorMessage(error: unknown): string {
+  const maybeApiError = error as {
+    readonly errorCode?: unknown;
+    readonly errorResponse?: unknown;
+    readonly message?: unknown;
+  };
+  const parsedEnvelope = errorEnvelopeSchema.safeParse(
+    maybeApiError.errorResponse,
+  );
+  const errorCode =
+    typeof maybeApiError.errorCode === "number"
+      ? maybeApiError.errorCode
+      : parsedEnvelope.success
+        ? parsedEnvelope.data.error_code
+        : null;
+
+  if (errorCode !== null && errorCode in AUTH_DEVICE_ERROR_MESSAGES) {
+    return AUTH_DEVICE_ERROR_MESSAGES[errorCode] ?? "Device login failed.";
+  }
+
+  if (parsedEnvelope.success) {
+    return parsedEnvelope.data.message;
+  }
+
+  return typeof maybeApiError.message === "string"
+    ? maybeApiError.message
+    : "Device login failed.";
+}


### PR DESCRIPTION
## Summary

Closes #971. Adds first-party device-authorization-grant login so headless boxes (WSL / SSH / containers / no `\$DISPLAY`) can authenticate without typing a password into the terminal or copy-pasting an API key. `nyxid login --device` prints a one-time code + verification URL, the user approves on any signed-in browser, the CLI receives normal first-party access + refresh tokens — same flow shape as `gh auth login` and `docker login`.

The reporter's framing of "wire up an existing flow" was rejected after audit: the existing `/devices/code/*` flow provisions an IoT Node + proxy-scoped API key, not a user session; `/cli-pairings/*` requires the CLI to already be logged in. This PR adds a small dedicated `/auth/device/*` surface instead. Rationale in the per-task commit messages and CLAUDE.md §12.

## What ships

| Layer | New / changed |
|---|---|
| Backend model | `auth_device_codes` collection (UUID id, HMAC of device_code + user_code, status state machine, atomic delivery ciphertext fields, TTL on \`expires_at\`, partial-unique on user_code for pending rows). Redacted Debug. |
| Backend errors | New \`AppError\` variants 11200-11207 with stable \`error_key\` strings and HTTP status mapping (existing \`{ error, error_code, message }\` envelope preserved — zero contract change). |
| Backend service | Generalized \`crypto::hmac_keys::derive_hmac_key(label)\` with domain separation; refactored existing \`cli_pairing_hmac_key\` to use it (byte-for-byte preserving). New \`auth_device_service\` with normalize_user_code (Crockford folds I→1, L→1, O→0, U→V), initiate, poll_and_claim (atomic via \`find_one_and_update(...).return_document(Before)\`), preview, approve (mints tokens via \`token_service::create_session_and_issue_tokens\`, encrypts via \`EncryptionKeys\`, audits, rolls back session on failure), decrypt_tokens helper. |
| Backend handlers | 4 new HTTP handlers under \`/api/v1/auth/device/{request, poll, approve, preview}\`. \`request\` + \`poll\` + \`preview\` on public router; \`approve\` on \`api_v1_human_only\` router. New \`reject_api_key_tokens\` middleware enforces the human-only mount on \`approve\` (rejects API keys, service accounts, delegated tokens before handler execution). \`preview\` is intentionally public — see Post-review refinements below. |
| Backend rate limit | 5 distinct limiters: \`auth_device_{request, poll, approve, approve_per_user, preview}_limiter\`. All trusted-proxy-aware via existing \`resolve_client_ip_for_rate_limit\`. |
| Frontend | New root route \`/login/device\` (deliberately not under \`DashboardLayout\` so the onboarding overlay can't block first-time users). Zod schemas, TanStack Query hooks, anti-phishing UI block surfacing \`client_label\` / \`client_user_agent\` / "Started N seconds ago" / warning copy. \`return_to\` used for the unauth redirect (matches existing \`/cli/pair\` pattern). |
| CLI | New \`--device\` flag on \`LoginArgs\`. Refactored \`browser::open_browser\` to return a \`Result\` so the dispatch can detect failure and fall back. Dispatch order: \`--password\` → \`--device\` → CI short-circuit (\`CI\`/\`GITHUB_ACTIONS\`/\`BUILDKITE\`/\`CIRCLECI\`/\`JENKINS_URL\`/\`GITLAB_CI\` set → exit with \`nyxid api-key\` hint, no network) → headless auto-fallback (stderr-TTY check, not stdin) → browser → device on \`BrowserLoginError::CannotOpenBrowser\`. Backward-compat: 404 from \`/auth/device/request\` → falls back to browser flow with a hint. |

## Approach + verification

Built as 7 sequential tasks (T1 model, T2 errors, T3a service core, T3b approve, T4 handlers, T5 frontend, T6 CLI, T7 E2E + docs). Each task: spec, codex implementer in its own worktree, then an independent Claude reviewer with explicit field-by-field / line-by-line verification rubric. Reviewers were Sonnet 4.6 for foundational / mechanical tasks and Opus 4.8 for crypto / auth / handler tasks.

Reviewer-applied fixes during the run (audit trail in branch history):
- T3b: \`review: add concurrent-approve rollback test\` — caught that the three failure tests all reject before token mint, so the \`updated.is_none()\` revoke branch had zero coverage; added \`approve_loser_of_concurrent_race_leaves_no_usable_session\` with \`tokio::join!\`'d concurrent approvers.
- T7: \`review: add mobile out-of-scope note to CLAUDE.md §12\` — spec required this; implementer missed it.

Codex pre-audit also caught and we fixed before any worker spawned: the wrong function name (\`auth_service::issue_tokens_for_user\` vs the real \`token_service::create_session_and_issue_tokens\`), the wrong encryption API (\`KeyProvider\` vs \`EncryptionKeys\`), an impossible row-local brute-force lockout design (moved to per-IP + per-user limiter), the single-limiter rate-limit design (split into 5), the wrong frontend redirect parameter (\`next\` vs \`return_to\`), and the wrong CLI module path (\`api_client.rs\` vs \`api.rs\`).

## Test plan

- [x] Backend: 28+ auth-device tests across model / service / handler / E2E (live Mongo). Includes:
  - HMAC domain separation
  - Concurrent atomic claim race (tokio::join! → exactly one Ready, one AlreadyDelivered)
  - Slow-down increment semantics
  - Ciphertext-fields-absent-after-delivery (direct Mongo query asserts \`\$unset\`)
  - Concurrent-approve rollback (exactly one non-revoked session survives)
  - Trusted-proxy XFF spoof rejection (security-critical)
  - API-key auth rejected on approve (mount enforcement, not handler check). Preview was originally on the same mount; post-review it moved to the public router (see refinements below), and is now covered by \`auth_device_preview_accepts_anonymous_caller\` instead.
  - Full happy path: request → approve → poll → \`/users/me\` → \`/auth/refresh\` rotation → \`/users/me\` with rotated token
  - Audit log: \`event=\"auth_device_code_approved\"\`, \`api_key_id=None\`, redacted user_code format \`AB****GH\`
- [x] Frontend: 1413 tests pass, 7 vitest specs on auth-device schemas, page renders standalone via Vite dev server
- [x] CLI: 1021 tests pass + wizard bundle freshness pass. Mock-based unit tests cover every error_code path, CI short-circuit, profile isolation under \`~/.nyxid/profiles/alt/\`, 404 fallback to browser flow, browser-open-failure fallback to device flow.
- [x] Manual smoke on a real headless terminal — **left to the author after disk cleanup**:
  - [ ] Fresh \`nyxid login --device\` end-to-end on a local box (instructions in PR thread)
  - [ ] \`DISPLAY=\"\"\` triggers auto-fallback on Linux
  - [ ] \`CI=1 nyxid login\` exits with api-key hint, no network call
  - [ ] \`/settings?tab=sessions\` shows the new session with UA \`nyxid-cli/X.Y.Z (device-code)\`
  - [ ] Revoke from \`/sessions\` invalidates the CLI within one refresh cycle
  - [ ] Existing tokens NOT invalidated by deploy (stale-session test across deploy)

## Out of scope

- Adding \`urn:ietf:params:oauth:grant-type:device_code\` to \`/oauth/token\` for third-party OAuth clients — first-party CLI ≠ third-party OAuth apps; follow-up issue.
- Mobile deep-link approval from \`/login/device\` to the existing approval app — follow-up if requested.
- Touching the existing \`/devices/code/*\` IoT/Node provisioning flow.
- Sunsetting \`--password\` or the browser flow.

## Breaking changes

None. Purely additive: new collection, new routes, new error codes, new CLI flag, new frontend root route. Existing tokens, sessions, JWT keys, env vars, password login, browser login, API keys, OAuth clients, node tokens, oracle tokens — all untouched. One behavioral change worth naming: \`nyxid login\` (no flag) on a headless Linux box used to silently hang on the never-arriving browser callback; it now auto-falls back to device flow. Escape hatch: \`NYXID_LOGIN_NO_DEVICE_FALLBACK=1\`.

## Commit graph

The branch is a series of merge commits (T1 → T2 → T3a → T3b → T4 → T5 → T6 → T7) with the per-task feat + review commits preserved underneath. Each merge subject is \`merge: T<N> <summary> (#971)\` so the audit trail is greppable. On top of T7 a small chain of follow-up commits captures the post-review refinements below:

- \`cd68d42c refactor(auth-device): GH-style flow, public preview, two-step approve\` — the substantive change (frontend two-step + auth gate, public preview mount, CLI bare URL + Y/n prompt, hook tests, backend anon-preview test).
- \`76caa3a8 fix(auth-device): collapse if-let for clippy + unbreak browser-fallback test under CI\` — clippy \`collapsible_if\` on the new if-let, plus env-lock around \`browser_open_failure_falls_back_to_device_flow\` which was failing on GH Actions (where \`CI=true\` is preset) even before this PR's refinements.
- \`3a0705c5 style(auth-device): rustfmt single-line the env-prev collect\` — one rustfmt nit.
- \`f2418d4b docs(auth-device): point AI/SSH headless examples at --device + api-key\` — final docs sweep across the AI playbook, services architecture diagram, and SSH tunneling guide.

## Post-review refinements

Single follow-up commit on the branch (`refactor(auth-device): GH-style flow, public preview, two-step approve`) tightens the UX to faithfully match `gh auth login` / `docker login`. No protocol or schema changes; same endpoints, same error codes, same tokens.

**Flow order: terminal → URL → login → code → terminal** (`gh`-style page-entry gate)

- `/login/device` is auth-gated at page mount — anonymous visitors redirect to `/login?return_to=/login/device` and bounce back after login. Removes the prior "code > login > code" loop where a typed code would have been lost on the redirect.
- Router's `validateSearch` for `/login/device` returns `{}` — any `?user_code=` query param is stripped at routing time. The frontend never reads it; the input always starts empty. Manual entry is the anti-phishing primitive.
- Two explicit clicks replace auto-firing preview:
  - **Continue** → `POST /auth/device/preview`. `usePreviewAuthDevice` is now a `useMutation`, not a `useQuery` — no fetch on typing/focus/mount/reconnect.
  - **Approve** → `POST /auth/device/approve`.
  - Both buttons disabled while their mutation is pending; both share a 750 ms client-side cooldown via `lastClickAtRef`. Input is disabled during pending preview/approve to prevent in-flight typos.

**CLI**

- Print only the bare `verification_uri` — never `verification_uri_complete` (the URL with code embedded). The CLI still receives both fields from `/auth/device/request`; the bare URL is what the human sees.
- On stdin+stderr TTYs, prompt `Open in your browser? [Y/n]`; on Enter (or `y`) call `crate::browser::open_browser`. Non-TTY contexts (CI, piped) skip the prompt and start polling immediately.

**Backend**

- `/api/v1/auth/device/preview` moved from `api_v1_human_only` to the public `auth_device_public_routes`. The response is non-sensitive — `client_label`, `client_user_agent`, and timestamps are all values the device itself supplied at `/request` time; `status` is enum-bounded. Per-IP rate limit (`auth_device_preview_limiter`) unchanged. Defense-in-depth simplification: removes one mount-coupled auth check while leaving the page gating (which is the UX-level enforcement) in place. `approve` stays human-only.

**Test coverage added**

- New backend test: `auth_device_preview_accepts_anonymous_caller` (initiates a code, posts `/preview` with `None` auth, asserts 200 + correct payload shape).
- New frontend hook tests in `frontend/src/hooks/use-auth-device.test.tsx` (8 cases):
  - `usePreviewAuthDevice`: idle on mount (no auto-fire — pins the Query→Mutation refactor), correct POST body, rejects malformed `initiated_at`, rejects unknown `status` enum, `reset()` cycles cleanly between codes.
  - `useApproveAuthDevice`: idle on mount, schema normalises `abcd-efgh` → `ABCDEFGH` before posting, rejects responses that aren't `{ok: true}`.
- Removed `auth_device_preview_rejects_api_key_auth` (no longer applies — preview is public).
- Renamed `e2e_api_key_auth_rejected_on_approve_and_preview` → `…_on_approve` and dropped its preview block.

**Test totals** (all green except one unrelated pre-existing failure):

| Suite | Result |
|---|---|
| Frontend tsc | clean |
| Frontend vitest | 1421 / 1421 (+8) |
| CLI cargo test | 1022 / 1022 |
| Backend cargo test (full) | 4382 / 4383 |
| Pre-existing failure | `proxy_resolution_integration_tests::org_member_proxy_uses_bound_org_gcp_service_account_credential` — last touched by #917, not this PR. Out of scope. |

**Docs**

- `CLAUDE.md` §12 expanded: CLI output, dispatch ladder, and "Verification page UX" bullet describing the auth gate, two-step flow, throttle, and code-stripping. Public-preview rationale updated.
- `AGENTS.md` is a symlink to `CLAUDE.md` — auto-updated.
- `docs/site/cli/getting-started/authenticate.md`: new "Headless / SSH / no browser" section.
- `docs/site/cli/reference/others.md`: documents the three login forms (browser default, `--device`, `--password`).
- `docs/site/ai/getting-started/connect-your-agent.md`: fixed a **pre-existing** doc bug referencing `--password-env NYXID_PASSWORD` (a flag that doesn't exist on `nyxid login`); replaced with the device-code recommendation.
- `docs/AI_AGENT_PLAYBOOK.md`: same `--password-env` bug fixed in the AI-agent quickstart, and §10b gained a 3-bullet callout disambiguating the three "device-code" features in NyxID (provider OAuth, **auth-device login** under `/auth/device/*`, IoT device-grant under `/devices/code/*`).
- `docs/AI_SERVICES_ARCHITECTURE.md`: mermaid CLI subgraph label now reads `nyxid login<br/>Browser SSO / --device / --password` so the diagram reflects all three flows.
- `docs/SSH_TUNNELING.md`: headless subsection updated — device-code (auto-fallback or `--device`) is the primary recommendation; API key is called out for unattended CI; `--password` is mentioned as a legacy fallback rather than the headless recommendation.
- Verified flag-agnostic (no edits needed): `README.md`, `docs/connecting-services/cli.md`, `docs/NYXID_NODE.md`, `docs/OPENCLAW_INTEGRATION.md`, `docs/AGENT_ISOLATION.md`, `docs/site/ai/getting-started/first-agent-call.md`, `docs/site/ai/guides/{agent-isolation,llms-txt-playbook}.md`, `docs/site/shared/concepts/agent-isolation.md`, `docs/TELEMETRY.md`, `docs/CLI_WIZARD_V2.md`, `docs/CLI_WIZARD_V3.md`. Out of scope (distinct feature): `docs/device-code-binding.md` (IoT binding under `/devices/code/*`).

