### PR TITLE
feat(oracle): general --attach-file upload (image / pdf / ...)

### DIFF
--- a/backend/src/handlers/oracle_tasks.rs
+++ b/backend/src/handlers/oracle_tasks.rs
@@ -41,6 +41,13 @@ pub struct SubmitOracleTaskRequest {
     pub pdf_base64: Option<String>,
     #[serde(default)]
     pub pdf_name: Option<String>,
+    /// Optional input file attachment (image / PDF / ..., base64) + filename,
+    /// uploaded by the worker on the first turn so the model can answer
+    /// questions about it. Mime is inferred from the filename extension.
+    #[serde(default)]
+    pub attachment_base64: Option<String>,
+    #[serde(default)]
+    pub attachment_name: Option<String>,
     /// Optional submitter-scoped idempotency key: retried submits with
     /// the same value return the original task.
     #[serde(default)]
@@ -259,6 +266,8 @@ pub async fn submit_task(
             conversation_id: body.conversation_id,
             pdf_base64: body.pdf_base64,
             pdf_name: body.pdf_name,
+            attachment_base64: body.attachment_base64,
+            attachment_name: body.attachment_name,
             client_ref: body.client_ref,
         },
     )
@@ -277,6 +286,7 @@ pub async fn submit_task(
             "is_followup": outcome.task.is_followup,
             "prompt_chars": outcome.task.prompt.chars().count(),
             "has_pdf": outcome.task.pdf_base64.is_some(),
+            "has_attachment": outcome.task.attachment_base64.is_some(),
             "deduplicated": outcome.deduplicated,
         })),
     );
