### PR TITLE
style(icons): 20px service icons in the org role-permissions grid

### DIFF
--- a/frontend/src/pages/org-detail.tsx
+++ b/frontend/src/pages/org-detail.tsx
@@ -945,7 +945,7 @@ function RolePermissionCard({
                     />
                     <ServiceIcon
                       slug={service.catalog_service_slug}
-                      size="2xs"
+                      size="sm"
                     />
                     <Label
                       htmlFor={id}


### PR DESCRIPTION
Follow-up to #1077.

The org **Role permissions** scope cards have two-line rows (service name + slug). The shared 14px (`2xs`) checkbox/dropdown size read too small there next to the two-line label, so this bumps **just that grid** to `sm` (20px).

Everything else stays at 14px per review — single-line allowed-service lists and dropdown/select items are unchanged.

One line: `org-detail.tsx` RolePermissionCard `ServiceIcon size="2xs"` → `"sm"`.

Verified in-browser at `/orgs/{id}?tab=role-permissions` — icons now measure 20px and balance the two-line rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)