### PR TITLE
fix(security): harden channel-relay access tokens against replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -418,6 +418,13 @@ JWT_ACCESS_TTL_SECS=900             # 15 minutes
 JWT_REFRESH_TTL_SECS=604800         # 7 days
 JWT_RELAY_REPLY_TTL_SECS=1800       # 30 minutes (per-callback reply token TTL)
 JWT_RELAY_CALLBACK_TTL_SECS=300     # 5 minutes (callback authentication JWT TTL)
+JWT_RELAY_ACCESS_TTL_SECS=300       # 5 minutes (X-NyxID-User-Token relay access token TTL;
+                                    # first-party bearer shipped to a bot callback URL, kept
+                                    # short vs the 900s general access token. Relay access
+                                    # tokens are usable only on proxy/LLM surfaces — rejected
+                                    # elsewhere by reject_relay_tokens — inherit the agent key's
+                                    # service/node allowlist, and are invalidated when that agent
+                                    # key is revoked (ensure_relay_agent_key_active).)
 SA_TOKEN_TTL_SECS=3600              # 1 hour (service account tokens)
 ENVIRONMENT=development
 RATE_LIMIT_PER_SECOND=10

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -39,6 +39,13 @@ pub struct AppConfig {
     pub jwt_relay_reply_ttl_secs: i64,
     /// Relay callback token TTL in seconds (default: 300 = 5 min)
     pub jwt_relay_callback_ttl_secs: i64,
+    /// Relay *access* token TTL in seconds (default: 300 = 5 min).
+    ///
+    /// This is the `X-NyxID-User-Token` shipped to a client-controlled bot
+    /// callback URL. It is a first-party bearer credential that leaves NyxID's
+    /// trust boundary, so it is kept far shorter than the general access token
+    /// TTL to bound the replay window if the callback surface is observed.
+    pub jwt_relay_access_ttl_secs: i64,
     /// Refresh token TTL in seconds (default: 604800 = 7 days)
     pub jwt_refresh_ttl_secs: i64,
 
@@ -344,6 +351,7 @@ impl std::fmt::Debug for AppConfig {
                 "jwt_relay_callback_ttl_secs",
                 &self.jwt_relay_callback_ttl_secs,
             )
+            .field("jwt_relay_access_ttl_secs", &self.jwt_relay_access_ttl_secs)
             .field("jwt_refresh_ttl_secs", &self.jwt_refresh_ttl_secs)
             .field(
                 "release_integrity_manifest_url",
@@ -686,6 +694,10 @@ impl AppConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1800),
             jwt_relay_callback_ttl_secs: env::var("JWT_RELAY_CALLBACK_TTL_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(300),
+            jwt_relay_access_ttl_secs: env::var("JWT_RELAY_ACCESS_TTL_SECS")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(300),
@@ -1233,6 +1245,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -959,6 +959,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -135,6 +135,7 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -375,7 +375,10 @@ pub fn generate_relay_access_token(
         sub: user_id.to_string(),
         iss: config.jwt_issuer.clone(),
         aud: config.base_url.clone(),
-        exp: now + config.jwt_access_ttl_secs,
+        // Relay access tokens are shipped to a client-controlled callback URL,
+        // so they use the dedicated (shorter) relay-access TTL rather than the
+        // general access-token TTL to bound the replay window on leak.
+        exp: now + config.jwt_relay_access_ttl_secs,
         iat: now,
         jti: Uuid::new_v4().to_string(),
         scope: scope.to_string(),
@@ -962,6 +965,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),
@@ -1105,6 +1109,44 @@ mod tests {
 
         let claims = verify_token(&keys, &config, &token).unwrap();
         assert_eq!(claims.exp - claims.iat, 300);
+    }
+
+    #[test]
+    fn relay_access_token_uses_relay_ttl_not_access_ttl() {
+        let (keys, config) = test_keys_and_config();
+        let user_id = Uuid::new_v4();
+        let agent_scope = RelayAgentScope {
+            api_key_id: "key-123".to_string(),
+            api_key_name: "agent".to_string(),
+            allowed_service_ids: vec!["svc-1".to_string()],
+            allowed_node_ids: vec![],
+            allow_all_services: false,
+            allow_all_nodes: true,
+        };
+        let token = generate_relay_access_token(
+            &keys,
+            &config,
+            &user_id,
+            "openid profile email proxy",
+            None,
+            &agent_scope,
+        )
+        .unwrap();
+
+        let claims = verify_token(&keys, &config, &token).unwrap();
+        assert_eq!(claims.relay, Some(true));
+        assert_eq!(claims.token_type, "access");
+        assert_eq!(claims.relay_api_key_id.as_deref(), Some("key-123"));
+        assert_eq!(claims.relay_allow_all_services, Some(false));
+        assert_eq!(
+            claims.relay_allowed_service_ids.as_deref(),
+            Some(["svc-1".to_string()].as_slice())
+        );
+        // Relay tokens are shipped to a client-controlled callback URL, so they
+        // must use the dedicated (shorter) relay-access TTL, NOT the general
+        // access-token TTL. In the test config these differ (300 vs 900).
+        assert_eq!(claims.exp - claims.iat, config.jwt_relay_access_ttl_secs);
+        assert_ne!(claims.exp - claims.iat, config.jwt_access_ttl_secs);
     }
 
     #[test]

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -280,6 +280,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/handlers/channel_relay.rs
+++ b/backend/src/handlers/channel_relay.rs
@@ -494,11 +494,30 @@ async fn resolve_reply_token_context(
     })
 }
 