@@ -523,6 +533,8 @@ mod tests {
             tag: None,
             pdf_base64: Some("cGRm".to_string()),
             pdf_name: Some("a.pdf".to_string()),
+            attachment_base64: None,
+            attachment_name: None,
             conversation_id: Some("conv_1".to_string()),
             is_followup: false,
             required_worker_label: None,

--- a/backend/src/handlers/oracle_worker.rs
+++ b/backend/src/handlers/oracle_worker.rs
@@ -329,6 +329,8 @@ mod tests {
                 tag: None,
                 pdf_base64: None,
                 pdf_name: None,
+                attachment_base64: None,
+                attachment_name: None,
                 required_project_url: None,
                 assigned_worker: "tab_1".to_string(),
                 submitted_at: "2026-06-11T00:00:00Z".to_string(),

--- a/backend/src/models/oracle_task.rs
+++ b/backend/src/models/oracle_task.rs
@@ -106,6 +106,15 @@ pub struct OracleTask {
     pub pdf_base64: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pdf_name: Option<String>,
+    /// Optional input file attachment (image / PDF / ..., base64), uploaded by
+    /// the worker on the first turn so the model can answer questions about it.
+    /// Mime is derived from `attachment_name`'s extension by the worker.
+    /// Size-capped at submit. Separate from the legacy `pdf_base64` field, which
+    /// is kept for backward compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachment_base64: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachment_name: Option<String>,
     /// Multi-turn session this task belongs to (None = single-shot).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conversation_id: Option<String>,
@@ -189,6 +198,8 @@ mod tests {
             tag: Some("bedc-deep".to_string()),
             pdf_base64: None,
             pdf_name: None,
+            attachment_base64: None,
+            attachment_name: None,
             conversation_id: None,
             is_followup: false,
             required_worker_label: None,

--- a/backend/src/services/oracle_task_service.rs
+++ b/backend/src/services/oracle_task_service.rs
@@ -135,8 +135,8 @@ fn validate_submit_input(input: &SubmitTaskInput) -> AppResult<()> {
             "pdf_name exceeds {MAX_PDF_NAME_LEN} chars"
         )));
     }
-    if let Some(image) = &input.attachment_base64 {
-        if image.len() > MAX_PDF_BASE64_BYTES {
+    if let Some(attachment) = &input.attachment_base64 {
+        if attachment.len() > MAX_PDF_BASE64_BYTES {
             return Err(AppError::OraclePayloadTooLarge(format!(
                 "attachment_base64 exceeds {MAX_PDF_BASE64_BYTES} bytes"
             )));
@@ -1672,6 +1672,23 @@ mod tests {
             ..prompt_input("p")
         };
         assert!(validate_submit_input(&pdf_without_name).is_err());
+
+        // Mirror the pdf checks for the general --attach-file path.
+        let oversized_attachment = SubmitTaskInput {
+            attachment_base64: Some("x".repeat(MAX_PDF_BASE64_BYTES + 1)),
+            attachment_name: Some("a.png".to_string()),
+            ..prompt_input("p")
+        };
+        assert!(matches!(
+            validate_submit_input(&oversized_attachment),
+            Err(AppError::OraclePayloadTooLarge(_))
+        ));
+
+        let attachment_without_name = SubmitTaskInput {
+            attachment_base64: Some("abcd".to_string()),
+            ..prompt_input("p")
+        };
+        assert!(validate_submit_input(&attachment_without_name).is_err());
 
         let long_client_ref = SubmitTaskInput {
             client_ref: Some("c".repeat(129)),

--- a/backend/src/services/oracle_task_service.rs
+++ b/backend/src/services/oracle_task_service.rs
@@ -76,6 +76,8 @@ pub struct SubmitTaskInput {
     pub conversation_id: Option<String>,
     pub pdf_base64: Option<String>,
     pub pdf_name: Option<String>,
+    pub attachment_base64: Option<String>,
+    pub attachment_name: Option<String>,
     pub client_ref: Option<String>,
 }
 
@@ -131,6 +133,31 @@ fn validate_submit_input(input: &SubmitTaskInput) -> AppResult<()> {
     {
         return Err(AppError::ValidationError(format!(
             "pdf_name exceeds {MAX_PDF_NAME_LEN} chars"
+        )));
+    }
+    if let Some(image) = &input.attachment_base64 {
+        if image.len() > MAX_PDF_BASE64_BYTES {
+            return Err(AppError::OraclePayloadTooLarge(format!(
+                "attachment_base64 exceeds {MAX_PDF_BASE64_BYTES} bytes"
+            )));
+        }
+        if input
+            .attachment_name
+            .as_deref()
+            .is_none_or(|n| n.trim().is_empty())
+        {
+            return Err(AppError::ValidationError(
+                "attachment_name is required when attachment_base64 is set".to_string(),
+            ));
+        }
+    }
+    if input
+        .attachment_name
+        .as_deref()
+        .is_some_and(|n| n.len() > MAX_PDF_NAME_LEN)
+    {
+        return Err(AppError::ValidationError(format!(
+            "attachment_name exceeds {MAX_PDF_NAME_LEN} chars"
         )));
     }
     if input.tag.as_deref().is_some_and(|t| t.len() > MAX_TAG_LEN) {
@@ -261,6 +288,8 @@ pub async fn submit_task(
         tag: input.tag,
         pdf_base64: input.pdf_base64,
         pdf_name: input.pdf_name,
+        attachment_base64: input.attachment_base64,
+        attachment_name: input.attachment_name,
         conversation_id,
         is_followup,
         required_worker_label,
@@ -514,6 +543,8 @@ pub async fn extract_url(
         tag: None,
         pdf_base64: None,
         pdf_name: None,
+        attachment_base64: None,
+        attachment_name: None,
         conversation_id: None,
         is_followup: false,
         required_worker_label: None,
@@ -592,6 +623,8 @@ pub async fn attach_conversation(
         tag,
         pdf_base64: None,
         pdf_name: None,
+        attachment_base64: None,
+        attachment_name: None,
         conversation_id: Some(session.id.clone()),
         is_followup: false,
         required_worker_label: None,
@@ -861,6 +894,10 @@ pub struct WorkerTaskPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pdf_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_base64: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required_project_url: Option<String>,
     pub assigned_worker: String,
     pub submitted_at: String,
@@ -893,6 +930,8 @@ async fn worker_payload(
         tag: task.tag.clone(),
         pdf_base64: task.pdf_base64.clone(),
         pdf_name: task.pdf_name.clone(),
+        attachment_base64: task.attachment_base64.clone(),
+        attachment_name: task.attachment_name.clone(),
         required_project_url: task
             .project_url
             .clone()
@@ -1389,6 +1428,8 @@ pub async fn worker_submit_transcript(
                 tag: scrape_task.tag.clone(),
                 pdf_base64: None,
                 pdf_name: None,
+                attachment_base64: None,
+                attachment_name: None,
                 conversation_id: Some(session_id.clone()),
                 is_followup: true,
                 required_worker_label: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -4016,7 +4016,7 @@ pub enum OracleCommands {
         pdf: Option<String>,
         /// Attach any file (image, PDF, ...) to ask about; uploaded by the
         /// worker on the first turn. Mime is inferred from the extension.
-        #[arg(long, value_name = "PATH")]
+        #[arg(long, value_name = "PATH", conflicts_with = "pdf")]
         attach_file: Option<String>,
         /// Model hint forwarded to the worker (defaults to the pool's)
         #[arg(long)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -4014,6 +4014,10 @@ pub enum OracleCommands {
         /// Attach a PDF (uploaded by the worker on the first turn)
         #[arg(long, value_name = "PATH")]
         pdf: Option<String>,
+        /// Attach any file (image, PDF, ...) to ask about; uploaded by the
+        /// worker on the first turn. Mime is inferred from the extension.
+        #[arg(long, value_name = "PATH")]
+        attach_file: Option<String>,
         /// Model hint forwarded to the worker (defaults to the pool's)
         #[arg(long)]
         model: Option<String>,

--- a/cli/src/commands/oracle.rs
+++ b/cli/src/commands/oracle.rs
@@ -27,6 +27,7 @@ pub async fn run(command: OracleCommands) -> Result<()> {
             prompt,
             file,
             pdf,
+            attach_file,
             model,
             project_url,
             tag,
@@ -64,6 +65,17 @@ pub async fn run(command: OracleCommands) -> Result<()> {
                 body["pdf_base64"] =
                     Value::String(base64::engine::general_purpose::STANDARD.encode(&bytes));
                 body["pdf_name"] = Value::String(name.to_string());
+            }
+            if let Some(file_path) = &attach_file {
+                let bytes = std::fs::read(file_path)
+                    .with_context(|| format!("Failed to read attachment at {file_path}"))?;
+                let name = std::path::Path::new(file_path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("attachment.bin");
+                body["attachment_base64"] =
+                    Value::String(base64::engine::general_purpose::STANDARD.encode(&bytes));
+                body["attachment_name"] = Value::String(name.to_string());
             }
 
             let submit: Value = api
@@ -885,6 +897,7 @@ mod tests {
             prompt: Some("what is 2+2?".to_string()),
             file: None,
             pdf: None,
+            attach_file: None,
             model: Some("chatgpt-5.5-pro".to_string()),
             project_url: None,
             tag: Some("smoke".to_string()),
@@ -926,6 +939,7 @@ mod tests {
             prompt: Some("hello".to_string()),
             file: None,
             pdf: None,
+            attach_file: None,
             model: None,
             project_url: None,
             tag: None,
@@ -965,6 +979,7 @@ mod tests {
             prompt: Some("route this prompt".to_string()),
             file: None,
             pdf: None,
+            attach_file: None,
             model: None,
             project_url: Some("https://chatgpt.com/g/g-p-task/project".to_string()),
             tag: None,
@@ -1015,6 +1030,7 @@ mod tests {
             prompt: Some("2+2?".to_string()),
             file: None,
             pdf: None,
+            attach_file: None,
             model: None,
             project_url: None,
             tag: None,

--- a/integrations/oracle/cdp-worker/worker.mjs
+++ b/integrations/oracle/cdp-worker/worker.mjs
@@ -556,6 +556,9 @@ async function selectModel(page, modelLabel) {
   }
 }
 
+// NOTE: keep this table in sync with `fileMime` in
+// integrations/oracle/nyxid_oracle.user.js (same allowlist, separate runtime —
+// the userscript can't import and the worker ships as one self-contained file).
 function fileMime(name) {
   const ext = (name.split(".").pop() || "").toLowerCase();
   return (

--- a/integrations/oracle/cdp-worker/worker.mjs
+++ b/integrations/oracle/cdp-worker/worker.mjs
@@ -556,6 +556,67 @@ async function selectModel(page, modelLabel) {
   }
 }
 
+function fileMime(name) {
+  const ext = (name.split(".").pop() || "").toLowerCase();
+  return (
+    {
+      pdf: "application/pdf",
+      png: "image/png",
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      webp: "image/webp",
+      gif: "image/gif",
+      bmp: "image/bmp",
+      svg: "image/svg+xml",
+      txt: "text/plain",
+      csv: "text/csv",
+      md: "text/markdown",
+      json: "application/json",
+    }[ext] || "application/octet-stream"
+  );
+}
+
+// Attach a general input file (image / pdf / text / ...) to the composer on the
+// first turn so the model can answer questions about it. Mime is derived from
+// the filename extension. Parallels uploadPdf; same file-input + attachment-chip
+// detection. (uploadPdf is kept for the legacy pdf_base64 field.)
+async function uploadAttachment(page, task_id, task) {
+  if (!task.attachment_base64) return false;
+  const buffer = Buffer.from(task.attachment_base64, "base64");
+  const name = task.attachment_name || "attachment.bin";
+  const mime = fileMime(name);
+  log(`uploading attachment ${name} (${(buffer.length / 1024).toFixed(0)} KB, ${mime})`);
+  let fileInput = page.locator("input[type='file']").first();
+  if ((await fileInput.count()) === 0) {
+    const attach = page.locator("button[aria-label='Attach files'], button[aria-label='Upload file'], button[data-testid='composer-attach-button'], button[aria-haspopup='menu']").first();
+    if (await attach.count()) { await attach.click().catch(() => {}); await sleep(800); }
+    fileInput = page.locator("input[type='file']").first();
+  }
+  try {
+    await fileInput.setInputFiles({ name, mimeType: mime, buffer }, { timeout: 30000 });
+  } catch (e) { log(`attachment setInputFiles failed: ${e.message}`); return false; }
+  const start = Date.now();
+  let lastHeartbeat = start;
+  while (Date.now() - start < 120000) {
+    await sleep(1500);
+    if (Date.now() - lastHeartbeat >= HEARTBEAT_MS) {
+      lastHeartbeat = Date.now();
+      if (await ack(task_id, "uploading_attachment")) throw new Error("cancelled by server");
+    }
+    const { attached, uploading } = await page.evaluate((fname) => {
+      const txt = document.body.innerText || "";
+      return {
+        attached: txt.includes(fname)
+          || !!document.querySelector("[data-testid*='file'],[class*='file-chip'],[class*='attachment']"),
+        uploading: !!document.querySelector("[role='progressbar'],[class*='uploading']"),
+      };
+    }, name);
+    if (attached && !uploading) { log(`attachment attached (${Math.round((Date.now() - start) / 1000)}s)`); return true; }
+  }
+  log("attachment upload wait timed out — sending anyway");
+  return false;
+}
+
 async function uploadPdf(page, task_id, task) {
   if (!task.pdf_base64) return false;
   const buffer = Buffer.from(task.pdf_base64, "base64");
@@ -644,6 +705,11 @@ async function handlePrompt(page, task) {
   if (!task.is_followup && task.pdf_base64) {
     await ack(task_id, "uploading_pdf");
     await uploadPdf(page, task_id, task);
+  }
+  // Same first-turn-only guard for a general attachment (image / pdf / ...).
+  if (!task.is_followup && task.attachment_base64) {
+    await ack(task_id, "uploading_attachment");
+    await uploadAttachment(page, task_id, task);
   }
 
   const beforeCount = await page.evaluate(() => window.__nyx.assistantCount());

--- a/integrations/oracle/nyxid_oracle.user.js
+++ b/integrations/oracle/nyxid_oracle.user.js
@@ -484,12 +484,35 @@
     return false;
   }
 
-  async function uploadPDF(base64Data, fileName) {
-    log(`PDF upload: ${fileName} (${(base64Data.length * 0.75 / 1024).toFixed(0)} KB)`);
+  function fileMime(name) {
+    const ext = (name.split(".").pop() || "").toLowerCase();
+    return (
+      {
+        pdf: "application/pdf",
+        png: "image/png",
+        jpg: "image/jpeg",
+        jpeg: "image/jpeg",
+        webp: "image/webp",
+        gif: "image/gif",
+        bmp: "image/bmp",
+        svg: "image/svg+xml",
+        txt: "text/plain",
+        csv: "text/csv",
+        md: "text/markdown",
+        json: "application/json",
+      }[ext] || "application/octet-stream"
+    );
+  }
+
+  // Upload any file (image / pdf / ...) to the composer; mime is derived from
+  // the filename. Also serves the legacy pdf path (a `.pdf` name → application/pdf).
+  async function uploadFile(base64Data, fileName) {
+    const mime = fileMime(fileName);
+    log(`file upload: ${fileName} (${(base64Data.length * 0.75 / 1024).toFixed(0)} KB, ${mime})`);
     const byteChars = atob(base64Data);
     const byteArray = new Uint8Array(byteChars.length);
     for (let i = 0; i < byteChars.length; i++) byteArray[i] = byteChars.charCodeAt(i);
-    const file = new File([byteArray], fileName, { type: "application/pdf" });
+    const file = new File([byteArray], fileName, { type: mime });
 
     let injected = false;
 
@@ -1697,7 +1720,7 @@
   }
 
   async function processTask(task) {
-    const { task_id, prompt, conversation_url, is_followup, conversation_id, re_extract, pdf_base64, pdf_name, tag } = task;
+    const { task_id, prompt, conversation_url, is_followup, conversation_id, re_extract, pdf_base64, pdf_name, attachment_base64, attachment_name, tag } = task;
     const noOutputIdleTimeout = (tag === "bedc-deep-board-refill")
       ? REFILL_NO_OUTPUT_IDLE_TIMEOUT
       : NO_OUTPUT_IDLE_TIMEOUT;
@@ -1931,10 +1954,19 @@
       // memory, so re-uploading is wasted work.
       if (!is_followup && pdf_base64) {
         try {
-          const ok = await uploadPDF(pdf_base64, pdf_name || "main.pdf");
+          const ok = await uploadFile(pdf_base64, pdf_name || "main.pdf");
           if (!ok) log("PDF upload failed — proceeding without PDF context");
         } catch (e) {
           log(`PDF upload exception: ${e.message} — proceeding without PDF`);
+        }
+      }
+      // General attachment (image / pdf / ...), first turn only.
+      if (!is_followup && attachment_base64) {
+        try {
+          const ok = await uploadFile(attachment_base64, attachment_name || "attachment.bin");
+          if (!ok) log("attachment upload failed — proceeding without it");
+        } catch (e) {
+          log(`attachment upload exception: ${e.message} — proceeding without it`);
         }
       }
 
@@ -2148,6 +2180,8 @@
       tag: resp.tag || "",
       pdf_base64: resp.pdf_base64 || "",
       pdf_name: resp.pdf_name || "",
+      attachment_base64: resp.attachment_base64 || "",
+      attachment_name: resp.attachment_name || "",
       // NyxID ADD: "scrape" tasks attach an existing conversation by URL —
       // navigate there, extract the whole transcript, post it back. Default
       // "prompt" preserves the normal inject-and-answer flow.

--- a/integrations/oracle/nyxid_oracle.user.js
+++ b/integrations/oracle/nyxid_oracle.user.js
@@ -484,6 +484,9 @@
     return false;
   }
 
+  // NOTE: keep this table in sync with `fileMime` in
+  // integrations/oracle/cdp-worker/worker.mjs (same allowlist, separate runtime
+  // — the userscript can't import and the worker ships as one self-contained file).
   function fileMime(name) {
     const ext = (name.split(".").pop() || "").toLowerCase();
     return (
@@ -504,10 +507,12 @@
     );
   }
 
-  // Upload any file (image / pdf / ...) to the composer; mime is derived from
-  // the filename. Also serves the legacy pdf path (a `.pdf` name → application/pdf).
-  async function uploadFile(base64Data, fileName) {
-    const mime = fileMime(fileName);
+  // Upload any file (image / pdf / ...) to the composer. Mime is derived from the
+  // filename unless `mimeOverride` is given — the legacy pdf path passes
+  // "application/pdf" so a `pdf_name` without a `.pdf` extension still uploads as
+  // a PDF (preserving the pre-refactor behavior).
+  async function uploadFile(base64Data, fileName, mimeOverride) {
+    const mime = mimeOverride || fileMime(fileName);
     log(`file upload: ${fileName} (${(base64Data.length * 0.75 / 1024).toFixed(0)} KB, ${mime})`);
     const byteChars = atob(base64Data);
     const byteArray = new Uint8Array(byteChars.length);
@@ -1954,7 +1959,7 @@
       // memory, so re-uploading is wasted work.
       if (!is_followup && pdf_base64) {
         try {
-          const ok = await uploadFile(pdf_base64, pdf_name || "main.pdf");
+          const ok = await uploadFile(pdf_base64, pdf_name || "main.pdf", "application/pdf");
           if (!ok) log("PDF upload failed — proceeding without PDF context");
         } catch (e) {
           log(`PDF upload exception: ${e.message} — proceeding without PDF`);


### PR DESCRIPTION
## What

Adds a **general input-attachment** path to `oracle ask` so a vision/document model can answer questions about an uploaded file — and keeps `--pdf` fully working.

```
nyxid oracle ask <pool> "what's in this?" --attach-file diagram.png
nyxid oracle ask <pool> "summarize" --attach-file report.pdf
nyxid oracle ask <pool> "secret token?" --pdf doc.pdf      # still works
```

## Design / naming

- **`--attach-file <PATH>`**, not `--attach` — `oracle attach` is an existing **subcommand** (import a conversation by URL); reusing "attach" as a flag would be confusing. `--file` is also taken (prompt source).
- **Backward compatible:** `--pdf` and the API's `pdf_base64`/`pdf_name` are untouched — existing callers and scripts keep working. The general path uses new `attachment_base64`/`attachment_name`; the worker keeps `uploadPdf()` for the legacy field alongside the new `uploadAttachment()`.
- Mime is inferred from the filename extension (pdf, png, jpg, webp, gif, txt, csv, md, json, …; `application/octet-stream` fallback). So `--attach-file foo.pdf` also uploads a PDF.

## Changes

- **Backend** — `attachment_base64`/`attachment_name` on the task model, `SubmitOracleTaskRequest`, `SubmitTaskInput` (validated: size cap reuses the PDF byte cap; name length cap), and the `WorkerTaskPayload` dispatch DTO. `has_attachment` added to the submit audit (metadata only).
- **CLI** — `oracle ask --attach-file <PATH>`.
- **Worker** — `uploadAttachment()` (mime from extension) + first-turn-only guard; `uploadPdf()` retained for `pdf_base64`.

## Tests

- Local CI replica green: clippy `-D warnings`, backend tests, CLI tests (1032 + wizard-bundle freshness), Rust features matrix (aws-kms / gcp-kms / both). (The frontend/SDK jobs don't apply — no frontend/SDK changes.)
- **End-to-end** (local backend + CDP worker driving ChatGPT-5.5-Pro):
  - `--pdf secret.pdf` → `BANANA-7732` (back-compat, legacy `uploadPdf`)
  - `--attach-file secret.pdf` → `BANANA-7732` (PDF via general path, `application/pdf`)
  - `--attach-file diagram.png` → transcribed a 5-box / 7-arrow architecture diagram exactly

## Follow-ups (out of scope)

- The deployed `worker-tab-isolated.mjs` + Ornn skill carry the same `uploadAttachment` (for when the backend ships); skill republish is separate.
- Prod backend must be deployed for attachment input to work against prod (this branch's backend adds the field).
- Independent of PR #1028 (worker HTTPS guard) — different code regions, no conflict.