### PR TITLE
fix(skills): aevatar scheduler gotchas (415 content-type, payloadBase64, broker-binding gap)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nyxid",
   "description": "Brokers credentials for downstream services (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) so the agent never sees raw API keys or OAuth tokens. Thin wrapper over the nyxid CLI.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "ChronoAIProject"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nyxid",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Brokers credentials for downstream services (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) so the agent never sees raw API keys or OAuth tokens. Thin wrapper over the nyxid CLI.",
   "author": {
     "name": "ChronoAIProject",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nyxid",
   "displayName": "NyxID",
   "description": "Brokers credentials for downstream services (OpenAI, Anthropic, GitHub, Lark, custom APIs, SSH, MCP) so the agent never sees raw API keys or OAuth tokens. Thin wrapper over the nyxid CLI.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "ChronoAIProject",
     "url": "https://github.com/ChronoAIProject"

--- a/skills/aevatar-scheduler/SKILL.md
+++ b/skills/aevatar-scheduler/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-scheduler
 description: Create and manage cron schedules that fire an Aevatar service on a recurring basis, authenticated as the scope owner via NyxID — over the REST API. Use when a user wants to "schedule", "run on a cron", "set up a recurring run", "run every day/hour/Monday", "automate this service on a timer", "preview a cron", "pause/resume/disable a schedule", or "run it now". It builds the schedule against a published service (identity + endpoint + payload + serving revision), uses scope-owner NyxID auth (which requires the owner's NyxID broker binding), and covers preview, enable/disable, run-now, update, and delete. Publish the service first with the service-publisher skill.
-version: "1.4"
+version: "1.5"
 metadata:
   category: plain
   tag:
@@ -27,7 +27,10 @@ authenticated as **you** (the scope owner) through NyxID. Publish the service fi
 # token. A raw curl to the aevatar backend with ~/.nyxid/access_token resolves NO scope
 # (scopeResolved:false) and the stored token expires — it is not a usable path.
 # Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
+# NOTE: the aevatar backend requires `Content-Type: application/json` on writes (POST/PUT) —
+# omit it and every write returns HTTP 415 Unsupported Media Type. The helper sets it on
+# every call (harmless on bodyless GETs), so the POST/PUT examples below work as written.
+aev() { nyxid proxy request aevatar "$@" -H 'Content-Type: application/json'; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
 scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 ```
 
@@ -72,16 +75,45 @@ Use a real IANA `timezone`; the engine has no implicit local time.
 
 A scheduled service fire happens *later*, after your current token has expired, so the
 platform must be able to **re-mint** the scope owner's NyxID credential at fire time. That
-requires the scope owner to have an **authenticated NyxID owner binding** (the
-`urn:nyxid:scope:broker_binding` granted when you sign in through the Aevatar console /
-studio NyxID login). A plain NyxID-CLI token is **not** sufficient: creating a
-`scopeOwnerNyxId` schedule without that binding fails fast with
+requires an **authenticated NyxID owner binding** (`urn:nyxid:scope:broker_binding`),
+established by signing in through the Aevatar console / studio NyxID login (a browser PKCE
+`authorization_code` flow → `POST /api/auth/nyxid/finalize`). A plain NyxID-CLI token is
+**not** sufficient. Create-time validation does a *real* token mint, so a missing/revoked
+binding fails fast at create with one of:
 
-> HTTP 400 — "Authenticated NyxID owner binding is required for scope owner schedule auth;
-> complete or refresh NyxID login before creating a scope owner schedule."
+> HTTP 400 — "Authenticated NyxID owner binding is required for scope owner schedule auth…"
+> HTTP 400 — "NyxID binding was revoked for the scheduled subject. (Parameter 'configuration')"
 
-If you hit this, tell the user to complete/refresh their NyxID login in the Aevatar console
-(to establish the broker binding), then retry — do not try to work around it.
+**Diagnose before re-logging in** — the binding lives on the NyxID side, so check it directly:
+```bash
+NYX=$(tr -d '\n' < ~/.nyxid/base_url); TOK=$(tr -d '\n' < ~/.nyxid/access_token)
+curl -s -H "Authorization: Bearer $TOK" "$NYX/api/v1/users/me/broker-bindings" \
+  | jq -r '.bindings[] | "\(.client_name)  scopes=\(.scopes|join(","))  last_used=\(.last_used_at)"'
+```
+A non-revoked `aevatar` binding with the `proxy` scope means NyxID is healthy and the fault
+is Aevatar-side (it can be pinned to a stale binding). A **clean** console re-login (fully
+logged out first) refreshes a revoked binding — finalize replaces it on the revoked/stale
+probe path — so that usually clears it; an SSO-cached login may not re-run finalize.
+
+**There is no CLI / headless path to establish this binding** (NyxID mints broker bindings
+only via the `authorization_code` grant; the only Aevatar writer is the browser finalize).
+Tracked at **aevatarAI/aevatar#2491** — do not promise a CLI-only way to create a
+`scopeOwnerNyxId` schedule until it lands.
+
+### CLI-only alternative: skip the Aevatar scheduler entirely
+For a recurring run **without the browser console**, don't use `scopeOwnerNyxId` scheduling
+at all. The published service is already invocable — drive it from an **external timer**
+(cron, `launchd`, a node) that hits the invoke endpoint with a **non-expiring NyxID API key**
+(`nyxid api-key create --scopes proxy`; export as `NYXID_ACCESS_TOKEN`). No broker binding,
+no console:
+```bash
+NYXID_ACCESS_TOKEN="$KEY" nyxid proxy request aevatar \
+  "api/scopes/$scopeId/members/$memberId/invoke/chat:stream" -m POST --stream \
+  -H 'Content-Type: application/json' -d '{"prompt":"poll"}'
+```
+The member invoke endpoint carries `scopeId` in its path, so it runs even though a bare API
+key reports `scopeResolved:false` on the generic `api/studio/context` call. Trade-off: the
+timer runs on whatever machine you put it on (a cloud cron would live in Aevatar; this does not).
 
 ## Create the schedule
 
@@ -110,6 +142,21 @@ aev "api/schedules" -m POST -d "{
 > `revisionId` (and the service has no *active* serving revision), creation fails with
 > 400 "payloadJson requires a revisionId; provide one explicitly or activate a serving
 > revision." Pass the service's `defaultServingRevisionId`.
+
+> **Workflow-member services: use `payloadBase64`, not `payloadJson`.** A `member-<id>`
+> service produced by a Studio **bind** (the common workflow path) carries a serving
+> revision with **no protocol descriptor**, so `payloadJson` fails creation with
+> 400 "payloadTypeUrl '…ChatRequestEvent' could not be resolved: revision '…' has no
+> protocol descriptor set." The fix is to send the request as a packed proto in
+> `payloadBase64` instead — it bypasses the descriptor-based JSON encoding. The streaming
+> invoke (`…/invoke/chat:stream`) accepts the `{"prompt":"…"}` shorthand via a shim, but
+> the scheduler's typed path does not. For a `ChatRequestEvent` with `prompt` at field 1:
+> ```bash
+> # python3 -c "import base64;print(base64.b64encode(bytes([0x0a,len(p:=b'do the thing')])+p).decode())"
+> # → swap the `payloadJson` line for:  "payloadBase64": "CgxkbyB0aGUgdGhpbmc=",
+> ```
+> If your workflow ignores the prompt (e.g. a self-contained poll), any valid
+> `ChatRequestEvent` payload triggers the run.
 
 ### Auth (`serviceInvocation.auth`)
 

--- a/skills/aevatar-service-publisher/SKILL.md
+++ b/skills/aevatar-service-publisher/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-service-publisher
 description: Publish an Aevatar member, team, or workflow as an invocable service and (host permitting) register it with NyxID, then verify and invoke it — all over the REST API. Use when a user wants to "publish/bind a service", "expose my workflow/team as a service", "register it with NyxID", "make it callable", "get the service slug/URL", "invoke my service", or "version/deploy/roll out a service". It covers the simple scope binding, reading back a member's published service, the full account-level service lifecycle (revision → publish → deploy → rollout), how to confirm the NyxID registration (slug + status), and how to invoke an endpoint. Build the team/member first with the team-builder skill.
-version: "1.3"
+version: "1.4"
 metadata:
   category: plain
   tag:
@@ -28,7 +28,10 @@ You turn a member / team / workflow into an **invocable service** and verify whe
 # token. A raw curl to the aevatar backend with ~/.nyxid/access_token resolves NO scope
 # (scopeResolved:false) and the stored token expires — it is not a usable path.
 # Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
+# NOTE: the aevatar backend requires `Content-Type: application/json` on writes (POST/PUT) —
+# omit it and every write returns HTTP 415 Unsupported Media Type. The helper sets it on
+# every call (harmless on bodyless GETs), so the POST/PUT examples below work as written.
+aev() { nyxid proxy request aevatar "$@" -H 'Content-Type: application/json'; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
 scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 ```
 

--- a/skills/aevatar-team-builder/SKILL.md
+++ b/skills/aevatar-team-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-team-builder
 description: Build an Aevatar agent team and its members over the REST API. Use when a user wants to "create a team", "add a member", "make a workflow member / script member / gagent member", "set the team's entry point", or "assemble agents into a team". It creates the team, creates members whose implementation is a workflow (most common), a script, or a hosted gagent, binds each member's concrete implementation (the workflow YAML is attached here), waits for the async binding to succeed, and sets the team entry member. Author the workflow YAML first with the workflow-authoring skill; publish the result as a service with the service-publisher skill.
-version: "1.3"
+version: "1.4"
 metadata:
   category: plain
   tag:
@@ -29,7 +29,10 @@ output is an invocable team. Publishing it as a NyxID service is a separate step
 # token. A raw curl to the aevatar backend with ~/.nyxid/access_token resolves NO scope
 # (scopeResolved:false) and the stored token expires — it is not a usable path.
 # Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
+# NOTE: the aevatar backend requires `Content-Type: application/json` on writes (POST/PUT) —
+# omit it and every write returns HTTP 415 Unsupported Media Type. The helper sets it on
+# every call (harmless on bodyless GETs), so the POST/PUT examples below work as written.
+aev() { nyxid proxy request aevatar "$@" -H 'Content-Type: application/json'; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
 scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 ```
 

--- a/skills/aevatar-workflow-authoring/SKILL.md
+++ b/skills/aevatar-workflow-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-workflow-authoring
 description: Author, validate, and persist an executable aevatar workflow from a natural-language request — use it when the user wants to create, build, set up, or automate a multi-step task as a runnable aevatar workflow (make a workflow that…, automate…, build a pipeline…, set up a recurring…). It generates workflow YAML, dispatch-validates it, then saves it as a reusable workflow that can be re-run and watched in the observatory. Not for running an existing workflow — search for that and start it instead.
-version: "1.4"
+version: "1.5"
 metadata:
   category: tool-based
   tool-list:
@@ -366,7 +366,10 @@ source.)
 # auto-refreshes your token. A raw curl with ~/.nyxid/access_token resolves NO scope
 # (scopeResolved:false) and the stored token expires — it is not a usable path.
 # Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
+# NOTE: the aevatar backend requires `Content-Type: application/json` on writes (POST/PUT,
+# including the `draft-run` validation call below) — omit it and you get HTTP 415 Unsupported
+# Media Type. The helper sets it on every call (harmless on bodyless GETs).
+aev() { nyxid proxy request aevatar "$@" -H 'Content-Type: application/json'; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
 NYX=$(tr -d '\n' < ~/.nyxid/base_url)               # e.g. https://nyx.chrono-ai.fun
 scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 ```


### PR DESCRIPTION
## What

Documents the aevatar scheduler / control-plane gotchas hit while building a recurring workflow invocation end-to-end via the NyxID CLI. The skills' own copy-paste examples failed; this makes them work and adds the missing reality on scope-owner scheduling.

## Changes (skills + plugin version bump)

1. **Content-Type 415 fix** — `aevatar-scheduler`, `aevatar-team-builder`, `aevatar-service-publisher`, `aevatar-workflow-authoring`. The `aev()` bootstrap helper omitted `Content-Type: application/json`, so every `POST`/`PUT` (and the `draft-run` validation call) returned **HTTP 415 Unsupported Media Type**. The helper now sets it on all calls (harmless on bodyless GETs), so the documented examples work as written.

2. **`payloadBase64` for workflow-member schedules** — `aevatar-scheduler`. A `member-<id>` service from a Studio bind carries a serving revision with **no proto descriptor**, so the documented `payloadJson` example fails create with `"…ChatRequestEvent could not be resolved: revision '…' has no protocol descriptor set"`. Documented the `payloadBase64` workaround.

3. **Broker-binding reality** — `aevatar-scheduler`. The old "must use the console, do not work around it" framing was incomplete. Rewrote it with:
   - the NyxID `GET /api/v1/users/me/broker-bindings` **diagnostic** (attribute NyxID-healthy vs Aevatar-stale before re-logging in),
   - the **accurate** finalize behavior — a clean console re-login *does* refresh a revoked binding (finalize's revoked/stale probe path; verified against `NyxIdLoginFinalizationEndpointsTests.cs`),
   - the fact that there is **no CLI / headless path** to establish the binding (tracked at aevatarAI/aevatar#2491),
   - a **CLI-only alternative**: skip the scheduler, drive the published service from an external timer (cron / `launchd` / a node) → `…/invoke/chat:stream` with a non-expiring NyxID API key.

Plugin manifests bumped `0.6.0` → `0.6.1` (claude / cursor / codex).

## Evidence

All three reproduced live this session against the real aevatar backend (`dev`@`150ec1b`) and a real workflow-member service. The broker-binding root cause is code-grounded and filed upstream as aevatarAI/aevatar#2491.

## Note

If these skills are also published to Ornn, they'll need a re-publish to pick up the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
