### PR TITLE
fix(ci): make apt-get install non-interactive in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,17 @@ jobs:
           path: target/distrib/
           merge-multiple: true
       - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
+          # cargo-dist 0.30.0 emits `apt-get install …` without `-y`, which
+          # aborts in the aarch64-linux buildpack-deps:focal container because
+          # stdin is non-interactive. Pre-configure apt to assume yes; no-op on
+          # macOS targets and unprivileged host runners (no write access to
+          # /etc/apt/apt.conf.d).
+          if [ -d /etc/apt/apt.conf.d ] && [ -w /etc/apt/apt.conf.d ]; then
+            echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/99-noninteractive
+          fi
           ${{ matrix.packages_install }}
       - name: Build artifacts
         shell: bash


### PR DESCRIPTION
## Summary

- The v0.7.1 release run ([27676032301](https://github.com/ChronoAIProject/NyxID/actions/runs/27676032301)) failed in `build-local-artifacts (aarch64-unknown-linux-gnu)` because cargo-dist 0.30.0 emits `apt-get install …` without `-y`. Inside the `buildpack-deps:focal` container stdin is non-interactive, so apt prints `Do you want to continue? [Y/n] Abort.` and exits 1, short-circuiting `build-global-artifacts`, `host`, and `announce`.
- Fix: pre-configure apt to assume yes via a one-line drop-in at `/etc/apt/apt.conf.d/99-noninteractive` and set `DEBIAN_FRONTEND=noninteractive` on the step. `matrix.packages_install` itself is unchanged.
- The `[ -d /etc/apt/apt.conf.d ] && [ -w /etc/apt/apt.conf.d ]` guard makes the change a no-op on macOS targets (no `/etc/apt`) and the x86_64 host runner (`runner` user can't write to `/etc/apt` without sudo). Only the aarch64 container, which runs as root, picks up the assume-yes default.
- `allow-dirty = ["ci"]` is already set in `Cargo.toml:25`, so this edit survives future `dist generate`.

Root cause is the cargo-dist generator, not commit `fdb323e` ("chore: bump version to 0.7.1"). That commit only bumped version strings — the latent bug landed in `c54d2116` when the `[workspace.metadata.dist.dependencies.apt]` block + aarch64 container config were added. PR runs never hit it because `build-local-artifacts` only runs on tag pushes (`publishing: true`); `v0.7.1` was the first tag pushed after that config existed.

## Test plan

- [ ] Cut a throwaway pre-release tag (e.g. `v0.7.1-test.1`) and confirm `build-local-artifacts (aarch64-unknown-linux-gnu)` succeeds end-to-end through `apt-get install`.
- [ ] Confirm `build-local-artifacts (x86_64-unknown-linux-gnu)` and both macOS targets still green (guard path).
- [ ] Confirm `build-global-artifacts`, `host`, and `announce` proceed to completion now that the matrix isn't short-circuited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)