### PR TITLE
feat(skills): publish nyxid skill as installable plugin marketplace (Claude Code / Codex / Cursor)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "nyxid",
+  "description": "NyxID skills marketplace — credential broker so agents call downstream APIs (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) without ever seeing raw keys or tokens.",
+  "owner": {
+    "name": "ChronoAIProject"
+  },
+  "plugins": [
+    {
+      "name": "nyxid",
+      "description": "Brokers credentials for downstream services through the nyxid CLI so the agent never sees raw API keys or OAuth tokens. Use to connect/add a service, set up an API key, proxy requests, or manage credentials, nodes, MCP, channels and SSH.",
+      "version": "0.5.0",
+      "source": "./",
+      "author": {
+        "name": "ChronoAIProject"
+      },
+      "homepage": "https://github.com/ChronoAIProject/NyxID"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "nyxid",
+  "description": "Brokers credentials for downstream services (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) so the agent never sees raw API keys or OAuth tokens. Thin wrapper over the nyxid CLI.",
+  "version": "0.5.0",
+  "author": {
+    "name": "ChronoAIProject"
+  },
+  "homepage": "https://github.com/ChronoAIProject/NyxID",
+  "repository": "https://github.com/ChronoAIProject/NyxID",
+  "license": "Apache-2.0",
+  "keywords": [
+    "credentials",
+    "oauth",
+    "proxy",
+    "nyxid",
+    "sso",
+    "mcp",
+    "ssh",
+    "broker"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "nyxid",
+  "version": "0.5.0",
+  "description": "Brokers credentials for downstream services (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) so the agent never sees raw API keys or OAuth tokens. Thin wrapper over the nyxid CLI.",
+  "author": {
+    "name": "ChronoAIProject",
+    "url": "https://github.com/ChronoAIProject"
+  },
+  "homepage": "https://github.com/ChronoAIProject/NyxID",
+  "repository": "https://github.com/ChronoAIProject/NyxID",
+  "license": "Apache-2.0",
+  "keywords": [
+    "credentials",
+    "oauth",
+    "proxy",
+    "nyxid",
+    "sso",
+    "mcp",
+    "ssh",
+    "broker"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "NyxID",
+    "shortDescription": "Credential broker so agents never see raw API keys or tokens.",
+    "longDescription": "NyxID is an Auth/SSO platform that brokers credentials for downstream services. The skill operates entirely through the nyxid CLI: browse the service catalog, add and configure a service, proxy requests with automatic credential injection, manage credential nodes for localhost/private-network reach, wrap REST APIs as MCP tools, and issue scoped per-agent API keys with isolation, rate limiting, and audit attribution.",
+    "developerName": "ChronoAIProject",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Connect a downstream API through NyxID so I can call it without handling the raw key."
+    ],
+    "websiteURL": "https://github.com/ChronoAIProject/NyxID"
+  }
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "nyxid",
+  "displayName": "NyxID",
+  "description": "Brokers credentials for downstream services (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) so the agent never sees raw API keys or OAuth tokens. Thin wrapper over the nyxid CLI.",
+  "version": "0.5.0",
+  "author": {
+    "name": "ChronoAIProject",
+    "url": "https://github.com/ChronoAIProject"
+  },
+  "homepage": "https://github.com/ChronoAIProject/NyxID",
+  "repository": "https://github.com/ChronoAIProject/NyxID",
+  "license": "Apache-2.0",
+  "keywords": [
+    "credentials",
+    "oauth",
+    "proxy",
+    "nyxid",
+    "sso",
+    "mcp",
+    "ssh",
+    "broker"
+  ],
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ After the CLI is installed, choose where it should log in:
 >
 > The agent reads [`skills/INSTALL.md`](skills/INSTALL.md) end-to-end. It should use the CLI installer by default and only run the Docker backend setup if you explicitly ask to self-host.
 
+> **Prefer a plugin install?** If your agent has a plugin marketplace, add the NyxID skill that way instead of copying files — it stays in sync with the repo on update. The skill still calls the `nyxid` CLI (installed above), so keep that step.
+>
+> **Claude Code**
+>
+> ```
+> /plugin marketplace add ChronoAIProject/NyxID
+> /plugin install nyxid@nyxid
+> ```
+>
+> **Codex / Cursor** — point the runtime at `https://github.com/ChronoAIProject/NyxID`; it reads `.codex-plugin/plugin.json` / `.cursor-plugin/plugin.json` and loads the bundled skills from `skills/`.
+
 #### Hosted (Recommended)
 
 Start using NyxID in under a minute — no Docker, no setup.


### PR DESCRIPTION
## Summary

Makes the existing `skills/nyxid` skill installable through each AI runtime's plugin/marketplace mechanism, mirroring the layout of [`ChronoAIProject/consensus-rnd`](https://github.com/ChronoAIProject/consensus-rnd). No skill content changed — only manifest files were added.

The skill already lived at `skills/nyxid/SKILL.md`, which is exactly where the plugin loaders scan. The only thing missing was the manifest pair (plus per-runtime equivalents).

## What's added

| File | Purpose |
|---|---|
| `.claude-plugin/marketplace.json` | Declares the `nyxid` marketplace with one plugin (`source: "./"`) |
| `.claude-plugin/plugin.json` | Claude Code plugin manifest |
| `.codex-plugin/plugin.json` | Codex manifest — exposes `./skills/` + `interface` block |
| `.cursor-plugin/plugin.json` | Cursor manifest — exposes `./skills/` |

All four validate as well-formed JSON. Manifests carry the repo's identity: name `nyxid`, version `0.5.0` (matching `SKILL.md`), `Apache-2.0` license (matching `LICENSE` / `Cargo.toml`), author `ChronoAIProject`. No personal email is embedded.

## How users install (once merged to `main`)

**Claude Code**
\`\`\`
/plugin marketplace add ChronoAIProject/NyxID
/plugin install nyxid@nyxid
\`\`\`

**Codex / Cursor** — point the runtime at the repo; it reads `.codex-plugin/` / `.cursor-plugin/` and loads `./skills/`.

The skill still shells out to the `nyxid` CLI, so users run the CLI installer + `nyxid login` afterward exactly as documented in `skills/INSTALL.md`.

## Notes / follow-ups

- `source: "./"` means `/plugin marketplace add` shallow-clones the whole monorepo just to use `skills/`. Functional but heavy; a dedicated skills repo would be the lightweight alternative (out of scope here, kept for parity with consensus-rnd).
- Gemini parity (`gemini-extension.json` + `GEMINI.md`) intentionally omitted — can add if wanted.
- Follow-up: update `skills/INSTALL.md` to document the `/plugin marketplace add` path as the primary Claude Code install.

## Test plan

- [x] All four manifests parse as valid JSON
- [x] Skill present at scanned path `skills/nyxid/SKILL.md`
- [ ] `/plugin marketplace add <local-path>` then `/plugin install nyxid@nyxid` loads `/nyxid` in Claude Code
- [ ] After merge: `/plugin marketplace add ChronoAIProject/NyxID` resolves from `main`