### PR TITLE
docs(skills): document scheduled-run broker token TTL + token-class triage protocol

### DIFF
--- a/skills/aevatar-feasibility-advisor/SKILL.md
+++ b/skills/aevatar-feasibility-advisor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-feasibility-advisor
-description: Decide — honestly — whether a thing the user wants to build on Aevatar is possible, what its prerequisites are, or why it cannot be done, BEFORE anyone starts building. Use this first whenever a user describes a goal rather than a concrete artifact — "can aevatar do X", "I want a bot that…", "build me something that posts to Twitter / reads my GitHub / replies on Telegram", "is it possible to…", "automate … every day". It teaches the one hard premise (every third-party capability is brokered by NyxID), the two distinct surfaces (outbound connector vs inbound channel), how to check what is actually connectable, the prerequisite for each capability class, what is host-gated (and so not self-serve), and what is genuinely impossible without new NyxID/Aevatar platform work — so you can negotiate scope and give the user a straight answer plus next steps instead of over-promising. It scopes; it does not build (hand off to workflow-authoring / team-builder / service-publisher / scheduler).
-version: "1.0"
+description: Decide — honestly — whether a thing the user wants to build on Aevatar is possible, what its prerequisites are, or why it cannot be done, BEFORE anyone starts building. Use this first whenever a user describes a goal rather than a concrete artifact — "can aevatar do X", "I want a bot that…", "build me something that posts to Twitter / reads my GitHub / replies on Telegram", "is it possible to…", "automate … every day", "let Lark Base trigger a workflow". It teaches the one hard premise (every third-party capability is brokered by NyxID), the two distinct surfaces (outbound connector vs inbound channel), external HTTP trigger options such as Lark Base automation, how to check what is actually connectable, the prerequisite for each capability class, what is host-gated (and so not self-serve), and what is genuinely impossible without new NyxID/Aevatar platform work — so you can negotiate scope and give the user a straight answer plus next steps instead of over-promising. It scopes; it does not build (hand off to workflow-authoring / team-builder / service-publisher / scheduler).
+version: "1.1"
 metadata:
   category: plain
   tag:
@@ -95,6 +95,7 @@ exists or doesn't without checking it.** The examples below are illustrative, no
 | **Inbound bot** that replies in-platform: **Lark / Telegram** | ✅ Yes | Connect the bot connector (`api-lark-bot` / `api-telegram-bot`) **and** register the channel (channel-admin / `channel_registrations`); NyxID provisions the webhook to Aevatar's relay. |
 | **Inbound bot** on a platform with a connector but **no channel module** (Discord, Slack, X, …) | ❌ Not self-serve | Outbound calls work, but inbound-reply needs a new Aevatar **channel module** + relay wiring = Aevatar platform work. Offer the outbound-only version as the alternative. |
 | **Publish** a workflow/team as an **invocable service** in-scope | ✅ Yes | Just bind it (`aevatar-service-publisher`). Usable within the user's scope immediately. |
+| An external automation **triggers an existing Aevatar workflow** (e.g. Lark Base row status changed → HTTP request → run member workflow) | ✅ Usually, without service externalExposure | Use the external system's HTTP action to call the NyxID proxy for the existing `aevatar` service with a NyxID API key (`proxy` scope), targeting an explicit `/api/scopes/{scopeId}/members/{memberId}/invoke/...` or `/teams/{teamId}/invoke/...` path. This is an external trigger, not a NyxID connector registration. See `aevatar-service-publisher`. |
 | Have that service **registered as a NyxID-brokered connector** (callable by others/externally) | ⚠️ Host-gated | The **host** must enable external exposure (`GAgentService:ExternalExposure: Enabled=true` + `RegisterAllPublishedServices` or an opt-in policy). You **cannot** turn this on as a client — verify `externalExposure` on the service and, if empty, tell the user to ask the host. |
 | **Schedule** a recurring run (cron) | ⚠️ Yes, with a binding | The scope owner needs a durable **NyxID broker binding** — i.e. an interactive **console** NyxID login, not just a CLI token. Without it, schedule creation 400s ("Authenticated NyxID owner binding is required"). |
 | A service backed by an **arbitrary custom agent / actor type** | ⚠️ Constrained | Member implementations are `workflow`, `script`, or **registered** `gagent` kinds (`GET /api/scopes/gagent-types`). You can't point a service at an arbitrary actor; wrap custom logic in a workflow or script, or use a registered gagent kind. |
