### PR TITLE
feat(oracle): deliver browser-generated images + wedge guard

### DIFF
--- a/backend/src/handlers/oracle_tasks.rs
+++ b/backend/src/handlers/oracle_tasks.rs
@@ -12,6 +12,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -84,6 +85,15 @@ pub struct ExtractResponse {
 }
 
 #[derive(Serialize)]
+pub struct OracleImageInfo {
+    pub mime: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub bytes: u64,
+    pub data_base64: String,
+}
+
+#[derive(Serialize)]
 pub struct OracleTaskInfo {
     pub task_id: String,
     pub pool_id: String,
@@ -107,6 +117,10 @@ pub struct OracleTaskInfo {
     pub response: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_chars: Option<u64>,
+    /// Images produced on an image-generation turn (bytes re-encoded as
+    /// base64 for JSON transport). Present only on the single-task GET.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<OracleImageInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chatgpt_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -183,6 +197,16 @@ fn task_info(task: &OracleTask, queue_position: u64) -> OracleTaskInfo {
         assigned_worker: task.assigned_worker_id.clone(),
         response: task.response.clone(),
         response_chars: task.response_chars,
+        images: task.images.as_ref().map(|imgs| {
+            imgs.iter()
+                .map(|im| OracleImageInfo {
+                    mime: im.mime.clone(),
+                    name: im.name.clone(),
+                    bytes: im.data.len() as u64,
+                    data_base64: base64::engine::general_purpose::STANDARD.encode(&im.data),
+                })
+                .collect()
+        }),
         chatgpt_url: task.chatgpt_url.clone(),
         failure_reason: task.failure_reason.clone(),
         created_at: task.created_at.to_rfc3339(),
@@ -512,6 +536,7 @@ mod tests {
             lease_expires_at: None,
             response: None,
             response_chars: None,
+            images: None,
             chatgpt_url: None,
             failure_reason: None,
             worker_script_version: None,

--- a/backend/src/handlers/oracle_worker.rs
+++ b/backend/src/handlers/oracle_worker.rs
@@ -128,10 +128,23 @@ pub async fn ack(
 }
 
 #[derive(Deserialize)]
+pub struct WorkerImageDto {
+    pub mime: String,
+    pub data_base64: String,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct WorkerResultRequest {
     pub task_id: String,
     pub worker: String,
     pub response: String,
+    /// Images produced on an image-generation turn (base64). Optional and
+    /// validated/capped server-side; an image-only turn sends an empty
+    /// `response` and a non-empty `images` list.
+    #[serde(default)]
+    pub images: Option<Vec<WorkerImageDto>>,
     #[serde(default)]
     pub chatgpt_url: Option<String>,
     #[serde(default)]
@@ -152,12 +165,24 @@ pub async fn submit_result(
     Json(body): Json<WorkerResultRequest>,
 ) -> AppResult<Json<WorkerResultResponse>> {
     let pool = authenticate_worker(&state, &headers).await?;
+    let req_images = body.images.unwrap_or_default();
+    let image_count = req_images.len();
+    let image_base64_chars: usize = req_images.iter().map(|i| i.data_base64.len()).sum();
+    let images: Vec<oracle_task_service::ResultImage> = req_images
+        .into_iter()
+        .map(|i| oracle_task_service::ResultImage {
+            mime: i.mime,
+            data_base64: i.data_base64,
+            name: i.name,
+        })
+        .collect();
     let outcome = oracle_task_service::worker_submit_result(
         &state.db,
         &pool,
         &body.worker,
         &body.task_id,
         &body.response,
+        images,
         body.chatgpt_url.as_deref(),
         body.model.as_deref(),
         body.script_version.as_deref(),
@@ -165,12 +190,14 @@ pub async fn submit_result(
     )
     .await?;
 
-    // Metadata-only trace: task id + outcome + size, never the body.
+    // Metadata-only trace: task id + outcome + sizes, never the body or bytes.
     tracing::info!(
         task_id = %body.task_id,
         pool_id = %pool.id,
         outcome = ?outcome,
         response_chars = body.response.chars().count(),
+        image_count,
+        image_base64_chars,
         "Oracle worker result received"
     );
 

--- a/backend/src/models/oracle_task.rs
+++ b/backend/src/models/oracle_task.rs
@@ -1,9 +1,37 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use super::bson_bytes;
 use super::bson_datetime;
 
 pub const COLLECTION_NAME: &str = "oracle_tasks";
+
+/// One image produced by the worker on an image-generation turn.
+///
+/// Bytes are stored as BSON Binary (via `bson_bytes`) rather than base64
+/// inside the document, so a few-MB image keeps the task doc well under
+/// MongoDB's 16 MB ceiling. Like prompt/response bodies, image bytes live
+/// only on the task doc and are TTL-expired via `OracleTask::expires_at`;
+/// the redacting Debug impl keeps the bytes out of logs.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OracleImage {
+    /// MIME type reported by the worker (always `image/*`).
+    pub mime: String,
+    #[serde(with = "bson_bytes::required")]
+    pub data: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl std::fmt::Debug for OracleImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OracleImage")
+            .field("mime", &self.mime)
+            .field("name", &self.name)
+            .field("bytes", &self.data.len())
+            .finish()
+    }
+}
 
 pub fn default_task_kind() -> String {
     "prompt".into()
@@ -113,6 +141,11 @@ pub struct OracleTask {
     pub response: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_chars: Option<u64>,
+    /// Images produced on an image-generation turn (bytes as BSON Binary).
+    /// An image-only turn completes with an empty `response` and a non-empty
+    /// `images` list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<OracleImage>>,
     /// Browser-side conversation URL reported by the worker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chatgpt_url: Option<String>,
@@ -169,6 +202,7 @@ mod tests {
             lease_expires_at: None,
             response: None,
             response_chars: None,
+            images: None,
             chatgpt_url: None,
             failure_reason: None,
             worker_script_version: None,

--- a/backend/src/services/oracle_task_service.rs
+++ b/backend/src/services/oracle_task_service.rs
@@ -23,7 +23,9 @@ use mongodb::options::{FindOneAndUpdateOptions, ReturnDocument};
 use crate::errors::{AppError, AppResult};
 use crate::models::oracle_pool::OraclePool;
 use crate::models::oracle_session::{COLLECTION_NAME as ORACLE_SESSIONS, OracleSession};
-use crate::models::oracle_task::{COLLECTION_NAME as ORACLE_TASKS, OracleTask, OracleTaskStatus};
+use crate::models::oracle_task::{
+    COLLECTION_NAME as ORACLE_TASKS, OracleImage, OracleTask, OracleTaskStatus,
+};
 use crate::models::oracle_worker::{
     COLLECTION_NAME as ORACLE_WORKERS, OracleWorker, worker_doc_id,
 };
@@ -32,6 +34,14 @@ use crate::services::oracle_pool_service;
 pub const MAX_PROMPT_CHARS: usize = 512_000;
 pub const MAX_PDF_BASE64_BYTES: usize = 12_000_000;
 pub const MAX_RESPONSE_CHARS: usize = 2_000_000;
+/// Result-image caps (server-authoritative; the worker self-caps lower).
+/// Decoded-byte totals are kept comfortably below the 16 MiB worker body
+/// cap (base64 inflates ~33%) and the 16 MB MongoDB document ceiling.
+pub const MAX_RESULT_IMAGES: usize = 8;
+pub const MAX_RESULT_IMAGE_BYTES: usize = 8_000_000;
+pub const MAX_RESULT_IMAGES_TOTAL_BYTES: usize = 10_000_000;
+const MAX_IMAGE_MIME_LEN: usize = 128;
+const MAX_IMAGE_NAME_LEN: usize = 256;
 const MAX_TAG_LEN: usize = 128;
 const MAX_MODEL_LABEL_LEN: usize = 128;
 const MAX_CLIENT_REF_LEN: usize = 128;
@@ -264,6 +274,7 @@ pub async fn submit_task(
         lease_expires_at: None,
         response: None,
         response_chars: None,
+        images: None,
         chatgpt_url: None,
         failure_reason: None,
         worker_script_version: None,
@@ -516,6 +527,7 @@ pub async fn extract_url(
         lease_expires_at: None,
         response: None,
         response_chars: None,
+        images: None,
         chatgpt_url: None,
         failure_reason: None,
         worker_script_version: None,
@@ -593,6 +605,7 @@ pub async fn attach_conversation(
         lease_expires_at: None,
         response: None,
         response_chars: None,
+        images: None,
         chatgpt_url: Some(chatgpt_url.to_string()),
         failure_reason: None,
         worker_script_version: None,
@@ -1077,8 +1090,56 @@ pub enum ResultOutcome {
     Ignored,
 }
 
-/// Store a worker's result. Empty or `ERROR:`-prefixed responses mark the
-/// task `failed` (extraction failure), mirroring the local oracle servers.
+/// Worker-reported image payload (base64 over the wire), validated and decoded
+/// to bytes before storage. The handler maps its request DTO to this type.
+pub struct ResultImage {
+    pub mime: String,
+    pub data_base64: String,
+    pub name: Option<String>,
+}
+
+/// Validate + decode worker images: drop non-`image/*` and undecodable entries,
+/// enforce the count cap and the per-image / aggregate decoded-byte caps.
+/// Best-effort — one malformed image is skipped, never fatal, so a bad entry
+/// can't fail an otherwise-good turn.
+fn decode_result_images(images: Vec<ResultImage>) -> Vec<OracleImage> {
+    use base64::Engine;
+    let mut out: Vec<OracleImage> = Vec::new();
+    let mut total = 0usize;
+    for img in images.into_iter().take(MAX_RESULT_IMAGES) {
+        let mime = img.mime.trim();
+        if !mime.starts_with("image/") || mime.len() > MAX_IMAGE_MIME_LEN {
+            continue;
+        }
+        let Ok(bytes) =
+            base64::engine::general_purpose::STANDARD.decode(img.data_base64.as_bytes())
+        else {
+            continue;
+        };
+        if bytes.is_empty() || bytes.len() > MAX_RESULT_IMAGE_BYTES {
+            continue;
+        }
+        if total + bytes.len() > MAX_RESULT_IMAGES_TOTAL_BYTES {
+            break;
+        }
+        total += bytes.len();
+        let name = img
+            .name
+            .map(|n| truncate_chars(&n, MAX_IMAGE_NAME_LEN))
+            .filter(|n| !n.is_empty());
+        out.push(OracleImage {
+            mime: mime.to_string(),
+            data: bytes,
+            name,
+        });
+    }
+    out
+}
+
+/// Store a worker's result. Empty/`ERROR:`-prefixed responses mark the task
+/// `failed` (extraction failure), mirroring the local oracle servers — but an
+/// image-generation turn legitimately has empty text, so a result carrying at
+/// least one valid image is treated as a success.
 #[allow(clippy::too_many_arguments)]
 pub async fn worker_submit_result(
     db: &mongodb::Database,
@@ -1086,6 +1147,7 @@ pub async fn worker_submit_result(
     worker_label: &str,
     task_id: &str,
     response: &str,
+    images: Vec<ResultImage>,
     chatgpt_url: Option<&str>,
     model: Option<&str>,
     script_version: Option<&str>,
@@ -1094,7 +1156,10 @@ pub async fn worker_submit_result(
     validate_worker_label(worker_label)?;
     let now = Utc::now();
     let trimmed = response.trim();
-    let is_failure = trimmed.is_empty() || trimmed.starts_with("ERROR:");
+    let stored_images = decode_result_images(images);
+    let has_images = !stored_images.is_empty();
+    // An image-only turn has empty text but is NOT a failure.
+    let is_failure = (trimmed.is_empty() && !has_images) || trimmed.starts_with("ERROR:");
     let stored_response = truncate_chars(response, MAX_RESPONSE_CHARS);
     let response_chars = stored_response.chars().count() as u64;
 
@@ -1106,6 +1171,26 @@ pub async fn worker_submit_result(
         "expires_at": bson::DateTime::from_chrono(terminal_expiry(retention_days)),
         "updated_at": bson::DateTime::from_chrono(now),
     };
+    if has_images {
+        // Store bytes as BSON Binary (compact) — keeps the doc under 16 MB.
+        let arr: Vec<bson::Bson> = stored_images
+            .iter()
+            .map(|im| {
+                let mut d = doc! {
+                    "mime": &im.mime,
+                    "data": bson::Binary {
+                        subtype: bson::spec::BinarySubtype::Generic,
+                        bytes: im.data.clone(),
+                    },
+                };
+                if let Some(n) = &im.name {
+                    d.insert("name", n);
+                }
+                bson::Bson::Document(d)
+            })
+            .collect();
+        set.insert("images", arr);
+    }
     if is_failure {
         set.insert(
             "failure_reason",
@@ -1317,6 +1402,7 @@ pub async fn worker_submit_transcript(
                 lease_expires_at: None,
                 response: Some(assistant_text),
                 response_chars: Some(response_chars),
+                images: None,
                 chatgpt_url: chatgpt_url
                     .filter(|u| !u.is_empty())
                     .map(|u| truncate_chars(u, MAX_URL_LEN))
@@ -1578,6 +1664,68 @@ mod tests {
     }
 
     #[test]
+    fn decode_result_images_validates_mime_caps_and_base64() {
+        use base64::Engine;
+        let b64 = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
+
+        // Valid image: kept, name truncated/echoed.
+        // Non-image mime: dropped. Bad base64: dropped.
+        // Over per-image cap: dropped.
+        let imgs = vec![
+            ResultImage {
+                mime: "image/png".to_string(),
+                data_base64: b64(b"\x89PNGabc"),
+                name: Some("apple.png".to_string()),
+            },
+            ResultImage {
+                mime: "application/pdf".to_string(),
+                data_base64: b64(b"%PDF-1.7"),
+                name: None,
+            },
+            ResultImage {
+                mime: "image/jpeg".to_string(),
+                data_base64: "not%%%base64".to_string(),
+                name: None,
+            },
+            ResultImage {
+                mime: "image/png".to_string(),
+                data_base64: b64(&vec![0u8; MAX_RESULT_IMAGE_BYTES + 1]),
+                name: None,
+            },
+        ];
+        let out = decode_result_images(imgs);
+        assert_eq!(out.len(), 1, "only the one valid image survives");
+        assert_eq!(out[0].mime, "image/png");
+        assert_eq!(out[0].data, b"\x89PNGabc");
+        assert_eq!(out[0].name.as_deref(), Some("apple.png"));
+    }
+
+    #[test]
+    fn decode_result_images_enforces_count_and_total_caps() {
+        use base64::Engine;
+        // Count cap: more than MAX_RESULT_IMAGES tiny images → truncated.
+        let many: Vec<ResultImage> = (0..(MAX_RESULT_IMAGES + 5))
+            .map(|_| ResultImage {
+                mime: "image/png".to_string(),
+                data_base64: base64::engine::general_purpose::STANDARD.encode(b"x"),
+                name: None,
+            })
+            .collect();
+        assert_eq!(decode_result_images(many).len(), MAX_RESULT_IMAGES);
+
+        // Total-bytes cap: two ~6MB images, total cap 10MB → second dropped.
+        let half = MAX_RESULT_IMAGES_TOTAL_BYTES / 2 + 1_000_000;
+        let big: Vec<ResultImage> = (0..2)
+            .map(|_| ResultImage {
+                mime: "image/png".to_string(),
+                data_base64: base64::engine::general_purpose::STANDARD.encode(vec![1u8; half]),
+                name: None,
+            })
+            .collect();
+        assert_eq!(decode_result_images(big).len(), 1);
+    }
+
+    #[test]
     fn worker_label_validation() {
         assert!(validate_worker_label("tab_1").is_ok());
         assert!(validate_worker_label("bedc-2").is_ok());
@@ -1704,6 +1852,7 @@ mod tests {
             "tab_1",
             &first.task.id,
             "The answer is 42.",
+            vec![],
             Some("https://chatgpt.com/c/abc"),
             Some("chatgpt-5.5-pro"),
             Some("v1"),
@@ -1726,6 +1875,7 @@ mod tests {
             "tab_2",
             &second.task.id,
             "ERROR: Response too short or empty",
+            vec![],
             None,
             None,
             None,
@@ -1747,6 +1897,7 @@ mod tests {
             "tab_1",
             &first.task.id,
             "stale",
+            vec![],
             None,
             None,
             None,
@@ -1872,6 +2023,7 @@ mod tests {
             "tab_1",
             &old.task.id,
             "from dead tab",
+            vec![],
             None,
             None,
             None,
@@ -1939,6 +2091,7 @@ mod tests {
             "tab_1",
             &t1.task.id,
             "turn one answer",
+            vec![],
             Some("https://chatgpt.com/c/xyz"),
             None,
             None,
@@ -2039,6 +2192,7 @@ mod tests {
             "tab_1",
             &t1.task.id,
             "turn one answer",
+            vec![],
             Some("https://chatgpt.com/c/xyz"),
             None,
             None,
@@ -2131,6 +2285,7 @@ mod tests {
             "tab_1",
             &t1.task.id,
             "turn one answer",
+            vec![],
             Some("https://chatgpt.com/c/xyz"),
             None,
             None,
@@ -2221,6 +2376,7 @@ mod tests {
             "tab_1",
             &t1.task.id,
             "ERROR: extraction failed",
+            vec![],
             Some("https://chatgpt.com/c/xyz"),
             None,
             None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3922,6 +3922,11 @@ pub enum OracleCommands {
         /// Submit and print the task id without waiting
         #[arg(long)]
         no_wait: bool,
+        /// Save any generated image(s) to this path (or directory). With
+        /// multiple images, the name is used as a prefix. Default: auto-named
+        /// `oracle-<task_id>-<n>.<ext>` in the current directory.
+        #[arg(long, value_name = "PATH")]
+        out: Option<String>,
         #[command(flatten)]
         auth: AuthArgs,
     },
@@ -3929,6 +3934,9 @@ pub enum OracleCommands {
     Result {
         /// Task id returned by `oracle ask --no-wait`
         task_id: String,
+        /// Save any generated image(s) to this path (or directory)
+        #[arg(long, value_name = "PATH")]
+        out: Option<String>,
         #[command(flatten)]
         auth: AuthArgs,
     },

--- a/cli/src/commands/oracle.rs
+++ b/cli/src/commands/oracle.rs
@@ -84,14 +84,20 @@ pub async fn run(command: OracleCommands) -> Result<()> {
                 eprintln!("Conversation: {conv}");
             }
             let task = poll_until_terminal(&mut api, &task_id, wait).await?;
-            save_result_images(output, &task, out.as_deref())?;
+            // Non-fatal: a failed image write must not swallow the text answer.
+            if let Err(e) = save_result_images(output, &task, out.as_deref()) {
+                eprintln!("warning: could not save image(s): {e:#}");
+            }
             print_result(output, &task)
         }
         OracleCommands::Result { task_id, out, auth } => {
             let output = auth.output;
             let mut api = ApiClient::from_auth_checked(&auth).await?;
             let task: Value = api.get(&format!("/oracle/tasks/{task_id}")).await?;
-            save_result_images(output, &task, out.as_deref())?;
+            // Non-fatal: a failed image write must not swallow the text answer.
+            if let Err(e) = save_result_images(output, &task, out.as_deref()) {
+                eprintln!("warning: could not save image(s): {e:#}");
+            }
             print_result(output, &task)
         }
         OracleCommands::Cancel { task_id, auth } => {

--- a/cli/src/commands/oracle.rs
+++ b/cli/src/commands/oracle.rs
@@ -35,6 +35,7 @@ pub async fn run(command: OracleCommands) -> Result<()> {
             client_ref,
             wait,
             no_wait,
+            out,
             auth,
         } => {
             let output = auth.output;
@@ -83,12 +84,14 @@ pub async fn run(command: OracleCommands) -> Result<()> {
                 eprintln!("Conversation: {conv}");
             }
             let task = poll_until_terminal(&mut api, &task_id, wait).await?;
+            save_result_images(output, &task, out.as_deref())?;
             print_result(output, &task)
         }
-        OracleCommands::Result { task_id, auth } => {
+        OracleCommands::Result { task_id, out, auth } => {
             let output = auth.output;
             let mut api = ApiClient::from_auth_checked(&auth).await?;
             let task: Value = api.get(&format!("/oracle/tasks/{task_id}")).await?;
+            save_result_images(output, &task, out.as_deref())?;
             print_result(output, &task)
         }
         OracleCommands::Cancel { task_id, auth } => {
@@ -543,6 +546,73 @@ fn print_extract_submit(output: OutputFormat, task_id: &str, submit: &Value) -> 
     Ok(())
 }
 
+fn mime_ext(mime: &str) -> &'static str {
+    match mime {
+        "image/jpeg" => "jpg",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        "image/svg+xml" => "svg",
+        _ => "png",
+    }
+}
+
+/// Resolve the on-disk path for image `idx` of `count`. With no `--out`, images
+/// are auto-named `oracle-<task_id>-<n>.<ext>` in the cwd. With `--out` and a
+/// single image, the path is used verbatim; with multiple images it becomes a
+/// prefix (`-<n>` inserted before any extension).
+fn resolve_image_path(
+    out: Option<&str>,
+    task_id: &str,
+    idx: usize,
+    count: usize,
+    ext: &str,
+) -> String {
+    match out {
+        None => format!("oracle-{task_id}-{}.{ext}", idx + 1),
+        Some(p) if count <= 1 => p.to_string(),
+        Some(p) => {
+            let slash = p.rfind('/').map(|s| s + 1).unwrap_or(0);
+            match p[slash..].rfind('.') {
+                Some(rel) => {
+                    let dot = slash + rel;
+                    format!("{}-{}{}", &p[..dot], idx + 1, &p[dot..])
+                }
+                None => format!("{p}-{}.{ext}", idx + 1),
+            }
+        }
+    }
+}
+
+/// Decode and write any images on a completed task to disk, printing the saved
+/// paths to stderr. Writes when `--out` is given, or in Table mode (JSON mode
+/// without `--out` leaves the base64 in the printed JSON instead).
+fn save_result_images(output: OutputFormat, task: &Value, out: Option<&str>) -> Result<()> {
+    let images = match task["images"].as_array() {
+        Some(a) if !a.is_empty() => a,
+        _ => return Ok(()),
+    };
+    if out.is_none() && !matches!(output, OutputFormat::Table) {
+        return Ok(());
+    }
+    let task_id = task["task_id"].as_str().unwrap_or("task");
+    let count = images.len();
+    for (i, img) in images.iter().enumerate() {
+        let b64 = img["data_base64"].as_str().unwrap_or("");
+        if b64.is_empty() {
+            continue;
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(b64.as_bytes())
+            .context("server returned undecodable image data")?;
+        let ext = mime_ext(img["mime"].as_str().unwrap_or("image/png"));
+        let path = resolve_image_path(out, task_id, i, count, ext);
+        std::fs::write(&path, &bytes)
+            .with_context(|| format!("failed to write image to {path}"))?;
+        eprintln!("Saved image to {path} ({} bytes)", bytes.len());
+    }
+    Ok(())
+}
+
 fn print_result(output: OutputFormat, task: &Value) -> Result<()> {
     match output {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(task)?),
@@ -720,6 +790,53 @@ mod tests {
     }
 
     #[test]
+    fn resolve_image_path_auto_names_without_out() {
+        assert_eq!(
+            resolve_image_path(None, "t1", 0, 1, "png"),
+            "oracle-t1-1.png"
+        );
+        assert_eq!(
+            resolve_image_path(None, "t1", 1, 2, "jpg"),
+            "oracle-t1-2.jpg"
+        );
+    }
+
+    #[test]
+    fn resolve_image_path_single_out_is_verbatim() {
+        assert_eq!(
+            resolve_image_path(Some("apple.png"), "t1", 0, 1, "png"),
+            "apple.png"
+        );
+        assert_eq!(
+            resolve_image_path(Some("out/apple.png"), "t1", 0, 1, "png"),
+            "out/apple.png"
+        );
+    }
+
+    #[test]
+    fn resolve_image_path_multi_out_is_prefix() {
+        // Extension present → -N inserted before it.
+        assert_eq!(
+            resolve_image_path(Some("apple.png"), "t1", 0, 2, "png"),
+            "apple-1.png"
+        );
+        assert_eq!(
+            resolve_image_path(Some("apple.png"), "t1", 1, 2, "png"),
+            "apple-2.png"
+        );
+        // No extension → -N.<ext> appended.
+        assert_eq!(
+            resolve_image_path(Some("apple"), "t1", 0, 2, "png"),
+            "apple-1.png"
+        );
+        // A dot only in the directory must not be treated as an extension.
+        assert_eq!(
+            resolve_image_path(Some("my.dir/apple"), "t1", 0, 2, "png"),
+            "my.dir/apple-1.png"
+        );
+    }
+
+    #[test]
     fn insert_opt_helpers_skip_none() {
         let mut body = serde_json::json!({});
         insert_opt_str(&mut body, "a", None);
@@ -770,6 +887,7 @@ mod tests {
             client_ref: None,
             wait: 3600,
             no_wait: true,
+            out: None,
             auth: mock_auth_with_output(server.uri(), OutputFormat::Json),
         })
         .await;
@@ -810,6 +928,7 @@ mod tests {
             client_ref: None,
             wait: 3600,
             no_wait: true,
+            out: None,
             auth: mock_auth_with_output(server.uri(), OutputFormat::Json),
         })
         .await
@@ -848,6 +967,7 @@ mod tests {
             client_ref: None,
             wait: 3600,
             no_wait: true,
+            out: None,
             auth: mock_auth_with_output(server.uri(), OutputFormat::Json),
         })
         .await
@@ -897,6 +1017,7 @@ mod tests {
             client_ref: None,
             wait: 30,
             no_wait: false,
+            out: None,
             auth: mock_auth_with_output(server.uri(), OutputFormat::Json),
         })
         .await
@@ -1048,6 +1169,7 @@ mod tests {
 
         let result = run(OracleCommands::Result {
             task_id: "task-x".to_string(),
+            out: None,
             // Table output is where failed status maps to an error exit.
             auth: mock_auth_with_output(server.uri(), OutputFormat::Table),
         })

--- a/integrations/oracle/cdp-worker/worker.mjs
+++ b/integrations/oracle/cdp-worker/worker.mjs
@@ -753,6 +753,11 @@ async function downloadImages(page, srcs) {
   const out = [];
   let total = 0;
   for (const src of (srcs || []).slice(0, MAX_IMAGES)) {
+    // Trust boundary (SSRF): this is where the privileged, cookie-bearing fetch
+    // happens, so enforce the content-host allowlist HERE — independent of
+    // extractImages' heuristics (its alt-based match is model-controlled and
+    // could otherwise smuggle an internal URL through). blob: is page-local.
+    if (!src.startsWith("blob:") && !/oaiusercontent|backend-api/.test(src)) continue;
     try {
       let buffer, mime;
       if (src.startsWith("blob:")) {

--- a/integrations/oracle/cdp-worker/worker.mjs
+++ b/integrations/oracle/cdp-worker/worker.mjs
@@ -286,15 +286,23 @@ window.__nyx = (function () {
     for (const img of Array.from(scope.querySelectorAll("img"))) {
       const src = img.currentSrc || img.src || "";
       if (!src || !/^(https?:|blob:)/.test(src)) continue;
-      const w = img.naturalWidth || img.width || 0;
-      const h = img.naturalHeight || img.height || 0;
+      // SSRF guard: the assistant turn is untrusted output, so only ever fetch
+      // ChatGPT's own content hosts — never a model-emitted <img src> pointing
+      // at an arbitrary/internal URL. Same allowlist downloadImages fetches.
       const looksContent =
         /oaiusercontent|backend-api|blob:/.test(src) ||
         /^generated image/i.test(img.alt || "");
-      if (!looksContent && (!w || w < 200)) continue;
+      if (!looksContent) continue;
+      const w = img.naturalWidth || img.width || 0;
+      const h = img.naturalHeight || img.height || 0;
       if (w && h && (w < 64 || h < 64)) continue;
-      if (seen.has(src)) continue;
-      seen.add(src);
+      // Dedupe by file id when present, so one generated image rendered at
+      // multiple resolutions (thumbnail/full/zoom) under different URLs
+      // collapses to a single entry; fall back to the exact src.
+      const idMatch = src.match(/file[-_][A-Za-z0-9]+/);
+      const key = idMatch ? idMatch[0] : src;
+      if (seen.has(key)) continue;
+      seen.add(key);
       out.push(src);
     }
     return out;
@@ -630,7 +638,10 @@ async function handlePrompt(page, task) {
   await input.click();
   await input.fill(task.prompt);
   await sleep(300);
-  if (task.pdf_base64) {
+  // Only attach a PDF on the FIRST turn of a conversation — never re-upload it
+  // into an existing chat if the server ever resends pdf_base64 on a follow-up
+  // (mirrors the userscript's `!is_followup && pdf_base64` guard).
+  if (!task.is_followup && task.pdf_base64) {
     await ack(task_id, "uploading_pdf");
     await uploadPdf(page, task_id, task);
   }

--- a/integrations/oracle/cdp-worker/worker.mjs
+++ b/integrations/oracle/cdp-worker/worker.mjs
@@ -39,11 +39,21 @@ const TOKEN = (() => {
 })();
 const LABEL = process.env.NYXID_WORKER_LABEL || "tab_1";
 const CDP_URL = process.env.CHROME_CDP_URL || "http://localhost:9222";
-const SCRIPT_VERSION = "cdp-1.0";
+const SCRIPT_VERSION = "cdp-1.3-image";
 const POLL_MS = Number(process.env.NYXID_POLL_MS || 5000);
 const STABLE_INTERVAL_MS = 8000;
 const MAX_WAIT_MS = Number(process.env.NYXID_MAX_WAIT_MS || 2 * 60 * 60 * 1000); // 2h
+// Wedge guard: if ChatGPT has clearly stopped (not generating) yet produced
+// nothing extractable after this long, fail the task fast and free the slot
+// instead of spinning to MAX_WAIT_MS. Mirrors the userscript's
+// NO_OUTPUT_IDLE_TIMEOUT (420s).
+const NO_OUTPUT_IDLE_MS = Number(process.env.NYXID_NO_OUTPUT_IDLE_MS || 7 * 60 * 1000);
 const HEARTBEAT_MS = 60000;
+// Result-image caps (the server re-validates and caps lower-or-equal). Kept
+// below the 16 MiB worker body cap once base64-inflated (~33%).
+const MAX_IMAGES = Number(process.env.NYXID_MAX_IMAGES || 4);
+const MAX_IMAGE_BYTES = Number(process.env.NYXID_MAX_IMAGE_BYTES || 6 * 1024 * 1024);
+const MAX_IMAGES_TOTAL_BYTES = Number(process.env.NYXID_MAX_IMAGES_TOTAL_BYTES || 9 * 1024 * 1024);
 
 if (!BASE_URL || !TOKEN) {
   console.error(
@@ -250,6 +260,46 @@ window.__nyx = (function () {
     return cleanText(extractTextWithMath(els[els.length - 1]));
   }
 
+  // Image URLs in the LATEST assistant turn (generated images). An image-gen
+  // turn renders its <img> inside a conversation-turn that does NOT carry
+  // data-message-author-role="assistant" (verified against the live DOM), so
+  // scope to the last conversation-turn — skipping it if it's the user's —
+  // and fall back to the last assistant message otherwise. Content images are
+  // matched by ChatGPT's file/CDN src patterns or a "Generated image" alt;
+  // small sprites/avatars are dropped. Dedupes the thumbnail/full/zoom copies
+  // that share one src.
+  function extractImages() {
+    const main = document.querySelector("main");
+    if (!main) return [];
+    let scope = null;
+    const turns = main.querySelectorAll('[data-testid^="conversation-turn"]');
+    if (turns.length) {
+      scope = turns[turns.length - 1];
+      if (scope.querySelector("[data-message-author-role='user']")) return [];
+    } else {
+      const els = main.querySelectorAll("[data-message-author-role='assistant']");
+      if (!els.length) return [];
+      scope = els[els.length - 1];
+    }
+    const out = [];
+    const seen = new Set();
+    for (const img of Array.from(scope.querySelectorAll("img"))) {
+      const src = img.currentSrc || img.src || "";
+      if (!src || !/^(https?:|blob:)/.test(src)) continue;
+      const w = img.naturalWidth || img.width || 0;
+      const h = img.naturalHeight || img.height || 0;
+      const looksContent =
+        /oaiusercontent|backend-api|blob:/.test(src) ||
+        /^generated image/i.test(img.alt || "");
+      if (!looksContent && (!w || w < 200)) continue;
+      if (w && h && (w < 64 || h < 64)) continue;
+      if (seen.has(src)) continue;
+      seen.add(src);
+      out.push(src);
+    }
+    return out;
+  }
+
   // Full conversation: every user/assistant turn in order.
   function extractTranscript() {
     const main = document.querySelector("main") || document.body;
@@ -283,7 +333,7 @@ window.__nyx = (function () {
     return { rendered: nodes.length, turns };
   }
 
-  return { isStillGenerating, assistantCount, extractResponse, extractTranscript, extractTranscriptKeys, scrollContainer, extractTextWithMath, cleanText };
+  return { isStillGenerating, assistantCount, extractResponse, extractImages, extractTranscript, extractTranscriptKeys, scrollContainer, extractTextWithMath, cleanText };
 })();
 `;
 
@@ -498,6 +548,48 @@ async function selectModel(page, modelLabel) {
   }
 }
 
+async function uploadPdf(page, task_id, task) {
+  if (!task.pdf_base64) return false;
+  const buffer = Buffer.from(task.pdf_base64, "base64");
+  const name = task.pdf_name || "attachment.pdf";
+  log(`uploading PDF ${name} (${(buffer.length / 1024).toFixed(0)} KB)`);
+  let fileInput = page.locator("input[type='file']").first();
+  if ((await fileInput.count()) === 0) {
+    const attach = page.locator("button[aria-label='Attach files'], button[aria-label='Upload file'], button[data-testid='composer-attach-button'], button[aria-haspopup='menu']").first();
+    if (await attach.count()) { await attach.click().catch(() => {}); await sleep(800); }
+    fileInput = page.locator("input[type='file']").first();
+  }
+  try {
+    await fileInput.setInputFiles({ name, mimeType: "application/pdf", buffer }, { timeout: 30000 });
+  } catch (e) { log(`PDF setInputFiles failed: ${e.message}`); return false; }
+  const start = Date.now();
+  let lastHeartbeat = start;
+  while (Date.now() - start < 120000) {
+    await sleep(1500);
+    // Keep the task lease warm + honor a server-side cancel during a long upload
+    // (matches the heartbeat discipline in waitForResponse).
+    if (Date.now() - lastHeartbeat >= HEARTBEAT_MS) {
+      lastHeartbeat = Date.now();
+      if (await ack(task_id, "uploading_pdf")) throw new Error("cancelled by server");
+    }
+    // Primary signal: the filename rendered in the composer attachment chip
+    // (verified against the live ChatGPT DOM). The data-testid*='file' / class
+    // fallbacks cover future DOM tweaks.
+    const { attached, uploading } = await page.evaluate((fname) => {
+      const txt = document.body.innerText || "";
+      return {
+        attached: txt.includes(fname)
+          || !!document.querySelector("[data-testid*='file'],[class*='file-chip'],[class*='attachment']")
+          || !!document.querySelector("img[alt*='pdf' i]"),
+        uploading: !!document.querySelector("[role='progressbar'],[class*='uploading']"),
+      };
+    }, name);
+    if (attached && !uploading) { log(`PDF attached (${Math.round((Date.now()-start)/1000)}s)`); return true; }
+  }
+  log("PDF upload wait timed out — sending anyway");
+  return false;
+}
+
 async function handlePrompt(page, task) {
   const { task_id } = task;
   log(`prompt task ${task_id} (followup=${!!task.is_followup})`);
@@ -538,6 +630,10 @@ async function handlePrompt(page, task) {
   await input.click();
   await input.fill(task.prompt);
   await sleep(300);
+  if (task.pdf_base64) {
+    await ack(task_id, "uploading_pdf");
+    await uploadPdf(page, task_id, task);
+  }
 
   const beforeCount = await page.evaluate(() => window.__nyx.assistantCount());
   const sendBtn = page
@@ -546,15 +642,18 @@ async function handlePrompt(page, task) {
   await sendBtn.click({ timeout: 30000 });
   await ack(task_id, "sent");
 
-  const response = await waitForResponse(page, task_id, beforeCount);
+  const { text, images } = await waitForResponse(page, task_id, beforeCount);
   const chatgpt_url = page.url();
-  if (!response || !response.trim()) {
+  const downloaded = await downloadImages(page, images);
+  // Image-only turns settle with empty text but a non-empty image list — still
+  // a success. Only an empty text AND no images is an extraction failure.
+  if ((!text || !text.trim()) && downloaded.length === 0) {
     await apiPost("/result", { task_id, worker: LABEL, response: "ERROR: empty extraction", chatgpt_url, model: task.model });
     log(`prompt ${task_id} → empty`);
     return;
   }
-  const res = await apiPost("/result", { task_id, worker: LABEL, response, chatgpt_url, model: task.model });
-  log(`prompt ${task_id} → ${res.status} (${response.length} chars)`);
+  const res = await apiPost("/result", { task_id, worker: LABEL, response: text || "", images: downloaded, chatgpt_url, model: task.model });
+  log(`prompt ${task_id} → ${res.status} (${(text || "").length} chars, ${downloaded.length} image(s))`);
 }
 
 function convId(url) {
@@ -562,6 +661,10 @@ function convId(url) {
   return m ? m[1] : null;
 }
 
+// Returns { text, images } where images is an array of on-page src strings
+// for the latest assistant turn. An image-generation turn settles with empty
+// text but a non-empty images list; the stability key spans both so the turn
+// terminates once text AND image srcs stop changing.
 async function waitForResponse(page, task_id, beforeCount) {
   const start = Date.now();
   let lastHeartbeat = start;
@@ -574,34 +677,111 @@ async function waitForResponse(page, task_id, beforeCount) {
       const cancelled = await ack(task_id, "waiting_response");
       if (cancelled) throw new Error("cancelled by server");
     }
-    const [generating, count, text] = await page.evaluate(() => [
+    const [generating, count, text, images] = await page.evaluate(() => [
       window.__nyx.isStillGenerating(),
       window.__nyx.assistantCount(),
       window.__nyx.extractResponse(),
+      window.__nyx.extractImages(),
     ]);
-    if (count <= beforeCount) continue; // answer not yet appended
+    const hasText = !!(text && text.length > 0);
+    const hasImages = Array.isArray(images) && images.length > 0;
+    // A text answer bumps the assistant-role count; an image-generation turn
+    // does NOT (its <img> lives in a conversation-turn with no assistant role),
+    // so images carry that case through. Until text or an image appears there's
+    // no new answer yet — wedge guard bails fast if ChatGPT has clearly stopped.
+    if (count <= beforeCount && !hasImages) {
+      if (!generating && Date.now() - start >= NO_OUTPUT_IDLE_MS) {
+        throw new Error("no assistant output (idle timeout)");
+      }
+      continue;
+    }
     if (generating) {
       stable = 0;
       continue;
     }
-    const key = (text || "").slice(0, 200) + "|" + (text || "").length;
-    if (key === lastKey && text && text.length > 0) {
+    if (!hasText && !hasImages) {
+      // New turn settled but produced nothing extractable (e.g. an unrenderable
+      // tool turn). Don't wedge — fail fast once the idle window elapses.
+      if (Date.now() - start >= NO_OUTPUT_IDLE_MS) {
+        throw new Error("assistant turn produced no extractable content (idle timeout)");
+      }
+      stable = 0;
+      continue;
+    }
+    const key =
+      (text || "").slice(0, 200) + "|" + (text || "").length + "|" + (images || []).join(",");
+    if (key === lastKey) {
       stable += 1;
-      if (stable >= 2) return text;
+      if (stable >= 2) return { text: text || "", images: images || [] };
     } else {
       stable = 0;
       lastKey = key;
     }
   }
-  // Timed out. Only return text if a NEW assistant message actually appeared
-  // since we sent the prompt; otherwise the latest message is stale (a
-  // previous turn), so return "" and let the server mark the task failed
-  // instead of handing back the wrong answer.
-  const [count, text] = await page.evaluate(() => [
+  // Timed out. Only return content if a NEW assistant turn actually appeared
+  // since we sent the prompt; otherwise the latest message is stale (a previous
+  // turn), so return empty and let the server mark the task failed instead of
+  // handing back the wrong answer.
+  const [count, text, images] = await page.evaluate(() => [
     window.__nyx.assistantCount(),
     window.__nyx.extractResponse(),
+    window.__nyx.extractImages(),
   ]);
-  return count > beforeCount ? text : "";
+  return count > beforeCount
+    ? { text: text || "", images: images || [] }
+    : { text: "", images: [] };
+}
+
+// Download the latest turn's images through the browser's authenticated
+// context — page.request.get carries the session cookies and isn't subject to
+// the same-origin policy, so it can read cross-origin oaiusercontent bytes a
+// page fetch() would get only as an opaque (unreadable) response. blob: URLs
+// resolve only inside the page, so those are fetched there. Returns the
+// worker-API image array; caps mirror the server (which re-validates).
+async function downloadImages(page, srcs) {
+  const out = [];
+  let total = 0;
+  for (const src of (srcs || []).slice(0, MAX_IMAGES)) {
+    try {
+      let buffer, mime;
+      if (src.startsWith("blob:")) {
+        const data = await page.evaluate(async (u) => {
+          const r = await fetch(u);
+          const b = await r.blob();
+          const buf = new Uint8Array(await b.arrayBuffer());
+          let bin = "";
+          for (let i = 0; i < buf.length; i++) bin += String.fromCharCode(buf[i]);
+          return { b64: btoa(bin), mime: b.type || "image/png" };
+        }, src);
+        buffer = Buffer.from(data.b64, "base64");
+        mime = data.mime;
+      } else {
+        const resp = await page.request.get(src, { timeout: 30000 });
+        if (!resp.ok()) {
+          log(`image fetch ${resp.status()} for ${src.slice(0, 80)}`);
+          continue;
+        }
+        buffer = await resp.body();
+        mime = (resp.headers()["content-type"] || "image/png").split(";")[0].trim();
+      }
+      if (!buffer || !buffer.length) continue;
+      if (buffer.length > MAX_IMAGE_BYTES) {
+        log(`image too large (${buffer.length}B), skipping`);
+        continue;
+      }
+      if (total + buffer.length > MAX_IMAGES_TOTAL_BYTES) {
+        log("image total cap reached, skipping remaining");
+        break;
+      }
+      total += buffer.length;
+      if (!/^image\//.test(mime)) mime = "image/png";
+      const ext = (mime.split("/")[1] || "png").replace(/[^a-z0-9]/gi, "") || "png";
+      out.push({ mime, name: `image_${out.length + 1}.${ext}`, data_base64: buffer.toString("base64") });
+    } catch (e) {
+      log(`image download failed: ${e.message}`);
+    }
+  }
+  return out;
 }
 
 // ── Scrape flow (attach existing conversation) ───────────────────────────


### PR DESCRIPTION
## Problem

A ChatGPT image-generation turn **wedged** an oracle task. The CDP worker's `waitForResponse` only terminated on stable assistant *text*, and an image-only turn produces none — so the task spun to `MAX_WAIT_MS` (2h), tied up one of the worker's inflight slots, and returned **neither the image nor any text**. (Reproduced: an apple-image prompt sat in `waiting_response` ~3.5 min until cancelled; the live worker log shows the same.)

## Changes

**Worker** (`integrations/oracle/cdp-worker/worker.mjs`)
- `extractImages()` pulls the latest turn's content image(s). Image-gen turns render `<img>` inside a `conversation-turn` that carries **no** `data-message-author-role="assistant"`, so extraction scopes to the last conversation-turn (not assistant-role) and matches only ChatGPT content-host srcs (`oaiusercontent` / `backend-api` / `blob:`). Dedupes by file id so multi-resolution copies collapse.
- `waitForResponse` now returns `{ text, images }`; images carry the terminator so an image-only turn completes. Adds a **no-output idle guard** (`NO_OUTPUT_IDLE_MS`, default 420s) so a stuck/empty turn fails fast instead of wedging — mirroring the userscript.
- `downloadImages()` fetches bytes through the browser's **authenticated context** (`page.request.get` carries session cookies, bypassing the cross-origin CORS wall a page `fetch` hits), restricted to the same content-host allowlist (SSRF guard — the assistant turn is untrusted output), capped per-image and in aggregate.

**Backend**
- `OracleImage { mime, data, name }` stored as **BSON Binary** (redacting `Debug`) — image bytes live on the task doc under the same TTL/privacy discipline as response bodies, keeping the doc under the 16 MB cap.
- `/oracle/worker/result` accepts `images[]`; `worker_submit_result` validates mime + per-image/total caps. An image-only turn (empty text + ≥1 image) is treated as a **success**, not a failure. `/tasks/{id}` returns images as base64.

**CLI**
- `oracle ask` / `oracle result --out <path>` saves generated images to disk (auto-named `oracle-<task_id>-<n>.<ext>` otherwise). Image save is **non-fatal** — a failed write warns and still prints the text answer.

### PDF upload (parity note)

This branch also carries a small **PDF-attachment** path that was in-flight on the worker before this work: `handlePrompt` calls a new `uploadPdf()` when a task has `pdf_base64`, guarded by `!is_followup` so a resent attachment never re-uploads into an existing conversation (mirrors the userscript). It reuses the existing `OracleTask.pdf_base64` / `pdf_name` fields already on `main` and the same heartbeat/cancel discipline as `waitForResponse`. It is **not** the focus of this PR and is not separately covered by the E2E below — flagging it explicitly rather than letting it land silently. Happy to split it into its own PR if preferred.

## Tests / verification

- Backend oracle tests **52/0** (incl. 2 new for image validation/caps), CLI oracle tests **17/0** (incl. 3 for `--out` path resolution). `cargo fmt --all -- --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **End-to-end** against a local backend + CDP worker driving a real logged-in Chrome: *"draw a red apple"* produced a **1254×1254 PNG** delivered all the way to disk via `--out`.

## Not in this PR / follow-ups

- The deployed `worker-tab-isolated.mjs` (URL-key variant) and the Ornn `nyxid-oracle-workers-setup` skill carry the same worker fix (published as skill v0.8); they live **outside this repo**.
- Backend must be **deployed** for prod image delivery; until then prod image turns fail-fast (no wedge) rather than hang.