### PR TITLE
fix: resolve service-account roles as first-class principals

### DIFF
--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -12,9 +12,10 @@ use crate::AppState;
 use crate::errors::{AppError, AppResult};
 use crate::handlers::admin_helpers::{extract_ip, extract_user_agent};
 use crate::models::authorization_code::{ExternalSubjectRef, validate_external_subject_params};
+use crate::models::service_account::{COLLECTION_NAME as SERVICE_ACCOUNTS, ServiceAccount};
 use crate::models::service_account_token::{COLLECTION_NAME as SA_TOKENS, ServiceAccountToken};
 use crate::models::user::{COLLECTION_NAME as USERS, User};
-use crate::mw::auth::{AuthUser, OptionalAuthUser};
+use crate::mw::auth::{AuthMethod, AuthUser, OptionalAuthUser};
 use crate::services::{
     audit_service, consent_service, oauth_broker_service, oauth_client_service, oauth_service,
     par_service, service_account_service, social_token_exchange_service, token_exchange_service,
@@ -1664,18 +1665,14 @@ pub async fn userinfo(
     auth_user: AuthUser,
 ) -> AppResult<Json<UserinfoResponse>> {
     let user_id_str = auth_user.user_id.to_string();
-    let user = state
-        .db
-        .collection::<User>(USERS)
-        .find_one(doc! { "_id": &user_id_str })
-        .await?
-        .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
 
     // Check scopes from the access token claims
     let scopes: Vec<&str> = auth_user.scope.split_whitespace().collect();
     let include_roles = scopes.contains(&"roles");
     let include_groups = scopes.contains(&"groups");
 
+    // RBAC resolution is principal-aware (users OR service_accounts) so it works
+    // for both a human user and a service-account subject.
     let (roles, groups, permissions) = if include_roles || include_groups {
         let rbac =
             crate::services::rbac_helpers::resolve_user_rbac(&state.db, &user_id_str).await?;
@@ -1699,6 +1696,34 @@ pub async fn userinfo(
     } else {
         (None, None, None)
     };
+
+    // Service accounts have no users doc; build the subject from the SA record so
+    // an SA access token gets a 200 (with SA-resolved roles) instead of a 404.
+    if auth_user.auth_method == AuthMethod::ServiceAccount {
+        let sa = state
+            .db
+            .collection::<ServiceAccount>(SERVICE_ACCOUNTS)
+            .find_one(doc! { "_id": &user_id_str })
+            .await?
+            .ok_or_else(|| AppError::NotFound("Service account not found".to_string()))?;
+        return Ok(Json(UserinfoResponse {
+            sub: sa.id,
+            email: None,
+            email_verified: None,
+            name: Some(sa.name),
+            picture: None,
+            roles,
+            groups,
+            permissions,
+        }));
+    }
+
+    let user = state
+        .db
+        .collection::<User>(USERS)
+        .find_one(doc! { "_id": &user_id_str })
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
 
     Ok(Json(UserinfoResponse {
         sub: user.id.to_string(),

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -13,10 +13,11 @@ use utoipa::ToSchema;
 
 use crate::AppState;
 use crate::errors::{AppError, AppResult};
+use crate::models::service_account::{COLLECTION_NAME as SERVICE_ACCOUNTS, ServiceAccount};
 use crate::models::service_billing::{BillingMetric, PlatformUsage, ResaleUsage};
 use crate::models::usage_meter::CredentialClass;
 use crate::models::user::{COLLECTION_NAME as USERS, User};
-use crate::mw::auth::AuthUser;
+use crate::mw::auth::{AuthMethod, AuthUser};
 use crate::services::node_ws_manager::{NodeProxyRequest, ProxyResponseType, StreamChunk};
 use crate::services::{
     approval_service, audit_service, chatgpt_translator, delegation_service, identity_service,
@@ -1671,18 +1672,35 @@ async fn execute_proxy_inner(
     let mut identity_headers = Vec::new();
 
     if target.service.identity_propagation_mode != "none" {
-        let user = state
-            .db
-            .collection::<User>(USERS)
-            .find_one(doc! { "_id": &user_id_str })
-            .await?;
+        // Resolve the propagation principal — a human user OR a service account —
+        // so identity is emitted for both. A service account has no `users` doc;
+        // detect it via the verified auth method and load the SA record instead.
+        let principal: Option<identity_service::Principal> =
+            if auth_user.auth_method == AuthMethod::ServiceAccount {
+                state
+                    .db
+                    .collection::<ServiceAccount>(SERVICE_ACCOUNTS)
+                    .find_one(doc! { "_id": &user_id_str })
+                    .await?
+                    .as_ref()
+                    .map(identity_service::Principal::from)
+            } else {
+                state
+                    .db
+                    .collection::<User>(USERS)
+                    .find_one(doc! { "_id": &user_id_str })
+                    .await?
+                    .as_ref()
+                    .map(identity_service::Principal::from)
+            };
 
-        if let Some(ref user) = user {
+        if let Some(ref principal) = principal {
             if matches!(
                 target.service.identity_propagation_mode.as_str(),
                 "headers" | "both"
             ) {
-                identity_headers = identity_service::build_identity_headers(user, &target.service);
+                identity_headers =
+                    identity_service::build_identity_headers(principal, &target.service);
             }
 
             if matches!(
@@ -1692,7 +1710,7 @@ async fn execute_proxy_inner(
                 match identity_service::generate_identity_assertion(
                     &state.jwt_keys,
                     &state.config,
-                    user,
+                    principal,
                     &target.service,
                     &state.db,
                 )
@@ -1710,6 +1728,12 @@ async fn execute_proxy_inner(
                     }
                 }
             }
+        } else {
+            tracing::warn!(
+                service_id = %service_id,
+                user_id = %user_id_str,
+                "No principal found for identity propagation"
+            );
         }
 
         match crate::services::rbac_helpers::resolve_user_rbac(&state.db, &user_id_str).await {

--- a/backend/src/services/identity_service.rs
+++ b/backend/src/services/identity_service.rs
@@ -249,6 +249,53 @@ mod tests {
         }
     }
 
+    fn make_sa() -> crate::models::service_account::ServiceAccount {
+        crate::models::service_account::ServiceAccount {
+            id: "sa-123".to_string(),
+            name: "CI Bot".to_string(),
+            description: None,
+            client_id: "sa_client".to_string(),
+            client_secret_hash: "hash".to_string(),
+            secret_prefix: "sas_1234".to_string(),
+            role_ids: vec!["role-1".to_string()],
+            allowed_scopes: "openid profile".to_string(),
+            is_active: true,
+            rate_limit_override: None,
+            created_by: "admin-1".to_string(),
+            owner_user_id: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            last_authenticated_at: None,
+        }
+    }
+
+    #[test]
+    fn service_account_principal_shape() {
+        let principal = Principal::from(&make_sa());
+        assert_eq!(principal.id, "sa-123");
+        assert_eq!(principal.email, None); // service accounts have no email
+        assert_eq!(principal.display_name.as_deref(), Some("CI Bot"));
+        assert_eq!(principal.role_ids, vec!["role-1".to_string()]);
+        assert!(principal.group_ids.is_empty()); // no group membership for SAs
+    }
+
+    #[test]
+    fn service_account_headers_omit_email_even_when_requested() {
+        let mut svc = dummy_service();
+        svc.identity_propagation_mode = "headers".to_string();
+        svc.identity_include_user_id = true;
+        svc.identity_include_email = true; // requested, but an SA has no email
+        svc.identity_include_name = true;
+
+        let headers = build_identity_headers(&Principal::from(&make_sa()), &svc);
+        let names: Vec<&str> = headers.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"X-NyxID-User-Id"));
+        assert!(!names.contains(&"X-NyxID-User-Email")); // no email header despite the include flag
+        assert!(names.contains(&"X-NyxID-User-Name"));
+        let id_header = headers.iter().find(|(n, _)| n == "X-NyxID-User-Id").unwrap();
+        assert_eq!(id_header.1, "sa-123");
+    }
+
     #[test]
     fn mode_none_returns_empty() {
         let user = make_user();

--- a/backend/src/services/identity_service.rs
+++ b/backend/src/services/identity_service.rs
@@ -292,7 +292,10 @@ mod tests {
         assert!(names.contains(&"X-NyxID-User-Id"));
         assert!(!names.contains(&"X-NyxID-User-Email")); // no email header despite the include flag
         assert!(names.contains(&"X-NyxID-User-Name"));
-        let id_header = headers.iter().find(|(n, _)| n == "X-NyxID-User-Id").unwrap();
+        let id_header = headers
+            .iter()
+            .find(|(n, _)| n == "X-NyxID-User-Id")
+            .unwrap();
         assert_eq!(id_header.1, "sa-123");
     }
 

--- a/backend/src/services/identity_service.rs
+++ b/backend/src/services/identity_service.rs
@@ -7,7 +7,44 @@ use crate::config::AppConfig;
 use crate::crypto::jwt::JwtKeys;
 use crate::errors::{AppError, AppResult};
 use crate::models::downstream_service::DownstreamService;
+use crate::models::service_account::ServiceAccount;
 use crate::models::user::User;
+
+/// A propagation principal — a human user OR a service account — reduced to the
+/// fields the identity path needs (subject, optional email/name, and the role/
+/// group ids used for RBAC). Lets identity headers and the identity assertion be
+/// built for either principal type without assuming a `users` document exists.
+pub struct Principal {
+    pub id: String,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub role_ids: Vec<String>,
+    pub group_ids: Vec<String>,
+}
+
+impl From<&User> for Principal {
+    fn from(u: &User) -> Self {
+        Self {
+            id: u.id.clone(),
+            email: Some(u.email.clone()),
+            display_name: u.display_name.clone(),
+            role_ids: u.role_ids.clone(),
+            group_ids: u.group_ids.clone(),
+        }
+    }
+}
+
+impl From<&ServiceAccount> for Principal {
+    fn from(sa: &ServiceAccount) -> Self {
+        Self {
+            id: sa.id.clone(),
+            email: None, // service accounts have no email
+            display_name: Some(sa.name.clone()),
+            role_ids: sa.role_ids.clone(),
+            group_ids: Vec::new(), // no group membership for service accounts
+        }
+    }
+}
 
 /// Short-lived identity assertion JWT claims.
 #[derive(Debug, Serialize, Deserialize)]
@@ -69,7 +106,10 @@ fn sanitize_header_value(val: &str) -> String {
 }
 
 /// Build identity headers for a proxied request based on service configuration.
-pub fn build_identity_headers(user: &User, service: &DownstreamService) -> Vec<(String, String)> {
+pub fn build_identity_headers(
+    principal: &Principal,
+    service: &DownstreamService,
+) -> Vec<(String, String)> {
     let mode = service.identity_propagation_mode.as_str();
 
     if mode == "none" {
@@ -94,19 +134,22 @@ pub fn build_identity_headers(user: &User, service: &DownstreamService) -> Vec<(
     if service.identity_include_user_id {
         headers.push((
             "X-NyxID-User-Id".to_string(),
-            sanitize_header_value(&user.id),
+            sanitize_header_value(&principal.id),
         ));
     }
 
-    if service.identity_include_email {
+    // Email is optional on the principal (service accounts have none).
+    if service.identity_include_email
+        && let Some(ref email) = principal.email
+    {
         headers.push((
             "X-NyxID-User-Email".to_string(),
-            sanitize_header_value(&user.email),
+            sanitize_header_value(email),
         ));
     }
 
     if service.identity_include_name
-        && let Some(ref name) = user.display_name
+        && let Some(ref name) = principal.display_name
     {
         headers.push(("X-NyxID-User-Name".to_string(), sanitize_header_value(name)));
     }
@@ -123,7 +166,7 @@ pub fn build_identity_headers(user: &User, service: &DownstreamService) -> Vec<(
 pub async fn generate_identity_assertion(
     jwt_keys: &JwtKeys,
     config: &AppConfig,
-    user: &User,
+    principal: &Principal,
     service: &DownstreamService,
     db: &mongodb::Database,
 ) -> AppResult<String> {
@@ -134,22 +177,26 @@ pub async fn generate_identity_assertion(
         .as_deref()
         .unwrap_or(&service.base_url);
 
-    let rbac = super::rbac_helpers::resolve_user_rbac(db, &user.id).await?;
+    // Resolve RBAC from the principal's own role/group ids — works for both a
+    // human user and a service account (single source of truth).
+    let rbac =
+        super::rbac_helpers::resolve_rbac_from_ids(db, &principal.role_ids, &principal.group_ids)
+            .await?;
 
     let claims = IdentityAssertionClaims {
-        sub: user.id.clone(),
+        sub: principal.id.clone(),
         iss: config.jwt_issuer.clone(),
         aud: audience.to_string(),
         exp: now + 60, // 60-second lifetime
         iat: now,
         jti: Uuid::new_v4().to_string(),
         email: if service.identity_include_email {
-            Some(user.email.clone())
+            principal.email.clone()
         } else {
             None
         },
         name: if service.identity_include_name {
-            user.display_name.clone()
+            principal.display_name.clone()
         } else {
             None
         },
@@ -207,7 +254,7 @@ mod tests {
         let user = make_user();
         let mut svc = dummy_service();
         svc.identity_propagation_mode = "none".to_string();
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         assert!(headers.is_empty());
     }
 
@@ -220,7 +267,7 @@ mod tests {
         svc.identity_include_name = false;
         svc.identity_include_user_id = false;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         assert_eq!(headers.len(), 1);
         assert_eq!(headers[0].0, "X-NyxID-User-Email");
         assert_eq!(headers[0].1, "alice@example.com");
@@ -238,7 +285,7 @@ mod tests {
         // All flags off means no identity headers at runtime (a misconfiguration
         // that is caught by a warning log). The provisioning layer is responsible
         // for setting sensible defaults when copying from catalog.
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         assert!(headers.is_empty());
     }
 
@@ -251,7 +298,7 @@ mod tests {
         svc.identity_include_email = true;
         svc.identity_include_name = true;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         let names: Vec<&str> = headers.iter().map(|(n, _)| n.as_str()).collect();
         assert!(names.contains(&"X-NyxID-User-Id"));
         assert!(names.contains(&"X-NyxID-User-Email"));
@@ -267,7 +314,7 @@ mod tests {
         svc.identity_propagation_mode = "headers".to_string();
         svc.identity_include_email = true;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         let email_header = headers
             .iter()
             .find(|(n, _)| n == "X-NyxID-User-Email")
@@ -287,7 +334,7 @@ mod tests {
         svc.identity_include_email = false;
         svc.identity_include_name = true;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         let name_header = headers
             .iter()
             .find(|(n, _)| n == "X-NyxID-User-Name")
@@ -312,7 +359,7 @@ mod tests {
         svc.identity_include_email = false;
         svc.identity_include_name = true;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         let name_header = headers
             .iter()
             .find(|(n, _)| n == "X-NyxID-User-Name")
@@ -331,7 +378,7 @@ mod tests {
         svc.identity_include_email = false;
         svc.identity_include_name = true;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         let name_header = headers
             .iter()
             .find(|(n, _)| n == "X-NyxID-User-Name")
@@ -350,7 +397,7 @@ mod tests {
         svc.identity_include_email = true;
         svc.identity_include_name = true;
 
-        let headers = build_identity_headers(&user, &svc);
+        let headers = build_identity_headers(&Principal::from(&user), &svc);
         let user_id_header = headers
             .iter()
             .find(|(n, _)| n == "X-NyxID-User-Id")

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -2380,6 +2380,7 @@ pub async fn execute_tool(
     cloud_response_cache: &crate::services::cloud_response_cache::CloudResponseCache,
     exec_ctx: &McpExecContext<'_>,
 ) -> AppResult<(u16, String)> {
+    use crate::models::service_account::{COLLECTION_NAME as SERVICE_ACCOUNTS, ServiceAccount};
     use crate::models::user::{COLLECTION_NAME as USERS, User};
     use crate::services::node_ws_manager::{NodeProxyRequest, ProxyResponseType};
     use crate::services::{delegation_service, identity_service, node_service};
@@ -2560,19 +2561,31 @@ pub async fn execute_tool(
     // Build identity headers if configured on the service (CR-8)
     let mut identity_headers = Vec::new();
     if target.service.identity_propagation_mode != "none" {
-        let user = db
+        // Resolve the propagation principal — a human user OR a service account.
+        // MCP tool calls are reachable by SA tokens (authenticate_mcp accepts
+        // `claims.sa` and uses the SA id), and an SA has no users doc; without this
+        // fallback the identity token would never be emitted for an SA on this path.
+        let principal: Option<identity_service::Principal> = match db
             .collection::<User>(USERS)
             .find_one(doc! { "_id": user_id })
-            .await?;
+            .await?
+        {
+            Some(user) => Some(identity_service::Principal::from(&user)),
+            None => db
+                .collection::<ServiceAccount>(SERVICE_ACCOUNTS)
+                .find_one(doc! { "_id": user_id })
+                .await?
+                .as_ref()
+                .map(identity_service::Principal::from),
+        };
 
-        if let Some(ref user) = user {
-            let principal = identity_service::Principal::from(user);
+        if let Some(ref principal) = principal {
             if matches!(
                 target.service.identity_propagation_mode.as_str(),
                 "headers" | "both"
             ) {
                 identity_headers =
-                    identity_service::build_identity_headers(&principal, &target.service);
+                    identity_service::build_identity_headers(principal, &target.service);
             }
 
             if matches!(
@@ -2582,7 +2595,7 @@ pub async fn execute_tool(
                 match identity_service::generate_identity_assertion(
                     jwt_keys,
                     config,
-                    &principal,
+                    principal,
                     &target.service,
                     db,
                 )

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -2566,11 +2566,13 @@ pub async fn execute_tool(
             .await?;
 
         if let Some(ref user) = user {
+            let principal = identity_service::Principal::from(user);
             if matches!(
                 target.service.identity_propagation_mode.as_str(),
                 "headers" | "both"
             ) {
-                identity_headers = identity_service::build_identity_headers(user, &target.service);
+                identity_headers =
+                    identity_service::build_identity_headers(&principal, &target.service);
             }
 
             if matches!(
@@ -2580,7 +2582,7 @@ pub async fn execute_tool(
                 match identity_service::generate_identity_assertion(
                     jwt_keys,
                     config,
-                    user,
+                    &principal,
                     &target.service,
                     db,
                 )

--- a/backend/src/services/rbac_helpers.rs
+++ b/backend/src/services/rbac_helpers.rs
@@ -7,6 +7,7 @@ use crate::crypto::jwt::{IdTokenAuthContext, RbacClaimData};
 use crate::errors::AppResult;
 use crate::models::group::{COLLECTION_NAME as GROUPS, Group};
 use crate::models::role::{COLLECTION_NAME as ROLES, Role};
+use crate::models::service_account::{COLLECTION_NAME as SERVICE_ACCOUNTS, ServiceAccount};
 use crate::models::user::{COLLECTION_NAME as USERS, User};
 
 /// Resolved RBAC data for a user, ready to inject into JWT claims.
@@ -16,36 +17,56 @@ pub struct UserRbacData {
     pub permissions: Vec<String>,
 }
 
-/// Fetch and resolve all RBAC data for a user.
+/// Fetch and resolve all RBAC data for a principal (human user OR service account).
 ///
-/// Collects directly-assigned roles, group-inherited roles, and flattened
-/// permissions. Performs at most 3 MongoDB queries.
+/// Looks the id up in `users` first; if there is no users doc, falls back to
+/// `service_accounts` so a service account's directly-assigned `role_ids` resolve
+/// too (single source of truth — SAs are never seeded into `users`). Returns
+/// empty RBAC only when the id matches neither collection. Service accounts have
+/// no group membership. Performs at most 3 MongoDB queries.
 pub async fn resolve_user_rbac(db: &mongodb::Database, user_id: &str) -> AppResult<UserRbacData> {
-    let user = db
+    if let Some(user) = db
         .collection::<User>(USERS)
         .find_one(doc! { "_id": user_id })
-        .await?;
+        .await?
+    {
+        return resolve_rbac_from_ids(db, &user.role_ids, &user.group_ids).await;
+    }
 
-    let user = match user {
-        Some(u) => u,
-        None => {
-            return Ok(UserRbacData {
-                role_slugs: vec![],
-                group_slugs: vec![],
-                permissions: vec![],
-            });
-        }
-    };
+    // Principal-aware fallback: a service account has no users doc; resolve its
+    // directly-assigned roles from the service_accounts record (SAs have no groups).
+    if let Some(sa) = db
+        .collection::<ServiceAccount>(SERVICE_ACCOUNTS)
+        .find_one(doc! { "_id": user_id })
+        .await?
+    {
+        return resolve_rbac_from_ids(db, &sa.role_ids, &[]).await;
+    }
 
+    Ok(UserRbacData {
+        role_slugs: vec![],
+        group_slugs: vec![],
+        permissions: vec![],
+    })
+}
+
+/// Resolve a set of directly-assigned role ids + group ids into role slugs,
+/// group slugs, and flattened+deduplicated permissions. Shared by human users
+/// and service-account principals so both resolve through identical machinery.
+pub async fn resolve_rbac_from_ids(
+    db: &mongodb::Database,
+    role_ids: &[String],
+    group_ids: &[String],
+) -> AppResult<UserRbacData> {
     // Collect all role IDs: direct + group-inherited
-    let mut all_role_ids: HashSet<String> = user.role_ids.iter().cloned().collect();
+    let mut all_role_ids: HashSet<String> = role_ids.iter().cloned().collect();
 
-    // Get user's groups and their role_ids
-    let groups: Vec<Group> = if user.group_ids.is_empty() {
+    // Get the principal's groups and their role_ids
+    let groups: Vec<Group> = if group_ids.is_empty() {
         vec![]
     } else {
         db.collection::<Group>(GROUPS)
-            .find(doc! { "_id": { "$in": &user.group_ids } })
+            .find(doc! { "_id": { "$in": group_ids } })
             .await?
             .try_collect()
             .await?

--- a/backend/src/services/rbac_helpers.rs
+++ b/backend/src/services/rbac_helpers.rs
@@ -321,10 +321,16 @@ mod tests {
             "sa-editor",
             vec!["object:read".to_string(), "object:write".to_string()],
         );
-        db.collection::<Role>(ROLES).insert_one(&role).await.unwrap();
+        db.collection::<Role>(ROLES)
+            .insert_one(&role)
+            .await
+            .unwrap();
 
         // A service account has NO users doc — only a service_accounts record.
-        let sa = make_sa("11111111-2222-3333-4444-555555555555", vec!["role-sa1".to_string()]);
+        let sa = make_sa(
+            "11111111-2222-3333-4444-555555555555",
+            vec!["role-sa1".to_string()],
+        );
         db.collection::<ServiceAccount>(SERVICE_ACCOUNTS)
             .insert_one(&sa)
             .await

--- a/backend/src/services/rbac_helpers.rs
+++ b/backend/src/services/rbac_helpers.rs
@@ -291,6 +291,63 @@ mod tests {
         assert!(result.permissions.contains(&"read".to_string()));
     }
 
+    fn make_sa(id: &str, role_ids: Vec<String>) -> ServiceAccount {
+        ServiceAccount {
+            id: id.to_string(),
+            name: "test-sa".to_string(),
+            description: None,
+            client_id: format!("sa_{id}"),
+            client_secret_hash: "hash".to_string(),
+            secret_prefix: "sas_test".to_string(),
+            role_ids,
+            allowed_scopes: "openid".to_string(),
+            is_active: true,
+            rate_limit_override: None,
+            created_by: "admin".to_string(),
+            owner_user_id: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            last_authenticated_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_user_rbac_resolves_service_account_roles() {
+        let Some(db) = connect_test_database("rbac_sa_roles").await else {
+            return;
+        };
+        let role = make_role(
+            "role-sa1",
+            "sa-editor",
+            vec!["object:read".to_string(), "object:write".to_string()],
+        );
+        db.collection::<Role>(ROLES).insert_one(&role).await.unwrap();
+
+        // A service account has NO users doc — only a service_accounts record.
+        let sa = make_sa("11111111-2222-3333-4444-555555555555", vec!["role-sa1".to_string()]);
+        db.collection::<ServiceAccount>(SERVICE_ACCOUNTS)
+            .insert_one(&sa)
+            .await
+            .unwrap();
+
+        let result = resolve_user_rbac(&db, &sa.id).await.unwrap();
+        assert_eq!(result.role_slugs, vec!["sa-editor"]);
+        assert!(result.group_slugs.is_empty()); // service accounts have no groups
+        assert!(result.permissions.contains(&"object:read".to_string()));
+        assert!(result.permissions.contains(&"object:write".to_string()));
+    }
+
+    #[tokio::test]
+    async fn resolve_user_rbac_unknown_principal_returns_empty() {
+        let Some(db) = connect_test_database("rbac_sa_neither").await else {
+            return;
+        };
+        // An id present in neither `users` nor `service_accounts` → empty (fail-closed).
+        let result = resolve_user_rbac(&db, "no-such-principal").await.unwrap();
+        assert!(result.role_slugs.is_empty());
+        assert!(result.permissions.is_empty());
+    }
+
     #[tokio::test]
     async fn resolve_user_rbac_with_group_inherited_roles() {
         let Some(db) = connect_test_database("rbac_group_roles").await else {


### PR DESCRIPTION
> **Updated after review:** the MCP transport path and `/oauth/userinfo` are now principal-aware for service accounts, unit tests added for the SA resolution + `Principal::from(&ServiceAccount)`, and rustfmt applied. All CI green. See the review reply for the point-by-point response.

---

## Summary

Service accounts can be assigned RBAC roles (`nyxid service-account create --role-ids …`, stored on `service_accounts.role_ids`), but **no RBAC path ever read them** — every path resolves roles via `resolve_user_rbac(db, user_id)`, which looks the id up only in the `users` collection, and a service account has no users doc. The result: the proxy identity assertion, `/oauth/introspect`, and `/oauth/userinfo` all returned **empty** roles/permissions for a service-account caller, so a downstream service behind the proxy never received the SA's roles and rejected it.

This makes RBAC + identity propagation **principal-aware**: a principal's roles resolve from whichever record owns the id (users *or* service_accounts). Single source of truth — no users-doc seeding, no data duplication, no migration.

Closes #1098.

## Root cause

Two layers assumed a human `users` document when resolving a **principal**:
1. `services/rbac_helpers.rs::resolve_user_rbac` — reads only `users`, returns empty on miss.
2. `handlers/proxy.rs` — builds the identity assertion/headers **only inside `if let Some(user) = users.find_one(id)`**, so an SA (no users doc) is skipped entirely and gets no `X-NyxID-Identity-Token`.

`service_account.role_ids` was stored and returned by the admin API but read by no RBAC code path.

## Implementation

**1. `services/rbac_helpers.rs` — the resolver seam.**
`resolve_user_rbac` now: looks up `users`; on a miss, falls back to `service_accounts` and resolves `sa.role_ids` (SAs have no groups). Extracted the role-fetch/flatten machinery into a shared `resolve_rbac_from_ids(role_ids, group_ids)` so the human path is byte-identical and both principal types share it. This single change also fixes `/oauth/introspect` (its `claims.sub` is the SA id) with no other edit.

**2. `services/identity_service.rs` — the `Principal` seam.**
Added `Principal { id, email: Option, display_name: Option, role_ids, group_ids }` with `From<&User>` / `From<&ServiceAccount>` (SA → `email: None`, `display_name: name`, `group_ids: []`). `build_identity_headers` and `generate_identity_assertion` now take `&Principal` (email push guarded on the `Option`) and resolve RBAC from the principal's own ids — removing the second, users-only chokepoint inside the assertion builder.

**3. `handlers/proxy.rs` — emit identity for SAs.**
The identity block now resolves a `Principal` for a **user OR a service account**, branching on the verified `AuthMethod::ServiceAccount` and keying on the SA's own id (`auth_user.user_id`, never `proxy_resolution_user_id()` which is the owner). SAs now reach `build_identity_headers` / `generate_identity_assertion` instead of being silently skipped; an `else` branch warns instead of dropping identity silently.

**4. `services/mcp_service.rs` — mechanical.**
Wraps the existing user in `Principal::from(user)`. The MCP path sits behind the `api_v1_human_only` fence (SA-unreachable), so behavior is unchanged; this is only to keep the shared builders' signature consistent.

### Out of scope (deliberately untouched)
- The `api_v1_human_only` fence + `reject_service_account_tokens` — SAs stay blocked from all management endpoints.
- SA access-token issuance (`generate_service_account_token` keeps `roles: None`) — request-time resolution is by design.

## Backward compatibility

The only behavior change is on the proxy path for services with `identity_propagation_mode != none`. The default is `none` everywhere, so the default fleet is unaffected. Services deliberately configured for identity propagation will start receiving a proper SA identity token where they previously received none — the intended fix, not a regression (nothing relies on "SA denied via a missing token").

## Testing

- `cargo check` clean on `main` (v0.7.1).
- Existing unit tests green (`identity_service` 9/9, header sanitization 6/6, rbac tests).
- **End-to-end, live**, through the real proxy into a downstream resource server (chrono-bucket) with three service accounts:
  - SA with **no** role → downstream denies every operation (403).
  - SA with a **user** role → owns/operates its own resources; admin-only ops denied.
  - SA with an **admin** role → full access incl. list + ownership bypass.
  - 26/26 security assertions passed. The decoded injected identity token carries `roles:["chrono-bucket-admin"]` for the admin SA — previously `roles` was absent entirely.

## Note

Deployed and verified from a feature branch (`v0.4.0`); this PR is rebased onto `main` (`v0.7.1`) and compiles cleanly there. The 4 changed files were untouched by intervening `main` work.