@@ -123,6 +124,12 @@ State these plainly when they bite:
   get it at `<api_key_url>`.>" Then confirm with `GET /api/v1/services` that the slug appears.
 - **Register an inbound channel** (Lark/Telegram) → connect the bot connector, then register the
   channel via the channel-admin tool so NyxID wires the webhook to Aevatar's relay.
+- **External HTTP trigger** (Lark Base / webhook sender / external cron) → do **not** ask for
+  Aevatar `externalExposure` first. If the external system can call a public HTTPS URL with
+  headers and JSON, call NyxID's proxy route for the already-connected `aevatar` service using
+  a NyxID API key with `proxy` scope, and include the real scope/member/team id in the Aevatar
+  path. If the sender cannot tolerate SSE or cannot shape the typed payload, add a small
+  adapter/custom NyxID service or ask the host to configure Aevatar's webhook ingress.
 - **NyxID service registration** → ask the **host** to enable external exposure for the service;
   you can only drive publish + verify the `externalExposure` block.
 - **Scheduling** → "Do an interactive NyxID login in the Aevatar console once (establishes the
@@ -140,6 +147,10 @@ Give the user a straight answer in this shape — never a vague "maybe":
 - ⚠️ **Yes, but it needs an action you can't self-serve** — "The pipeline is fine, but exposing
   it as a NyxID connector for *others* to call requires the **host** to enable external exposure.
   In your own scope it works today without that."
+- ✅ **Yes, no externalExposure needed for this shape** — "Lark Base can trigger your existing
+  member workflow by sending an HTTPS request to NyxID's `aevatar` proxy with a NyxID API key,
+  targeting `/api/scopes/{scopeId}/members/{memberId}/invoke/chat:stream`. ExternalExposure is
+  only needed if you want this workflow registered as a reusable NyxID connector/slug."
 - ❌ **Not as described** — "An auto-replying **Twitter bot** isn't possible: there's no inbound
   Twitter channel on Aevatar (only Lark and Telegram). What *is* possible: a workflow that
   **posts** to X on a schedule (via the `api-twitter` connector), or an inbound bot on **Telegram**

--- a/skills/aevatar-platform-map/SKILL.md
+++ b/skills/aevatar-platform-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-platform-map
-description: Entry point, panorama, and router for the entire Aevatar skill family — load this FIRST whenever someone wants to build, run, publish, schedule, or operate anything on Aevatar ("create an agent team", "make a workflow / member", "publish or bind a service", "register it with NyxID", "set up a recurring / cron run", "invoke my service"), wants to know whether something is even possible ("can Aevatar do X?", "能不能用 aevatar 实现"), or just wants to know what Aevatar can do. It teaches the object model (scope → team → member[workflow|script|gagent] → service → schedule), how to authenticate as a NyxID-bearer REST client, how to resolve your scope, and the two caller modes (client REST vs in-session server-side tools). It does not do the work itself — it routes you to the right companion skill (feasibility-advisor, workflow-authoring, team-builder, service-publisher, scheduler, plus diagnostics probes and the safety-net fallback), held together by the shared `aevatar` tag.
-version: "1.6"
+description: Entry point, panorama, and router for the entire Aevatar skill family — load this FIRST whenever someone wants to build, run, publish, schedule, externally trigger, or operate anything on Aevatar ("create an agent team", "make a workflow / member", "publish or bind a service", "register it with NyxID", "set up a recurring / cron run", "invoke my service", "let Lark Base trigger my workflow"), wants to know whether something is even possible ("can Aevatar do X?", "能不能用 aevatar 实现"), or just wants to know what Aevatar can do. It teaches the object model (scope → team → member[workflow|script|gagent] → service → schedule/external trigger), how to authenticate as a NyxID-bearer REST client, how to resolve your scope, and the two caller modes (client REST vs in-session server-side tools). It does not do the work itself — it routes you to the right companion skill (feasibility-advisor, workflow-authoring, team-builder, service-publisher, scheduler, plus diagnostics probes and the safety-net fallback), held together by the shared `aevatar` tag.
+version: "1.7"
 metadata:
   category: plain
   tag:
