### PR TITLE
feat(frontend): polish dashboard brand mark, favicon, and tab titles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/nyxid-app-icon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/nyxid-coloured-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <title>NyxID - Open-source Agent Connectivity Gateway</title>
     <meta name="description" content="Connect Claude, Cursor, or your own AI agents to public, internal, and localhost APIs with secure access control. Approve every connection from your phone." />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/nyxid-coloured-icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <title>NyxID - Open-source Agent Connectivity Gateway</title>
+    <title>nyxid</title>
     <meta name="description" content="Connect Claude, Cursor, or your own AI agents to public, internal, and localhost APIs with secure access control. Approve every connection from your phone." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -12,7 +12,6 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useLogout } from "@/hooks/use-auth";
 import { useShouldShowOnboarding } from "@/hooks/use-onboarding";
 import { useApplyTheme } from "@/hooks/use-theme";
-import { NyxidIcon } from "@/components/brand/nyxid-icon";
 import { NyxidLogo } from "@/components/brand/nyxid-logo";
 import { OnboardingTakeover } from "@/components/dashboard/onboarding-takeover";
 import { ThemeToggle } from "@/components/dashboard/theme-toggle";
@@ -276,18 +275,17 @@ function TopBar({
           </button>
         ) : (
           <Link to="/dashboard" className="pl-2">
-            <NyxidIcon />
+            <NyxidLogo className="h-6 w-auto" />
           </Link>
         )}
       </div>
 
-      {/* Desktop: logo zone — matches sidebar width */}
+      {/* Desktop: logo zone — fits the full brand mark; breadcrumb starts after */}
       <Link
         to="/dashboard"
-        className="hidden md:flex items-center shrink-0 justify-center w-[52px] transition-[width] duration-300 ease-in-out"
-        style={{ width: "var(--sidebar-width, 52px)", justifyContent: "start", paddingLeft: "16px" }}
+        className="hidden md:flex items-center shrink-0 pl-4 pr-2"
       >
-        <NyxidIcon className="h-5 w-5 shrink-0" />
+        <NyxidLogo className="h-5 w-auto" />
       </Link>
 
       {/* Content zone */}

--- a/frontend/src/components/layout/dashboard-layout.tsx
+++ b/frontend/src/components/layout/dashboard-layout.tsx
@@ -59,11 +59,16 @@ export function DashboardLayout() {
   const [mobileNavState, setMobileNavState] = useState<"closed" | "open" | "closing">("closed");
   const [rightPanel, setRightPanel] = useState<React.ReactNode>(null);
   const [breadcrumbLabel, setBreadcrumbLabel] = useState<string | null>(null);
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
 
   // Applies the resolved theme class to <html> on mount, reverts to dark on
   // unmount. Must run before the onboarding early-returns below to satisfy
   // rules-of-hooks.
   useApplyTheme();
+
+  useEffect(() => {
+    document.title = `nyxid - ${sectionTitleFor(pathname)}`;
+  }, [pathname]);
 
   const closeMobileNav = useCallback(() => setMobileNavState("closing"), []);
 
@@ -131,6 +136,27 @@ export function DashboardLayout() {
     </BreadcrumbLabelContext.Provider>
     </RightPanelContext.Provider>
   );
+}
+
+const SECTION_TITLES: Record<string, string> = {
+  dashboard: "dashboard",
+  keys: "ai services",
+  orgs: "org",
+  nodes: "nodes",
+  "channel-bots": "channel bots",
+  settings: "settings",
+  guide: "guide",
+  approvals: "approvals",
+  developer: "developer apps",
+  "ai-setup": "ai setup",
+  "integration-guide": "integration guide",
+  admin: "admin",
+  "design-system": "design system",
+};
+
+function sectionTitleFor(pathname: string): string {
+  const first = pathname.split("/").filter(Boolean)[0] ?? "";
+  return SECTION_TITLES[first] ?? "dashboard";
 }
 
 const SIDEBAR_ITEMS: Record<string, string> = {

--- a/frontend/src/features/docs/docs-index-page.tsx
+++ b/frontend/src/features/docs/docs-index-page.tsx
@@ -7,7 +7,7 @@ import { DOCS_TABS, DOCS_SHARED } from "./manifest";
 export function DocsIndexPage() {
   useEffect(() => {
     const prev = document.title;
-    document.title = "NyxID Documentation";
+    document.title = "nyxid - docs";
     return () => {
       document.title = prev;
     };

--- a/frontend/src/features/docs/docs-page.tsx
+++ b/frontend/src/features/docs/docs-page.tsx
@@ -196,7 +196,8 @@ export function DocsPage() {
   // Tags we create are removed on unmount; tags we only edit are restored.
   useEffect(() => {
     if (status !== "ok" || !doc) return;
-    const fullTitle = `${doc.title || known?.title || "Docs"} · NyxID Docs`;
+    const fullTitle = "nyxid - docs";
+    const ogTitle = `${doc.title || known?.title || "Docs"} · NyxID Docs`;
     const description = doc.description;
     const url = `${window.location.origin}/docs/${slug}`;
 
@@ -248,7 +249,7 @@ export function DocsPage() {
       url,
     );
     upsert('meta[property="og:type"]', ogMeta("og:type"), "content", "article");
-    upsert('meta[property="og:title"]', ogMeta("og:title"), "content", fullTitle);
+    upsert('meta[property="og:title"]', ogMeta("og:title"), "content", ogTitle);
     upsert('meta[property="og:description"]', ogMeta("og:description"), "content", description);
     upsert('meta[property="og:url"]', ogMeta("og:url"), "content", url);
     upsert('meta[name="twitter:card"]', meta("twitter:card"), "content", "summary");


### PR DESCRIPTION
## Summary

- Show the full `NyxidLogo` (mark + wordmark) in the dashboard top bar instead of the standalone `NyxidIcon`, matching how the brand renders on auth, docs, oauth consent, and legal pages.
- Switch the browser favicon from the rounded-tile app icon (designed for iOS/Android home screens) to the standalone purple N glyph (`/nyxid-coloured-icon.svg`).
- Standardize every browser-tab title on a short brand-first pattern — `nyxid - {section}` (e.g. `nyxid - ai services`, `nyxid - docs`, `nyxid - settings`) — instead of page-specific descriptions that read awkwardly when tabs are pinned or stacked. `og:title` on docs pages keeps the descriptive form so social-share previews still surface the article name.

## Test plan

- [ ] `npm --prefix frontend run dev`, log in, confirm the top bar shows the full "N NyxID" wordmark on both mobile (collapsed header) and desktop.
- [ ] Hard-refresh the tab and confirm the favicon is the standalone purple N (Chrome caches favicons aggressively — may need to close+reopen the tab).
- [ ] Navigate through `/dashboard`, `/keys`, `/orgs`, `/nodes`, `/settings`, `/docs/...` and confirm the tab title updates to `nyxid - {section}` for each.
- [ ] On a docs page, view source / inspect `<head>` and confirm `<meta property="og:title">` still contains the descriptive form (e.g. "What is AI-assisted access · NyxID Docs").

🤖 Generated with [Claude Code](https://claude.com/claude-code)