### PR TITLE
fix(oauth): decode repeated resource/service-selection keys — consent-screen login 422 (#1115)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -670,7 +670,7 @@ dependencies = [
  "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -697,10 +697,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-macros"
-version = "0.5.0"
+name = "axum-extra"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde_core",
+ "serde_html_form",
+ "serde_path_to_error",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3965,6 +3990,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "axum",
+ "axum-extra",
  "base64 0.22.1",
  "bson",
  "bytes",
@@ -4005,7 +4031,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "totp-rs",
  "tower 0.5.3",
  "tower-http",
@@ -4065,7 +4091,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "toml",
  "tower 0.5.3",
  "tower-http",
@@ -5842,6 +5868,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6670,18 +6709,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -6693,7 +6720,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite 0.29.0",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -6984,23 +7011,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1 0.10.6",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -7180,12 +7190,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-decode"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -89,6 +89,7 @@ aws-config = { version = "1", optional = true }
 aws-sdk-kms = { version = "1", optional = true }
 google-cloud-kms = { version = "0.6", optional = true }
 tempfile = "3.27.0"
+axum-extra = { version = "0.12.6", features = ["form", "query"] }
 
 [features]
 default = []

--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -1,9 +1,13 @@
 use axum::{
     Json,
-    extract::{Form, Query, State, rejection::QueryRejection},
+    extract::State,
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
+// axum-extra's Form/Query decode repeated keys (`resource=a&resource=b`,
+// `allowed_service_ids=...`) into Vec fields via serde_html_form; axum's
+// built-in serde_urlencoded extractors reject them (#1115).
+use axum_extra::extract::{Form, Query, QueryRejection};
 use base64::Engine as _;
 use chrono::Utc;
 use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
@@ -2235,7 +2239,7 @@ pub async fn introspect(
 pub async fn list_bindings_by_external_subject(
     State(state): State<AppState>,
     headers: HeaderMap,
-    axum::extract::Query(query): axum::extract::Query<ListBindingsByExternalSubjectQuery>,
+    Query(query): Query<ListBindingsByExternalSubjectQuery>,
 ) -> AppResult<Json<ListBindingsResponse>> {
     let empty = || {
         Json(ListBindingsResponse {
@@ -2306,7 +2310,7 @@ pub async fn get_binding(
     State(state): State<AppState>,
     headers: HeaderMap,
     axum::extract::Path(raw_binding_id): axum::extract::Path<String>,
-    axum::extract::Query(query): axum::extract::Query<GetBindingQuery>,
+    Query(query): Query<GetBindingQuery>,
 ) -> AppResult<Json<GetBindingResponse>> {
     let not_found = || AppError::NotFound("binding not found".to_string());
     let basic = parse_basic_client_credentials(&headers).map_err(|_| not_found())?;
@@ -2356,7 +2360,7 @@ pub async fn delete_binding(
     State(state): State<AppState>,
     headers: HeaderMap,
     axum::extract::Path(raw_binding_id): axum::extract::Path<String>,
-    axum::extract::Query(query): axum::extract::Query<GetBindingQuery>,
+    Query(query): Query<GetBindingQuery>,
 ) -> StatusCode {
     let basic = parse_basic_client_credentials(&headers).ok().flatten();
     let (client_id, client_secret) = match client_credentials_from_basic_or_params(
@@ -2631,6 +2635,117 @@ pub async fn register_client(
             client_id_issued_at: client.created_at.timestamp(),
         }),
     ))
+}
+
+#[cfg(test)]
+mod wire_decoding_tests {
+    //! Regression tests for #1115: the consent decision form and RFC 8707
+    //! `resource` parameters arrive as repeated urlencoded keys
+    //! (`allowed_service_ids=a&allowed_service_ids=b`). axum's built-in
+    //! serde_urlencoded extractors reject repeated keys targeting `Vec`
+    //! fields; these tests decode real wire bodies through the axum-extra
+    //! extractors actually mounted on the handlers.
+    use super::*;
+    use axum::extract::{FromRequest, FromRequestParts};
+
+    fn form_request(body: &str) -> axum::http::Request<axum::body::Body> {
+        axum::http::Request::builder()
+            .method("POST")
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(axum::body::Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn consent_decision_form_decodes_single_and_repeated_service_ids() {
+        // Single selected service: the exact production failure in #1115.
+        let single = "response_type=code&client_id=c1&redirect_uri=http%3A%2F%2Flocalhost%2Fcb\
+             &decision=allow&allow_all_services=false\
+             &allowed_service_ids=a64de078-f99f-4583-aeb0-040dc584d142";
+        let Form(form) = Form::<ConsentDecisionForm>::from_request(form_request(single), &())
+            .await
+            .expect("single allowed_service_ids value must decode");
+        assert_eq!(
+            form.allowed_service_ids,
+            vec!["a64de078-f99f-4583-aeb0-040dc584d142".to_string()]
+        );
+        assert!(!form.allow_all_services);
+
+        let repeated = "response_type=code&client_id=c1&redirect_uri=http%3A%2F%2Flocalhost%2Fcb\
+             &decision=allow&allow_all_services=false\
+             &allowed_service_ids=svc-1&allowed_service_ids=svc-2\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fopenai\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fanthropic";
+        let Form(form) = Form::<ConsentDecisionForm>::from_request(form_request(repeated), &())
+            .await
+            .expect("repeated allowed_service_ids and resource values must decode");
+        assert_eq!(form.allowed_service_ids, vec!["svc-1", "svc-2"]);
+        assert_eq!(form.resource.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn consent_decision_form_defaults_absent_vec_fields_to_empty() {
+        let body = "response_type=code&client_id=c1&redirect_uri=http%3A%2F%2Flocalhost%2Fcb\
+             &decision=allow&allow_all_services=true";
+        let Form(form) = Form::<ConsentDecisionForm>::from_request(form_request(body), &())
+            .await
+            .expect("absent vec fields must decode to empty");
+        assert!(form.allowed_service_ids.is_empty());
+        assert!(form.resource.is_empty());
+        assert!(form.allow_all_services);
+    }
+
+    #[tokio::test]
+    async fn authorize_query_decodes_repeated_resource_params() {
+        let uri = "/oauth/authorize?response_type=code&client_id=c1\
+             &redirect_uri=http%3A%2F%2Flocalhost%2Fcb\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fopenai\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fanthropic";
+        let request = axum::http::Request::builder()
+            .uri(uri)
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let (mut parts, _) = request.into_parts();
+        let Query(query) = Query::<AuthorizeQuery>::from_request_parts(&mut parts, &())
+            .await
+            .expect("repeated resource query params must decode");
+        assert_eq!(query.resource.len(), 2);
+        assert_eq!(query.client_id, "c1");
+    }
+
+    #[tokio::test]
+    async fn token_request_decodes_repeated_resource_and_plain_grants() {
+        let with_resource = "grant_type=refresh_token&refresh_token=rt-1\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fopenai\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fanthropic";
+        let Form(body) = Form::<TokenRequest>::from_request(form_request(with_resource), &())
+            .await
+            .expect("repeated resource values must decode");
+        assert_eq!(body.resource.len(), 2);
+
+        // Scalar-only token request (standard OAuth client shape) is unchanged.
+        let plain = "grant_type=authorization_code&code=abc&client_id=c1\
+             &redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_verifier=ver";
+        let Form(body) = Form::<TokenRequest>::from_request(form_request(plain), &())
+            .await
+            .expect("scalar-only token request must decode");
+        assert_eq!(body.grant_type, "authorization_code");
+        assert_eq!(body.code.as_deref(), Some("abc"));
+        assert!(body.resource.is_empty());
+    }
+
+    #[tokio::test]
+    async fn par_form_decodes_repeated_resource_params() {
+        let body = "response_type=code&client_id=c1&client_secret=s1\
+             &redirect_uri=http%3A%2F%2Flocalhost%2Fcb\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fopenai\
+             &resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Fanthropic";
+        let Form(form) =
+            Form::<PushedAuthorizationRequestForm>::from_request(form_request(body), &())
+                .await
+                .expect("repeated resource values must decode");
+        assert_eq!(form.resource.len(), 2);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #1115

## Problem

Selecting services on the OAuth consent screen breaks login: `POST /oauth/authorize/decision` returns **422** `Failed to deserialize form body: allowed_service_ids: invalid type: string "...", expected a sequence`.

Root cause: the `Vec<String>` fields introduced in #1090 (`allowed_service_ids`, `resource`) are decoded by axum's built-in `Form`/`Query` extractors, whose `serde_urlencoded` backend cannot decode repeated urlencoded keys into a `Vec`. Every request that actually sends the field fails; only absent-field requests (covered by `#[serde(default)]`) worked, which is why CI stayed green — no test exercised real wire encoding.

Affected surfaces (all `handlers/oauth.rs`): consent decision form, `GET /oauth/authorize` (`resource`), `POST /oauth/par` (`resource`), `POST /oauth/token` (`resource`).

## Fix

- Add `axum-extra` (features `form`, `query`); its extractors use `serde_html_form`, which decodes repeated keys and is a drop-in superset for scalar fields (standard OAuth client requests decode identically).
- Switch `handlers/oauth.rs` to the axum-extra `Form`/`Query` (including the previously fully-qualified `GetBindingQuery`/`ListBindingsByExternalSubjectQuery` sites for one consistent extractor in the file).
- No other handler files carry `Vec` fields on urlencoded surfaces (verified by sweep); they keep axum's built-ins.
- `build_authorize_url`/`build_consent_url` already emit repeated `resource=` params, so the login round-trip works once decoding is fixed.

## Tests

New `wire_decoding_tests` module decodes real urlencoded bodies/queries through the mounted extractor types:
- single `allowed_service_ids` value — the exact production failure
- repeated `allowed_service_ids` + `resource` on the consent form
- absent Vec fields => empty (allow-all/identity-only paths unchanged)
- repeated `resource` on authorize query, token request, PAR form
- scalar-only `authorization_code` token request decodes unchanged

`cargo test -p nyxid handlers::oauth`: 45 passed (incl. DB-backed consent/authorize tests). Clippy clean.