+/// Reject relay access tokens (`X-NyxID-User-Token`) on the reply/edit paths.
+///
+/// A relay token carries the originating agent key's id, so without this guard
+/// it would satisfy the `conversation.agent_api_key_id == caller_api_key_id`
+/// check and be able to post/edit bot replies. Relay tokens are a first-party
+/// bearer credential that leaves NyxID's trust boundary and are scoped to
+/// proxy/LLM only; replying must use a real agent API key or the per-callback
+/// reply token (both documented in CHANNEL_BOT_RELAY.md).
+fn reject_relay_auth(auth_user: &AuthUser) -> AppResult<()> {
+    if auth_user.auth_method == crate::mw::auth::AuthMethod::Relay {
+        return Err(AppError::Forbidden(
+            "Relay tokens cannot post channel replies; use the agent API key or the per-callback reply token".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn resolve_api_key_reply_context(
     state: &AppState,
     auth_user: &AuthUser,
     body: &AsyncReplyRequest,
 ) -> AppResult<ReplyRequestContext> {
+    reject_relay_auth(auth_user)?;
+
     let original = channel_relay_service::get_message(&state.db, &body.message_id).await?;
     let conversation = load_active_conversation(state, &original.conversation_id).await?;
 
@@ -579,6 +598,8 @@ async fn resolve_api_key_edit_context(
     auth_user: &AuthUser,
     body: &UpdateReplyRequest,
 ) -> AppResult<EditRequestContext> {
+    reject_relay_auth(auth_user)?;
+
     let caller_api_key_id = auth_user.api_key_id.as_deref().ok_or_else(|| {
         AppError::Forbidden("This endpoint requires API key authentication".to_string())
     })?;
@@ -1080,6 +1101,37 @@ mod tests {
             ip_address: None,
             user_agent: None,
         }
+    }
+
+    fn auth_user_with_method(method: crate::mw::auth::AuthMethod) -> AuthUser {
+        AuthUser {
+            user_id: Uuid::new_v4(),
+            session_id: None,
+            scope: "openid profile email proxy".to_string(),
+            acting_client_id: None,
+            approval_owner_user_id: None,
+            auth_method: method,
+            allow_all_services: true,
+            allow_all_nodes: true,
+            allowed_service_ids: vec![],
+            allowed_node_ids: vec![],
+            api_key_id: Some("key-1".to_string()),
+            api_key_name: Some("agent".to_string()),
+            rate_limit_per_second: None,
+            rate_limit_burst: None,
+            ip_address: None,
+            user_agent: None,
+        }
+    }
+
+    #[test]
+    fn reject_relay_auth_blocks_relay_but_allows_api_key() {
+        use crate::mw::auth::AuthMethod;
+        // A relay token carries an agent-key id, so without this guard it would
+        // pass the conversation.agent_api_key_id equality check on the reply path.
+        assert!(reject_relay_auth(&auth_user_with_method(AuthMethod::Relay)).is_err());
+        // Genuine agent API keys and other methods are unaffected.
+        assert!(reject_relay_auth(&auth_user_with_method(AuthMethod::ApiKey)).is_ok());
     }
 
     async fn insert_reply_token_use(

--- a/backend/src/handlers/channel_webhooks.rs
+++ b/backend/src/handlers/channel_webhooks.rs
@@ -666,6 +666,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -286,6 +286,18 @@ impl McpAuthContext {
             .unwrap_or_else(|| self.user_id.clone())
     }
 
+    /// Whether this auth is stateless for MCP session purposes: it must
+    /// re-present its credential on every request rather than relying on a
+    /// persisted MCP session. API keys are stateless, and so are relay tokens
+    /// (`X-NyxID-User-Token`): a relay token must NOT be able to mint a
+    /// long-lived Session that outlives its short TTL / agent-key revocation and
+    /// silently upgrades to `AuthMethod::Session` (allow-all, approval-bypassing)
+    /// on the session-fallback path. Forcing statelessness re-runs the relay
+    /// liveness check and allowlist inheritance on every call.
+    fn is_stateless(&self) -> bool {
+        self.is_api_key || self.auth_method == AuthMethod::Relay
+    }
+
     fn approval_requester_type(&self) -> Option<&'static str> {
         match &self.auth_method {
             AuthMethod::ApiKey => Some("api_key"),
@@ -395,6 +407,21 @@ async fn authenticate_mcp(
                     return Err(mcp_403_insufficient_scope());
                 }
 
+                // Relay tokens: verify the originating agent key is still active
+                // and resolve its service/node allowlist BEFORE `claims.sub` is
+                // moved below. This MCP path previously built its auth context
+                // without reading the relay scope claims, silently treating relay
+                // tokens as unrestricted (allow_all); route it through the same
+                // shared helper the HTTP middleware uses.
+                let relay_scope = if claims.relay == Some(true) {
+                    auth::ensure_relay_agent_key_active(&state.db, &claims)
+                        .await
+                        .map_err(|_| mcp_401(&state.config.base_url))?;
+                    Some(auth::relay_scope_from_claims(&claims))
+                } else {
+                    None
+                };
+
                 // Service account tokens have sa=true; verify against
                 // the service_accounts collection instead of users.
                 let (user_id, approval_owner_user_id) = if claims.sa == Some(true) {
@@ -416,6 +443,22 @@ async fn authenticate_mcp(
                 };
 
                 let mut ctx = McpAuthContext::user(user_id, auth_method);
+                if let Some((
+                    allow_all_services,
+                    allow_all_nodes,
+                    allowed_service_ids,
+                    allowed_node_ids,
+                    api_key_id,
+                    api_key_name,
+                )) = relay_scope
+                {
+                    ctx.allow_all_services = allow_all_services;
+                    ctx.allow_all_nodes = allow_all_nodes;
+                    ctx.allowed_service_ids = allowed_service_ids;
+                    ctx.allowed_node_ids = allowed_node_ids;
+                    ctx.api_key_id = api_key_id;
+                    ctx.api_key_name = api_key_name;
+                }
                 ctx.acting_client_id = claims.act.map(|a| a.sub);
                 ctx.approval_owner_user_id = approval_owner_user_id;
                 ctx.ip_address = request_ip.clone();
@@ -641,7 +684,7 @@ pub async fn mcp_post(State(state): State<AppState>, headers: HeaderMap, body: S
                 &state,
                 &user_id,
                 &request,
-                auth.is_api_key,
+                auth.is_stateless(),
                 auth.api_key_id.as_deref(),
                 auth.api_key_name.as_deref(),
                 auth.ip_address.as_deref(),
@@ -694,8 +737,9 @@ fn app_error_to_rpc(id: Option<serde_json::Value>, err: &crate::errors::AppError
 /// Resolve the MCP session for a request.
 ///
 /// For OAuth/JWT/session auth: session is required and validated against user_id.
-/// For API-key auth: session is optional. If the header is present it must be
-/// valid; if absent the request proceeds statelessly (returns `None`).
+/// For stateless auth (API keys and relay tokens): session is optional. If the
+/// header is present it must be valid; if absent the request proceeds
+/// statelessly (returns `None`), re-authenticating on every call.
 #[allow(clippy::result_large_err)]
 fn resolve_session(
     state: &AppState,
@@ -706,7 +750,7 @@ fn resolve_session(
 ) -> Result<Option<String>, Response> {
     let raw_sid = headers.get("mcp-session-id").and_then(|v| v.to_str().ok());
 
-    match (auth.is_api_key, raw_sid) {
+    match (auth.is_stateless(), raw_sid) {
         (true, None) => Ok(None),
         (true, Some(sid)) => {
             let sid = sid.to_string();
@@ -740,9 +784,10 @@ pub async fn mcp_get(State(state): State<AppState>, headers: HeaderMap) -> Respo
         return app_error_to_rpc(None, &e);
     }
 
-    // API-key requests without a session have nothing to stream: return empty
-    // keep-alive SSE rather than 400. Real clients use POST /mcp for each call.
-    if auth.is_api_key && headers.get("mcp-session-id").is_none() {
+    // Stateless (API-key / relay) requests without a session have nothing to
+    // stream: return empty keep-alive SSE rather than 400. Real clients use
+    // POST /mcp for each call.
+    if auth.is_stateless() && headers.get("mcp-session-id").is_none() {
         let stream = tokio_stream::empty::<Result<Event, Infallible>>();
         return Sse::new(stream)
             .keep_alive(
@@ -812,8 +857,9 @@ pub async fn mcp_delete(State(state): State<AppState>, headers: HeaderMap) -> Re
         return app_error_to_rpc(None, &e);
     }
 
-    // API-key request without a session: nothing to delete, return 204.
-    if auth.is_api_key && headers.get("mcp-session-id").is_none() {
+    // Stateless (API-key / relay) request without a session: nothing to delete,
+    // return 204.
+    if auth.is_stateless() && headers.get("mcp-session-id").is_none() {
         return StatusCode::NO_CONTENT.into_response();
     }
 
@@ -895,16 +941,19 @@ fn handle_initialize(
     state: &AppState,
     user_id: &str,
     request: &JsonRpcRequest,
-    is_api_key: bool,
+    stateless: bool,
     api_key_id: Option<&str>,
     api_key_name: Option<&str>,
     ip_address: Option<&str>,
     user_agent: Option<&str>,
     tele: &TelemetryContext,
 ) -> Response {
-    // API-key auth is stateless: each request authenticates independently,
-    // so no MCP session is created on initialize.
-    let session_id = if is_api_key {
+    // Stateless auth (API keys and relay tokens) authenticates independently on
+    // every request, so no MCP session is created on initialize. This is what
+    // stops a relay token from minting a Session it could later replay as
+    // AuthMethod::Session (allow-all, approval-bypassing) without re-presenting
+    // the relay JWT.
+    let session_id = if stateless {
         None
     } else {
         match state.mcp_sessions.create_with_proxy_access(user_id, true) {
@@ -2869,6 +2918,25 @@ mod tests {
         assert!(ctx.allow_all_services);
         assert!(ctx.allow_all_nodes);
         assert!(ctx.api_key_id.is_none());
+    }
+
+    #[test]
+    fn relay_auth_is_stateless_like_api_key() {
+        // Relay tokens must be stateless in MCP: no session is minted on
+        // initialize, so they cannot later be replayed as AuthMethod::Session.
+        let relay = McpAuthContext::user("user-1".to_string(), AuthMethod::Relay);
+        assert!(relay.is_stateless());
+
+        // Session/OAuth/plain-access auth is NOT stateless (uses MCP sessions).
+        let session = McpAuthContext::user("user-1".to_string(), AuthMethod::Session);
+        assert!(!session.is_stateless());
+        let access = McpAuthContext::user("user-1".to_string(), AuthMethod::AccessToken);
+        assert!(!access.is_stateless());
+
+        // API keys are stateless (existing behavior).
+        let mut api_key = McpAuthContext::user("user-1".to_string(), AuthMethod::ApiKey);
+        api_key.is_api_key = true;
+        assert!(api_key.is_stateless());
     }
 
     #[test]

--- a/backend/src/mw/auth.rs
+++ b/backend/src/mw/auth.rs
@@ -14,6 +14,7 @@ use crate::AppState;
 use crate::crypto::jwt;
 use crate::crypto::token::hash_token;
 use crate::errors::AppError;
+use crate::models::api_key::{ApiKey, COLLECTION_NAME as API_KEYS};
 use crate::models::service_account::{COLLECTION_NAME as SERVICE_ACCOUNTS, ServiceAccount};
 use crate::models::service_account_token::{COLLECTION_NAME as SA_TOKENS, ServiceAccountToken};
 use crate::models::session::{COLLECTION_NAME as SESSIONS, Session};
@@ -29,8 +30,11 @@ pub enum AuthMethod {
     Session,
     /// Bearer access token (JWT)
     AccessToken,
-    /// Channel relay callback token (JWT with `relay: true`).
-    /// Bypasses approval enforcement like Session.
+    /// Channel relay access token (JWT with `relay: true`), minted per inbound
+    /// bot message and shipped to the client callback URL as `X-NyxID-User-Token`.
+    /// Accepted only on proxy/LLM surfaces (rejected elsewhere by
+    /// `reject_relay_tokens`); inherits the originating agent key's service/node
+    /// allowlist and does NOT bypass approval enforcement (only `Session` does).
     Relay,
     /// X-API-Key header
     ApiKey,
@@ -542,6 +546,16 @@ impl FromRequestParts<AppState> for AuthUser {
                         AuthMethod::AccessToken
                     };
 
+                    // For relay tokens, verify the originating agent key is still
+                    // active. Relay tokens are stateless JWTs that leave NyxID's
+                    // trust boundary (shipped to a client callback URL); this DB
+                    // check is the revocation lever the relay branch previously
+                    // lacked, so deleting/deactivating the agent key immediately
+                    // kills its relay tokens (matching the ApiKey path).
+                    if auth_method == AuthMethod::Relay {
+                        ensure_relay_agent_key_active(&state.db, &claims).await?;
+                    }
+
                     // For relay tokens, inherit the agent key's scope restrictions.
                     // For regular access tokens, allow all (scope enforced at JWT level).
                     let (
@@ -552,14 +566,7 @@ impl FromRequestParts<AppState> for AuthUser {
                         api_key_id,
                         api_key_name,
                     ) = if auth_method == AuthMethod::Relay {
-                        (
-                            claims.relay_allow_all_services.unwrap_or(true),
-                            claims.relay_allow_all_nodes.unwrap_or(true),
-                            claims.relay_allowed_service_ids.clone().unwrap_or_default(),
-                            claims.relay_allowed_node_ids.clone().unwrap_or_default(),
-                            claims.relay_api_key_id.clone(),
-                            claims.relay_api_key_name.clone(),
-                        )
+                        relay_scope_from_claims(&claims)
                     } else {
                         (true, true, vec![], vec![], None, None)
                     };
@@ -740,6 +747,125 @@ impl FromRequestParts<AppState> for AuthUser {
             ))
         }
     }
+}
+
+/// Resolve the service/node scope a relay token grants from its embedded
+/// agent-key claims: `(allow_all_services, allow_all_nodes,
+/// allowed_service_ids, allowed_node_ids, api_key_id, api_key_name)`.
+///
+/// Shared by the `AuthUser` extractor and the MCP transport so both enforce the
+/// SAME agent-key allowlist. Previously the MCP path built its auth context
+/// without reading these claims, silently treating relay tokens as unrestricted
+/// (`allow_all_*` = true); routing both paths through this helper closes that
+/// divergence.
+pub fn relay_scope_from_claims(
+    claims: &crate::crypto::jwt::Claims,
+) -> (
+    bool,
+    bool,
+    Vec<String>,
+    Vec<String>,
+    Option<String>,
+    Option<String>,
+) {
+    (
+        claims.relay_allow_all_services.unwrap_or(true),
+        claims.relay_allow_all_nodes.unwrap_or(true),
+        claims.relay_allowed_service_ids.clone().unwrap_or_default(),
+        claims.relay_allowed_node_ids.clone().unwrap_or_default(),
+        claims.relay_api_key_id.clone(),
+        claims.relay_api_key_name.clone(),
+    )
+}
+
+/// Verify the agent API key a relay token was minted from is still active.
+///
+/// Relay tokens (`X-NyxID-User-Token`) are stateless JWTs delivered to a
+/// client-controlled callback URL and accepted as ordinary bearer auth on the
+/// proxy/LLM surfaces. Without this check the token stayed valid for its full
+/// TTL even after the agent key was deleted/deactivated (API keys are
+/// soft-deleted via `is_active = false`). Requiring a live agent key gives
+/// operators a real revocation lever and fails closed if the id is absent.
+pub async fn ensure_relay_agent_key_active(
+    db: &mongodb::Database,
+    claims: &crate::crypto::jwt::Claims,
+) -> Result<(), AppError> {
+    let api_key_id = claims.relay_api_key_id.as_deref().ok_or_else(|| {
+        AppError::Unauthorized("Relay token is missing its agent key binding".to_string())
+    })?;
+
+    let active = db
+        .collection::<ApiKey>(API_KEYS)
+        .find_one(doc! { "_id": api_key_id, "is_active": true })
+        .await
+        .map_err(|e| AppError::Internal(format!("Relay agent key lookup failed: {e}")))?
+        .is_some();
+
+    if !active {
+        return Err(AppError::Unauthorized(
+            "Relay token's agent key is inactive or revoked".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Middleware that rejects relay access tokens from non-proxy endpoints.
+///
+/// Relay tokens (`X-NyxID-User-Token`, JWT with `relay: true`) exist so a bot
+/// callback recipient can proxy on behalf of the bot owner. They are a
+/// first-party bearer credential that crosses NyxID's trust boundary, so they
+/// must be usable ONLY on the delegated proxy/LLM surfaces. This middleware is
+/// applied to every other `/api/v1` route group so a leaked/replayed relay
+/// token cannot reach user, admin, key-management, or session endpoints.
+pub async fn reject_relay_tokens(
+    request: axum::http::Request<axum::body::Body>,
+    next: Next,
+) -> Result<impl IntoResponse, AppError> {
+    if is_relay_request(&request) {
+        return Err(AppError::Forbidden(
+            "Relay tokens cannot access this endpoint".to_string(),
+        ));
+    }
+    Ok(next.run(request).await)
+}
+
+/// Check if the request bears a relay token.
+fn is_relay_request(request: &axum::http::Request<axum::body::Body>) -> bool {
+    if let Some(auth_header) = request.headers().get("authorization")
+        && let Ok(auth_str) = auth_header.to_str()
+        && let Some(token) = auth_str.strip_prefix("Bearer ")
+        && is_jwt_relay(token)
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Peek at the JWT payload (without verifying signature) to check the `relay`
+/// field. Mirrors `is_jwt_delegated`: a lightweight early check; a forged token
+/// is still rejected later by signature verification in the `AuthUser`
+/// extractor.
+fn is_jwt_relay(token: &str) -> bool {
+    let parts: Vec<&str> = token.splitn(3, '.').collect();
+    if parts.len() < 2 {
+        return false;
+    }
+
+    let payload = match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(parts[1]) {
+        Ok(bytes) => bytes,
+        Err(_) => match base64::engine::general_purpose::URL_SAFE.decode(parts[1]) {
+            Ok(bytes) => bytes,
+            Err(_) => return false,
+        },
+    };
+
+    if let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&payload) {
+        return claims.get("relay") == Some(&serde_json::Value::Bool(true));
+    }
+
+    false
 }
 
 /// Middleware that rejects delegated tokens from accessing protected endpoints.
@@ -1690,6 +1816,50 @@ mod tests {
     fn relay_auth_method_without_proxy_scope_cannot_rest_proxy() {
         let user = test_auth_user(AuthMethod::Relay, "read");
         assert!(!user.can_use_rest_proxy());
+    }
+
+    // -- reject_relay_tokens detection (deny-by-default off the proxy surfaces) --
+
+    fn fake_jwt(payload_json: &str) -> String {
+        use base64::Engine as _;
+        let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload_json.as_bytes());
+        format!("header.{b64}.sig")
+    }
+
+    #[test]
+    fn is_jwt_relay_detects_relay_claim() {
+        assert!(is_jwt_relay(&fake_jwt(r#"{"relay":true}"#)));
+        assert!(!is_jwt_relay(&fake_jwt(r#"{"relay":false}"#)));
+        assert!(!is_jwt_relay(&fake_jwt(r#"{"sub":"u1"}"#)));
+        assert!(!is_jwt_relay("not-a-jwt"));
+        assert!(!is_jwt_relay(""));
+    }
+
+    #[test]
+    fn is_relay_request_matches_bearer_relay_jwt() {
+        let relay = fake_jwt(r#"{"relay":true}"#);
+        let req = Request::builder()
+            .uri("/api/v1/keys")
+            .header("authorization", format!("Bearer {relay}"))
+            .body(Body::empty())
+            .unwrap();
+        assert!(is_relay_request(&req));
+
+        // A normal (non-relay) access token must NOT be treated as relay.
+        let non_relay = fake_jwt(r#"{"sub":"u1"}"#);
+        let req2 = Request::builder()
+            .uri("/api/v1/keys")
+            .header("authorization", format!("Bearer {non_relay}"))
+            .body(Body::empty())
+            .unwrap();
+        assert!(!is_relay_request(&req2));
+
+        // No Authorization header at all.
+        let req3 = Request::builder()
+            .uri("/api/v1/keys")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!is_relay_request(&req3));
     }
 
     // -- parse_cookie edge cases --

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -10,7 +10,8 @@ use tower_http::limit::RequestBodyLimitLayer;
 use crate::AppState;
 use crate::handlers;
 use crate::mw::auth::{
-    reject_api_key_tokens, reject_delegated_tokens, reject_service_account_tokens,
+    reject_api_key_tokens, reject_delegated_tokens, reject_relay_tokens,
+    reject_service_account_tokens,
 };
 
 /// Per RFC 9207 / OAuth 2.0 for Browser-Based Apps, the token endpoint,
@@ -984,7 +985,8 @@ pub fn build_router(
         .nest("/connections", connection_routes)
         .nest("/providers", provider_routes)
         .nest("/oracle", oracle_consumer_routes)
-        .layer(middleware::from_fn(reject_delegated_tokens));
+        .layer(middleware::from_fn(reject_delegated_tokens))
+        .layer(middleware::from_fn(reject_relay_tokens));
 
     // Routes that BLOCK service account tokens (human-only endpoints)
     let api_v1_human_only = Router::new()
@@ -1051,7 +1053,8 @@ pub fn build_router(
         .route("/public/config", get(handlers::health::public_config))
         .layer(middleware::from_fn(reject_delegated_tokens))
         .layer(middleware::from_fn(reject_api_key_tokens))
-        .layer(middleware::from_fn(reject_service_account_tokens));
+        .layer(middleware::from_fn(reject_service_account_tokens))
+        .layer(middleware::from_fn(reject_relay_tokens));
 
     let api_v1 = api_v1_public
         .merge(api_v1_delegated)

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -1051,6 +1051,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -777,6 +777,7 @@ mod tests {
             jwt_access_ttl_secs: 900,
             jwt_relay_reply_ttl_secs: 1800,
             jwt_relay_callback_ttl_secs: 300,
+            jwt_relay_access_ttl_secs: 300,
             jwt_refresh_ttl_secs: 604800,
             release_integrity_manifest_url: None,
             credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/backend/src/services/token_exchange_service.rs
+++ b/backend/src/services/token_exchange_service.rs
@@ -69,6 +69,25 @@ pub async fn exchange_token(
         ));
     }
 
+    // Reject relay tokens: a relay access token (`X-NyxID-User-Token`) is a
+    // short-lived credential shipped to a client-controlled callback URL. If it
+    // could be exchanged, a captured relay token would launder into a
+    // refreshable delegated token, decoupling the attacker's window from the
+    // relay token's short TTL -- the same indefinite-TTL-extension the delegated
+    // rejection above prevents.
+    if subject_claims.relay == Some(true) {
+        log_exchange_failure(
+            db,
+            Some(&subject_claims.sub),
+            client_id,
+            "relay_exchange_rejected",
+        );
+        return Err(AppError::BadRequest(
+            "Cannot exchange a relay token -- subject_token must be a direct first-party access token"
+                .to_string(),
+        ));
+    }
+
     let user_id_str = &subject_claims.sub;
 
     // Step 4: Verify user has consented to this client

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -174,6 +174,7 @@ pub(crate) fn test_app_config() -> AppConfig {
         jwt_access_ttl_secs: 900,
         jwt_relay_reply_ttl_secs: 1800,
         jwt_relay_callback_ttl_secs: 300,
+        jwt_relay_access_ttl_secs: 300,
         jwt_refresh_ttl_secs: 604800,
         release_integrity_manifest_url: None,
         credential_accept_dist_dir: "frontend/dist/credential-accept".to_string(),

--- a/docs/AI_AGENT_PLAYBOOK.md
+++ b/docs/AI_AGENT_PLAYBOOK.md
@@ -3230,7 +3230,7 @@ When a message arrives, NyxID POSTs a normalized payload to the agent's callback
 
 The payload includes both normalized fields and `raw_platform_data` (the full original webhook JSON from the platform). Most agents use the normalized fields; agents that need platform-specific features (Telegram inline keyboards, Discord embeds, Lark interactive cards) can read `raw_platform_data` directly.
 
-Headers: `X-NyxID-Signature` (HMAC-SHA256), `X-NyxID-Message-Id`, `X-NyxID-Timestamp`, `X-NyxID-Platform`, `X-NyxID-User-Token` (short-lived access token for the bot owner -- use as `Authorization: Bearer <token>` to call NyxID APIs on behalf of the user).
+Headers: `X-NyxID-Signature` (HMAC-SHA256), `X-NyxID-Message-Id`, `X-NyxID-Timestamp`, `X-NyxID-Platform`, `X-NyxID-User-Token` (short-lived relay access token for the bot owner, default 300s -- use as `Authorization: Bearer <token>` to call NyxID's proxy/LLM gateway on behalf of the user; it is rejected on non-proxy endpoints and is invalidated when the agent key is revoked).
 
 ### Agent Reply
 

--- a/docs/CHANNEL_BOT_RELAY.md
+++ b/docs/CHANNEL_BOT_RELAY.md
@@ -504,7 +504,7 @@ The payload normalizes messages into a common format so agents can handle all pl
 | `X-NyxID-Message-Id` | UUID of the `channel_message` record |
 | `X-NyxID-Timestamp` | ISO 8601 timestamp (for replay protection) |
 | `X-NyxID-Platform` | Platform identifier (`telegram`, `discord`, `lark`, `feishu`) |
-| `X-NyxID-User-Token` | Short-lived access token for the bot owner. The agent can use this as `Authorization: Bearer <token>` to call NyxID APIs (proxy, approvals, etc.) on behalf of the user. Scoped to `proxy read`. Absent if token generation fails. |
+| `X-NyxID-User-Token` | Short-lived access token for the bot owner (`JWT_RELAY_ACCESS_TTL_SECS`, default `300`s). The agent uses it as `Authorization: Bearer <token>` to call NyxID's **proxy / LLM gateway / MCP** (and approval *status* polling) on behalf of the user. It is a relay token: it is **rejected** on account, admin, key-management, session, channel-reply, and other non-proxy endpoints; it inherits the originating agent key's service/node allowlist; on MCP it is stateless (no session is minted, so it re-authenticates every call); and it stops working the moment that agent key is revoked/deactivated. To *reply* to a conversation, use the agent API key or the per-callback `reply_token`, not this token. Absent if token generation fails. |
 
 #### Callback Authentication (JWT)
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -108,6 +108,7 @@ Complete the Stripe sandbox checkout opened by the command. The verifier passes 
 | `JWT_REFRESH_TTL_SECS` | `604800` (7 days) | Refresh token lifetime in seconds |
 | `JWT_RELAY_REPLY_TTL_SECS` | `1800` (30 min) | Lifetime of the per-callback reply token issued with channel-relay inbound callbacks (see [CHANNEL_BOT_RELAY.md](CHANNEL_BOT_RELAY.md#reply-token)). Tokens are single-use, scoped to one inbound message + conversation + agent, and cannot be used against other NyxID endpoints. |
 | `JWT_RELAY_CALLBACK_TTL_SECS` | `300` (5 min) | Lifetime of the signed channel-relay callback JWT sent in `X-NyxID-Callback-Token`. |
+| `JWT_RELAY_ACCESS_TTL_SECS` | `300` (5 min) | Lifetime of the `X-NyxID-User-Token` relay access token shipped to a bot callback URL. Kept short (vs. the 900s general access token) because it is a first-party bearer credential that leaves NyxID's trust boundary. It is usable only on proxy/LLM surfaces (rejected elsewhere), inherits the originating agent key's service/node allowlist, and is invalidated when that agent key is revoked. |
 | `SA_TOKEN_TTL_SECS` | `3600` (1 hour) | Service account token lifetime in seconds |
 
 In development mode, RSA keys are auto-generated if the files do not exist. In production, you must provide pre-generated keys:


### PR DESCRIPTION
## Summary

Fixes a **confirmed critical** cross-user impersonation vulnerability reported by the aevatar team (incident + source review).

`X-NyxID-User-Token` was a **general-purpose 900s `proxy`-scoped access token** minted per inbound bot message (`sub` = bot owner), shipped to a client-controlled callback URL, and accepted back as ordinary `Bearer` auth with **no revocation / liveness / single-use check** — fully replayable as the target user on `/proxy`, `/llm`, and `/mcp` for its whole lifetime by anyone who observes it on the shared webhook surface.

Every claim in the report was independently verified against current source and adversarially stress-tested (exploitable on all three lenses).

## Constraint

`X-NyxID-User-Token` is a **documented public contract** (`CHANNEL_BOT_RELAY.md`) for on-behalf-of proxy calls, and `/proxy`+`/llm` live in `api_v1_delegated` which intentionally allows agent tokens. A hard block would break aevatar and every channel-bot integration. This PR instead makes the token **non-general and revocable** while keeping it working on its intended surfaces.

## Changes

| Area | Change |
|---|---|
| TTL | Dedicated `JWT_RELAY_ACCESS_TTL_SECS` (**300s**, was 900) at the mint site |
| Surface scoping | `reject_relay_tokens` middleware on `api_v1_shared` + `api_v1_human_only` — relay reaches only proxy/LLM/MCP; rejected on users/admin/key-mgmt/sessions/etc. |
| Revocation | `ensure_relay_agent_key_active` — relay tokens are invalidated the moment the originating agent key is revoked/deactivated (extractor + MCP) |
| MCP over-grant | Shared `relay_scope_from_claims` — MCP now inherits the agent-key service/node allowlist instead of allow-all |
| MCP session laundering | Relay is **stateless** on MCP (`is_stateless()`) — no session minted, so it can't be replayed as `AuthMethod::Session` (allow-all, approval-bypassing) |
| Token exchange | `exchange_token` rejects `relay:true` subjects — no laundering into a refreshable delegated token |
| Reply path | `/channel-relay/reply(/update)` reject relay tokens; replies must use the agent API key or the per-callback `reply_token` |

The MCP-session-laundering and reply-path fixes were surfaced by an adversarial self-review of the diff.

## Verification

- Compiles clean; pre-commit `cargo fmt` + `cargo clippy` pass.
- **9/9 relay unit tests pass** (6 new + 3 existing relay-proxy tests, which remain valid — the documented proxy use is preserved).
- Adversarial review's regression + correctness lenses came back clean.

Docs updated: `CHANNEL_BOT_RELAY.md`, `AI_AGENT_PLAYBOOK.md`, `ENV.md`, `CLAUDE.md`.

## Residual risk (needs aevatar coordination)

A captured relay token is **still replayable on `/proxy` + `/llm` within the ≤300s window** — because that surface *is* the feature. It's now bounded hard (short TTL + agent-key revocation + no laundering + allowlist scope), but not eliminated. Fully closing requires a contract change: DPoP/mTLS proof-of-possession, a single-use-per-message nonce, or **removing `user_access_token` entirely** so agents use their own scoped API key (same owner identity, no replayable secret leaving our boundary). Recommended follow-up.

## Operational actions (post-merge)

- Rotate downstream `UserApiKey` credentials + bound agent keys for any bot owner whose callback host may have been observed.
- Review `audit_logs` for `requester_type="relay"` proxy/LLM events as the detective signal.
- Audit `api_key.callback_url` values for plain-`http://` targets.

## Not addressed here

- **Binding enumeration** (`GET /oauth/bindings`): real but info-disclosure only (returns a non-exchangeable SHA-256 hash, scoped to the caller's own client) — lower priority, tracked separately.
- `oauth_broker_service::exchange_via_binding` was verified **correct** (client-ownership + 128-bit binding secret) — left untouched.