@@ -28,7 +28,7 @@ self-contained, so you can also jump straight in once you know the step.
 subject id), and a request almost always walks one chain:
 
 ```
-scope → team → member (workflow | script | gagent) → service → schedule
+scope → team → member (workflow | script | gagent) → service → schedule / external trigger
 ```
 
 **Settle three things before you route** (each has a full section below — this is the checklist):
@@ -56,7 +56,8 @@ scope  (= your NyxID subject id; your private workspace; everything hangs off it
   │            • script     (an app script)
   │            • gagent     (a hosted agent actor)
   ├── service    a member/team published so it can be invoked + (host-gated) registered to NyxID
-  └── schedule   fires a service on a cron, authenticated as you (NyxID)
+  ├── schedule   fires a service on a cron, authenticated as you (NyxID)
+  └── external trigger  Lark Base / webhook / external cron calls the service invoke path
 ```
 
 The lifecycle the user almost always wants:
@@ -121,6 +122,7 @@ endpoints (they are not).
 | Create a **team**, create **members** (workflow/script/gagent), bind them, set the entry member | `aevatar-team-builder` | `/api/scopes/{id}/teams`, `/members`, `/members/{id}/binding` |
 | **Publish** a member/team **as a service** and **register it to NyxID**; verify it | `aevatar-service-publisher` | `/api/scopes/{id}/binding`, `/api/services/*`, `/members/{id}/published-service` |
 | Run it on a **cron schedule** (authenticated as you) | `aevatar-scheduler` | `/api/schedules`, `:run-now`, `:enable`, `:disable` |
+| Trigger an existing workflow from an external HTTP sender such as **Lark Base** | `aevatar-feasibility-advisor` first, then `aevatar-service-publisher` | NyxID `/api/v1/proxy/s/aevatar/api/scopes/{scopeId}/members/{memberId}/invoke/...`, host-managed `/api/workflow-webhooks/{routeKey}` if configured |
 | **Invoke**, watch **runs**, observe | (this map + service-publisher's invoke section) | `/invoke/{endpointId}`, `/runs/*`, `/api/workflow/observatory/*` |
 
 If a companion skill is not already loaded, find it with an ornn skill search for the
@@ -182,7 +184,9 @@ map is the canonical entry point; the rest are pulled on demand.
 4. **Set the team entry member** — `PUT /api/scopes/{scopeId}/teams/{teamId}/entry-member {memberId}`.
 5. **Publish as a service + register to NyxID**, then verify the NyxID slug —
    `aevatar-service-publisher`.
-6. **Schedule** it on a cron, authenticated as the scope owner — `aevatar-scheduler`.
+6. **Schedule** it on a cron, authenticated as the scope owner — `aevatar-scheduler`; or
+   trigger it from an external HTTP system such as Lark Base by calling NyxID's `aevatar`
+   proxy with a NyxID API key — `aevatar-service-publisher`.
 
 ## Honesty rules (so you never over-promise)
 
@@ -195,6 +199,10 @@ map is the canonical entry point; the rest are pulled on demand.
   the service's `externalExposure` block stays empty, say so: the service is still usable
   in-scope, just not exposed as a NyxID-brokered connector. (Details in
   `aevatar-service-publisher`.)
+- **External HTTP trigger is different from externalExposure.** Lark Base / external cron /
+  webhook senders can often trigger an existing member/team by calling the NyxID proxy for
+  `aevatar` with a NyxID API key and an explicit scope path. Host externalExposure is only
+  for turning the Aevatar service itself into a reusable NyxID connector/slug.
 - **Many steps are async.** Bindings, deployments, and runs settle over time. Read state
   back (binding run status, invocation readiness, run timeline) instead of assuming
   success from a 2xx.

--- a/skills/aevatar-scheduler/SKILL.md
+++ b/skills/aevatar-scheduler/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-scheduler
 description: Create and manage cron schedules that fire an Aevatar service on a recurring basis, authenticated as the scope owner via NyxID — over the REST API. Use when a user wants to "schedule", "run on a cron", "set up a recurring run", "run every day/hour/Monday", "automate this service on a timer", "preview a cron", "pause/resume/disable a schedule", or "run it now" — or hits token_expired on a scheduled run's late steps. It builds the schedule against a published service (identity + endpoint + payload + serving revision), uses scope-owner NyxID auth (which requires the owner's NyxID broker binding), documents the fire-time credential's fixed 5-minute lifetime and how to design runs around it, and covers preview, enable/disable, run-now, update, and delete. Publish the service first with the service-publisher skill.
-version: "1.6"
+version: "1.7"
 metadata:
   category: plain
   tag:
@@ -112,8 +112,12 @@ NYXID_ACCESS_TOKEN="$KEY" nyxid proxy request aevatar \
   -H 'Content-Type: application/json' -d '{"prompt":"poll"}'
 ```
 The member invoke endpoint carries `scopeId` in its path, so it runs even though a bare API
-key reports `scopeResolved:false` on the generic `api/studio/context` call. Trade-off: the
-timer runs on whatever machine you put it on (a cloud cron would live in Aevatar; this does not).
+key reports `scopeResolved:false` on the generic `api/studio/context` call. The same pattern
+works for **event-driven external triggers** such as Lark Base automation's "send HTTP request"
+action: store the NyxID API key as the external system's secret and POST to the explicit
+member/team invoke path. This is not Aevatar `externalExposure`; externalExposure is only
+needed when the workflow must be registered as a reusable NyxID connector/slug. Trade-off:
+the timer or event sender runs outside Aevatar (a cloud cron would live in Aevatar; this does not).
 
 ## The fire-time credential lives 5 minutes — design the run around it
 

--- a/skills/aevatar-scheduler/SKILL.md
+++ b/skills/aevatar-scheduler/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-scheduler
-description: Create and manage cron schedules that fire an Aevatar service on a recurring basis, authenticated as the scope owner via NyxID — over the REST API. Use when a user wants to "schedule", "run on a cron", "set up a recurring run", "run every day/hour/Monday", "automate this service on a timer", "preview a cron", "pause/resume/disable a schedule", or "run it now". It builds the schedule against a published service (identity + endpoint + payload + serving revision), uses scope-owner NyxID auth (which requires the owner's NyxID broker binding), and covers preview, enable/disable, run-now, update, and delete. Publish the service first with the service-publisher skill.
-version: "1.5"
+description: Create and manage cron schedules that fire an Aevatar service on a recurring basis, authenticated as the scope owner via NyxID — over the REST API. Use when a user wants to "schedule", "run on a cron", "set up a recurring run", "run every day/hour/Monday", "automate this service on a timer", "preview a cron", "pause/resume/disable a schedule", or "run it now" — or hits token_expired on a scheduled run's late steps. It builds the schedule against a published service (identity + endpoint + payload + serving revision), uses scope-owner NyxID auth (which requires the owner's NyxID broker binding), documents the fire-time credential's fixed 5-minute lifetime and how to design runs around it, and covers preview, enable/disable, run-now, update, and delete. Publish the service first with the service-publisher skill.
+version: "1.6"
 metadata:
   category: plain
   tag:
@@ -114,6 +114,29 @@ NYXID_ACCESS_TOKEN="$KEY" nyxid proxy request aevatar \
 The member invoke endpoint carries `scopeId` in its path, so it runs even though a bare API
 key reports `scopeResolved:false` on the generic `api/studio/context` call. Trade-off: the
 timer runs on whatever machine you put it on (a cloud cron would live in Aevatar; this does not).
+
+## The fire-time credential lives 5 minutes — design the run around it
+
+At every fire, Aevatar exchanges the stored broker binding for a **fresh access token** (OAuth
+token-exchange, `subject_token_type=urn:nyxid:params:oauth:token-type:binding-id`) and projects
+that **one** token into the run as its caller credential — minted once, shared by the whole run
+(aevatar: `agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs`,
+`src/platform/Aevatar.GAgentService.Infrastructure/Schedules/ScheduledServiceInvocationDispatchPort.cs`).
+Broker-issued tokens are pinned to **`BROKER_ACCESS_TTL_SECS = 300`** (NyxID
+`backend/src/services/oauth_broker_service.rs`) so a revoked binding stops working within
+5 minutes without introspection. Deliberate design, not a bug.
+
+**Consequence:** every NyxID-authenticated step in the fired run must complete within ~5 minutes
+of fire. In a longer run, late steps failing with `token_expired` is the **expected** platform
+behavior — keep scheduled runs short, front-load the NyxID-authenticated steps, or split long
+pipelines into separate schedules. Do not "fix" it by retrying the same run shape.
+
+**Token classes are not interchangeable — never quote one class's TTL for another.** Your
+interactive login token lives for hours (`JWT_ACCESS_TTL_SECS`, a deployment config — code
+default is 900 s); the scheduled run's credential lives 300 s (fixed constant); NyxID API keys
+(`nyxid api-key create`) don't expire at all. When diagnosing any expiry, read the lifetime
+instead of recalling it: decode the JWT actually in hand and report `exp − iat` (numbers only —
+never print the token), or cite the owning repo's constant.
 
 ## Create the schedule
 

--- a/skills/aevatar-service-publisher/SKILL.md
+++ b/skills/aevatar-service-publisher/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-service-publisher
-description: Publish an Aevatar member, team, or workflow as an invocable service and (host permitting) register it with NyxID, then verify and invoke it — all over the REST API. Use when a user wants to "publish/bind a service", "expose my workflow/team as a service", "register it with NyxID", "make it callable", "get the service slug/URL", "invoke my service", or "version/deploy/roll out a service". It covers the simple scope binding, reading back a member's published service, the full account-level service lifecycle (revision → publish → deploy → rollout), how to confirm the NyxID registration (slug + status), and how to invoke an endpoint. Build the team/member first with the team-builder skill.
-version: "1.4"
+description: Publish an Aevatar member, team, or workflow as an invocable service and (host permitting) register it with NyxID, then verify, invoke, or wire external HTTP triggers such as Lark Base automation — all over the REST API. Use when a user wants to "publish/bind a service", "expose my workflow/team as a service", "register it with NyxID", "make it callable", "get the service slug/URL", "invoke my service", "let Lark Base call my workflow", "trigger this workflow from an external webhook", or "version/deploy/roll out a service". It covers the simple scope binding, reading back a member's published service, the full account-level service lifecycle (revision → publish → deploy → rollout), how to confirm the NyxID registration (slug + status), how to invoke an endpoint, and how to distinguish direct NyxID proxy triggering from host-gated externalExposure. Build the team/member first with the team-builder skill.
+version: "1.5"
 metadata:
   category: plain
   tag:
@@ -52,6 +52,13 @@ enabled and the service is in scope of that policy. You can drive publish + acti
 read the result, but you cannot turn host exposure on from the client. So always **verify**
 (below) and report honestly: if no NyxID slug appears, the service is still usable
 in-scope, it just is not a NyxID-brokered connector.
+
+Do not confuse that with an **external trigger**. An external system such as Lark Base does
+not need the workflow itself registered as a NyxID connector if it is only triggering the
+owner's existing member/team/service. It can call the already-connected NyxID `aevatar`
+proxy with a NyxID API key, using an explicit Aevatar scope/member/team invoke path. Ask
+for host `externalExposure` only when the requirement is "make this Aevatar service a
+reusable NyxID connector/slug for other callers."
 
 ## Path A — A member you already bound (from team-builder)
 
@@ -158,6 +165,74 @@ Teams and account-level services invoke the same way:
 Watch runs: `GET /api/scopes/{scopeId}/services/{serviceId}/runs` and `…/runs/{runId}`
 (and `:resume` / `:stop` / `:signal`). For a visual timeline use the observatory:
 `GET /api/workflow/observatory/runs`.
+
+## External HTTP triggers (Lark Base, webhook sender, external cron)
+
+Feasibility rule: if the external system can send an HTTPS request to a public URL with
+headers and a JSON body, it can usually trigger an Aevatar member/team workflow through
+NyxID without Aevatar service `externalExposure`. Lark Base automation's "send HTTP
+request" action fits this class: it is an outbound HTTP action to a specified URL, not an
+Aevatar inbound chat channel.
+
+### Direct NyxID proxy trigger
+
+Create a non-expiring NyxID API key with `proxy` scope and store it as the external
+system's secret:
+
+```bash
+nyxid api-key create --name "lark-base-aevatar-trigger" --scopes proxy
+```
+
+Then configure the external HTTP action as:
+
+```http
+POST https://nyx-api.chrono-ai.fun/api/v1/proxy/s/aevatar/api/scopes/{scopeId}/members/{memberId}/invoke/chat:stream
+Authorization: Bearer <NYXID_API_KEY>
+Content-Type: application/json
+Accept: text/event-stream
+
+{"prompt":"Apply Lark email approval for {{record_id}} / {{email}}"}
+```
+
+Use the **member** or **team** invoke path that already carries `scopeId`; do not rely on
+`api/studio/context` from a bare API key, because that generic context can report
+`scopeResolved:false`. For a team entry member:
+
+```http
+POST /api/v1/proxy/s/aevatar/api/scopes/{scopeId}/teams/{teamId}/invoke/chat:stream
+```
+
+Trade-offs:
+- `.../invoke/chat:stream` accepts the prompt shorthand but returns SSE. Use it when the
+  external sender can ignore/accept a streaming response and you only need to trigger the run.
+- Non-stream `.../invoke/{endpointId}` returns a JSON receipt, but it expects a typed
+  request envelope (`payloadTypeUrl` plus `payloadBase64`, or `payloadJson` only when the
+  serving revision has a descriptor). A bare `{ "prompt": "..." }` is invalid.
+- If the external tool cannot set headers, cannot keep secrets safely, cannot tolerate SSE,
+  or cannot build the typed envelope, use an adapter path below instead of forcing it.
+
+### Adapter path
+
+Use a small webhook/HTTP adapter (or a custom NyxID service) when you need a normal JSON
+ACK, body transformation, request signing, idempotency, or Lark-specific payload cleanup.
+The adapter receives the Lark Base request, validates its own secret, maps the record fields
+to an Aevatar prompt or typed payload, calls the NyxID proxy, and returns a simple 2xx/JSON
+response to Lark Base.
+
+### Host-managed webhook ingress
+
+Aevatar also has a host-configured workflow webhook ingress at:
+
+```http
+POST /api/workflow-webhooks/{routeKey}
+```
+
+It supports binding-level `RouteKey`, `SourceId`, `WorkflowName`, `ScopeId`,
+`PromptTemplate` or `PromptJsonPath`, delivery-id extraction, replay dedupe, and HMAC-SHA256
+auth (`X-Aevatar-Timestamp` plus `X-Aevatar-Signature` over `timestamp.body` by default).
+This is a good first-class bridge for Lark Base-style webhooks **if the host configures the
+binding and secret** (`WorkflowWebhookIngress:Enabled` + binding + replay store). It is not
+currently a normal client self-serve operation, so report it as host-managed.
 
 ## Next
 

--- a/skills/aevatar-triage/SKILL.md
+++ b/skills/aevatar-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-triage
 description: Use AFTER something goes wrong while using Aevatar — a user hits an error, failure, or confusing behavior and you must find whether it lives in Aevatar, NyxID, or Ornn, then act. Triggers - "aevatar is erroring", "why did my workflow fail", "my scheduled run did not fire", "my bot does not reply", "connector 401/403", "skill won't pull/upload", "is this an aevatar, nyxid, or ornn bug", "file an issue", "am I using this right". It attributes the failure by tracing the request path, pulls that layer's real public source for a code-grounded root cause citing file and line, then branches - draft and, only on explicit user confirmation, file a precise GitHub issue when behavior violates the layer's published contract, or explain the correct usage from the code when it is a usage mistake. The after-it-breaks counterpart to aevatar-feasibility-advisor; never auto-files, de-dups first, never claims a root cause without a code citation. Works locally (git + gh) and server-side (nyxid_proxy + api-github).
-version: "1.1"
+version: "1.2"
 metadata:
   category: plain
   tag:
@@ -73,6 +73,7 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 | **scheduled run stopped firing** (fired before; `nextFireAt` frozen in the past, `fireCount` flat, `failureCount=0`, empty `lastError`) | **Aevatar** (scheduler / actor not re-armed across pod churn) | compare to peer schedules; pod `startTime` / `restartCount`; is it still enabled? did a deploy/restart line up with the last good fire? |
 | **scheduled run never fires, or fires but errors on credential** | **Aevatar scheduler ⨯ NyxID** (binding) | is it enabled and is `nextFireAt` computed? `lastError` like "binding not found" / "exactly one credential source" -> the *fired call's* invocation credential (scope-owner broker binding) |
 | **schedule fires (`fireCount` climbs) but the real-world effect never happens** | **Aevatar** (the fired call's path / credential) | dispatch success ≠ effect — check the external side-effect out-of-band; the proxy can hand back `{"error":true}` inside a `200` |
+| **scheduled run starts fine, then late steps hit `token_expired` ~5 min after fire** | **by design (NyxID broker TTL)** | the run's caller credential is minted once at fire and pinned to `BROKER_ACCESS_TTL_SECS = 300` (NyxID `backend/src/services/oauth_broker_service.rs`) — fast-revocation design, not a bug; correlate failure onset with **fire time** (per-run ~5 min mark ⇒ broker TTL) vs a fixed wall-clock time (⇒ something else); fix by shortening the run / front-loading NyxID-authenticated steps, not by retrying |
 | **inbound bot doesn't reply** (Lark/Telegram) | **cross-layer — walk it** | did NyxID relay webhook fire? is the bot connector connected? did the Aevatar channel run start (observatory)? credential = the *sender's* NyxID, present and live? |
 | **`/whoami` says "bound" but tool calls get `credential_denied`** | **NyxID** (grant revoked — false green) | live token-exchange returns `invalid_grant` while the local readmodel still reads "bound"; whoami checks only the local mirror, not the live grant |
 | approval prompt stuck | **NyxID approvals + Aevatar suspension** | NyxID approval request id; Aevatar workflow wait/suspend state |
@@ -80,6 +81,17 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 
 **Do not stop at the first match.** Gather the disambiguating evidence and *eliminate* — a plausible
 first guess that you haven't excluded the alternatives for is not an attribution.
+
+**Token lifetimes: read, never recall.** The stack holds several credential classes with wildly
+different TTLs — interactive login access token (`JWT_ACCESS_TTL_SECS`, deployment config; code
+default 900 s, production instances often set hours), broker/delegated tokens (fixed 300 s,
+`oauth_broker_service.rs` / `crypto/jwt.rs`), service-account tokens (`SA_TOKEN_TTL_SECS`, default
+3600 s), non-expiring NyxID API keys. Two statements like "the token lives 8 hours" and "the run
+credential lives 5 minutes" can both be true — about different classes — so a TTL claim that
+doesn't name its token class is not evidence. Before attributing any expiry: decode the JWT
+actually involved and report `exp − iat` (numbers only, never the token), or cite the owning
+repo's constant. A lifetime quoted from memory is the classic source of confident-but-wrong
+attributions here.
 
 ## Step 3 — Pull the repo and reach a code-grounded root cause
 

--- a/skills/aevatar-triage/SKILL.md
+++ b/skills/aevatar-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-triage
 description: Use AFTER something goes wrong while using Aevatar — a user hits an error, failure, or confusing behavior and you must find whether it lives in Aevatar, NyxID, or Ornn, then act. Triggers - "aevatar is erroring", "why did my workflow fail", "my scheduled run did not fire", "my bot does not reply", "connector 401/403", "skill won't pull/upload", "is this an aevatar, nyxid, or ornn bug", "file an issue", "am I using this right". It attributes the failure by tracing the request path, pulls that layer's real public source for a code-grounded root cause citing file and line, then branches - draft and, only on explicit user confirmation, file a precise GitHub issue when behavior violates the layer's published contract, or explain the correct usage from the code when it is a usage mistake. The after-it-breaks counterpart to aevatar-feasibility-advisor; never auto-files, de-dups first, never claims a root cause without a code citation. Works locally (git + gh) and server-side (nyxid_proxy + api-github).
-version: "1.2"
+version: "1.3"
 metadata:
   category: plain
   tag:
@@ -113,6 +113,9 @@ reading; the tree evolves.**
   connector adapters in `src/Aevatar.AI.ToolProviders.*` (incl. NyxId, Ornn); readmodels in
   `src/Aevatar.CQRS.Projection.*`; engine + HTTP/OpenAPI in `src/workflow/`; **contract** in
   `src/Aevatar.AI.Abstractions` + `docs/canon/`; errors as workflow exceptions + control-plane 4xx/5xx.
+  **Read the deployed branch: Aevatar currently ships from `feature/integrate` — *not* the repo
+  default and *not* `dev`.** Reading the wrong branch is the fast way to a wrong root cause; confirm
+  the branch against the live image tag (deploy branches move — verify, don't assume).
 - **NyxID** (`ChronoAIProject/NyxID`): endpoint handlers in `backend/src/handlers/` (proxy, auth,
   oauth, approvals, mcp, node/ssh); vault logic in `backend/src/services/`; **all error variants +
   numeric codes in `backend/src/errors/`** (observed ranges — confirm: ~2000 auth, ~3000 approval,
@@ -201,8 +204,9 @@ authoritative side, say so and escalate there (query that layer's own API / stat
 ### Local coding agent — preferred for deep RCA
 ```bash
 # read the suspected layer (shallow clone; reuse an existing clone if present)
-gh repo clone aevatarAI/aevatar        # or ChronoAIProject/NyxID , ChronoAIProject/Ornn
-#   git clone --depth=1 https://github.com/<owner>/<repo>
+# Aevatar ships from feature/integrate (NOT the repo default, NOT dev) — read THAT ref:
+gh repo clone aevatarAI/aevatar -- -b feature/integrate     # NyxID / Ornn: their own deployed branch (confirm)
+#   git clone --depth=1 -b feature/integrate https://github.com/aevatarAI/aevatar
 # is it already fixed but not deployed? (check before drafting a defect)
 git -C <repo> log <deployed-sha>..origin/<branch> --oneline
 # de-dup before drafting
@@ -215,8 +219,9 @@ gh issue create -R <owner>/<repo> --title "[<layer>] ..." --body "..."
 ### Server-side, in an aevatar session — constrained fallback
 Use the runtime **`nyxid_proxy` tool** (not the `nyxid` CLI), `slug=api-github`, base
 `https://api.github.com`:
-- read code: `GET /repos/{owner}/{repo}/contents/{path}` , `GET /search/code?q=...+repo:owner/repo`
-  (repos are public; raw fetch also works).
+- read code at the **deployed ref**: `GET /repos/{owner}/{repo}/contents/{path}?ref=<deployed-branch>`
+  — for `aevatarAI/aevatar` that ref is **`feature/integrate`** (not the default, not `dev`) —
+  `GET /search/code?q=...+repo:owner/repo` (repos are public; raw fetch also works).
 - de-dup: `GET /search/issues?q=repo:owner/repo+is:issue+<keywords>`.
 - file (confirmed only): `POST /repos/{owner}/{repo}/issues`.
 


### PR DESCRIPTION
## Problem

Scheduled Aevatar runs authenticate with a broker token minted **once at fire time** via the binding-id token-exchange, and broker tokens are pinned to `BROKER_ACCESS_TTL_SECS = 300` (`backend/src/services/oauth_broker_service.rs` — the fast-revocation design). So in any fired run longer than ~5 minutes, late NyxID-authenticated steps hit `token_expired` **by design**.

Neither `aevatar-scheduler` nor `aevatar-triage` documented this. In practice this gap makes agents hallucinate credential lifetimes when triaging: quoting the interactive login TTL (hours, `JWT_ACCESS_TTL_SECS` deployment config) for the run credential, or asserting numbers from memory ("the token lives ~7 min") without decoding the JWT. Two TTL claims can both be true about different token classes; a claim that doesn't name its class is not evidence.

## Changes

- **aevatar-scheduler** (1.5 → 1.6): new section "The fire-time credential lives 5 minutes — design the run around it": the mint-once-per-fire chain (aevatar `NyxIdRemoteCapabilityBroker.cs` → `ScheduledServiceInvocationDispatchPort.cs`), the design consequence (keep runs short / front-load NyxID-authenticated steps / split pipelines), and the read-not-recall rule (decode `exp − iat`, never print the token). Description gains the `token_expired` trigger.
- **aevatar-triage** (1.1 → 1.2): new symptom-table row for "run starts fine, late steps hit `token_expired` ~5 min after fire" (attribution: by design, with the fire-time-vs-wall-clock disambiguation test), plus a "Token lifetimes: read, never recall" note listing the token classes and requiring any TTL claim to name its class and cite a decoded JWT or the owning repo's constant.

## Notes for the curator

- The ornn-hosted copies of this family version independently (ornn currently serves an `aevatar-triage@1.2` from a separate lineage and pins `aevatar-scheduler@1.4` in the `aevatar-platform` skillset), so re-sync/bump on upload as you see fit.
- All numbers cited are from this repo's source, not from memory: `BROKER_ACCESS_TTL_SECS = 300` (oauth_broker_service.rs), `DELEGATED_TOKEN_TTL_SECS = 300` (crypto/jwt.rs), `JWT_ACCESS_TTL_SECS` code default 900 s (config.rs), `SA_TOKEN_TTL_SECS` default 3600 s (config.rs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)