### PR TITLE
fix(oracle): enforce HTTPS for the CDP worker token

### DIFF
--- a/integrations/oracle/cdp-worker/worker.mjs
+++ b/integrations/oracle/cdp-worker/worker.mjs
@@ -63,6 +63,27 @@ if (!BASE_URL || !TOKEN) {
   process.exit(1);
 }
 
+// Refuse to put the long-lived worker token on the wire in cleartext. Allow
+// https:// anywhere; allow http:// only for loopback (local dev). This is the
+// one credential-to-network risk that isn't intrinsic to the relay design.
+{
+  let u;
+  try {
+    u = new URL(BASE_URL);
+  } catch {
+    console.error(`Invalid NYXID_BASE_URL: ${BASE_URL}`);
+    process.exit(1);
+  }
+  const loopback = ["localhost", "127.0.0.1", "::1", "[::1]"].includes(u.hostname);
+  if (u.protocol !== "https:" && !(u.protocol === "http:" && loopback)) {
+    console.error(
+      `Refusing to send the worker token over ${u.protocol}//${u.hostname} — ` +
+        "use https:// (http:// is allowed only for localhost)."
+    );
+    process.exit(1);
+  }
+}
+
 const API = `${BASE_URL}/api/v1/oracle/worker`;
 
 function log(msg) {


### PR DESCRIPTION
## What

The oracle CDP worker reads a long-lived pool worker token (`nyx_owk_…`) and sends it as `Authorization: Bearer …` to `NYXID_BASE_URL`. Nothing enforced TLS, so a misconfigured `http://` base URL would transmit the token in **cleartext**.

This adds a startup guard: the worker **refuses to start** unless `NYXID_BASE_URL` is `https://` — `http://` is allowed only for loopback (`localhost`/`127.0.0.1`/`::1`) for local dev. Non-breaking: prod is already `https://`, local dev uses `localhost`.

## Why

Closes the one genuinely-reducible item from the AgentSeal trust audit of the `nyxid-oracle-workers-setup` skill (the **credential-to-network** finding). The same guard ships in the skill's bundled worker (published as **v1.0**), alongside a new `references/security.md` that documents and scopes every audit finding (credential handling, fixed HTTPS destination, host-locked image fetches, static/auditable injected DOM code, user-scoped reversible launchd install).

The remaining audit findings (credential access, system modification, injected-code) are **intrinsic** to a credentialed launchd browser-automation daemon — documented and minimized, not removable.

## Test

`node --check` + DOM_CORE parse clean. Worker verified to start against `https://` (prod) and `http://localhost` (dev), and to refuse other `http://`.