### PR TITLE
feat(admin): add scalable OAuth client table controls

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -377,7 +377,92 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
         )
         .await?;
 
-    // ── oauth_clients ── (no special indexes beyond _id)
+    // ── oauth_clients ──
+    let oauth_clients = db.collection::<mongodb::bson::Document>("oauth_clients");
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_created_at_id".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "created_by": 1, "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_creator_created_at".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "client_type": 1, "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_type_created_at".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "is_active": 1, "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_active_created_at".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "client_name": 1, "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_name_created_at".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "broker_capability_enabled": 1, "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_broker_created_at".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    oauth_clients
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "allowed_scopes": 1, "created_at": 1, "_id": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("oauth_clients_allowed_scopes_created_at".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
 
     // ── oauth_broker_bindings ──
     let oauth_broker_bindings = db.collection::<OauthBrokerBinding>(OAUTH_BROKER_BINDINGS);

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -898,6 +898,41 @@ pub struct UpdateOAuthClientRequest {
     pub client_name: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+pub struct OAuthClientListQuery {
+    pub page: Option<u64>,
+    pub per_page: Option<u64>,
+    pub search: Option<String>,
+    pub search_filters: Option<String>,
+    pub client_type: Option<String>,
+    pub creator_type: Option<String>,
+    pub broker: Option<String>,
+    pub is_active: Option<String>,
+    pub scope: Option<String>,
+    pub created_dates: Option<String>,
+    pub created_from: Option<String>,
+    pub created_to: Option<String>,
+    pub sort: Option<String>,
+}
+
+impl OAuthClientListQuery {
+    fn has_table_controls(&self) -> bool {
+        self.page.is_some()
+            || self.per_page.is_some()
+            || self.search.is_some()
+            || self.search_filters.is_some()
+            || self.client_type.is_some()
+            || self.creator_type.is_some()
+            || self.broker.is_some()
+            || self.is_active.is_some()
+            || self.scope.is_some()
+            || self.created_dates.is_some()
+            || self.created_from.is_some()
+            || self.created_to.is_some()
+            || self.sort.is_some()
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct OAuthClientResponse {
     pub id: String,
@@ -918,8 +953,74 @@ pub struct OAuthClientResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub struct OAuthClientListResponse {
+#[serde(untagged)]
+pub enum OAuthClientListResponse {
+    Legacy(OAuthClientLegacyListResponse),
+    Paginated(Box<OAuthClientPaginatedListResponse>),
+}
+
+#[derive(Debug, Serialize)]
+pub struct OAuthClientLegacyListResponse {
     pub clients: Vec<OAuthClientResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OAuthClientPaginatedListResponse {
+    pub clients: Vec<OAuthClientResponse>,
+    pub total: u64,
+    pub page: u64,
+    pub per_page: u64,
+    pub filter_options: OAuthClientFilterOptions,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OAuthClientFilterOptions {
+    pub client_types: Vec<&'static str>,
+    pub creator_types: Vec<&'static str>,
+    pub broker_filters: Vec<&'static str>,
+    pub statuses: Vec<bool>,
+    pub allowed_scopes: Vec<&'static str>,
+    pub sorts: Vec<&'static str>,
+    pub search_fields: Vec<OAuthClientSearchField>,
+    pub fields: Vec<OAuthClientFilterField>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct OAuthClientSearchField {
+    pub key: &'static str,
+    pub label: &'static str,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthClientFilterValueType {
+    Enum,
+    Boolean,
+    Date,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthClientFilterOperator {
+    Is,
+    Includes,
+    Between,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct OAuthClientFilterOption {
+    pub value: &'static str,
+    pub label: &'static str,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct OAuthClientFilterField {
+    pub key: &'static str,
+    pub label: &'static str,
+    pub value_type: OAuthClientFilterValueType,
+    pub operator: OAuthClientFilterOperator,
+    pub multiple: bool,
+    pub options: Vec<OAuthClientFilterOption>,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
@@ -1030,6 +1131,109 @@ fn broker_settings_response(state: &AppState) -> BrokerSettingsResponse {
             policy.broker_require_admin_capability_env_default,
             policy.broker_require_admin_capability_override,
         ),
+    }
+}
+
+fn oauth_client_filter_option(value: &'static str, label: &'static str) -> OAuthClientFilterOption {
+    OAuthClientFilterOption { value, label }
+}
+
+fn oauth_scope_label(scope: &'static str) -> &'static str {
+    match scope {
+        "openid" => "OpenID",
+        "profile" => "Profile",
+        "email" => "Email",
+        "roles" => "Roles",
+        "groups" => "Groups",
+        "offline_access" => "Offline access",
+        "proxy" => "Proxy",
+        "urn:nyxid:scope:broker_binding" => "Broker binding",
+        _ => scope,
+    }
+}
+
+fn oauth_client_filter_options() -> OAuthClientFilterOptions {
+    OAuthClientFilterOptions {
+        client_types: oauth_client_service::ADMIN_CLIENT_TYPE_FILTERS.to_vec(),
+        creator_types: oauth_client_service::ADMIN_CREATOR_TYPE_FILTERS.to_vec(),
+        broker_filters: oauth_client_service::ADMIN_BROKER_FILTERS.to_vec(),
+        statuses: vec![true, false],
+        allowed_scopes: oauth_client_service::KNOWN_OIDC_SCOPES.to_vec(),
+        sorts: oauth_client_service::ADMIN_SORT_OPTIONS.to_vec(),
+        search_fields: oauth_client_service::ADMIN_SEARCH_FIELDS
+            .iter()
+            .map(|(key, label)| OAuthClientSearchField { key, label })
+            .collect(),
+        fields: vec![
+            OAuthClientFilterField {
+                key: "is_active",
+                label: "Status",
+                value_type: OAuthClientFilterValueType::Boolean,
+                operator: OAuthClientFilterOperator::Is,
+                multiple: true,
+                options: vec![
+                    oauth_client_filter_option("true", "Active"),
+                    oauth_client_filter_option("false", "Inactive"),
+                ],
+            },
+            OAuthClientFilterField {
+                key: "client_type",
+                label: "Client type",
+                value_type: OAuthClientFilterValueType::Enum,
+                operator: OAuthClientFilterOperator::Is,
+                multiple: true,
+                options: vec![
+                    oauth_client_filter_option("public", "Public"),
+                    oauth_client_filter_option("confidential", "Confidential"),
+                    oauth_client_filter_option("other", "Other"),
+                ],
+            },
+            OAuthClientFilterField {
+                key: "creator_type",
+                label: "Creator",
+                value_type: OAuthClientFilterValueType::Enum,
+                operator: OAuthClientFilterOperator::Is,
+                multiple: true,
+                options: vec![
+                    oauth_client_filter_option("dynamic_registration", "Dynamic registration"),
+                    oauth_client_filter_option("system", "System"),
+                    oauth_client_filter_option("owned", "User / org"),
+                    oauth_client_filter_option("ownerless", "Ownerless"),
+                ],
+            },
+            OAuthClientFilterField {
+                key: "broker",
+                label: "Broker capability",
+                value_type: OAuthClientFilterValueType::Enum,
+                operator: OAuthClientFilterOperator::Is,
+                multiple: true,
+                options: vec![
+                    oauth_client_filter_option("enabled", "Enabled"),
+                    oauth_client_filter_option("disabled", "Disabled"),
+                    oauth_client_filter_option("flag", "Enabled by admin grant"),
+                    oauth_client_filter_option("scope", "Enabled by broker scope"),
+                ],
+            },
+            OAuthClientFilterField {
+                key: "scope",
+                label: "Allowed scope",
+                value_type: OAuthClientFilterValueType::Enum,
+                operator: OAuthClientFilterOperator::Includes,
+                multiple: true,
+                options: oauth_client_service::KNOWN_OIDC_SCOPES
+                    .iter()
+                    .map(|scope| oauth_client_filter_option(scope, oauth_scope_label(scope)))
+                    .collect(),
+            },
+            OAuthClientFilterField {
+                key: "created_at",
+                label: "Created",
+                value_type: OAuthClientFilterValueType::Date,
+                operator: OAuthClientFilterOperator::Between,
+                multiple: true,
+                options: vec![],
+            },
+        ],
     }
 }
 
@@ -1150,17 +1354,64 @@ pub async fn create_oauth_client(
 pub async fn list_oauth_clients(
     State(state): State<AppState>,
     auth_user: AuthUser,
+    Query(query): Query<OAuthClientListQuery>,
 ) -> AppResult<Json<OAuthClientListResponse>> {
     require_admin_or_operator(&state, &auth_user, "admin.oauth_clients.list").await?;
 
-    let clients = oauth_client_service::list_clients(&state.db).await?;
+    let broker_policy = state.broker_policy();
+    if !query.has_table_controls() {
+        let clients = oauth_client_service::list_clients_legacy(&state.db).await?;
+        let items = clients
+            .into_iter()
+            .map(|client| {
+                oauth_client_response(client, None, broker_policy.broker_require_admin_capability)
+            })
+            .collect();
+        return Ok(Json(OAuthClientListResponse::Legacy(
+            OAuthClientLegacyListResponse { clients: items },
+        )));
+    }
+
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(25).clamp(1, 100);
+    let sort = query.sort.as_deref().unwrap_or("-created_at");
+    let (clients, total) = oauth_client_service::list_clients(
+        &state.db,
+        oauth_client_service::AdminOAuthClientListParams {
+            page,
+            per_page,
+            search: query.search.as_deref(),
+            search_filters: query.search_filters.as_deref(),
+            client_type: query.client_type.as_deref(),
+            creator_type: query.creator_type.as_deref(),
+            broker: query.broker.as_deref(),
+            is_active: query.is_active.as_deref(),
+            scope: query.scope.as_deref(),
+            created_dates: query.created_dates.as_deref(),
+            created_from: query.created_from.as_deref(),
+            created_to: query.created_to.as_deref(),
+            sort,
+            broker_require_admin_capability: broker_policy.broker_require_admin_capability,
+        },
+    )
+    .await?;
 
     let items: Vec<OAuthClientResponse> = clients
         .into_iter()
-        .map(|client| oauth_client_response(client, None, state.broker_require_admin_capability()))
+        .map(|client| {
+            oauth_client_response(client, None, broker_policy.broker_require_admin_capability)
+        })
         .collect();
 
-    Ok(Json(OAuthClientListResponse { clients: items }))
+    Ok(Json(OAuthClientListResponse::Paginated(Box::new(
+        OAuthClientPaginatedListResponse {
+            clients: items,
+            total,
+            page,
+            per_page,
+            filter_options: oauth_client_filter_options(),
+        },
+    ))))
 }
 
 /// PATCH /api/v1/admin/oauth-clients/:client_id
@@ -1538,6 +1789,176 @@ mod tests {
         let json = serde_json::to_value(&resp).expect("serialize");
         assert_eq!(json["message"], "done");
     }
+
+    #[test]
+    fn oauth_client_list_query_accepts_scalar_multi_status_and_date_values() {
+        let scalar_uri: http::Uri = "/api/v1/admin/oauth-clients?is_active=true"
+            .parse()
+            .unwrap();
+        let Query(scalar) = Query::<OAuthClientListQuery>::try_from_uri(&scalar_uri).unwrap();
+        assert_eq!(scalar.is_active.as_deref(), Some("true"));
+
+        let multi_uri: http::Uri = "/api/v1/admin/oauth-clients?is_active=true%2Cfalse&client_type=public%2Cconfidential&created_from=2026-07-03&created_to=2026-07-10&created_dates=2026-06-01%2C2026-06-15"
+            .parse()
+            .unwrap();
+        let Query(multi) = Query::<OAuthClientListQuery>::try_from_uri(&multi_uri).unwrap();
+        assert_eq!(multi.is_active.as_deref(), Some("true,false"));
+        assert_eq!(multi.client_type.as_deref(), Some("public,confidential"));
+        assert_eq!(multi.created_from.as_deref(), Some("2026-07-03"));
+        assert_eq!(multi.created_to.as_deref(), Some("2026-07-10"));
+        assert_eq!(
+            multi.created_dates.as_deref(),
+            Some("2026-06-01,2026-06-15")
+        );
+
+        let search_uri: http::Uri = "/api/v1/admin/oauth-clients?search_filters=%5B%7B%22field%22%3A%22client%22%2C%22values%22%3A%5B%22console%22%2C%22portal%22%5D%7D%5D"
+            .parse()
+            .unwrap();
+        let Query(search) = Query::<OAuthClientListQuery>::try_from_uri(&search_uri).unwrap();
+        assert_eq!(
+            search.search_filters.as_deref(),
+            Some(r#"[{"field":"client","values":["console","portal"]}]"#)
+        );
+    }
+
+    #[test]
+    fn oauth_client_list_query_only_opts_in_for_recognized_table_controls() {
+        let unknown_uri: http::Uri = "/api/v1/admin/oauth-clients?future_parameter=value"
+            .parse()
+            .unwrap();
+        let Query(unknown) = Query::<OAuthClientListQuery>::try_from_uri(&unknown_uri).unwrap();
+        assert!(!unknown.has_table_controls());
+
+        for query in [
+            "page=1",
+            "per_page=25",
+            "search=client",
+            "search_filters=%5B%7B%22field%22%3A%22client%22%2C%22values%22%3A%5B%22console%22%5D%7D%5D",
+            "client_type=public",
+            "creator_type=system",
+            "broker=enabled",
+            "is_active=true",
+            "scope=openid",
+            "created_dates=2026-07-03",
+            "created_from=2026-07-01",
+            "created_to=2026-07-31",
+            "sort=-created_at",
+        ] {
+            let uri: http::Uri = format!("/api/v1/admin/oauth-clients?{query}")
+                .parse()
+                .unwrap();
+            let Query(parsed) = Query::<OAuthClientListQuery>::try_from_uri(&uri).unwrap();
+            assert!(
+                parsed.has_table_controls(),
+                "recognized parameter must opt into table behavior: {query}"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_client_filter_metadata_describes_every_supported_field() {
+        let metadata = oauth_client_filter_options();
+        assert_eq!(
+            metadata
+                .search_fields
+                .iter()
+                .map(|field| (field.key, field.label))
+                .collect::<Vec<_>>(),
+            [
+                ("client", "Client"),
+                ("client_type", "Client type"),
+                ("created_by", "Created by"),
+                ("allowed_scopes", "Allowed scopes"),
+            ]
+        );
+        assert_eq!(
+            metadata
+                .fields
+                .iter()
+                .filter(|field| field.multiple)
+                .count(),
+            6
+        );
+        assert_eq!(
+            metadata
+                .fields
+                .iter()
+                .map(|field| field.key)
+                .collect::<Vec<_>>(),
+            [
+                "is_active",
+                "client_type",
+                "creator_type",
+                "broker",
+                "scope",
+                "created_at",
+            ]
+        );
+
+        let status = metadata
+            .fields
+            .iter()
+            .find(|field| field.key == "is_active")
+            .expect("status metadata");
+        assert_eq!(status.value_type, OAuthClientFilterValueType::Boolean);
+        assert_eq!(status.operator, OAuthClientFilterOperator::Is);
+        assert!(status.multiple);
+        assert_eq!(
+            status
+                .options
+                .iter()
+                .map(|option| (option.value, option.label))
+                .collect::<Vec<_>>(),
+            [("true", "Active"), ("false", "Inactive")]
+        );
+
+        let scopes = metadata
+            .fields
+            .iter()
+            .find(|field| field.key == "scope")
+            .expect("scope metadata");
+        assert_eq!(scopes.value_type, OAuthClientFilterValueType::Enum);
+        assert_eq!(scopes.operator, OAuthClientFilterOperator::Includes);
+        assert!(scopes.multiple);
+        assert_eq!(
+            scopes.options.len(),
+            oauth_client_service::KNOWN_OIDC_SCOPES.len()
+        );
+        assert!(scopes.options.iter().any(|option| {
+            option.value == crate::services::oauth_broker_service::BROKER_BINDING_SCOPE
+                && option.label == "Broker binding"
+        }));
+
+        let created_at = metadata
+            .fields
+            .iter()
+            .find(|field| field.key == "created_at")
+            .expect("created-at metadata");
+        assert_eq!(created_at.value_type, OAuthClientFilterValueType::Date);
+        assert_eq!(created_at.operator, OAuthClientFilterOperator::Between);
+        assert_eq!(created_at.label, "Created");
+        assert!(created_at.multiple);
+        assert!(created_at.options.is_empty());
+
+        for sort in [
+            "client_name",
+            "client_type",
+            "created_by",
+            "broker",
+            "is_active",
+            "allowed_scopes",
+            "created_at",
+        ] {
+            assert!(
+                metadata.sorts.contains(&sort),
+                "missing ascending {sort} sort"
+            );
+            assert!(
+                metadata.sorts.contains(&format!("-{sort}").as_str()),
+                "missing descending {sort} sort"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1834,6 +2255,116 @@ mod operator_route_tests {
         assert_eq!(
             admin_policy_response.broker_capability_source,
             BrokerCapabilitySource::None
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_lists_paginated_oauth_clients_with_metadata_and_no_secret() {
+        let Some(db) = connect_test_database("admin_oauth_client_list_operator").await else {
+            eprintln!("skipping admin oauth-client list test: no local MongoDB available");
+            return;
+        };
+        let operator_id = insert_user(&db, false, true).await;
+        db.collection::<OauthClient>(OAUTH_CLIENTS)
+            .insert_one(test_oauth_client("operator-visible-client"))
+            .await
+            .expect("insert OAuth client");
+
+        let response = list_oauth_clients(
+            State(test_app_state(db)),
+            test_auth_user(&operator_id),
+            Query(OAuthClientListQuery {
+                page: Some(1),
+                ..OAuthClientListQuery::default()
+            }),
+        )
+        .await
+        .expect("operator can list OAuth clients")
+        .0;
+
+        let OAuthClientListResponse::Paginated(response) = response else {
+            panic!("explicit page must select paginated response");
+        };
+        assert_eq!(response.total, 1);
+        assert_eq!(response.page, 1);
+        assert_eq!(response.per_page, 25);
+        assert_eq!(response.clients.len(), 1);
+        assert!(response.clients[0].client_secret.is_none());
+        assert_eq!(
+            response.filter_options.client_types,
+            oauth_client_service::ADMIN_CLIENT_TYPE_FILTERS
+        );
+        assert_eq!(
+            response.filter_options.allowed_scopes,
+            oauth_client_service::KNOWN_OIDC_SCOPES
+        );
+        assert_eq!(response.filter_options.fields.len(), 6);
+        assert_eq!(
+            response
+                .filter_options
+                .fields
+                .iter()
+                .map(|field| field.key)
+                .collect::<Vec<_>>(),
+            [
+                "is_active",
+                "client_type",
+                "creator_type",
+                "broker",
+                "scope",
+                "created_at",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_no_query_gets_complete_legacy_shape_without_secrets() {
+        let Some(db) = connect_test_database("admin_oauth_client_list_legacy_operator").await
+        else {
+            eprintln!("skipping admin OAuth-client legacy list test: no local MongoDB available");
+            return;
+        };
+        let operator_id = insert_user(&db, false, true).await;
+        let now = chrono::Utc::now();
+        let mut older = test_oauth_client("legacy-first");
+        older.created_at = now - chrono::Duration::days(1);
+        older.updated_at = older.created_at;
+        let mut newer = test_oauth_client("legacy-second");
+        newer.created_at = now;
+        newer.updated_at = newer.created_at;
+        db.collection::<OauthClient>(OAUTH_CLIENTS)
+            .insert_many([older, newer])
+            .await
+            .expect("insert legacy OAuth clients");
+
+        let response = list_oauth_clients(
+            State(test_app_state(db)),
+            test_auth_user(&operator_id),
+            Query(OAuthClientListQuery::default()),
+        )
+        .await
+        .expect("operator can use legacy OAuth-client list")
+        .0;
+        let json = serde_json::to_value(&response).expect("serialize legacy response");
+        assert_eq!(
+            json.as_object()
+                .expect("legacy response object")
+                .keys()
+                .collect::<Vec<_>>(),
+            ["clients"]
+        );
+
+        let OAuthClientListResponse::Legacy(response) = response else {
+            panic!("no-query request must select legacy response");
+        };
+        assert_eq!(response.clients.len(), 2);
+        assert_eq!(response.clients[0].id, "legacy-second");
+        assert_eq!(response.clients[1].id, "legacy-first");
+        assert!(
+            response
+                .clients
+                .iter()
+                .all(|client| client.client_secret.is_none())
         );
     }
 

--- a/backend/src/services/oauth_client_service.rs
+++ b/backend/src/services/oauth_client_service.rs
@@ -1,6 +1,7 @@
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
 use futures::TryStreamExt;
-use mongodb::bson::{self, Binary, doc, spec::BinarySubtype};
+use mongodb::bson::{self, Binary, Bson, Document, doc, spec::BinarySubtype};
+use serde::Deserialize;
 use std::collections::HashSet;
 use url::Url;
 use uuid::Uuid;
@@ -44,6 +45,41 @@ pub const DEFAULT_ALLOWED_SCOPES: &str = "openid profile email";
 /// still gated by what the client requests at `/oauth/authorize` and what the
 /// user consents to.
 pub const DEFAULT_MCP_ALLOWED_SCOPES: &str = "openid profile email roles groups proxy";
+
+pub const ADMIN_CLIENT_TYPE_FILTERS: &[&str] = &["public", "confidential", "other"];
+pub const ADMIN_CREATOR_TYPE_FILTERS: &[&str] =
+    &["dynamic_registration", "system", "owned", "ownerless"];
+pub const ADMIN_BROKER_FILTERS: &[&str] = &["enabled", "disabled", "flag", "scope"];
+pub const ADMIN_SEARCH_FIELDS: &[(&str, &str)] = &[
+    ("client", "Client"),
+    ("client_type", "Client type"),
+    ("created_by", "Created by"),
+    ("allowed_scopes", "Allowed scopes"),
+];
+const ADMIN_STATUS_FILTERS: &[&str] = &["true", "false"];
+pub const ADMIN_SORT_OPTIONS: &[&str] = &[
+    "-created_at",
+    "created_at",
+    "client_name",
+    "-client_name",
+    "client_type",
+    "-client_type",
+    "created_by",
+    "-created_by",
+    "broker",
+    "-broker",
+    "-is_active",
+    "is_active",
+    "allowed_scopes",
+    "-allowed_scopes",
+];
+
+const ADMIN_SEARCH_MAX_CHARS: usize = 256;
+const ADMIN_SEARCH_FILTER_MAX_GROUPS: usize = 5;
+const ADMIN_SEARCH_FILTER_MAX_VALUES_PER_GROUP: usize = 8;
+const ADMIN_SEARCH_FILTER_MAX_TOTAL_VALUES: usize = 32;
+const ADMIN_CREATED_DATES_MAX_VALUES: usize = 32;
+const ADMIN_BROKER_SORT_FIELD: &str = "__nyxid_admin_broker_sort";
 
 /// Validate and canonicalize `allowed_scopes`.
 ///
@@ -325,17 +361,587 @@ pub async fn create_client(
     Ok((client, raw_secret))
 }
 
-/// List all OAuth clients (active and inactive).
-pub async fn list_clients(db: &mongodb::Database) -> AppResult<Vec<OauthClient>> {
-    let clients: Vec<OauthClient> = db
+/// Validated filters for the platform-admin OAuth-client list.
+pub struct AdminOAuthClientListParams<'a> {
+    pub page: u64,
+    pub per_page: u64,
+    pub search: Option<&'a str>,
+    pub search_filters: Option<&'a str>,
+    pub client_type: Option<&'a str>,
+    pub creator_type: Option<&'a str>,
+    pub broker: Option<&'a str>,
+    pub is_active: Option<&'a str>,
+    pub scope: Option<&'a str>,
+    pub created_dates: Option<&'a str>,
+    pub created_from: Option<&'a str>,
+    pub created_to: Option<&'a str>,
+    pub sort: &'a str,
+    pub broker_require_admin_capability: bool,
+}
+
+/// List every OAuth client using the legacy newest-first ordering.
+pub async fn list_clients_legacy(db: &mongodb::Database) -> AppResult<Vec<OauthClient>> {
+    Ok(db
         .collection::<OauthClient>(OAUTH_CLIENTS)
         .find(doc! {})
         .sort(doc! { "created_at": -1 })
         .await?
         .try_collect()
-        .await?;
+        .await?)
+}
 
-    Ok(clients)
+/// List OAuth clients using bounded, server-side admin-table controls.
+pub async fn list_clients(
+    db: &mongodb::Database,
+    params: AdminOAuthClientListParams<'_>,
+) -> AppResult<(Vec<OauthClient>, u64)> {
+    if params.page == 0 || !(1..=100).contains(&params.per_page) {
+        return Err(AppError::ValidationError(
+            "page must be at least 1 and per_page must be between 1 and 100".to_string(),
+        ));
+    }
+
+    let offset = params
+        .page
+        .checked_sub(1)
+        .and_then(|page| page.checked_mul(params.per_page))
+        .ok_or_else(|| AppError::ValidationError("page is too large".to_string()))?;
+    let filter = admin_oauth_client_filter(&params)?;
+    let sort = admin_oauth_client_sort(params.sort)?;
+    let collection = db.collection::<OauthClient>(OAUTH_CLIENTS);
+
+    let total = collection.count_documents(filter.clone()).await?;
+    if offset >= total {
+        return Ok((Vec::new(), total));
+    }
+    if i64::try_from(offset).is_err() {
+        return Err(AppError::ValidationError("page is too large".to_string()));
+    }
+
+    let clients: Vec<OauthClient> = if sort.contains_key(ADMIN_BROKER_SORT_FIELD) {
+        let offset = i64::try_from(offset)
+            .map_err(|_| AppError::ValidationError("page is too large".to_string()))?;
+        let pipeline = admin_broker_sort_pipeline(
+            filter,
+            sort,
+            offset,
+            params.per_page as i64,
+            params.broker_require_admin_capability,
+        );
+        collection
+            .aggregate(pipeline)
+            .with_type::<OauthClient>()
+            .allow_disk_use(true)
+            .await?
+            .try_collect()
+            .await?
+    } else {
+        collection
+            .find(filter)
+            .sort(sort)
+            .skip(offset)
+            .limit(params.per_page as i64)
+            .await?
+            .try_collect()
+            .await?
+    };
+
+    Ok((clients, total))
+}
+
+fn admin_oauth_client_filter(params: &AdminOAuthClientListParams<'_>) -> AppResult<Document> {
+    let mut clauses = Vec::new();
+
+    if let Some(search) = params
+        .search
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if search.chars().count() > ADMIN_SEARCH_MAX_CHARS {
+            return Err(AppError::ValidationError(format!(
+                "search must be {ADMIN_SEARCH_MAX_CHARS} characters or less"
+            )));
+        }
+        let escaped = regex::escape(search);
+        clauses.push(doc! {
+            "$or": [
+                { "client_name": { "$regex": &escaped, "$options": "i" } },
+                { "_id": { "$regex": &escaped, "$options": "i" } },
+                { "client_type": { "$regex": &escaped, "$options": "i" } },
+                { "created_by": { "$regex": &escaped, "$options": "i" } },
+                { "allowed_scopes": { "$regex": &escaped, "$options": "i" } },
+            ]
+        });
+    }
+
+    if let Some(search_filters) = params.search_filters {
+        clauses.extend(admin_search_filter_clauses(search_filters)?);
+    }
+
+    if let Some(client_type) = params.client_type {
+        let values =
+            admin_csv_filter_values("client_type", client_type, ADMIN_CLIENT_TYPE_FILTERS)?;
+        clauses.push(one_or_many(
+            values
+                .into_iter()
+                .map(|value| match value {
+                    "public" | "confidential" => doc! { "client_type": value },
+                    "other" => {
+                        doc! { "client_type": { "$nin": ["public", "confidential"] } }
+                    }
+                    _ => unreachable!("client_type was validated against its fixed domain"),
+                })
+                .collect(),
+        ));
+    }
+
+    if let Some(creator_type) = params.creator_type {
+        let values =
+            admin_csv_filter_values("creator_type", creator_type, ADMIN_CREATOR_TYPE_FILTERS)?;
+        clauses.push(one_or_many(
+            values
+                .into_iter()
+                .map(|value| match value {
+                    "dynamic_registration" | "system" => doc! { "created_by": value },
+                    "owned" => doc! {
+                        "created_by": {
+                            "$exists": true,
+                            "$nin": [
+                                Bson::Null,
+                                Bson::String("dynamic_registration".to_string()),
+                                Bson::String("system".to_string()),
+                            ]
+                        }
+                    },
+                    "ownerless" => doc! { "created_by": Bson::Null },
+                    _ => unreachable!("creator_type was validated against its fixed domain"),
+                })
+                .collect(),
+        ));
+    }
+
+    if let Some(broker) = params.broker {
+        let values = admin_csv_filter_values("broker", broker, ADMIN_BROKER_FILTERS)?;
+        let branches = values
+            .into_iter()
+            .map(|value| admin_broker_filter(value, params.broker_require_admin_capability))
+            .collect::<AppResult<Vec<_>>>()?;
+        clauses.push(one_or_many(branches));
+    }
+
+    if let Some(is_active) = params.is_active {
+        let values = admin_csv_filter_values("is_active", is_active, ADMIN_STATUS_FILTERS)?;
+        if values.len() == 1 {
+            clauses.push(doc! { "is_active": values[0] == "true" });
+        }
+    }
+
+    if let Some(scope) = params.scope {
+        let values = admin_csv_filter_values("scope", scope, KNOWN_OIDC_SCOPES)?;
+        clauses.push(one_or_many(
+            values
+                .into_iter()
+                .map(|value| scope_token_filter(value, true))
+                .collect(),
+        ));
+    }
+
+    if let Some(created_at) =
+        admin_created_at_filter(params.created_dates, params.created_from, params.created_to)?
+    {
+        clauses.push(created_at);
+    }
+
+    Ok(match clauses.len() {
+        0 => doc! {},
+        1 => clauses.remove(0),
+        _ => doc! { "$and": clauses },
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AdminSearchFilterInput {
+    field: String,
+    values: Vec<String>,
+}
+
+fn admin_search_filter_clauses(raw: &str) -> AppResult<Vec<Document>> {
+    let groups: Vec<AdminSearchFilterInput> = serde_json::from_str(raw).map_err(|_| {
+        AppError::ValidationError(
+            "search_filters must be a JSON array of field and values objects".to_string(),
+        )
+    })?;
+
+    if groups.is_empty() {
+        return Err(AppError::ValidationError(
+            "search_filters must contain at least one field group".to_string(),
+        ));
+    }
+    if groups.len() > ADMIN_SEARCH_FILTER_MAX_GROUPS {
+        return Err(AppError::ValidationError(format!(
+            "search_filters must contain at most {ADMIN_SEARCH_FILTER_MAX_GROUPS} field groups"
+        )));
+    }
+
+    let mut seen_fields = HashSet::new();
+    let mut total_values = 0usize;
+    let mut clauses = Vec::with_capacity(groups.len());
+
+    for group in groups {
+        let stored_field = match group.field.as_str() {
+            "client" => None,
+            "client_type" => Some("client_type"),
+            "created_by" => Some("created_by"),
+            "allowed_scopes" => Some("allowed_scopes"),
+            _ => {
+                return Err(AppError::ValidationError(format!(
+                    "search_filters field must be one of: {}",
+                    ADMIN_SEARCH_FIELDS
+                        .iter()
+                        .map(|(key, _)| *key)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
+            }
+        };
+
+        if !seen_fields.insert(group.field.clone()) {
+            return Err(AppError::ValidationError(format!(
+                "search_filters must not repeat field {}",
+                group.field
+            )));
+        }
+        if group.values.is_empty() {
+            return Err(AppError::ValidationError(format!(
+                "search_filters values for {} must not be empty",
+                group.field
+            )));
+        }
+        if group.values.len() > ADMIN_SEARCH_FILTER_MAX_VALUES_PER_GROUP {
+            return Err(AppError::ValidationError(format!(
+                "search_filters values for {} must contain at most {ADMIN_SEARCH_FILTER_MAX_VALUES_PER_GROUP} entries",
+                group.field
+            )));
+        }
+
+        total_values = total_values
+            .checked_add(group.values.len())
+            .ok_or_else(|| {
+                AppError::ValidationError("search_filters contains too many values".to_string())
+            })?;
+        if total_values > ADMIN_SEARCH_FILTER_MAX_TOTAL_VALUES {
+            return Err(AppError::ValidationError(format!(
+                "search_filters must contain at most {ADMIN_SEARCH_FILTER_MAX_TOTAL_VALUES} values"
+            )));
+        }
+
+        let mut value_clauses = Vec::with_capacity(group.values.len());
+        for raw_value in group.values {
+            let value = raw_value.trim();
+            if value.is_empty() {
+                return Err(AppError::ValidationError(format!(
+                    "search_filters values for {} must not be empty",
+                    group.field
+                )));
+            }
+            if value.chars().count() > ADMIN_SEARCH_MAX_CHARS {
+                return Err(AppError::ValidationError(format!(
+                    "search_filters values must be {ADMIN_SEARCH_MAX_CHARS} characters or less"
+                )));
+            }
+
+            let regex = doc! {
+                "$regex": regex::escape(value),
+                "$options": "i",
+            };
+            value_clauses.push(match stored_field {
+                Some(field) => doc! { field: regex },
+                None => doc! {
+                    "$or": [
+                        { "client_name": regex.clone() },
+                        { "_id": regex },
+                    ]
+                },
+            });
+        }
+        clauses.push(one_or_many(value_clauses));
+    }
+
+    Ok(clauses)
+}
+
+fn admin_created_at_filter(
+    created_dates: Option<&str>,
+    created_from: Option<&str>,
+    created_to: Option<&str>,
+) -> AppResult<Option<Document>> {
+    if let Some(created_dates) = created_dates {
+        if created_from.is_some() || created_to.is_some() {
+            return Err(AppError::ValidationError(
+                "created_dates cannot be combined with created_from or created_to".to_string(),
+            ));
+        }
+
+        let raw_dates = created_dates.split(',').collect::<Vec<_>>();
+        if raw_dates.len() > ADMIN_CREATED_DATES_MAX_VALUES {
+            return Err(AppError::ValidationError(format!(
+                "created_dates must contain at most {ADMIN_CREATED_DATES_MAX_VALUES} values"
+            )));
+        }
+
+        let mut seen = HashSet::new();
+        let mut date_filters = Vec::new();
+        for raw_date in raw_dates {
+            let value = raw_date.trim();
+            if value.is_empty() {
+                return Err(AppError::ValidationError(
+                    "created_dates must not contain empty values".to_string(),
+                ));
+            }
+            let date = parse_admin_calendar_date("created_dates", value)?;
+            if !seen.insert(date) {
+                continue;
+            }
+            let exclusive_to = date.succ_opt().ok_or_else(|| {
+                AppError::ValidationError(
+                    "created_dates contains a date outside the supported range".to_string(),
+                )
+            })?;
+            date_filters.push(doc! {
+                "created_at": {
+                    "$gte": midnight_utc(date),
+                    "$lt": midnight_utc(exclusive_to),
+                }
+            });
+        }
+
+        return Ok(Some(one_or_many(date_filters)));
+    }
+
+    let created_from = created_from
+        .map(|value| parse_admin_calendar_date("created_from", value))
+        .transpose()?;
+    let created_to = created_to
+        .map(|value| parse_admin_calendar_date("created_to", value))
+        .transpose()?;
+
+    if created_from.is_some_and(|from| created_to.is_some_and(|to| from > to)) {
+        return Err(AppError::ValidationError(
+            "created_from must be on or before created_to".to_string(),
+        ));
+    }
+
+    let mut bounds = Document::new();
+    if let Some(from) = created_from {
+        bounds.insert("$gte", midnight_utc(from));
+    }
+    if let Some(to) = created_to {
+        let exclusive_to = to.succ_opt().ok_or_else(|| {
+            AppError::ValidationError("created_to is outside the supported date range".to_string())
+        })?;
+        bounds.insert("$lt", midnight_utc(exclusive_to));
+    }
+
+    Ok((!bounds.is_empty()).then(|| doc! { "created_at": bounds }))
+}
+
+fn parse_admin_calendar_date(field: &str, value: &str) -> AppResult<NaiveDate> {
+    let bytes = value.as_bytes();
+    let has_exact_format = bytes.len() == 10
+        && bytes.iter().enumerate().all(|(index, byte)| match index {
+            4 | 7 => *byte == b'-',
+            _ => byte.is_ascii_digit(),
+        });
+    if !has_exact_format {
+        return Err(AppError::ValidationError(format!(
+            "{field} must be a valid date in YYYY-MM-DD format"
+        )));
+    }
+
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| {
+        AppError::ValidationError(format!("{field} must be a valid date in YYYY-MM-DD format"))
+    })
+}
+
+fn midnight_utc(date: NaiveDate) -> bson::DateTime {
+    bson::DateTime::from_chrono(
+        date.and_hms_opt(0, 0, 0)
+            .expect("midnight is valid for every calendar date")
+            .and_utc(),
+    )
+}
+
+fn admin_csv_filter_values<'a>(
+    field: &str,
+    raw: &'a str,
+    allowed: &[&str],
+) -> AppResult<Vec<&'a str>> {
+    let mut seen = HashSet::new();
+    let mut values = Vec::new();
+
+    for raw_value in raw.split(',') {
+        let value = raw_value.trim();
+        if value.is_empty() {
+            return Err(AppError::ValidationError(format!(
+                "{field} must not contain empty values"
+            )));
+        }
+        if !allowed.contains(&value) {
+            return Err(AppError::ValidationError(format!(
+                "{field} must contain only: {}",
+                allowed.join(", ")
+            )));
+        }
+        if seen.insert(value) {
+            values.push(value);
+        }
+    }
+
+    Ok(values)
+}
+
+fn one_or_many(mut filters: Vec<Document>) -> Document {
+    if filters.len() == 1 {
+        filters.remove(0)
+    } else {
+        doc! { "$or": filters }
+    }
+}
+
+fn admin_broker_filter(broker: &str, broker_require_admin_capability: bool) -> AppResult<Document> {
+    let flag_enabled = doc! { "broker_capability_enabled": true };
+    let flag_not_enabled = doc! { "broker_capability_enabled": { "$ne": true } };
+    let has_scope = scope_token_filter(
+        crate::services::oauth_broker_service::BROKER_BINDING_SCOPE,
+        true,
+    );
+    let lacks_scope = scope_token_filter(
+        crate::services::oauth_broker_service::BROKER_BINDING_SCOPE,
+        false,
+    );
+
+    let filter = match broker {
+        "flag" => flag_enabled,
+        "scope" if broker_require_admin_capability => doc! { "_id": { "$exists": false } },
+        "scope" => doc! { "$and": [flag_not_enabled, has_scope] },
+        "enabled" if broker_require_admin_capability => flag_enabled,
+        "enabled" => doc! { "$or": [flag_enabled, has_scope] },
+        "disabled" if broker_require_admin_capability => flag_not_enabled,
+        "disabled" => doc! { "$and": [flag_not_enabled, lacks_scope] },
+        _ => {
+            return Err(AppError::ValidationError(format!(
+                "broker must be one of: {}",
+                ADMIN_BROKER_FILTERS.join(", ")
+            )));
+        }
+    };
+
+    Ok(filter)
+}
+
+fn scope_token_filter(scope: &str, present: bool) -> Document {
+    let pattern = scope_token_pattern(scope);
+    if present {
+        doc! { "allowed_scopes": { "$regex": pattern } }
+    } else {
+        doc! { "allowed_scopes": { "$not": { "$regex": pattern } } }
+    }
+}
+
+fn scope_token_pattern(scope: &str) -> String {
+    format!(r"(^|\s){}(\s|$)", regex::escape(scope))
+}
+
+fn admin_oauth_client_sort(sort: &str) -> AppResult<Document> {
+    let (field, direction) = match sort.strip_prefix('-') {
+        Some(field) => (field, -1),
+        None => (sort, 1),
+    };
+    if !matches!(
+        field,
+        "created_at"
+            | "client_name"
+            | "client_type"
+            | "created_by"
+            | "broker"
+            | "is_active"
+            | "allowed_scopes"
+    ) {
+        return Err(AppError::ValidationError(
+            "sort must target created_at, client_name, client_type, created_by, broker, is_active, or allowed_scopes".to_string(),
+        ));
+    }
+
+    let mut sort_doc = Document::new();
+    let stored_field = if field == "broker" {
+        ADMIN_BROKER_SORT_FIELD
+    } else {
+        field
+    };
+    sort_doc.insert(stored_field, direction);
+    if field != "created_at" {
+        sort_doc.insert("created_at", direction);
+    }
+    sort_doc.insert("_id", direction);
+    Ok(sort_doc)
+}
+
+fn admin_broker_sort_pipeline(
+    filter: Document,
+    sort: Document,
+    offset: i64,
+    per_page: i64,
+    broker_require_admin_capability: bool,
+) -> Vec<Document> {
+    let mut computed_fields = Document::new();
+    computed_fields.insert(
+        ADMIN_BROKER_SORT_FIELD,
+        admin_broker_sort_expression(broker_require_admin_capability),
+    );
+
+    vec![
+        doc! { "$match": filter },
+        doc! { "$set": computed_fields },
+        doc! { "$sort": sort },
+        doc! { "$skip": offset },
+        doc! { "$limit": per_page },
+        doc! { "$unset": ADMIN_BROKER_SORT_FIELD },
+    ]
+}
+
+/// Match the response's broker source ordering: none, legacy scope, explicit flag.
+fn admin_broker_sort_expression(broker_require_admin_capability: bool) -> Document {
+    let mut branches = vec![doc! {
+        "case": {
+            "$eq": [
+                { "$ifNull": ["$broker_capability_enabled", false] },
+                true,
+            ]
+        },
+        "then": 2,
+    }];
+
+    if !broker_require_admin_capability {
+        branches.push(doc! {
+            "case": {
+                "$regexMatch": {
+                    "input": { "$ifNull": ["$allowed_scopes", ""] },
+                    "regex": scope_token_pattern(
+                        crate::services::oauth_broker_service::BROKER_BINDING_SCOPE,
+                    ),
+                }
+            },
+            "then": 1,
+        });
+    }
+
+    doc! {
+        "$switch": {
+            "branches": branches,
+            "default": 0,
+        }
+    }
 }
 
 /// List OAuth clients created by a specific user.
@@ -665,6 +1271,650 @@ pub async fn rotate_client_secret_for_creator(
 mod tests {
     use super::*;
 
+    fn admin_list_params() -> AdminOAuthClientListParams<'static> {
+        AdminOAuthClientListParams {
+            page: 1,
+            per_page: 25,
+            search: None,
+            search_filters: None,
+            client_type: None,
+            creator_type: None,
+            broker: None,
+            is_active: None,
+            scope: None,
+            created_dates: None,
+            created_from: None,
+            created_to: None,
+            sort: "-created_at",
+            broker_require_admin_capability: false,
+        }
+    }
+
+    #[test]
+    fn admin_list_filter_composes_search_and_broker_or_clauses() {
+        let params = AdminOAuthClientListParams {
+            search: Some("aevatar.*"),
+            broker: Some("enabled"),
+            is_active: Some("true"),
+            ..admin_list_params()
+        };
+
+        let filter = admin_oauth_client_filter(&params).expect("valid filters");
+        let clauses = filter.get_array("$and").expect("combined filter");
+        assert_eq!(clauses.len(), 3);
+
+        let search = clauses[0].as_document().expect("search clause");
+        let search_branches = search.get_array("$or").expect("search branches");
+        assert_eq!(search_branches.len(), 5);
+        let client_name = search_branches[0]
+            .as_document()
+            .and_then(|branch| branch.get_document("client_name").ok())
+            .expect("client-name regex");
+        assert_eq!(client_name.get_str("$regex").unwrap(), r"aevatar\.\*");
+        assert!(
+            search_branches[1]
+                .as_document()
+                .is_some_and(|branch| branch.contains_key("_id"))
+        );
+        assert!(
+            search_branches[2]
+                .as_document()
+                .is_some_and(|branch| branch.contains_key("client_type"))
+        );
+        assert!(
+            search_branches[3]
+                .as_document()
+                .is_some_and(|branch| branch.contains_key("created_by"))
+        );
+        assert!(
+            search_branches[4]
+                .as_document()
+                .is_some_and(|branch| branch.contains_key("allowed_scopes"))
+        );
+
+        let broker = clauses[1].as_document().expect("broker clause");
+        assert_eq!(broker.get_array("$or").unwrap().len(), 2);
+        assert_eq!(clauses[2], Bson::Document(doc! { "is_active": true }));
+    }
+
+    #[test]
+    fn admin_field_search_ors_values_and_ands_fields_and_legacy_search() {
+        let params = AdminOAuthClientListParams {
+            search: Some("legacy"),
+            search_filters: Some(
+                r#"[
+                    {"field":"client","values":[" console.* ","Portal"]},
+                    {"field":"client_type","values":["public"]}
+                ]"#,
+            ),
+            ..admin_list_params()
+        };
+
+        let filter = admin_oauth_client_filter(&params).expect("valid field search");
+        let clauses = filter.get_array("$and").expect("search groups use AND");
+        assert_eq!(clauses.len(), 3);
+
+        let global_search = clauses[0]
+            .as_document()
+            .and_then(|clause| clause.get_array("$or").ok())
+            .expect("legacy global search remains its own OR group");
+        assert_eq!(global_search.len(), 5);
+
+        let names = clauses[1]
+            .as_document()
+            .and_then(|clause| clause.get_array("$or").ok())
+            .expect("values in one search field use OR");
+        assert_eq!(names.len(), 2);
+        let first_client_branches = names[0]
+            .as_document()
+            .and_then(|branch| branch.get_array("$or").ok())
+            .expect("each Client value matches name or ID");
+        let first_name_regex = first_client_branches[0]
+            .as_document()
+            .and_then(|branch| branch.get_document("client_name").ok())
+            .expect("client-name condition");
+        assert_eq!(first_name_regex.get_str("$regex").unwrap(), r"console\.\*");
+        assert_eq!(first_name_regex.get_str("$options").unwrap(), "i");
+        let first_id_regex = first_client_branches[1]
+            .as_document()
+            .and_then(|branch| branch.get_document("_id").ok())
+            .expect("client-ID condition");
+        assert_eq!(first_id_regex, first_name_regex);
+
+        assert_eq!(
+            clauses[2],
+            Bson::Document(doc! {
+                "client_type": { "$regex": "public", "$options": "i" }
+            })
+        );
+    }
+
+    #[test]
+    fn admin_client_field_searches_name_and_id_with_escaped_literals() {
+        let clauses =
+            admin_search_filter_clauses(r#"[{"field":"client","values":["client[01]+$"]}]"#)
+                .expect("valid Client-column search");
+
+        let client_branches = clauses[0].get_array("$or").expect("name-or-ID search");
+        assert_eq!(client_branches.len(), 2);
+        for field in ["client_name", "_id"] {
+            let condition = client_branches
+                .iter()
+                .find_map(|branch| branch.as_document()?.get_document(field).ok())
+                .expect("Client search field");
+            assert_eq!(condition.get_str("$regex").unwrap(), r"client\[01\]\+\$");
+            assert_eq!(condition.get_str("$options").unwrap(), "i");
+        }
+    }
+
+    #[test]
+    fn admin_field_search_rejects_malformed_shape_fields_and_values() {
+        let overlong_value = "x".repeat(ADMIN_SEARCH_MAX_CHARS + 1);
+        let too_many_values = serde_json::json!([{
+            "field": "client",
+            "values": (0..=ADMIN_SEARCH_FILTER_MAX_VALUES_PER_GROUP)
+                .map(|index| format!("value-{index}"))
+                .collect::<Vec<_>>(),
+        }])
+        .to_string();
+        let overlong_json = serde_json::json!([{
+            "field": "client",
+            "values": [overlong_value],
+        }])
+        .to_string();
+
+        let invalid = [
+            "{".to_string(),
+            "{}".to_string(),
+            "[]".to_string(),
+            r#"[{"field":"unknown","values":["value"]}]"#.to_string(),
+            r#"[{"field":"client_name","values":["value"]}]"#.to_string(),
+            r#"[{"field":"client","values":["one"]},{"field":"client","values":["two"]}]"#
+                .to_string(),
+            r#"[{"field":"client","values":[]}]"#.to_string(),
+            r#"[{"field":"client","values":["   "]}]"#.to_string(),
+            r#"[{"field":"client","values":["value"],"extra":true}]"#.to_string(),
+            too_many_values,
+            overlong_json,
+        ];
+
+        for raw in invalid {
+            assert!(
+                matches!(
+                    admin_search_filter_clauses(&raw),
+                    Err(AppError::ValidationError(_))
+                ),
+                "expected invalid search_filters to fail: {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn admin_list_scalar_filters_keep_single_value_semantics() {
+        assert_eq!(
+            admin_oauth_client_filter(&AdminOAuthClientListParams {
+                client_type: Some("public"),
+                ..admin_list_params()
+            })
+            .unwrap(),
+            doc! { "client_type": "public" }
+        );
+        assert_eq!(
+            admin_oauth_client_filter(&AdminOAuthClientListParams {
+                creator_type: Some("system"),
+                ..admin_list_params()
+            })
+            .unwrap(),
+            doc! { "created_by": "system" }
+        );
+        assert_eq!(
+            admin_oauth_client_filter(&AdminOAuthClientListParams {
+                is_active: Some("false"),
+                ..admin_list_params()
+            })
+            .unwrap(),
+            doc! { "is_active": false }
+        );
+    }
+
+    #[test]
+    fn admin_list_multi_value_filters_or_within_fields_and_and_across_fields() {
+        let filter = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            client_type: Some(" public, confidential,public "),
+            creator_type: Some("system, ownerless"),
+            is_active: Some("true,false"),
+            scope: Some("profile, email"),
+            ..admin_list_params()
+        })
+        .unwrap();
+
+        let field_clauses = filter.get_array("$and").expect("different fields use AND");
+        assert_eq!(field_clauses.len(), 3, "both statuses add no restriction");
+
+        let client_types = field_clauses[0]
+            .as_document()
+            .and_then(|condition| condition.get_array("$or").ok())
+            .expect("client types use OR");
+        assert_eq!(client_types.len(), 2, "duplicates are canonicalized");
+        assert_eq!(
+            client_types,
+            &vec![
+                Bson::Document(doc! { "client_type": "public" }),
+                Bson::Document(doc! { "client_type": "confidential" }),
+            ]
+        );
+
+        let creator_types = field_clauses[1]
+            .as_document()
+            .and_then(|condition| condition.get_array("$or").ok())
+            .expect("creator types use OR");
+        assert_eq!(creator_types.len(), 2);
+
+        let scopes = field_clauses[2]
+            .as_document()
+            .and_then(|condition| condition.get_array("$or").ok())
+            .expect("scopes use OR");
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(
+            scopes[0]
+                .as_document()
+                .and_then(|condition| condition.get_document("allowed_scopes").ok())
+                .and_then(|condition| condition.get_str("$regex").ok()),
+            Some(r"(^|\s)profile(\s|$)")
+        );
+        assert_eq!(
+            scopes[1]
+                .as_document()
+                .and_then(|condition| condition.get_document("allowed_scopes").ok())
+                .and_then(|condition| condition.get_str("$regex").ok()),
+            Some(r"(^|\s)email(\s|$)")
+        );
+    }
+
+    #[test]
+    fn admin_csv_filters_trim_dedupe_and_reject_invalid_values() {
+        assert_eq!(
+            admin_csv_filter_values(
+                "client_type",
+                " public, confidential,public ",
+                ADMIN_CLIENT_TYPE_FILTERS,
+            )
+            .unwrap(),
+            ["public", "confidential"]
+        );
+
+        for raw in ["", ",", "public,", ",public", "public,,confidential"] {
+            assert!(matches!(
+                admin_csv_filter_values("client_type", raw, ADMIN_CLIENT_TYPE_FILTERS),
+                Err(AppError::ValidationError(_))
+            ));
+        }
+        assert!(matches!(
+            admin_csv_filter_values("client_type", "public,native", ADMIN_CLIENT_TYPE_FILTERS,),
+            Err(AppError::ValidationError(_))
+        ));
+    }
+
+    #[test]
+    fn admin_broker_filters_match_runtime_policy_semantics() {
+        assert_eq!(
+            admin_broker_filter("flag", false).unwrap(),
+            doc! { "broker_capability_enabled": true }
+        );
+        assert_eq!(
+            admin_broker_filter("scope", true).unwrap(),
+            doc! { "_id": { "$exists": false } }
+        );
+        assert_eq!(
+            admin_broker_filter("enabled", true).unwrap(),
+            doc! { "broker_capability_enabled": true }
+        );
+        assert_eq!(
+            admin_broker_filter("disabled", true).unwrap(),
+            doc! { "broker_capability_enabled": { "$ne": true } }
+        );
+
+        let scope = admin_broker_filter("scope", false).unwrap();
+        let scope_clauses = scope.get_array("$and").unwrap();
+        assert_eq!(
+            scope_clauses[0],
+            Bson::Document(doc! { "broker_capability_enabled": { "$ne": true } })
+        );
+        let scope_regex = scope_clauses[1]
+            .as_document()
+            .and_then(|clause| clause.get_document("allowed_scopes").ok())
+            .and_then(|condition| condition.get_str("$regex").ok())
+            .expect("scope regex");
+        assert!(scope_regex.starts_with(r"(^|\s)"));
+        assert!(scope_regex.ends_with(r"(\s|$)"));
+
+        let disabled = admin_broker_filter("disabled", false).unwrap();
+        let disabled_clauses = disabled.get_array("$and").unwrap();
+        let absent_scope = disabled_clauses[1]
+            .as_document()
+            .and_then(|clause| clause.get_document("allowed_scopes").ok())
+            .and_then(|condition| condition.get_document("$not").ok())
+            .expect("negative scope condition");
+        assert!(absent_scope.contains_key("$regex"));
+    }
+
+    #[test]
+    fn admin_multi_broker_filters_union_policy_aware_branches() {
+        let legacy = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            broker: Some("scope, flag,scope"),
+            broker_require_admin_capability: false,
+            ..admin_list_params()
+        })
+        .unwrap();
+        let legacy_branches = legacy.get_array("$or").expect("broker values use OR");
+        assert_eq!(legacy_branches.len(), 2, "duplicates are canonicalized");
+        assert!(
+            legacy_branches[0]
+                .as_document()
+                .is_some_and(|branch| branch.contains_key("$and"))
+        );
+        assert_eq!(
+            legacy_branches[1],
+            Bson::Document(doc! { "broker_capability_enabled": true })
+        );
+
+        let strict = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            broker: Some("scope,flag"),
+            broker_require_admin_capability: true,
+            ..admin_list_params()
+        })
+        .unwrap();
+        let strict_branches = strict.get_array("$or").expect("broker values use OR");
+        assert_eq!(
+            strict_branches[0],
+            Bson::Document(doc! { "_id": { "$exists": false } })
+        );
+        assert_eq!(
+            strict_branches[1],
+            Bson::Document(doc! { "broker_capability_enabled": true })
+        );
+    }
+
+    #[test]
+    fn admin_scope_filter_is_exact_and_validated() {
+        let params = AdminOAuthClientListParams {
+            scope: Some("profile"),
+            ..admin_list_params()
+        };
+        let filter = admin_oauth_client_filter(&params).unwrap();
+        let condition = filter.get_document("allowed_scopes").unwrap();
+        assert_eq!(condition.get_str("$regex").unwrap(), r"(^|\s)profile(\s|$)");
+
+        let invalid = AdminOAuthClientListParams {
+            scope: Some("profile:write"),
+            ..admin_list_params()
+        };
+        assert!(matches!(
+            admin_oauth_client_filter(&invalid),
+            Err(AppError::ValidationError(_))
+        ));
+
+        let multi = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            scope: Some("profile,email"),
+            ..admin_list_params()
+        })
+        .unwrap();
+        assert_eq!(multi.get_array("$or").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn admin_created_at_filter_uses_inclusive_utc_calendar_days() {
+        let range = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            created_from: Some("2026-07-03"),
+            created_to: Some("2026-07-10"),
+            ..admin_list_params()
+        })
+        .expect("valid date range");
+        let bounds = range.get_document("created_at").expect("created-at bounds");
+        assert_eq!(
+            bounds.get_datetime("$gte").unwrap().to_chrono(),
+            chrono::DateTime::parse_from_rfc3339("2026-07-03T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc)
+        );
+        assert_eq!(
+            bounds.get_datetime("$lt").unwrap().to_chrono(),
+            chrono::DateTime::parse_from_rfc3339("2026-07-11T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc)
+        );
+
+        let from_only = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            created_from: Some("2026-07-03"),
+            ..admin_list_params()
+        })
+        .expect("valid lower bound");
+        let from_bounds = from_only.get_document("created_at").unwrap();
+        assert!(from_bounds.contains_key("$gte"));
+        assert!(!from_bounds.contains_key("$lt"));
+
+        let to_only = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            created_to: Some("2026-07-10"),
+            ..admin_list_params()
+        })
+        .expect("valid upper bound");
+        let to_bounds = to_only.get_document("created_at").unwrap();
+        assert!(!to_bounds.contains_key("$gte"));
+        assert!(to_bounds.contains_key("$lt"));
+    }
+
+    #[test]
+    fn admin_created_dates_filter_ors_trimmed_deduplicated_utc_days() {
+        let filter = admin_oauth_client_filter(&AdminOAuthClientListParams {
+            search: Some("console"),
+            created_dates: Some("2026-07-03, 2026-07-10,2026-07-03"),
+            ..admin_list_params()
+        })
+        .expect("valid exact dates");
+        let clauses = filter
+            .get_array("$and")
+            .expect("dates are ANDed with search");
+        assert_eq!(clauses.len(), 2);
+
+        let dates = clauses[1]
+            .as_document()
+            .and_then(|clause| clause.get_array("$or").ok())
+            .expect("exact dates use OR");
+        assert_eq!(dates.len(), 2, "duplicate dates are removed");
+
+        for (date_filter, expected_from, expected_to) in [
+            (&dates[0], "2026-07-03T00:00:00Z", "2026-07-04T00:00:00Z"),
+            (&dates[1], "2026-07-10T00:00:00Z", "2026-07-11T00:00:00Z"),
+        ] {
+            let bounds = date_filter
+                .as_document()
+                .and_then(|filter| filter.get_document("created_at").ok())
+                .expect("full-day bounds");
+            assert_eq!(
+                bounds.get_datetime("$gte").unwrap().to_chrono(),
+                chrono::DateTime::parse_from_rfc3339(expected_from)
+                    .unwrap()
+                    .with_timezone(&Utc)
+            );
+            assert_eq!(
+                bounds.get_datetime("$lt").unwrap().to_chrono(),
+                chrono::DateTime::parse_from_rfc3339(expected_to)
+                    .unwrap()
+                    .with_timezone(&Utc)
+            );
+        }
+    }
+
+    #[test]
+    fn admin_created_dates_filter_rejects_conflicts_invalid_values_and_excess() {
+        for params in [
+            AdminOAuthClientListParams {
+                created_dates: Some("2026-07-03"),
+                created_from: Some("2026-07-01"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_dates: Some("2026-07-03"),
+                created_to: Some("2026-07-10"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_dates: Some(""),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_dates: Some("2026-07-03,"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_dates: Some("2026-02-30"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_dates: Some("07/03/2026"),
+                ..admin_list_params()
+            },
+        ] {
+            assert!(matches!(
+                admin_oauth_client_filter(&params),
+                Err(AppError::ValidationError(_))
+            ));
+        }
+
+        let too_many = vec!["2026-07-03"; ADMIN_CREATED_DATES_MAX_VALUES + 1].join(",");
+        assert!(matches!(
+            admin_oauth_client_filter(&AdminOAuthClientListParams {
+                created_dates: Some(&too_many),
+                ..admin_list_params()
+            }),
+            Err(AppError::ValidationError(_))
+        ));
+    }
+
+    #[test]
+    fn admin_created_at_filter_rejects_invalid_and_inverted_dates() {
+        for params in [
+            AdminOAuthClientListParams {
+                created_from: Some("2026-02-30"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_to: Some("07/10/2026"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_from: Some(" 2026-07-10"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_to: Some("2026-０7-10"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                created_from: Some("2026-07-11"),
+                created_to: Some("2026-07-10"),
+                ..admin_list_params()
+            },
+        ] {
+            assert!(matches!(
+                admin_oauth_client_filter(&params),
+                Err(AppError::ValidationError(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn admin_sort_is_allowlisted_and_stable() {
+        assert_eq!(
+            admin_oauth_client_sort("-created_at").unwrap(),
+            doc! { "created_at": -1, "_id": -1 }
+        );
+        assert_eq!(
+            admin_oauth_client_sort("client_name").unwrap(),
+            doc! { "client_name": 1, "created_at": 1, "_id": 1 }
+        );
+        assert_eq!(
+            admin_oauth_client_sort("allowed_scopes").unwrap(),
+            doc! { "allowed_scopes": 1, "created_at": 1, "_id": 1 }
+        );
+        let broker_sort = admin_oauth_client_sort("-broker").unwrap();
+        assert_eq!(broker_sort.get_i32(ADMIN_BROKER_SORT_FIELD).unwrap(), -1);
+        assert_eq!(broker_sort.get_i32("created_at").unwrap(), -1);
+        assert_eq!(broker_sort.get_i32("_id").unwrap(), -1);
+        assert!(matches!(
+            admin_oauth_client_sort("client_secret_hash"),
+            Err(AppError::ValidationError(_))
+        ));
+        assert!(matches!(
+            admin_oauth_client_sort("created_at,-client_name"),
+            Err(AppError::ValidationError(_))
+        ));
+    }
+
+    #[test]
+    fn admin_broker_sort_expression_tracks_runtime_policy() {
+        let legacy = admin_broker_sort_expression(false);
+        let legacy_branches = legacy
+            .get_document("$switch")
+            .and_then(|switch| switch.get_array("branches"))
+            .expect("legacy broker sort branches");
+        assert_eq!(legacy_branches.len(), 2);
+        let scope_regex = legacy_branches[1]
+            .as_document()
+            .and_then(|branch| branch.get_document("case").ok())
+            .and_then(|case| case.get_document("$regexMatch").ok())
+            .and_then(|regex_match| regex_match.get_str("regex").ok())
+            .expect("exact broker-scope expression");
+        assert_eq!(
+            scope_regex,
+            scope_token_pattern(crate::services::oauth_broker_service::BROKER_BINDING_SCOPE)
+        );
+
+        let strict = admin_broker_sort_expression(true);
+        let strict_branches = strict
+            .get_document("$switch")
+            .and_then(|switch| switch.get_array("branches"))
+            .expect("strict broker sort branches");
+        assert_eq!(strict_branches.len(), 1);
+    }
+
+    #[test]
+    fn admin_list_filter_rejects_unknown_domains_and_long_search() {
+        for params in [
+            AdminOAuthClientListParams {
+                client_type: Some("native"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                creator_type: Some("robot"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                broker: Some("maybe"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                is_active: Some("yes"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                scope: Some("openid,"),
+                ..admin_list_params()
+            },
+            AdminOAuthClientListParams {
+                search: Some(
+                    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                ),
+                ..admin_list_params()
+            },
+        ] {
+            assert!(matches!(
+                admin_oauth_client_filter(&params),
+                Err(AppError::ValidationError(_))
+            ));
+        }
+    }
+
     #[test]
     fn valid_default_scopes() {
         let result = validate_allowed_scopes("openid profile email").unwrap();
@@ -820,6 +2070,75 @@ mod tests {
         use crate::models::refresh_token::RefreshToken;
         use crate::test_utils::connect_test_database;
 
+        fn list_fixture(
+            id: &str,
+            name: &str,
+            created_by: &str,
+            allowed_scopes: &str,
+            broker_capability_enabled: bool,
+            is_active: bool,
+            created_at: chrono::DateTime<Utc>,
+        ) -> OauthClient {
+            OauthClient {
+                id: id.to_string(),
+                client_name: name.to_string(),
+                client_secret_hash: "NONE".to_string(),
+                redirect_uris: vec![],
+                allowed_scopes: allowed_scopes.to_string(),
+                grant_types: "authorization_code".to_string(),
+                client_type: "public".to_string(),
+                is_active,
+                delegation_scopes: String::new(),
+                default_service_catalog_slugs: Vec::new(),
+                broker_capability_enabled,
+                revocation_webhook_url: None,
+                revocation_webhook_secret_encrypted: None,
+                created_by: Some(created_by.to_string()),
+                created_at,
+                updated_at: created_at,
+            }
+        }
+
+        #[tokio::test]
+        async fn admin_legacy_list_returns_complete_collection_newest_first() {
+            let Some(db) = connect_test_database("oauth_admin_legacy_list").await else {
+                eprintln!("skipping oauth_admin_legacy_list test: no local MongoDB available");
+                return;
+            };
+            let now = Utc::now();
+            let clients = (0..30)
+                .map(|index| {
+                    list_fixture(
+                        &format!("legacy-{index:02}"),
+                        &format!("Legacy {index:02}"),
+                        "system",
+                        "openid",
+                        false,
+                        true,
+                        now + chrono::Duration::seconds(index),
+                    )
+                })
+                .collect::<Vec<_>>();
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many(clients)
+                .await
+                .expect("insert legacy list fixtures");
+
+            let listed = list_clients_legacy(&db).await.expect("list legacy clients");
+            assert_eq!(listed.len(), 30, "legacy reads are not page-limited");
+            assert_eq!(
+                listed
+                    .iter()
+                    .map(|client| client.id.clone())
+                    .collect::<Vec<_>>(),
+                (0..30)
+                    .rev()
+                    .map(|index| format!("legacy-{index:02}"))
+                    .collect::<Vec<_>>(),
+                "legacy reads preserve the original newest-first order"
+            );
+        }
+
         async fn insert_dcr_client(
             db: &mongodb::Database,
             id: &str,
@@ -849,6 +2168,497 @@ mod tests {
                 .await
                 .expect("insert dcr fixture");
             client
+        }
+
+        #[tokio::test]
+        async fn admin_list_combines_filters_and_paginates_stably() {
+            let Some(db) = connect_test_database("oauth_admin_list").await else {
+                eprintln!("skipping oauth_admin_list test: no local MongoDB available");
+                return;
+            };
+            let now = Utc::now();
+            let broker_scope = crate::services::oauth_broker_service::BROKER_BINDING_SCOPE;
+            let clients = vec![
+                list_fixture(
+                    "aevatar-new",
+                    "Aevatar Console",
+                    "dynamic_registration",
+                    &format!("openid offline_access {broker_scope}"),
+                    false,
+                    true,
+                    now,
+                ),
+                list_fixture(
+                    "aevatar-old",
+                    "Aevatar Console",
+                    "dynamic_registration",
+                    &format!("openid offline_access {broker_scope}"),
+                    false,
+                    true,
+                    now,
+                ),
+                list_fixture(
+                    "aevatar-flag",
+                    "Aevatar Console",
+                    "dynamic_registration",
+                    "openid offline_access",
+                    true,
+                    true,
+                    now - chrono::Duration::minutes(2),
+                ),
+                list_fixture(
+                    "system-inactive",
+                    "NyxID MCP Client",
+                    "system",
+                    DEFAULT_MCP_ALLOWED_SCOPES,
+                    false,
+                    false,
+                    now - chrono::Duration::minutes(3),
+                ),
+            ];
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many(clients)
+                .await
+                .expect("insert list fixtures");
+
+            let list_page = |page| AdminOAuthClientListParams {
+                page,
+                per_page: 1,
+                search: Some("aevatar"),
+                search_filters: None,
+                client_type: Some("public"),
+                creator_type: Some("dynamic_registration"),
+                broker: Some("scope"),
+                is_active: Some("true"),
+                scope: Some("offline_access"),
+                created_dates: None,
+                created_from: None,
+                created_to: None,
+                sort: "-created_at",
+                broker_require_admin_capability: false,
+            };
+
+            let (first, first_total) = list_clients(&db, list_page(1)).await.unwrap();
+            let (second, second_total) = list_clients(&db, list_page(2)).await.unwrap();
+            assert_eq!(first_total, 2);
+            assert_eq!(second_total, 2);
+            assert_eq!(
+                first
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["aevatar-old"]
+            );
+            assert_eq!(
+                second
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["aevatar-new"]
+            );
+
+            let (past_end, past_end_total) = list_clients(&db, list_page(u64::MAX))
+                .await
+                .expect("out-of-range pages should not reach MongoDB skip serialization");
+            assert!(past_end.is_empty());
+            assert_eq!(past_end_total, 2);
+        }
+
+        #[tokio::test]
+        async fn admin_list_multi_filters_use_or_with_exact_scopes_and_stable_pages() {
+            let Some(db) = connect_test_database("oauth_admin_multi_list").await else {
+                eprintln!("skipping oauth_admin_multi_list test: no local MongoDB available");
+                return;
+            };
+            let now = Utc::now();
+
+            let alpha = list_fixture(
+                "alpha-profile",
+                "Alpha",
+                "dynamic_registration",
+                "openid profile",
+                false,
+                true,
+                now,
+            );
+            let mut beta = list_fixture(
+                "beta-email",
+                "Beta",
+                "system",
+                "openid email",
+                false,
+                false,
+                now,
+            );
+            beta.client_type = "confidential".to_string();
+            let lookalike = list_fixture(
+                "profile-lookalike",
+                "Lookalike",
+                "system",
+                "openid profile_extra",
+                false,
+                true,
+                now,
+            );
+            let mut no_selected_scope = list_fixture(
+                "no-selected-scope",
+                "No selected scope",
+                "dynamic_registration",
+                "openid groups",
+                false,
+                true,
+                now,
+            );
+            no_selected_scope.client_type = "confidential".to_string();
+            let owned = list_fixture(
+                "owned-email",
+                "Owned",
+                "user-id",
+                "openid email",
+                false,
+                true,
+                now,
+            );
+
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many([alpha, beta, lookalike, no_selected_scope, owned])
+                .await
+                .expect("insert multi-filter fixtures");
+
+            let list_page = |page| AdminOAuthClientListParams {
+                page,
+                per_page: 1,
+                search: None,
+                search_filters: None,
+                client_type: Some("public, confidential"),
+                creator_type: Some("dynamic_registration, system"),
+                broker: None,
+                is_active: Some("true,false"),
+                scope: Some("profile,email"),
+                created_dates: None,
+                created_from: None,
+                created_to: None,
+                sort: "client_name",
+                broker_require_admin_capability: false,
+            };
+
+            let (first, first_total) = list_clients(&db, list_page(1)).await.unwrap();
+            let (second, second_total) = list_clients(&db, list_page(2)).await.unwrap();
+            assert_eq!(first_total, 2);
+            assert_eq!(second_total, 2);
+            assert_eq!(first[0].id, "alpha-profile");
+            assert_eq!(second[0].id, "beta-email");
+        }
+
+        #[tokio::test]
+        async fn admin_list_filters_inclusive_dates_and_searches_all_visible_text() {
+            let Some(db) = connect_test_database("oauth_admin_date_search").await else {
+                eprintln!("skipping oauth_admin_date_search test: no local MongoDB available");
+                return;
+            };
+            let at = |value: &str| {
+                chrono::DateTime::parse_from_rfc3339(value)
+                    .unwrap()
+                    .with_timezone(&Utc)
+            };
+            let mut confidential = list_fixture(
+                "date-start",
+                "First boundary",
+                "system",
+                "openid",
+                false,
+                true,
+                at("2026-07-03T00:00:00Z"),
+            );
+            confidential.client_type = "confidential".to_string();
+            let scope_match = list_fixture(
+                "date-end",
+                "Last boundary",
+                "system",
+                "openid needle-scope",
+                false,
+                true,
+                at("2026-07-10T23:59:59Z"),
+            );
+            let outside = list_fixture(
+                "date-outside",
+                "Outside",
+                "system",
+                "openid needle-scope",
+                false,
+                true,
+                at("2026-07-11T00:00:00Z"),
+            );
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many([confidential, scope_match, outside])
+                .await
+                .expect("insert date-search fixtures");
+
+            let range = AdminOAuthClientListParams {
+                per_page: 100,
+                created_from: Some("2026-07-03"),
+                created_to: Some("2026-07-10"),
+                sort: "created_at",
+                ..admin_list_params()
+            };
+            let (clients, total) = list_clients(&db, range).await.expect("filter date range");
+            assert_eq!(total, 2);
+            assert_eq!(
+                clients
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["date-start", "date-end"]
+            );
+
+            for (search, expected_id) in
+                [("CONFIDENTIAL", "date-start"), ("NEEDLE-SCOPE", "date-end")]
+            {
+                let (clients, total) = list_clients(
+                    &db,
+                    AdminOAuthClientListParams {
+                        per_page: 100,
+                        search: Some(search),
+                        created_from: Some("2026-07-03"),
+                        created_to: Some("2026-07-10"),
+                        ..admin_list_params()
+                    },
+                )
+                .await
+                .expect("search within date range");
+                assert_eq!(total, 1);
+                assert_eq!(clients[0].id, expected_id);
+            }
+        }
+
+        #[tokio::test]
+        async fn admin_list_multi_broker_filter_respects_runtime_policy_and_overlap() {
+            let Some(db) = connect_test_database("oauth_admin_multi_broker").await else {
+                eprintln!("skipping oauth_admin_multi_broker test: no local MongoDB available");
+                return;
+            };
+            let now = Utc::now();
+            let broker_scope = crate::services::oauth_broker_service::BROKER_BINDING_SCOPE;
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many([
+                    list_fixture(
+                        "scope",
+                        "Scope",
+                        "system",
+                        &format!("openid {broker_scope}"),
+                        false,
+                        true,
+                        now,
+                    ),
+                    list_fixture("disabled", "Disabled", "system", "openid", false, true, now),
+                    list_fixture("flag", "Flag", "system", "openid", true, true, now),
+                    list_fixture(
+                        "flag-and-scope",
+                        "Flag and scope",
+                        "system",
+                        &format!("openid {broker_scope}"),
+                        true,
+                        true,
+                        now,
+                    ),
+                ])
+                .await
+                .expect("insert multi-broker fixtures");
+
+            let list = |broker, strict| AdminOAuthClientListParams {
+                per_page: 100,
+                broker: Some(broker),
+                broker_require_admin_capability: strict,
+                sort: "client_name",
+                ..admin_list_params()
+            };
+
+            let (legacy, legacy_total) =
+                list_clients(&db, list("scope,flag", false)).await.unwrap();
+            assert_eq!(legacy_total, 3);
+            assert_eq!(
+                legacy
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<HashSet<_>>(),
+                HashSet::from(["scope", "flag", "flag-and-scope"])
+            );
+
+            let (strict, strict_total) = list_clients(&db, list("scope,flag", true)).await.unwrap();
+            assert_eq!(strict_total, 2);
+            assert_eq!(
+                strict
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<HashSet<_>>(),
+                HashSet::from(["flag", "flag-and-scope"])
+            );
+
+            let (_, overlap_total) = list_clients(&db, list("enabled,flag", false))
+                .await
+                .unwrap();
+            assert_eq!(
+                overlap_total, 3,
+                "overlapping branches must not duplicate rows"
+            );
+
+            let (_, exhaustive_total) = list_clients(&db, list("enabled,disabled", false))
+                .await
+                .unwrap();
+            assert_eq!(exhaustive_total, 4);
+        }
+
+        #[tokio::test]
+        async fn admin_list_sorts_broker_sources_with_runtime_policy() {
+            let Some(db) = connect_test_database("oauth_admin_broker_sort").await else {
+                eprintln!("skipping oauth_admin_broker_sort test: no local MongoDB available");
+                return;
+            };
+            let now = Utc::now();
+            let broker_scope = crate::services::oauth_broker_service::BROKER_BINDING_SCOPE;
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many(vec![
+                    list_fixture(
+                        "scope",
+                        "Scope",
+                        "dynamic_registration",
+                        &format!("openid {broker_scope}"),
+                        false,
+                        true,
+                        now - chrono::Duration::minutes(4),
+                    ),
+                    list_fixture(
+                        "disabled",
+                        "Disabled",
+                        "dynamic_registration",
+                        "openid",
+                        false,
+                        true,
+                        now - chrono::Duration::minutes(3),
+                    ),
+                    list_fixture(
+                        "scope-lookalike",
+                        "Scope lookalike",
+                        "dynamic_registration",
+                        &format!("openid {broker_scope}_extra"),
+                        false,
+                        true,
+                        now - chrono::Duration::minutes(2),
+                    ),
+                    list_fixture(
+                        "flag",
+                        "Flag",
+                        "dynamic_registration",
+                        "openid email",
+                        true,
+                        true,
+                        now - chrono::Duration::minutes(1),
+                    ),
+                ])
+                .await
+                .expect("insert broker-sort fixtures");
+
+            let (legacy, total) = list_clients(
+                &db,
+                AdminOAuthClientListParams {
+                    per_page: 100,
+                    sort: "broker",
+                    broker_require_admin_capability: false,
+                    ..admin_list_params()
+                },
+            )
+            .await
+            .expect("sort legacy broker sources");
+            assert_eq!(total, 4);
+            assert_eq!(
+                legacy
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["disabled", "scope-lookalike", "scope", "flag"]
+            );
+
+            let (descending, _) = list_clients(
+                &db,
+                AdminOAuthClientListParams {
+                    per_page: 100,
+                    sort: "-broker",
+                    broker_require_admin_capability: false,
+                    ..admin_list_params()
+                },
+            )
+            .await
+            .expect("sort broker sources descending");
+            assert_eq!(
+                descending
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["flag", "scope", "scope-lookalike", "disabled"]
+            );
+
+            let (strict, _) = list_clients(
+                &db,
+                AdminOAuthClientListParams {
+                    per_page: 100,
+                    sort: "broker",
+                    broker_require_admin_capability: true,
+                    ..admin_list_params()
+                },
+            )
+            .await
+            .expect("sort broker sources under strict policy");
+            assert_eq!(
+                strict
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["scope", "disabled", "scope-lookalike", "flag"]
+            );
+        }
+
+        #[tokio::test]
+        async fn admin_list_sorts_allowed_scopes_as_displayed() {
+            let Some(db) = connect_test_database("oauth_admin_scope_sort").await else {
+                eprintln!("skipping oauth_admin_scope_sort test: no local MongoDB available");
+                return;
+            };
+            let now = Utc::now();
+            db.collection::<OauthClient>(OAUTH_CLIENTS)
+                .insert_many(vec![
+                    list_fixture(
+                        "profile",
+                        "Profile",
+                        "system",
+                        "openid profile",
+                        false,
+                        true,
+                        now,
+                    ),
+                    list_fixture("minimal", "Minimal", "system", "openid", false, true, now),
+                    list_fixture("email", "Email", "system", "openid email", false, true, now),
+                ])
+                .await
+                .expect("insert scope-sort fixtures");
+
+            let (clients, total) = list_clients(
+                &db,
+                AdminOAuthClientListParams {
+                    per_page: 100,
+                    sort: "allowed_scopes",
+                    ..admin_list_params()
+                },
+            )
+            .await
+            .expect("sort allowed scopes");
+            assert_eq!(total, 3);
+            assert_eq!(
+                clients
+                    .iter()
+                    .map(|client| client.id.as_str())
+                    .collect::<Vec<_>>(),
+                ["minimal", "email", "profile"]
+            );
         }
 
         async fn insert_client_with_consent_and_refresh_token(

--- a/docs/API.md
+++ b/docs/API.md
@@ -4887,11 +4887,45 @@ curl -X POST http://localhost:3001/api/v1/admin/oauth-clients \
 
 #### GET /api/v1/admin/oauth-clients
 
-List all registered OAuth clients. Client secrets are never included in the list response.
+List registered OAuth clients. Client secrets are never included in either response mode.
 
-**Auth:** Admin
+For backward compatibility, a request with none of the recognized table query parameters returns the complete unfiltered collection in the original `created_at` descending order using the legacy response shape `{ "clients": [...] }`. Unknown query parameters do not opt into table mode. Supplying any recognized table parameter, including `page=1`, opts into the bounded paginated response with filtering, sorting, and `filter_options` metadata described below.
 
-**Response (200):**
+`filter_options` is independent of the rows on the current page. Its additive `fields` array describes the field identifier, display label, value type, fixed operator, multi-select support, and labeled choices for each filter-builder field; the legacy domain arrays remain available for existing clients. The `created_at` field supports either exact multi-date selection through `created_dates` or a range through `created_from` and `created_to`.
+
+**Auth:** Admin or operator
+
+**Query Parameters:**
+
+| Parameter      | Type    | Default       | Description |
+|----------------|---------|---------------|-------------|
+| `page`         | integer | `1`           | One-based page number |
+| `per_page`     | integer | `25`          | Rows per page, clamped to `1..=100` |
+| `search`       | string  | --            | Literal case-insensitive search over client name, client ID, client type, creator, and allowed scopes; maximum 256 characters |
+| `search_filters` | JSON string | --         | URL-encoded field-scoped search groups; see the search semantics and limits below |
+| `client_type`  | string  | --            | One or more of `public`, `confidential`, or `other` |
+| `creator_type` | string  | --            | One or more of `dynamic_registration`, `system`, `owned`, or `ownerless` |
+| `broker`       | string  | --            | One or more of `enabled`, `disabled`, `flag`, or `scope`; evaluated against the current broker rollout policy |
+| `is_active`    | string  | --            | `true`, `false`, or both |
+| `scope`        | string  | --            | One or more exact allowed-scope tokens from `filter_options.allowed_scopes` |
+| `created_dates` | string | --             | One or more exact UTC creation dates as comma-separated `YYYY-MM-DD` values; maximum 32 |
+| `created_from` | date    | --            | Earliest creation date to include, as a UTC calendar date in `YYYY-MM-DD` format |
+| `created_to`   | date    | --            | Latest creation date to include, as a UTC calendar date in `YYYY-MM-DD` format |
+| `sort`         | string  | `-created_at` | Allowlisted field; prefix `-` for descending. Fields: `client_name`, `client_type`, `created_by`, `broker`, `is_active`, `allowed_scopes`, `created_at` |
+
+The five structured filter parameters accept comma-separated values, for example `client_type=public,confidential&scope=openid,email`. Values within one field are combined with OR; separate fields are combined with AND. Tokens are trimmed, duplicate values are canonicalized, and empty or unknown values return `400 validation_error`. Scalar requests such as `is_active=true` retain their existing behavior. `is_active=true,false` is equivalent to omitting the status filter. A multi-value `scope` filter matches a client containing any selected exact whitespace-delimited scope token; it does not require every selected scope and does not match lookalike prefixes or suffixes.
+
+`search_filters` is a URL-encoded JSON array of field groups. Supported fields are `client`, `client_type`, `created_by`, and `allowed_scopes`; the response advertises the same set in `filter_options.search_fields`. Each group has the shape `{"field":"client","values":["console","portal"]}`. The `client` field corresponds to the visible Client column and matches both client name and client ID. Values within the same field are literal case-insensitive matches combined with OR. Different field groups are combined with AND. A simultaneously supplied legacy `search` is another AND group, while retaining its OR-across-all-fields behavior.
+
+The array permits at most five unique field groups, eight values per group, and 32 values in total. Every value is trimmed, must be non-empty, and may contain at most 256 Unicode characters. Unknown or duplicate fields, empty arrays or values, extra object properties, malformed JSON, and exceeded limits return `400 validation_error`. Search values are treated literally; regular-expression metacharacters have no special meaning.
+
+`created_dates` accepts up to 32 comma-separated UTC calendar dates. Values are trimmed and deduplicated, but empty or malformed values are rejected. Each selected date matches its complete UTC day, and selected dates are combined with OR. `created_dates` cannot be combined with `created_from` or `created_to`; doing so returns `400 validation_error`.
+
+`created_from` and `created_to` may be supplied independently or together. Both are interpreted as UTC calendar dates. The lower bound is inclusive at `00:00:00Z`; the upper bound includes the entire selected day and is implemented as an exclusive comparison against the following day's `00:00:00Z`. Invalid dates and ranges where `created_from` is after `created_to` return `400 validation_error`. The selected exact-date or range group is ANDed with search and every structured filter.
+
+`broker` sorting uses the effective source shown in the table: ascending order is disabled (`none`), enabled by legacy scope (`scope`), then enabled by explicit flag (`flag`). Descending order reverses it. When the runtime policy requires explicit admin capability, scope-only clients sort as disabled. `allowed_scopes` sorts the stored canonical space-separated scope string. Every sort adds `created_at` and `_id` tie-breakers (or just `_id` when sorting by `created_at`) in the requested direction, so pagination order is deterministic.
+
+**Legacy response (200, no recognized table parameters):**
 
 ```json
 {
@@ -4900,9 +4934,14 @@ List all registered OAuth clients. Client secrets are never included in the list
       "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       "client_name": "My Web App",
       "client_type": "confidential",
+      "created_by": "550e8400-e29b-41d4-a716-446655440000",
       "redirect_uris": ["https://app.example.com/callback"],
       "allowed_scopes": "openid profile email",
       "delegation_scopes": "",
+      "broker_capability_enabled": false,
+      "broker_capability_effective": false,
+      "broker_capability_source": "none",
+      "revocation_webhook_url": null,
       "is_active": true,
       "client_secret": null,
       "created_at": "2025-06-01T10:00:00+00:00"
@@ -4911,10 +4950,184 @@ List all registered OAuth clients. Client secrets are never included in the list
 }
 ```
 
+**Paginated response (200, any recognized table parameter):**
+
+```json
+{
+  "clients": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "client_name": "My Web App",
+      "client_type": "confidential",
+      "created_by": "550e8400-e29b-41d4-a716-446655440000",
+      "redirect_uris": ["https://app.example.com/callback"],
+      "allowed_scopes": "openid profile email",
+      "delegation_scopes": "",
+      "broker_capability_enabled": false,
+      "broker_capability_effective": false,
+      "broker_capability_source": "none",
+      "revocation_webhook_url": null,
+      "is_active": true,
+      "client_secret": null,
+      "created_at": "2025-06-01T10:00:00+00:00"
+    }
+  ],
+  "total": 142,
+  "page": 1,
+  "per_page": 25,
+  "filter_options": {
+    "client_types": ["public", "confidential", "other"],
+    "creator_types": ["dynamic_registration", "system", "owned", "ownerless"],
+    "broker_filters": ["enabled", "disabled", "flag", "scope"],
+    "statuses": [true, false],
+    "allowed_scopes": [
+      "openid",
+      "profile",
+      "email",
+      "roles",
+      "groups",
+      "offline_access",
+      "proxy",
+      "urn:nyxid:scope:broker_binding"
+    ],
+    "sorts": [
+      "-created_at",
+      "created_at",
+      "client_name",
+      "-client_name",
+      "client_type",
+      "-client_type",
+      "created_by",
+      "-created_by",
+      "broker",
+      "-broker",
+      "-is_active",
+      "is_active",
+      "allowed_scopes",
+      "-allowed_scopes"
+    ],
+    "search_fields": [
+      { "key": "client", "label": "Client" },
+      { "key": "client_type", "label": "Client type" },
+      { "key": "created_by", "label": "Created by" },
+      { "key": "allowed_scopes", "label": "Allowed scopes" }
+    ],
+    "fields": [
+      {
+        "key": "is_active",
+        "label": "Status",
+        "value_type": "boolean",
+        "operator": "is",
+        "multiple": true,
+        "options": [
+          { "value": "true", "label": "Active" },
+          { "value": "false", "label": "Inactive" }
+        ]
+      },
+      {
+        "key": "client_type",
+        "label": "Client type",
+        "value_type": "enum",
+        "operator": "is",
+        "multiple": true,
+        "options": [
+          { "value": "public", "label": "Public" },
+          { "value": "confidential", "label": "Confidential" },
+          { "value": "other", "label": "Other" }
+        ]
+      },
+      {
+        "key": "creator_type",
+        "label": "Creator",
+        "value_type": "enum",
+        "operator": "is",
+        "multiple": true,
+        "options": [
+          { "value": "dynamic_registration", "label": "Dynamic registration" },
+          { "value": "system", "label": "System" },
+          { "value": "owned", "label": "User / org" },
+          { "value": "ownerless", "label": "Ownerless" }
+        ]
+      },
+      {
+        "key": "broker",
+        "label": "Broker capability",
+        "value_type": "enum",
+        "operator": "is",
+        "multiple": true,
+        "options": [
+          { "value": "enabled", "label": "Enabled" },
+          { "value": "disabled", "label": "Disabled" },
+          { "value": "flag", "label": "Enabled by admin grant" },
+          { "value": "scope", "label": "Enabled by broker scope" }
+        ]
+      },
+      {
+        "key": "scope",
+        "label": "Allowed scope",
+        "value_type": "enum",
+        "operator": "includes",
+        "multiple": true,
+        "options": [
+          { "value": "openid", "label": "OpenID" },
+          { "value": "profile", "label": "Profile" },
+          { "value": "email", "label": "Email" },
+          { "value": "roles", "label": "Roles" },
+          { "value": "groups", "label": "Groups" },
+          { "value": "offline_access", "label": "Offline access" },
+          { "value": "proxy", "label": "Proxy" },
+          {
+            "value": "urn:nyxid:scope:broker_binding",
+            "label": "Broker binding"
+          }
+        ]
+      },
+      {
+        "key": "created_at",
+        "label": "Created",
+        "value_type": "date",
+        "operator": "between",
+        "multiple": true,
+        "options": []
+      }
+    ]
+  }
+}
+```
+
 **Example:**
 
 ```bash
-curl http://localhost:3001/api/v1/admin/oauth-clients \
+curl "http://localhost:3001/api/v1/admin/oauth-clients?page=1&per_page=25&client_type=public&sort=-created_at" \
+  -H "Authorization: Bearer <admin_access_token>"
+```
+
+Multi-select filters use one comma-separated query value per field:
+
+```bash
+curl "http://localhost:3001/api/v1/admin/oauth-clients?page=1&per_page=25&client_type=public,confidential&scope=openid,email&is_active=true&sort=client_name" \
+  -H "Authorization: Bearer <admin_access_token>"
+```
+
+Date bounds select complete UTC days and can be combined with search and other filters:
+
+```bash
+curl "http://localhost:3001/api/v1/admin/oauth-clients?search=openid&created_from=2026-07-01&created_to=2026-07-10&sort=-created_at" \
+  -H "Authorization: Bearer <admin_access_token>"
+```
+
+Exact dates use OR within the Created field and cannot be combined with range bounds:
+
+```bash
+curl "http://localhost:3001/api/v1/admin/oauth-clients?created_dates=2026-07-01,2026-07-10&sort=-created_at" \
+  -H "Authorization: Bearer <admin_access_token>"
+```
+
+Field-scoped search values in one field use OR, while separate fields use AND:
+
+```bash
+curl --get "http://localhost:3001/api/v1/admin/oauth-clients" \
+  --data-urlencode 'search_filters=[{"field":"client","values":["console","portal"]},{"field":"client_type","values":["public"]}]' \
   -H "Authorization: Bearer <admin_access_token>"
 ```
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -51,6 +51,30 @@ export default defineConfig([
     },
   },
   {
+    files: ['src/components/data-table/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@/types/admin',
+              message: 'Keep reusable data-table controls domain-neutral.',
+            },
+            {
+              name: '@/lib/admin-oauth-clients',
+              message: 'Keep OAuth query encoding in the page adapter.',
+            },
+            {
+              name: '@/hooks/use-admin-oauth-clients',
+              message: 'Keep data fetching outside reusable table controls.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['src/main.tsx'],
     rules: {
       'react-refresh/only-export-components': 'off',

--- a/frontend/src/components/data-table/data-table-controls.test.tsx
+++ b/frontend/src/components/data-table/data-table-controls.test.tsx
@@ -1,0 +1,522 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AppliedDataTableFilter,
+  DataTableFilterField,
+  DataTableFilterSelections,
+  DataTableSearchApplyMode,
+  DataTableSearchField,
+} from "@/types/data-table";
+import {
+  DataTableFilterChips,
+  DataTableFilterPopover,
+  DataTableSearch,
+} from "./data-table-controls";
+
+vi.mock("@/components/ui/date-picker", () => ({
+  DatePicker: (
+    props:
+      | {
+          readonly mode: "multiple";
+          readonly values: readonly string[];
+          readonly maxSelections?: number;
+          readonly onValuesChange: (values: readonly string[]) => void;
+          readonly ariaLabel?: string;
+        }
+      | {
+          readonly mode?: "single";
+          readonly value: string | null;
+          readonly onChange: (value: string | null) => void;
+          readonly ariaLabel?: string;
+          readonly minDate?: string;
+        },
+  ) => {
+    if (props.mode === "multiple") {
+      return (
+        <input
+          type="date"
+          aria-label={props.ariaLabel}
+          data-max-selections={props.maxSelections}
+          value=""
+          onChange={(event) => {
+            const value = event.target.value;
+            if (value && !props.values.includes(value)) {
+              props.onValuesChange([...props.values, value].sort());
+            }
+          }}
+        />
+      );
+    }
+    return (
+      <input
+        type="date"
+        aria-label={props.ariaLabel}
+        value={props.value ?? ""}
+        min={props.minDate}
+        onChange={(event) => props.onChange(event.target.value || null)}
+      />
+    );
+  },
+}));
+
+type SearchKey = "actor" | "resource";
+type FilterKey = "severity" | "review_state" | "occurred_at" | "retained_until";
+
+const SEARCH_FIELDS: readonly DataTableSearchField<SearchKey>[] = [
+  { key: "actor", label: "Actor" },
+  { key: "resource", label: "Resource" },
+];
+
+const SEVERITY_FIELD: DataTableFilterField<FilterKey> = {
+  key: "severity",
+  label: "Severity",
+  value_type: "enum",
+  operator: "is",
+  multiple: true,
+  options: [
+    { value: "info", label: "Informational" },
+    { value: "warning", label: "Warning" },
+    { value: "critical", label: "Critical" },
+  ],
+};
+
+const REVIEW_STATE_FIELD: DataTableFilterField<FilterKey> = {
+  key: "review_state",
+  label: "Review state",
+  value_type: "boolean",
+  operator: "is",
+  multiple: false,
+  options: [
+    { value: "reviewed", label: "Reviewed" },
+    { value: "unreviewed", label: "Unreviewed" },
+  ],
+};
+
+const DATE_FIELD: DataTableFilterField<FilterKey> = {
+  key: "occurred_at",
+  label: "Occurred",
+  value_type: "date",
+  operator: "between",
+  multiple: true,
+  options: [],
+  max_values: 2,
+  date_modes: ["dates", "range"],
+};
+
+const RANGE_ONLY_DATE_FIELD: DataTableFilterField<FilterKey> = {
+  ...DATE_FIELD,
+  date_modes: ["range"],
+};
+
+const DATES_ONLY_DATE_FIELD: DataTableFilterField<FilterKey> = {
+  key: "retained_until",
+  label: "Retained until",
+  value_type: "date",
+  operator: "is",
+  multiple: true,
+  options: [],
+  date_modes: ["dates"],
+};
+
+function SearchHarness({
+  initialValue = "",
+  initialField = null,
+  onApply,
+  onCancel = () => undefined,
+}: {
+  readonly initialValue?: string;
+  readonly initialField?: SearchKey | null;
+  readonly onApply: (mode: DataTableSearchApplyMode) => void;
+  readonly onCancel?: () => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const [selectedField, setSelectedField] = useState<SearchKey | null>(
+    initialField,
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div>
+      <DataTableSearch
+        fields={SEARCH_FIELDS}
+        value={value}
+        selectedField={selectedField}
+        inputRef={inputRef}
+        ariaLabel="Search audit events"
+        allFieldsLabel="Everything"
+        onValueChange={setValue}
+        onFieldChange={setSelectedField}
+        onApply={onApply}
+        onCancel={onCancel}
+      />
+      <button type="button">Outside control</button>
+    </div>
+  );
+}
+
+function FilterHarness({
+  fields,
+  initialKey,
+  values = {},
+  onApply,
+}: {
+  readonly fields: readonly DataTableFilterField<FilterKey>[];
+  readonly initialKey: FilterKey;
+  readonly values?: DataTableFilterSelections<FilterKey>;
+  readonly onApply: (selections: DataTableFilterSelections<FilterKey>) => void;
+}) {
+  const [selectedKey, setSelectedKey] = useState(initialKey);
+  return (
+    <DataTableFilterPopover
+      fields={fields}
+      values={values}
+      open
+      selectedKey={selectedKey}
+      activeCount={0}
+      onOpenChange={() => undefined}
+      onSelectField={setSelectedKey}
+      onApply={onApply}
+    />
+  );
+}
+
+describe("DataTableSearch", () => {
+  it("uses configurable labels and waits for Enter before applying typed text", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    render(<SearchHarness onApply={onApply} />);
+
+    const input = screen.getByRole("textbox", {
+      name: "Search audit events",
+    });
+    expect(input).toHaveAttribute("placeholder", "Search everything");
+
+    await user.type(input, "failed login");
+    expect(onApply).not.toHaveBeenCalled();
+
+    await user.keyboard("{Enter}");
+    expect(onApply).toHaveBeenCalledOnce();
+    expect(onApply).toHaveBeenCalledWith("submit");
+  });
+
+  it("applies on full-control blur but not when focus moves to its field selector", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    const firstRender = render(
+      <SearchHarness initialValue="billing" onApply={onApply} />,
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Search audit events",
+    });
+    const fieldSelector = screen.getByRole("combobox", {
+      name: "Search field",
+    });
+    await user.click(input);
+    await user.click(fieldSelector);
+    expect(onApply).not.toHaveBeenCalled();
+
+    firstRender.unmount();
+    render(<SearchHarness initialValue="billing" onApply={onApply} />);
+    await user.click(
+      screen.getByRole("textbox", { name: "Search audit events" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Outside control" }));
+    expect(onApply).toHaveBeenCalledWith("blur");
+  });
+
+  it("selects from configured fields and cancels the draft with Escape", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <SearchHarness
+        initialValue="ledger"
+        onApply={() => undefined}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("combobox", {
+        name: "Search field",
+      }),
+    );
+    await user.click(screen.getByRole("option", { name: "Resource" }));
+    expect(
+      screen.getByRole("textbox", { name: "Search audit events" }),
+    ).toHaveAttribute("placeholder", "Search resource");
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Search audit events" }),
+      "{Escape}",
+    );
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});
+
+describe("DataTableFilterPopover", () => {
+  it("replaces an open draft when controlled filter values change", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    const { rerender } = render(
+      <FilterHarness
+        fields={[SEVERITY_FIELD]}
+        initialKey="severity"
+        values={{ severity: ["info"] }}
+        onApply={onApply}
+      />,
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "Informational" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Critical" }),
+    ).not.toBeChecked();
+
+    rerender(
+      <FilterHarness
+        fields={[SEVERITY_FIELD]}
+        initialKey="severity"
+        values={{ severity: ["critical"] }}
+        onApply={onApply}
+      />,
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "Informational" }),
+    ).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Critical" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+    expect(onApply).toHaveBeenCalledWith({ severity: ["critical"] });
+  });
+
+  it("treats Select all as a distinct tri-state option and conditionally shows Clear all", async () => {
+    const user = userEvent.setup();
+    render(
+      <FilterHarness
+        fields={[SEVERITY_FIELD]}
+        initialKey="severity"
+        onApply={() => undefined}
+      />,
+    );
+
+    const selectAll = screen.getByRole("checkbox", {
+      name: "Select all 3 values",
+    });
+    expect(selectAll).toHaveAttribute("aria-checked", "false");
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+
+    await user.click(screen.getByRole("checkbox", { name: "Warning" }));
+    expect(selectAll).toHaveAttribute("aria-checked", "mixed");
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeVisible();
+
+    await user.click(selectAll);
+    expect(selectAll).toHaveAttribute("aria-checked", "true");
+
+    await user.click(selectAll);
+    expect(selectAll).toHaveAttribute("aria-checked", "false");
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("keeps a single-select field to one selected value", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    render(
+      <FilterHarness
+        fields={[REVIEW_STATE_FIELD]}
+        initialKey="review_state"
+        onApply={onApply}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reviewed" }));
+    await user.click(screen.getByRole("button", { name: "Unreviewed" }));
+    expect(screen.getByRole("button", { name: "Reviewed" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Unreviewed" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+    expect(onApply).toHaveBeenCalledWith({
+      review_state: ["unreviewed"],
+    });
+  });
+
+  it("uses configured date labels and limits while applying multiple exact dates", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    render(
+      <FilterHarness
+        fields={[DATE_FIELD]}
+        initialKey="occurred_at"
+        onApply={onApply}
+      />,
+    );
+
+    expect(screen.queryByRole("checkbox", { name: /Select all/ })).toBeNull();
+    const picker = screen.getByLabelText("Occurred on selected dates");
+    expect(picker).toHaveAttribute("data-max-selections", "2");
+    fireEvent.change(picker, { target: { value: "2026-07-03" } });
+    fireEvent.change(picker, { target: { value: "2026-07-08" } });
+    expect(screen.getByText("2 selected")).toBeVisible();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove selected date 2026-07-03",
+      }),
+    );
+    expect(screen.getByText("1 selected")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(screen.getByText("0 selected")).toBeVisible();
+
+    fireEvent.change(picker, { target: { value: "2026-07-03" } });
+    fireEvent.change(picker, { target: { value: "2026-07-08" } });
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+
+    expect(onApply).toHaveBeenCalledWith({
+      occurred_at: ["dates", "2026-07-03", "2026-07-08"],
+    });
+  });
+
+  it("supports an inclusive date range and blocks an inverted range", async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    render(
+      <FilterHarness
+        fields={[DATE_FIELD]}
+        initialKey="occurred_at"
+        onApply={onApply}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Date range" }));
+    fireEvent.change(screen.getByLabelText("Occurred from date"), {
+      target: { value: "2026-07-01" },
+    });
+    fireEvent.change(screen.getByLabelText("Occurred to date"), {
+      target: { value: "2026-07-31" },
+    });
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+    expect(onApply).toHaveBeenLastCalledWith({
+      occurred_at: ["range", "2026-07-01", "2026-07-31"],
+    });
+
+    fireEvent.change(screen.getByLabelText("Occurred from date"), {
+      target: { value: "2026-08-01" },
+    });
+    expect(
+      screen.getByText("The end date must be on or after the start date."),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Apply filters" }),
+    ).toBeDisabled();
+  });
+
+  it("keeps date mode UI isolated when switching between date fields", async () => {
+    const user = userEvent.setup();
+    render(
+      <FilterHarness
+        fields={[RANGE_ONLY_DATE_FIELD, DATES_ONLY_DATE_FIELD]}
+        initialKey="occurred_at"
+        values={{
+          occurred_at: ["range", "2026-07-01", "2026-07-31"],
+          retained_until: ["dates", "2026-08-15"],
+        }}
+        onApply={() => undefined}
+      />,
+    );
+
+    expect(screen.getByLabelText("Occurred from date")).toHaveValue(
+      "2026-07-01",
+    );
+    expect(screen.queryByLabelText("Occurred on selected dates")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /Retained until/ }));
+    expect(
+      screen.getByLabelText("Retained until on selected dates"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 selected")).toBeVisible();
+    expect(screen.queryByLabelText("Retained until from date")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /Occurred/ }));
+    expect(screen.getByLabelText("Occurred from date")).toHaveValue(
+      "2026-07-01",
+    );
+    expect(screen.queryByLabelText("Occurred on selected dates")).toBeNull();
+  });
+});
+
+describe("DataTableFilterChips", () => {
+  it("renders global search and configured filters without AND separators", () => {
+    const filters: readonly AppliedDataTableFilter<FilterKey>[] = [
+      {
+        field: SEVERITY_FIELD,
+        values: ["critical"],
+        valueLabels: ["Critical"],
+      },
+      {
+        field: DATE_FIELD,
+        values: ["2026-07-03", "2026-07-03"],
+        valueLabels: ["Jul 3, 2026"],
+        operatorLabel: "is on",
+        valueSummary: "Jul 3, 2026",
+      },
+    ];
+    render(
+      <DataTableFilterChips
+        search="alice@example.com"
+        searchFields={SEARCH_FIELDS}
+        searchFilters={[]}
+        filters={filters}
+        onEditSearch={() => undefined}
+        onRemoveSearch={() => undefined}
+        onEditSearchValue={() => undefined}
+        onRemoveSearchValue={() => undefined}
+        onEdit={() => undefined}
+        onRemove={() => undefined}
+        onClear={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByText("AND")).not.toBeInTheDocument();
+    expect(screen.getByText('"alice@example.com"')).toBeVisible();
+    expect(screen.getByText("Jul 3, 2026")).toBeVisible();
+  });
+
+  it("shows OR within one scoped field without inter-chip operators", () => {
+    render(
+      <DataTableFilterChips
+        search=""
+        searchFields={SEARCH_FIELDS}
+        searchFilters={[
+          { field: "actor", values: ["alice", "bob"] },
+          { field: "resource", values: ["billing"] },
+        ]}
+        filters={[]}
+        onEditSearch={() => undefined}
+        onRemoveSearch={() => undefined}
+        onEditSearchValue={() => undefined}
+        onRemoveSearchValue={() => undefined}
+        onEdit={() => undefined}
+        onRemove={() => undefined}
+        onClear={() => undefined}
+      />,
+    );
+
+    expect(screen.getAllByText("OR")).toHaveLength(1);
+    expect(screen.queryByText("AND")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("group", {
+        name: "Actor search, matches any term",
+      }),
+    ).toHaveTextContent(/Actor contains.*"alice".*OR.*"bob"/);
+  });
+});

--- a/frontend/src/components/data-table/data-table-controls.tsx
+++ b/frontend/src/components/data-table/data-table-controls.tsx
@@ -1,0 +1,1012 @@
+import {
+  Fragment,
+  useRef,
+  useState,
+  type FocusEvent,
+  type FormEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import {
+  Calendar,
+  CalendarRange,
+  Check,
+  ChevronRight,
+  Filter,
+  Minus,
+  Search,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DatePicker } from "@/components/ui/date-picker";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import type {
+  AppliedDataTableFilter,
+  DataTableFilterField,
+  DataTableFilterSelections,
+  DataTableSearchApplyMode,
+  DataTableSearchField,
+  DataTableSearchGroup,
+} from "@/types/data-table";
+
+const ALL_FIELDS_VALUE = "__data_table_all_fields__";
+const DEFAULT_DATE_MODES = ["dates", "range"] as const;
+
+const FILTER_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+export interface DataTableSearchProps<SearchKey extends string> {
+  readonly fields: readonly DataTableSearchField<SearchKey>[];
+  readonly value: string;
+  readonly selectedField: SearchKey | null;
+  readonly inputRef: RefObject<HTMLInputElement | null>;
+  readonly ariaLabel: string;
+  readonly allFieldsLabel?: string;
+  readonly fieldAriaLabel?: string;
+  readonly maxLength?: number;
+  readonly onValueChange: (value: string) => void;
+  readonly onFieldChange: (field: SearchKey | null) => void;
+  readonly onApply: (mode: DataTableSearchApplyMode) => void;
+  readonly onCancel: () => void;
+}
+
+export function DataTableSearch<SearchKey extends string>({
+  fields,
+  value,
+  selectedField,
+  inputRef,
+  ariaLabel,
+  allFieldsLabel = "All fields",
+  fieldAriaLabel = "Search field",
+  maxLength = 256,
+  onValueChange,
+  onFieldChange,
+  onApply,
+  onCancel,
+}: DataTableSearchProps<SearchKey>) {
+  const controlRef = useRef<HTMLFormElement>(null);
+  const [fieldSelectOpen, setFieldSelectOpen] = useState(false);
+  const selectedLabel =
+    selectedField === null
+      ? allFieldsLabel
+      : (fields.find((field) => field.key === selectedField)?.label ??
+        selectedField);
+
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    onApply("submit");
+  }
+
+  function handleControlBlur(event: FocusEvent<HTMLFormElement>) {
+    if (
+      event.relatedTarget instanceof Node &&
+      controlRef.current?.contains(event.relatedTarget)
+    ) {
+      return;
+    }
+    if (fieldSelectOpen) return;
+    if (value.trim()) onApply("blur");
+  }
+
+  function handleFieldChange(rawValue: string) {
+    if (rawValue === ALL_FIELDS_VALUE) {
+      onFieldChange(null);
+      return;
+    }
+    const field = fields.find((candidate) => candidate.key === rawValue);
+    if (field) onFieldChange(field.key);
+  }
+
+  return (
+    <form
+      ref={controlRef}
+      onSubmit={handleSubmit}
+      onBlur={handleControlBlur}
+      role="search"
+      className="w-full min-w-0 flex-1 sm:min-w-[320px]"
+    >
+      <div className="flex h-11 min-w-0 items-stretch overflow-hidden rounded-lg border border-input bg-transparent transition-colors focus-within:border-white/[0.15] md:h-9">
+        <span className="flex w-9 shrink-0 items-center justify-center text-muted-foreground">
+          <Search className="h-3.5 w-3.5" aria-hidden="true" />
+        </span>
+        <input
+          ref={inputRef}
+          aria-label={ariaLabel}
+          placeholder={`Search ${selectedLabel.toLocaleLowerCase()}`}
+          value={value}
+          maxLength={maxLength}
+          enterKeyHint="search"
+          onChange={(event) => onValueChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onCancel();
+            }
+          }}
+          className="h-full min-w-0 flex-1 bg-transparent px-1 text-xs text-foreground outline-none placeholder:text-text-tertiary"
+        />
+        <button
+          type="button"
+          aria-label="Clear search draft"
+          title="Clear search draft"
+          disabled={!value}
+          tabIndex={value ? 0 : -1}
+          className="flex w-11 shrink-0 items-center justify-center border-l border-border/60 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:invisible md:w-9"
+          onClick={onCancel}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+        <Select
+          open={fieldSelectOpen}
+          onOpenChange={setFieldSelectOpen}
+          value={selectedField ?? ALL_FIELDS_VALUE}
+          onValueChange={handleFieldChange}
+        >
+          <SelectTrigger
+            aria-label={fieldAriaLabel}
+            title={`Search in ${selectedLabel}`}
+            className="h-full w-[124px] shrink-0 rounded-none border-y-0 border-r-0 border-l border-border/60 px-2.5 focus:border-border/60 sm:w-[146px]"
+          >
+            <span className="min-w-0 truncate">
+              <span className="text-muted-foreground">In: </span>
+              {selectedLabel}
+            </span>
+          </SelectTrigger>
+          <SelectContent align="end">
+            <SelectItem value={ALL_FIELDS_VALUE}>{allFieldsLabel}</SelectItem>
+            {fields.map((field) => (
+              <SelectItem key={field.key} value={field.key}>
+                {field.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </form>
+  );
+}
+
+export interface DataTableFilterPopoverProps<FilterKey extends string> {
+  readonly fields: readonly DataTableFilterField<FilterKey>[];
+  readonly values: DataTableFilterSelections<FilterKey>;
+  readonly open: boolean;
+  readonly selectedKey: FilterKey;
+  readonly activeCount: number;
+  readonly triggerLabel?: string;
+  readonly validateValues?: (
+    field: DataTableFilterField<FilterKey>,
+    values: readonly string[],
+  ) => boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onSelectField: (key: FilterKey) => void;
+  readonly onApply: (selections: DataTableFilterSelections<FilterKey>) => void;
+}
+
+export function DataTableFilterPopover<FilterKey extends string>({
+  fields,
+  values,
+  open,
+  selectedKey,
+  activeCount,
+  triggerLabel = "Filters",
+  validateValues,
+  onOpenChange,
+  onSelectField,
+  onApply,
+}: DataTableFilterPopoverProps<FilterKey>) {
+  const selectedField =
+    fields.find((field) => field.key === selectedKey) ?? fields[0];
+  const selectionKey = JSON.stringify(
+    fields.map((field) => [field.key, values[field.key] ?? []]),
+  );
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen && selectedField === undefined && fields[0]) {
+      onSelectField(fields[0].key);
+    }
+    onOpenChange(nextOpen);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant={activeCount > 0 ? "secondary" : "outline"}
+          className="h-11 shrink-0 gap-2 px-3 md:h-8"
+          disabled={fields.length === 0}
+          aria-label={
+            activeCount > 0
+              ? `${triggerLabel}, ${String(activeCount)} applied`
+              : triggerLabel
+          }
+        >
+          <Filter className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{triggerLabel}</span>
+          {activeCount > 0 && (
+            <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary">
+              {String(activeCount)}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-[min(36rem,calc(100vw-1.5rem))] overflow-hidden rounded-lg p-0"
+      >
+        <DataTableFilterPanel
+          key={`${open ? "open" : "closed"}:${selectionKey}`}
+          fields={fields}
+          values={values}
+          selectedField={selectedField}
+          validateValues={validateValues}
+          onSelectField={onSelectField}
+          onCancel={() => onOpenChange(false)}
+          onApply={(selections) => {
+            onApply(selections);
+            onOpenChange(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function DataTableFilterPanel<FilterKey extends string>({
+  fields,
+  values,
+  selectedField,
+  validateValues,
+  onSelectField,
+  onCancel,
+  onApply,
+}: {
+  readonly fields: readonly DataTableFilterField<FilterKey>[];
+  readonly values: DataTableFilterSelections<FilterKey>;
+  readonly selectedField: DataTableFilterField<FilterKey> | undefined;
+  readonly validateValues?: (
+    field: DataTableFilterField<FilterKey>,
+    values: readonly string[],
+  ) => boolean;
+  readonly onSelectField: (key: FilterKey) => void;
+  readonly onCancel: () => void;
+  readonly onApply: (selections: DataTableFilterSelections<FilterKey>) => void;
+}) {
+  const [draftSelections, setDraftSelections] = useState<
+    DataTableFilterSelections<FilterKey>
+  >(() => ({ ...values }));
+
+  return (
+    <div className="grid min-h-[260px] grid-cols-[minmax(112px,0.85fr)_minmax(0,1.35fr)]">
+      <div className="border-r border-border/70 bg-muted/20 p-1.5">
+        {fields.map((field) => {
+          const fieldValues = draftSelections[field.key] ?? [];
+          const selectedValueCount =
+            field.value_type === "date"
+              ? Number(fieldValues.slice(1).some(Boolean))
+              : fieldValues.length;
+          const active = selectedValueCount > 0;
+          const selected = field.key === selectedField?.key;
+          return (
+            <button
+              key={field.key}
+              type="button"
+              className={cn(
+                "flex min-h-11 w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring md:min-h-9",
+                selected
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+              )}
+              aria-pressed={selected}
+              onClick={() => onSelectField(field.key)}
+            >
+              <span className="min-w-0 flex-1 break-words">{field.label}</span>
+              {active && (
+                <span
+                  className="flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary"
+                  aria-label={`${String(selectedValueCount)} selected`}
+                >
+                  {String(selectedValueCount)}
+                </span>
+              )}
+              {selected && !active && (
+                <ChevronRight
+                  className="h-3.5 w-3.5 shrink-0"
+                  aria-hidden="true"
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedField ? (
+        <DataTableFilterEditor
+          key={`${selectedField.key}:${selectedField.date_modes?.join(",") ?? ""}`}
+          field={selectedField}
+          values={draftSelections[selectedField.key] ?? []}
+          validateValues={validateValues}
+          onValuesChange={(nextValues) =>
+            setDraftSelections((current) => ({
+              ...current,
+              [selectedField.key]: nextValues,
+            }))
+          }
+          onCancel={onCancel}
+          onApply={() => onApply(draftSelections)}
+        />
+      ) : (
+        <div />
+      )}
+    </div>
+  );
+}
+
+function DataTableFilterEditor<FilterKey extends string>({
+  field,
+  values,
+  validateValues,
+  onValuesChange,
+  onCancel,
+  onApply,
+}: {
+  readonly field: DataTableFilterField<FilterKey>;
+  readonly values: readonly string[];
+  readonly validateValues?: (
+    field: DataTableFilterField<FilterKey>,
+    values: readonly string[],
+  ) => boolean;
+  readonly onValuesChange: (values: readonly string[]) => void;
+  readonly onCancel: () => void;
+  readonly onApply: () => void;
+}) {
+  if (field.value_type === "date") {
+    return (
+      <DataTableDateFilterEditor
+        field={field}
+        values={values}
+        validateValues={validateValues}
+        onValuesChange={onValuesChange}
+        onCancel={onCancel}
+        onApply={onApply}
+      />
+    );
+  }
+
+  const multiple = field.multiple === true;
+  const allSelected =
+    field.options.length > 0 && values.length === field.options.length;
+  const partiallySelected = values.length > 0 && !allSelected;
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <div className="border-b border-border/70 px-3 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-xs font-semibold text-foreground">
+            {field.label}{" "}
+            <span className="font-normal text-muted-foreground">
+              {field.operator}
+            </span>
+          </p>
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {String(values.length)} selected
+          </span>
+        </div>
+      </div>
+      <div
+        role="group"
+        aria-label={`${field.label} values`}
+        className="max-h-[250px] flex-1 space-y-1 overflow-y-auto p-2"
+      >
+        {multiple && (
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={partiallySelected ? "mixed" : allSelected}
+            className={cn(
+              "mb-2 flex min-h-11 w-full items-center gap-2 rounded-md border border-dashed px-3 py-2 text-left text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring md:min-h-9",
+              allSelected || partiallySelected
+                ? "border-primary/45 bg-primary/[0.07] text-foreground"
+                : "border-border/80 bg-muted/20 text-muted-foreground hover:border-primary/35 hover:bg-muted/35 hover:text-foreground",
+            )}
+            onClick={() =>
+              onValuesChange(
+                allSelected ? [] : field.options.map((option) => option.value),
+              )
+            }
+          >
+            <span
+              className={cn(
+                "flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border",
+                allSelected || partiallySelected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-muted-foreground/40",
+              )}
+              aria-hidden="true"
+            >
+              {allSelected ? (
+                <Check className="h-3 w-3" />
+              ) : partiallySelected ? (
+                <Minus className="h-3 w-3" />
+              ) : null}
+            </span>
+            <span>Select all</span>
+            <span className="ml-auto text-[10px] font-normal text-muted-foreground">
+              {String(field.options.length)} values
+            </span>
+          </button>
+        )}
+        {field.options.map((option) => {
+          const checked = values.includes(option.value);
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role={multiple ? "checkbox" : undefined}
+              aria-checked={multiple ? checked : undefined}
+              aria-pressed={multiple ? undefined : checked}
+              title={option.label === option.value ? undefined : option.value}
+              className={cn(
+                "flex min-h-11 w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring md:min-h-9",
+                checked
+                  ? "border-primary/40 bg-primary/10 text-foreground"
+                  : "border-transparent text-muted-foreground hover:border-border hover:bg-accent/50 hover:text-foreground",
+              )}
+              onClick={() => {
+                if (!multiple) {
+                  onValuesChange([option.value]);
+                  return;
+                }
+                onValuesChange(
+                  checked
+                    ? values.filter((value) => value !== option.value)
+                    : [...values, option.value],
+                );
+              }}
+            >
+              <span
+                className={cn(
+                  "flex h-4 w-4 shrink-0 items-center justify-center border",
+                  multiple ? "rounded-[4px]" : "rounded-full",
+                  checked
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-muted-foreground/40",
+                )}
+                aria-hidden="true"
+              >
+                {checked && <Check className="h-3 w-3" />}
+              </span>
+              <span className="min-w-0 break-words">{option.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <DataTableFilterActions
+        hasValue={values.length > 0}
+        onClear={() => onValuesChange([])}
+        onCancel={onCancel}
+        onApply={onApply}
+      />
+    </div>
+  );
+}
+
+function DataTableDateFilterEditor<FilterKey extends string>({
+  field,
+  values,
+  validateValues,
+  onValuesChange,
+  onCancel,
+  onApply,
+}: {
+  readonly field: DataTableFilterField<FilterKey>;
+  readonly values: readonly string[];
+  readonly validateValues?: (
+    field: DataTableFilterField<FilterKey>,
+    values: readonly string[],
+  ) => boolean;
+  readonly onValuesChange: (values: readonly string[]) => void;
+  readonly onCancel: () => void;
+  readonly onApply: () => void;
+}) {
+  const dateModes =
+    field.date_modes && field.date_modes.length > 0
+      ? field.date_modes
+      : DEFAULT_DATE_MODES;
+  const initialMode =
+    values[0] === "range" && dateModes.includes("range")
+      ? "range"
+      : (dateModes[0] ?? "dates");
+  const [mode, setMode] = useState<"dates" | "range">(() => initialMode);
+  const selectedDates = values[0] === "dates" ? values.slice(1) : [];
+  const [from = "", to = ""] = values[0] === "range" ? values.slice(1) : [];
+  const nextValues =
+    mode === "dates" ? ["dates", ...selectedDates] : ["range", from, to];
+  const hasValue =
+    mode === "dates" ? selectedDates.length > 0 : Boolean(from || to);
+  const valid =
+    !hasValue ||
+    (validateValues
+      ? validateValues(field, nextValues)
+      : isValidDateFilter(nextValues));
+
+  function selectMode(nextMode: "dates" | "range") {
+    if (nextMode === mode) return;
+    setMode(nextMode);
+    onValuesChange([nextMode]);
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <div className="border-b border-border/70 px-3 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-xs font-semibold text-foreground">
+            {field.label}{" "}
+            <span className="font-normal text-muted-foreground">
+              {mode === "dates" ? "on any selected date" : "between"}
+            </span>
+          </p>
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {mode === "dates"
+              ? `${String(selectedDates.length)} selected`
+              : hasValue
+                ? "Range selected"
+                : "No range selected"}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex max-h-[250px] flex-1 flex-col gap-4 overflow-y-auto p-3">
+        {dateModes.length > 1 && (
+          <div
+            role="group"
+            aria-label={`${field.label} date filter mode`}
+            className="grid grid-cols-2 rounded-md border border-border/80 bg-muted/20 p-0.5"
+          >
+            {dateModes.includes("dates") && (
+              <button
+                type="button"
+                aria-pressed={mode === "dates"}
+                className={cn(
+                  "flex min-h-9 items-center justify-center gap-1.5 rounded px-2 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                  mode === "dates"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => selectMode("dates")}
+              >
+                <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+                Specific dates
+              </button>
+            )}
+            {dateModes.includes("range") && (
+              <button
+                type="button"
+                aria-pressed={mode === "range"}
+                className={cn(
+                  "flex min-h-9 items-center justify-center gap-1.5 rounded px-2 text-xs font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+                  mode === "range"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => selectMode("range")}
+              >
+                <CalendarRange className="h-3.5 w-3.5" aria-hidden="true" />
+                Date range
+              </button>
+            )}
+          </div>
+        )}
+
+        {mode === "dates" ? (
+          <div className="space-y-1.5">
+            <span className="text-[11px] font-medium text-muted-foreground">
+              Dates
+            </span>
+            <DatePicker
+              mode="multiple"
+              values={selectedDates}
+              maxSelections={field.max_values ?? 32}
+              ariaLabel={`${field.label} on selected dates`}
+              placeholder="Select dates"
+              onValuesChange={(dates) => onValuesChange(["dates", ...dates])}
+            />
+            {selectedDates.length > 0 && (
+              <div
+                className="flex flex-wrap gap-1.5 pt-1"
+                role="group"
+                aria-label={`Selected ${field.label.toLocaleLowerCase()} dates`}
+              >
+                {selectedDates.map((date) => (
+                  <button
+                    key={date}
+                    type="button"
+                    className="flex min-h-8 items-center gap-1.5 rounded-md border border-border/80 bg-muted/25 px-2 text-[11px] text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring"
+                    aria-label={`Remove selected date ${date}`}
+                    onClick={() =>
+                      onValuesChange([
+                        "dates",
+                        ...selectedDates.filter((value) => value !== date),
+                      ])
+                    }
+                  >
+                    <span>{selectedDateLabel(date)}</span>
+                    <X
+                      className="h-3 w-3 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-muted-foreground">
+                From
+              </span>
+              <DatePicker
+                value={from || null}
+                ariaLabel={`${field.label} from date`}
+                placeholder="Any date"
+                onChange={(value) =>
+                  onValuesChange(["range", value ?? "", value || to ? to : ""])
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-muted-foreground">
+                To
+              </span>
+              <DatePicker
+                value={to || null}
+                minDate={from || undefined}
+                ariaLabel={`${field.label} to date`}
+                placeholder="Any date"
+                onChange={(value) =>
+                  onValuesChange(["range", from, value ?? ""])
+                }
+              />
+            </div>
+          </div>
+        )}
+
+        {!valid && (
+          <p role="alert" className="text-xs text-destructive">
+            The end date must be on or after the start date.
+          </p>
+        )}
+      </div>
+
+      <DataTableFilterActions
+        hasValue={hasValue}
+        disabled={!valid}
+        onClear={() => onValuesChange([])}
+        onCancel={onCancel}
+        onApply={onApply}
+      />
+    </div>
+  );
+}
+
+function DataTableFilterActions({
+  hasValue,
+  disabled = false,
+  onClear,
+  onCancel,
+  onApply,
+}: {
+  readonly hasValue: boolean;
+  readonly disabled?: boolean;
+  readonly onClear: () => void;
+  readonly onCancel: () => void;
+  readonly onApply: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 border-t border-border/70 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-h-7">
+        {hasValue && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="px-2 text-muted-foreground"
+            onClick={onClear}
+          >
+            Clear all
+          </Button>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          disabled={disabled}
+          onClick={onApply}
+        >
+          Apply filters
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function selectedDateLabel(value: string): string {
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return value;
+  return FILTER_DATE_FORMATTER.format(new Date(Date.UTC(year, month - 1, day)));
+}
+
+function isCalendarDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function isValidDateFilter(values: readonly string[]): boolean {
+  const [mode, ...dateValues] = values;
+  if (mode === "dates") {
+    return dateValues.length > 0 && dateValues.every(isCalendarDate);
+  }
+  if (mode !== "range") return false;
+  const [from = "", to = "", ...extra] = dateValues;
+  return (
+    extra.length === 0 &&
+    Boolean(from || to) &&
+    (!from || isCalendarDate(from)) &&
+    (!to || isCalendarDate(to)) &&
+    (!from || !to || from <= to)
+  );
+}
+
+export interface DataTableFilterChipsProps<
+  SearchKey extends string,
+  FilterKey extends string,
+> {
+  readonly search: string;
+  readonly searchFields: readonly DataTableSearchField<SearchKey>[];
+  readonly searchFilters: readonly DataTableSearchGroup<SearchKey>[];
+  readonly filters: readonly AppliedDataTableFilter<FilterKey>[];
+  readonly allFieldsLabel?: string;
+  readonly ariaLabel?: string;
+  readonly onEditSearch: () => void;
+  readonly onRemoveSearch: () => void;
+  readonly onEditSearchValue: (field: SearchKey, value: string) => void;
+  readonly onRemoveSearchValue: (field: SearchKey, value: string) => void;
+  readonly onEdit: (key: FilterKey) => void;
+  readonly onRemove: (key: FilterKey) => void;
+  readonly onClear: () => void;
+}
+
+export function DataTableFilterChips<
+  SearchKey extends string,
+  FilterKey extends string,
+>({
+  search,
+  searchFields,
+  searchFilters,
+  filters,
+  allFieldsLabel = "All fields",
+  ariaLabel = "Applied filters",
+  onEditSearch,
+  onRemoveSearch,
+  onEditSearchValue,
+  onRemoveSearchValue,
+  onEdit,
+  onRemove,
+  onClear,
+}: DataTableFilterChipsProps<SearchKey, FilterKey>) {
+  if (!search && searchFilters.length === 0 && filters.length === 0)
+    return null;
+
+  const visibleSearch =
+    search.length > 48 ? `${search.slice(0, 48)}...` : search;
+  const searchLabels = new Map(
+    searchFields.map((field) => [field.key, field.label] as const),
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" aria-label={ariaLabel}>
+      {search && (
+        <div
+          role="group"
+          aria-label={`${allFieldsLabel} search`}
+          className="flex min-h-11 max-w-full items-stretch overflow-hidden rounded-md border border-border/80 bg-muted/25 text-xs md:min-h-9"
+        >
+          <button
+            type="button"
+            className="min-w-0 px-2.5 py-1.5 text-left outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            aria-label={`Edit ${allFieldsLabel} search: contains ${search}`}
+            title={search}
+            onClick={onEditSearch}
+          >
+            <span className="font-medium text-foreground">
+              {allFieldsLabel}
+            </span>{" "}
+            <span className="text-muted-foreground">contains</span>{" "}
+            <span className="break-all font-medium text-foreground">
+              &quot;{visibleSearch}&quot;
+            </span>
+          </button>
+          <button
+            type="button"
+            className="flex w-11 shrink-0 items-center justify-center border-l border-border/70 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring md:w-9"
+            aria-label={`Remove ${allFieldsLabel} search`}
+            title={`Remove ${allFieldsLabel} search`}
+            onClick={onRemoveSearch}
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+      {searchFilters.map((searchFilter) => {
+        const label =
+          searchLabels.get(searchFilter.field) ?? searchFilter.field;
+        return (
+          <div
+            key={searchFilter.field}
+            role="group"
+            aria-label={`${label} search, matches any term`}
+            className="flex min-h-11 max-w-full flex-wrap items-stretch overflow-hidden rounded-md border border-border/80 bg-muted/25 text-xs md:min-h-9"
+          >
+            <span className="flex items-center px-2.5 py-1.5">
+              <span className="font-medium text-foreground">{label}</span>{" "}
+              <span className="ml-1 text-muted-foreground">contains</span>
+            </span>
+            {searchFilter.values.map((value, valueIndex) => {
+              const visibleValue =
+                value.length > 36 ? `${value.slice(0, 36)}...` : value;
+              return (
+                <Fragment key={value.toLocaleLowerCase()}>
+                  {valueIndex > 0 && (
+                    <span className="flex items-center border-l border-border/70 px-2 text-[10px] font-semibold text-muted-foreground">
+                      OR
+                    </span>
+                  )}
+                  <div className="flex min-w-0 items-stretch border-l border-border/70">
+                    <button
+                      type="button"
+                      className="min-w-0 px-2 py-1.5 text-left font-medium text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                      aria-label={`Edit ${label} search: contains ${value}`}
+                      title={value}
+                      onClick={() =>
+                        onEditSearchValue(searchFilter.field, value)
+                      }
+                    >
+                      <span className="break-all">
+                        &quot;{visibleValue}&quot;
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex w-11 shrink-0 items-center justify-center text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring md:w-8"
+                      aria-label={`Remove ${label} search value: ${value}`}
+                      title={`Remove ${label} search value`}
+                      onClick={() =>
+                        onRemoveSearchValue(searchFilter.field, value)
+                      }
+                    >
+                      <X className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </div>
+                </Fragment>
+              );
+            })}
+          </div>
+        );
+      })}
+      {filters.map(
+        ({ field, values, valueLabels, operatorLabel, valueSummary }) => {
+          const resolvedOperatorLabel =
+            operatorLabel ??
+            (values.length > 1
+              ? field.operator === "includes"
+                ? "includes any of"
+                : "is any of"
+              : field.operator);
+          const hiddenValueCount = Math.max(0, valueLabels.length - 2);
+          const visibleValueSummary =
+            valueSummary ??
+            `${valueLabels.slice(0, 2).join(", ")}${
+              hiddenValueCount > 0 ? ` +${String(hiddenValueCount)} more` : ""
+            }`;
+          const fullValueSummary = valueSummary ?? valueLabels.join(", ");
+          return (
+            <div
+              key={field.key}
+              className="flex min-h-11 max-w-full items-stretch overflow-hidden rounded-md border border-border/80 bg-muted/25 text-xs md:min-h-9"
+            >
+              <button
+                type="button"
+                className="min-w-0 px-2.5 py-1.5 text-left outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                aria-label={`Edit ${field.label} filter: ${resolvedOperatorLabel} ${fullValueSummary}`}
+                title={fullValueSummary}
+                onClick={() => onEdit(field.key)}
+              >
+                <span className="font-medium text-foreground">
+                  {field.label}
+                </span>{" "}
+                <span className="text-muted-foreground">
+                  {resolvedOperatorLabel}
+                </span>{" "}
+                <span className="break-all font-medium text-foreground">
+                  {visibleValueSummary}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="flex w-11 shrink-0 items-center justify-center border-l border-border/70 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring md:w-9"
+                aria-label={`Remove ${field.label} filter`}
+                title={`Remove ${field.label} filter`}
+                onClick={() => onRemove(field.key)}
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          );
+        },
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-11 px-2 text-xs text-muted-foreground md:h-9"
+        onClick={onClear}
+      >
+        Clear filters
+      </Button>
+    </div>
+  );
+}
+
+export function DataTableControls({
+  search,
+  filter,
+  status,
+  chips,
+}: {
+  readonly search: ReactNode;
+  readonly filter: ReactNode;
+  readonly status?: ReactNode;
+  readonly chips?: ReactNode;
+}) {
+  return (
+    <div className="space-y-2 border-b border-border/60 p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {search}
+        <div className="ml-auto flex shrink-0 items-center">{filter}</div>
+        {status}
+      </div>
+      {chips}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/date-picker.test.tsx
+++ b/frontend/src/components/ui/date-picker.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { DatePicker } from "./date-picker";
+
+function MultiDatePickerHarness() {
+  const [values, setValues] = useState<readonly string[]>(["2026-07-03"]);
+  return (
+    <DatePicker
+      mode="multiple"
+      values={values}
+      onValuesChange={setValues}
+      ariaLabel="Creation dates"
+      placeholder="Select dates"
+    />
+  );
+}
+
+describe("DatePicker", () => {
+  it("toggles multiple dates without closing and supports Clear all", async () => {
+    const user = userEvent.setup();
+    render(<MultiDatePickerHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Creation dates" }));
+    const previousMonth = screen.getByRole("button", {
+      name: "Previous month",
+    });
+    const nextMonth = screen.getByRole("button", { name: "Next month" });
+    expect(screen.getByText("July 2026")).toBeVisible();
+
+    await user.click(previousMonth);
+    expect(screen.getByText("June 2026")).toBeVisible();
+    await user.click(nextMonth);
+    expect(screen.getByText("July 2026")).toBeVisible();
+
+    const julyThird = screen.getByRole("button", { name: "2026-07-03" });
+    const julyEighth = screen.getByRole("button", { name: "2026-07-08" });
+    expect(julyThird).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(julyEighth);
+    expect(
+      screen.getByRole("button", { name: "Creation dates" }),
+    ).toHaveTextContent("2 dates selected");
+    expect(julyEighth).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(julyThird);
+    expect(
+      screen.getByRole("button", { name: "Creation dates" }),
+    ).toHaveTextContent("July 8, 2026");
+    expect(julyThird).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(
+      screen.getByRole("button", { name: "Creation dates" }),
+    ).toHaveTextContent("Select dates");
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/date-picker.tsx
+++ b/frontend/src/components/ui/date-picker.tsx
@@ -46,23 +46,41 @@ function parseDate(value: string): Date | null {
   return new Date(y, m - 1, d);
 }
 
-interface DatePickerProps {
-  readonly value: string | null;
-  readonly onChange: (value: string | null) => void;
+interface CommonDatePickerProps {
   readonly minDate?: string;
   readonly placeholder?: string;
+  readonly ariaLabel?: string;
   readonly disabled?: boolean;
 }
 
-export function DatePicker({
-  value,
-  onChange,
-  minDate,
-  placeholder = "Select date",
-  disabled = false,
-}: DatePickerProps) {
+type DatePickerProps = CommonDatePickerProps &
+  (
+    | {
+        readonly mode?: "single";
+        readonly value: string | null;
+        readonly onChange: (value: string | null) => void;
+      }
+    | {
+        readonly mode: "multiple";
+        readonly values: readonly string[];
+        readonly onValuesChange: (values: readonly string[]) => void;
+        readonly maxSelections?: number;
+      }
+  );
+
+export function DatePicker(props: DatePickerProps) {
+  const {
+    minDate,
+    placeholder = "Select date",
+    ariaLabel,
+    disabled = false,
+  } = props;
+  const multiple = props.mode === "multiple";
+  const values = multiple ? props.values : props.value ? [props.value] : [];
+  const maxSelections = multiple ? (props.maxSelections ?? 32) : 1;
   const [open, setOpen] = useState(false);
-  const selected = useMemo(() => (value ? parseDate(value) : null), [value]);
+  const selected = values[0] ? parseDate(values[0]) : null;
+  const selectedValues = new Set(values);
   const min = useMemo(() => (minDate ? parseDate(minDate) : null), [minDate]);
 
   const today = useMemo(() => new Date(), []);
@@ -126,7 +144,8 @@ export function DatePicker({
     for (let d = 1; d <= daysInMonth; d++) {
       const date = new Date(viewYear, viewMonth, d);
       const isBeforeMin =
-        min !== null && date < new Date(min.getFullYear(), min.getMonth(), min.getDate());
+        min !== null &&
+        date < new Date(min.getFullYear(), min.getMonth(), min.getDate());
       result.push({ day: d, current: true, disabled: isBeforeMin, date });
     }
 
@@ -144,12 +163,7 @@ export function DatePicker({
   }, [viewYear, viewMonth, firstDay, prevMonthDays, daysInMonth, min]);
 
   function isSelected(date: Date): boolean {
-    if (!selected) return false;
-    return (
-      date.getFullYear() === selected.getFullYear() &&
-      date.getMonth() === selected.getMonth() &&
-      date.getDate() === selected.getDate()
-    );
+    return selectedValues.has(toDateString(date));
   }
 
   function isToday(date: Date): boolean {
@@ -161,13 +175,25 @@ export function DatePicker({
   }
 
   function selectDay(date: Date) {
-    onChange(toDateString(date));
+    const nextDate = toDateString(date);
+    if (multiple) {
+      props.onValuesChange(
+        selectedValues.has(nextDate)
+          ? values.filter((value) => value !== nextDate)
+          : [...values, nextDate].sort(),
+      );
+      return;
+    }
+    props.onChange(nextDate);
     setOpen(false);
   }
 
-  const displayValue = selected
-    ? `${MONTHS[selected.getMonth()]} ${selected.getDate()}, ${selected.getFullYear()}`
-    : null;
+  const displayValue =
+    multiple && values.length > 1
+      ? `${String(values.length)} dates selected`
+      : selected
+        ? `${MONTHS[selected.getMonth()]} ${selected.getDate()}, ${selected.getFullYear()}`
+        : null;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -175,6 +201,7 @@ export function DatePicker({
         <button
           type="button"
           disabled={disabled}
+          aria-label={ariaLabel}
           className={cn(
             "flex h-8 w-full items-center justify-between rounded-lg border border-input bg-transparent px-3 text-[12px] transition-colors",
             "hover:border-white/[0.15] focus-visible:outline-none focus-visible:border-white/[0.15]",
@@ -192,20 +219,22 @@ export function DatePicker({
           <div className="flex items-center justify-between">
             <button
               type="button"
+              aria-label="Previous month"
               onClick={prevMonth}
               className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/[0.06] hover:text-foreground"
             >
-              <ChevronLeft className="h-4 w-4" />
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
             </button>
             <span className="text-[12px] font-medium">
               {MONTHS[viewMonth]} {viewYear}
             </span>
             <button
               type="button"
+              aria-label="Next month"
               onClick={nextMonth}
               className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/[0.06] hover:text-foreground"
             >
-              <ChevronRight className="h-4 w-4" />
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
 
@@ -226,11 +255,15 @@ export function DatePicker({
             {cells.map((cell, i) => {
               const sel = isSelected(cell.date);
               const tod = isToday(cell.date);
+              const selectionLimitReached =
+                multiple && !sel && values.length >= maxSelections;
               return (
                 <button
                   key={i}
                   type="button"
-                  disabled={cell.disabled}
+                  disabled={cell.disabled || selectionLimitReached}
+                  aria-label={toDateString(cell.date)}
+                  aria-pressed={sel}
                   onClick={() => selectDay(cell.date)}
                   className={cn(
                     "flex h-8 w-full items-center justify-center rounded-md text-[12px] transition-colors",
@@ -239,9 +272,9 @@ export function DatePicker({
                       !sel &&
                       !cell.disabled &&
                       "text-foreground hover:bg-white/[0.06]",
-                    cell.disabled && "cursor-not-allowed opacity-30",
-                    sel &&
-                      "bg-primary text-primary-foreground font-medium",
+                    (cell.disabled || selectionLimitReached) &&
+                      "cursor-not-allowed opacity-30",
+                    sel && "bg-primary text-primary-foreground font-medium",
                     tod && !sel && "font-medium text-primary",
                   )}
                 >
@@ -257,27 +290,54 @@ export function DatePicker({
               type="button"
               variant="ghost"
               className="h-7 text-[11px]"
+              disabled={values.length === 0}
               onClick={() => {
-                onChange(null);
-                setOpen(false);
+                if (multiple) {
+                  props.onValuesChange([]);
+                } else {
+                  props.onChange(null);
+                  setOpen(false);
+                }
               }}
             >
-              Clear
+              {multiple ? "Clear all" : "Clear"}
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              className="h-7 text-[11px]"
-              onClick={() => {
-                const t = new Date();
-                setViewYear(t.getFullYear());
-                setViewMonth(t.getMonth());
-                onChange(toDateString(t));
-                setOpen(false);
-              }}
-            >
-              Today
-            </Button>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-7 text-[11px]"
+                onClick={() => {
+                  const t = new Date();
+                  const todayValue = toDateString(t);
+                  setViewYear(t.getFullYear());
+                  setViewMonth(t.getMonth());
+                  if (multiple) {
+                    if (
+                      !selectedValues.has(todayValue) &&
+                      values.length < maxSelections
+                    ) {
+                      props.onValuesChange([...values, todayValue].sort());
+                    }
+                  } else {
+                    props.onChange(todayValue);
+                    setOpen(false);
+                  }
+                }}
+              >
+                Today
+              </Button>
+              {multiple && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-7 text-[11px]"
+                  onClick={() => setOpen(false)}
+                >
+                  Done
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       </PopoverContent>

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -2,25 +2,32 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 /* ── NyxID Table ── */
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-));
+type TableProps = React.HTMLAttributes<HTMLTableElement> & {
+  readonly containerClassName?: string;
+};
+
+const Table = React.forwardRef<HTMLTableElement, TableProps>(
+  ({ className, containerClassName, ...props }, ref) => (
+    <div className={cn("relative w-full overflow-auto", containerClassName)}>
+      <table
+        ref={ref}
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  ),
+);
 Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b [&_tr]:hover:bg-transparent", className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn("[&_tr]:border-b [&_tr]:hover:bg-transparent", className)}
+    {...props}
+  />
 ));
 TableHeader.displayName = "TableHeader";
 

--- a/frontend/src/hooks/use-admin-oauth-clients.test.tsx
+++ b/frontend/src/hooks/use-admin-oauth-clients.test.tsx
@@ -8,6 +8,7 @@ import {
   useUpdateAdminOAuthClient,
   useUpdateBrokerSettings,
 } from "./use-admin-oauth-clients";
+import type { AdminOAuthClientListParams } from "@/types/admin";
 
 const { mockGet, mockPatch } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -39,15 +40,87 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const defaultParams: AdminOAuthClientListParams = {
+  page: 1,
+  per_page: 25,
+  sort: "-created_at",
+};
+
 describe("admin OAuth client hooks", () => {
   it("fetches the admin OAuth clients list", async () => {
-    mockGet.mockResolvedValue({ clients: [] });
-    const { result } = renderHook(() => useAdminOAuthClients(), {
+    mockGet.mockResolvedValue({
+      clients: [],
+      total: 0,
+      page: 1,
+      per_page: 25,
+      filter_options: {},
+    });
+    const { result } = renderHook(() => useAdminOAuthClients(defaultParams), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockGet).toHaveBeenCalledWith("/admin/oauth-clients");
+    expect(mockGet).toHaveBeenCalledWith(
+      "/admin/oauth-clients?page=1&per_page=25&sort=-created_at",
+    );
+  });
+
+  it("serializes every multi-value server-side table filter", async () => {
+    mockGet.mockResolvedValue({ clients: [] });
+    const params: AdminOAuthClientListParams = {
+      page: 3,
+      per_page: 50,
+      search: "aevatar console",
+      search_filters: JSON.stringify([
+        { field: "client", values: ["aevatar, console", "東京"] },
+        { field: "client_type", values: ["public", "confidential"] },
+      ]),
+      client_type: "public,confidential",
+      creator_type: "dynamic_registration,system",
+      broker: "enabled,scope",
+      is_active: "true,false",
+      scope: "openid,urn:nyxid:scope:broker_binding",
+      created_from: "2026-07-01",
+      created_to: "2026-07-31",
+      sort: "client_name",
+    };
+    const { result } = renderHook(() => useAdminOAuthClients(params), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const request = mockGet.mock.calls[0]?.[0] as string;
+    const query = new URLSearchParams(request.split("?")[1]);
+    expect(query.get("page")).toBe("3");
+    expect(query.get("per_page")).toBe("50");
+    expect(query.get("search")).toBe("aevatar console");
+    expect(query.get("search_filters")).toBe(params.search_filters);
+    expect(query.get("client_type")).toBe("public,confidential");
+    expect(query.get("creator_type")).toBe("dynamic_registration,system");
+    expect(query.get("broker")).toBe("enabled,scope");
+    expect(query.get("is_active")).toBe("true,false");
+    expect(query.get("scope")).toBe("openid,urn:nyxid:scope:broker_binding");
+    expect(query.get("created_from")).toBe("2026-07-01");
+    expect(query.get("created_to")).toBe("2026-07-31");
+    expect(query.get("sort")).toBe("client_name");
+  });
+
+  it("serializes exact creation dates", async () => {
+    mockGet.mockResolvedValue({ clients: [] });
+    const { result } = renderHook(
+      () =>
+        useAdminOAuthClients({
+          ...defaultParams,
+          created_dates: "2026-07-03,2026-07-08",
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const request = mockGet.mock.calls[0]?.[0] as string;
+    expect(
+      new URLSearchParams(request.split("?")[1]).get("created_dates"),
+    ).toBe("2026-07-03,2026-07-08");
   });
 
   it("patches an admin OAuth client by id", async () => {
@@ -63,6 +136,24 @@ describe("admin OAuth client hooks", () => {
 
     expect(mockPatch).toHaveBeenCalledWith("/admin/oauth-clients/client%2F1", {
       broker_capability_enabled: true,
+    });
+  });
+
+  it("invalidates every cached OAuth-client page after an update", async () => {
+    mockPatch.mockResolvedValue({ id: "client-1" });
+    const queryClient = createQueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateAdminOAuthClient(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await result.current.mutateAsync({
+      clientId: "client-1",
+      data: { is_active: false },
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["admin", "oauth-clients"],
     });
   });
 

--- a/frontend/src/hooks/use-admin-oauth-clients.ts
+++ b/frontend/src/hooks/use-admin-oauth-clients.ts
@@ -1,19 +1,49 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import type {
   AdminOAuthClient,
+  AdminOAuthClientListParams,
   AdminOAuthClientListResponse,
   BrokerSettingsResponse,
   UpdateAdminOAuthClientRequest,
   UpdateBrokerSettingsRequest,
 } from "@/types/admin";
 
-export function useAdminOAuthClients() {
+export function useAdminOAuthClients(params: AdminOAuthClientListParams) {
   return useQuery({
-    queryKey: ["admin", "oauth-clients"],
+    queryKey: ["admin", "oauth-clients", params],
     queryFn: async (): Promise<AdminOAuthClientListResponse> => {
-      return api.get<AdminOAuthClientListResponse>("/admin/oauth-clients");
+      const query = new URLSearchParams({
+        page: String(params.page),
+        per_page: String(params.per_page),
+        sort: params.sort,
+      });
+      if (params.search) query.set("search", params.search);
+      if (params.search_filters) {
+        query.set("search_filters", params.search_filters);
+      }
+      if (params.client_type) query.set("client_type", params.client_type);
+      if (params.creator_type) query.set("creator_type", params.creator_type);
+      if (params.broker) query.set("broker", params.broker);
+      if (params.is_active !== undefined) {
+        query.set("is_active", String(params.is_active));
+      }
+      if (params.scope) query.set("scope", params.scope);
+      if (params.created_dates) {
+        query.set("created_dates", params.created_dates);
+      }
+      if (params.created_from) query.set("created_from", params.created_from);
+      if (params.created_to) query.set("created_to", params.created_to);
+      return api.get<AdminOAuthClientListResponse>(
+        `/admin/oauth-clients?${query.toString()}`,
+      );
     },
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/frontend/src/lib/admin-oauth-clients.test.ts
+++ b/frontend/src/lib/admin-oauth-clients.test.ts
@@ -1,0 +1,572 @@
+import { describe, expect, it } from "vitest";
+import {
+  adminOAuthClientFilterPatch,
+  encodeAdminOAuthClientSearchFilters,
+  getAppliedAdminOAuthClientFilters,
+  getAdminOAuthClientFilterFields,
+  getAdminOAuthClientSearchFields,
+  getAdminOAuthClientSearchFilters,
+  normalizeAdminOAuthClientSearch,
+  parseAdminOAuthClientSearchFilters,
+  updateAdminOAuthClientSearchFilters,
+} from "./admin-oauth-clients";
+
+describe("normalizeAdminOAuthClientSearch", () => {
+  it("keeps valid non-default table state", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        page: "3",
+        per_page: "50",
+        search: "  aevatar  ",
+        client_type: "public",
+        creator_type: "dynamic_registration",
+        broker: "scope",
+        is_active: "true",
+        scope: "urn:nyxid:scope:broker_binding",
+        created_from: "2026-07-01",
+        created_to: "2026-07-31",
+        sort: "client_name",
+      }),
+    ).toEqual({
+      page: 3,
+      per_page: 50,
+      search: "aevatar",
+      client_type: "public",
+      creator_type: "dynamic_registration",
+      broker: "scope",
+      is_active: true,
+      scope: "urn:nyxid:scope:broker_binding",
+      created_from: "2026-07-01",
+      created_to: "2026-07-31",
+      sort: "client_name",
+    });
+  });
+
+  it("drops defaults and invalid values", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        page: "0",
+        per_page: "25",
+        search: " ",
+        client_type: "native",
+        creator_type: "robot",
+        broker: "maybe",
+        is_active: "yes",
+        scope: "profile write",
+        created_from: "2026-02-30",
+        created_to: "07/31/2026",
+        sort: "client_secret_hash",
+      }),
+    ).toEqual({});
+  });
+
+  it("keeps scalar status values boolean-compatible and caps search length", () => {
+    expect(normalizeAdminOAuthClientSearch({ is_active: false })).toEqual({
+      is_active: false,
+    });
+    expect(normalizeAdminOAuthClientSearch({ is_active: true })).toEqual({
+      is_active: true,
+    });
+    expect(
+      normalizeAdminOAuthClientSearch({ search: "x".repeat(257) }),
+    ).toEqual({});
+  });
+
+  it("canonicalizes and deduplicates comma-separated structured filters", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        client_type: " confidential,public,confidential ",
+        creator_type: "ownerless,system,ownerless",
+        broker: "scope,enabled,scope",
+        is_active: "false,true,false",
+        scope: "profile,openid,profile",
+      }),
+    ).toEqual({
+      client_type: "public,confidential",
+      creator_type: "system,ownerless",
+      broker: "enabled,scope",
+      is_active: "true,false",
+      scope: "openid,profile",
+    });
+  });
+
+  it("orders known scopes first and future scopes lexically", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        scope:
+          "urn:nyxid:scope:z_future,profile,urn:nyxid:scope:a_future,openid,urn:nyxid:scope:z_future",
+      }),
+    ).toEqual({
+      scope: "openid,profile,urn:nyxid:scope:a_future,urn:nyxid:scope:z_future",
+    });
+  });
+
+  it("drops an entire structured filter when a CSV member is invalid", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        client_type: "public,native",
+        creator_type: "system,robot",
+        broker: "enabled,maybe",
+        is_active: "true,yes",
+        scope: "openid,profile write",
+      }),
+    ).toEqual({});
+
+    expect(
+      normalizeAdminOAuthClientSearch({
+        client_type: "public,,confidential",
+        scope: "openid,",
+      }),
+    ).toEqual({});
+  });
+
+  it("keeps scalar structured-filter URLs backward compatible", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        client_type: "confidential",
+        creator_type: "dynamic_registration",
+        broker: "flag",
+        is_active: "false",
+        scope: "urn:nyxid:scope:future_capability",
+      }),
+    ).toEqual({
+      client_type: "confidential",
+      creator_type: "dynamic_registration",
+      broker: "flag",
+      is_active: false,
+      scope: "urn:nyxid:scope:future_capability",
+    });
+  });
+
+  it("normalizes strict calendar dates and preserves one-sided ranges", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({ created_from: "2026-07-03" }),
+    ).toEqual({ created_from: "2026-07-03" });
+    expect(
+      normalizeAdminOAuthClientSearch({ created_to: "2026-07-31" }),
+    ).toEqual({ created_to: "2026-07-31" });
+    expect(
+      normalizeAdminOAuthClientSearch({
+        created_from: "2026-02-30",
+        created_to: "2026-07-31",
+      }),
+    ).toEqual({ created_to: "2026-07-31" });
+  });
+
+  it("canonicalizes exact dates and gives them precedence over a range", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        created_dates: "2026-07-08, 2026-07-03,2026-07-08",
+      }),
+    ).toEqual({ created_dates: "2026-07-03,2026-07-08" });
+    expect(
+      normalizeAdminOAuthClientSearch({
+        created_dates: "2026-07-03,2026-07-08",
+        created_from: "2026-07-01",
+        created_to: "2026-07-31",
+      }),
+    ).toEqual({ created_dates: "2026-07-03,2026-07-08" });
+    expect(
+      normalizeAdminOAuthClientSearch({
+        created_dates: "2026-02-30,2026-07-08",
+      }),
+    ).toEqual({});
+  });
+
+  it("drops inverted date ranges", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        created_from: "2026-08-01",
+        created_to: "2026-07-31",
+      }),
+    ).toEqual({});
+  });
+
+  it("preserves a valid future scope token for server-side validation", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        scope: "urn:nyxid:scope:future_capability",
+      }),
+    ).toEqual({ scope: "urn:nyxid:scope:future_capability" });
+  });
+
+  it("accepts all server-backed column sort values", () => {
+    expect(normalizeAdminOAuthClientSearch({ sort: "-broker" })).toEqual({
+      sort: "-broker",
+    });
+    expect(normalizeAdminOAuthClientSearch({ sort: "allowed_scopes" })).toEqual(
+      { sort: "allowed_scopes" },
+    );
+  });
+
+  it("prefers typed server fields and fills missing fields from legacy metadata", () => {
+    const fields = getAdminOAuthClientFilterFields({
+      client_types: ["public"],
+      creator_types: ["system"],
+      broker_filters: ["enabled"],
+      statuses: [true, false],
+      allowed_scopes: ["openid"],
+      sorts: ["-created_at"],
+      fields: [
+        {
+          key: "is_active",
+          label: "Lifecycle",
+          value_type: "boolean",
+          operator: "is",
+          multiple: true,
+          options: [
+            { value: "true", label: "On" },
+            { value: "false", label: "Off" },
+          ],
+        },
+      ],
+    });
+
+    expect(fields).toHaveLength(5);
+    expect(fields[0]).toMatchObject({
+      key: "is_active",
+      label: "Lifecycle",
+      value_type: "boolean",
+      operator: "is",
+      multiple: true,
+    });
+    expect(fields.find((field) => field.key === "scope")).toMatchObject({
+      operator: "includes",
+      multiple: false,
+      options: [{ value: "openid", label: "OpenID" }],
+    });
+  });
+
+  it("accepts an advertised date field without adding it to legacy fallbacks", () => {
+    expect(getAdminOAuthClientFilterFields()).toHaveLength(5);
+
+    const fields = getAdminOAuthClientFilterFields({
+      client_types: ["public"],
+      creator_types: ["system"],
+      broker_filters: ["enabled"],
+      statuses: [true],
+      allowed_scopes: ["openid"],
+      sorts: ["-created_at"],
+      fields: [
+        {
+          key: "created_at",
+          label: "Created",
+          value_type: "date",
+          operator: "between",
+          multiple: true,
+          options: [],
+        },
+      ],
+    });
+
+    expect(fields).toHaveLength(6);
+    expect(fields[0]).toEqual({
+      key: "created_at",
+      label: "Created",
+      value_type: "date",
+      operator: "between",
+      multiple: true,
+      options: [],
+      date_modes: ["dates", "range"],
+      max_values: 32,
+    });
+  });
+
+  it("maps validated value sets into canonical URL state", () => {
+    expect(adminOAuthClientFilterPatch("is_active", ["false", "true"])).toEqual(
+      {
+        is_active: "true,false",
+      },
+    );
+    expect(adminOAuthClientFilterPatch("is_active", ["false"])).toEqual({
+      is_active: false,
+    });
+    expect(
+      adminOAuthClientFilterPatch("client_type", [
+        "confidential",
+        "public",
+        "confidential",
+      ]),
+    ).toEqual({ client_type: "public,confidential" });
+    expect(
+      adminOAuthClientFilterPatch("client_type", ["public", "native"]),
+    ).toBeUndefined();
+    expect(
+      adminOAuthClientFilterPatch("scope", [
+        "urn:nyxid:scope:future_capability",
+        "openid",
+        "urn:nyxid:scope:future_capability",
+      ]),
+    ).toEqual({
+      scope: "openid,urn:nyxid:scope:future_capability",
+    });
+    expect(adminOAuthClientFilterPatch("broker", undefined)).toEqual({
+      broker: undefined,
+    });
+    expect(adminOAuthClientFilterPatch("scope", [])).toEqual({
+      scope: undefined,
+    });
+    expect(
+      adminOAuthClientFilterPatch("scope", ["openid", "profile write"]),
+    ).toBeUndefined();
+    expect(
+      adminOAuthClientFilterPatch("created_at", [
+        "range",
+        "2026-07-01",
+        "2026-07-31",
+      ]),
+    ).toEqual({
+      created_dates: undefined,
+      created_from: "2026-07-01",
+      created_to: "2026-07-31",
+    });
+    expect(
+      adminOAuthClientFilterPatch("created_at", [
+        "dates",
+        "2026-07-08",
+        "2026-07-03",
+        "2026-07-08",
+      ]),
+    ).toEqual({
+      created_dates: "2026-07-03,2026-07-08",
+      created_from: undefined,
+      created_to: undefined,
+    });
+    expect(
+      adminOAuthClientFilterPatch("created_at", ["range", "", "2026-07-31"]),
+    ).toEqual({
+      created_dates: undefined,
+      created_from: undefined,
+      created_to: "2026-07-31",
+    });
+    expect(
+      adminOAuthClientFilterPatch("created_at", [
+        "range",
+        "2026-08-01",
+        "2026-07-31",
+      ]),
+    ).toBeUndefined();
+    expect(adminOAuthClientFilterPatch("created_at", undefined)).toEqual({
+      created_dates: undefined,
+      created_from: undefined,
+      created_to: undefined,
+    });
+  });
+
+  it("builds readable applied date filter labels", () => {
+    const dateField = {
+      key: "created_at",
+      label: "Created",
+      value_type: "date",
+      operator: "between",
+      multiple: false,
+      options: [],
+    } as const;
+
+    expect(
+      getAppliedAdminOAuthClientFilters([dateField], {
+        created_dates: "2026-07-03,2026-07-08,2026-07-21",
+      })[0],
+    ).toMatchObject({
+      operatorLabel: "is on any of",
+      valueSummary: "Jul 3, 2026, Jul 8, 2026 +1 more",
+    });
+    expect(
+      getAppliedAdminOAuthClientFilters([dateField], {
+        created_from: "2026-07-01",
+        created_to: "2026-07-31",
+      })[0],
+    ).toMatchObject({
+      operatorLabel: "is between",
+      valueSummary: "Jul 1, 2026 and Jul 31, 2026",
+    });
+    expect(
+      getAppliedAdminOAuthClientFilters([dateField], {
+        created_from: "2026-07-01",
+      })[0],
+    ).toMatchObject({
+      operatorLabel: "is on or after",
+      valueSummary: "Jul 1, 2026",
+    });
+    expect(
+      getAppliedAdminOAuthClientFilters([dateField], {
+        created_to: "2026-07-31",
+      })[0],
+    ).toMatchObject({
+      operatorLabel: "is on or before",
+      valueSummary: "Jul 31, 2026",
+    });
+  });
+
+  it("retains legacy scalar normalization before multi-select edits", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({
+        client_type: "public",
+        is_active: false,
+      }),
+    ).toEqual({ client_type: "public", is_active: false });
+  });
+
+  it("keeps legacy global search normalization for old URLs", () => {
+    expect(
+      normalizeAdminOAuthClientSearch({ search: "  client, 東京  " }),
+    ).toEqual({ search: "client, 東京" });
+  });
+
+  it("canonicalizes field searches while preserving commas and Unicode", () => {
+    const encoded = encodeAdminOAuthClientSearchFilters([
+      { field: "allowed_scopes", values: ["profile,email", "閲覧"] },
+      { field: "client", values: ["  Alpha, Beta  ", "Δelta"] },
+    ]);
+
+    expect(encoded).toBe(
+      '[{"field":"client","values":["Alpha, Beta","Δelta"]},{"field":"allowed_scopes","values":["profile,email","閲覧"]}]',
+    );
+    expect(parseAdminOAuthClientSearchFilters(encoded)).toEqual([
+      { field: "client", values: ["Alpha, Beta", "Δelta"] },
+      { field: "allowed_scopes", values: ["profile,email", "閲覧"] },
+    ]);
+  });
+
+  it("deduplicates same-field OR values case-insensitively", () => {
+    const encoded = encodeAdminOAuthClientSearchFilters([
+      {
+        field: "client",
+        values: ["Aevatar", " aevatar ", "Console"],
+      },
+    ]);
+
+    expect(parseAdminOAuthClientSearchFilters(encoded)).toEqual([
+      { field: "client", values: ["Aevatar", "Console"] },
+    ]);
+  });
+
+  it("orders field groups canonically without changing value order", () => {
+    expect(
+      parseAdminOAuthClientSearchFilters(
+        JSON.stringify([
+          { field: "created_by", values: ["second", "first"] },
+          { field: "client", values: ["id-2", "id-1"] },
+          { field: "client_type", values: ["public"] },
+        ]),
+      ),
+    ).toEqual([
+      { field: "client", values: ["id-2", "id-1"] },
+      { field: "client_type", values: ["public"] },
+      { field: "created_by", values: ["second", "first"] },
+    ]);
+  });
+
+  it("drops the entire field-search URL state when any group is invalid", () => {
+    const invalidValues: unknown[] = [
+      "not-json",
+      "[]",
+      JSON.stringify([{ field: "unknown", values: ["term"] }]),
+      JSON.stringify([
+        { field: "client", values: ["one"] },
+        { field: "client", values: ["two"] },
+      ]),
+      JSON.stringify([{ field: "client", values: [] }]),
+      JSON.stringify([{ field: "client", values: [" "] }]),
+      JSON.stringify([{ field: "client", values: ["x".repeat(257)] }]),
+      JSON.stringify([
+        {
+          field: "client",
+          values: Array.from({ length: 9 }, (_, index) => String(index)),
+        },
+      ]),
+      JSON.stringify([{ field: "client", values: ["term"], unexpected: true }]),
+    ];
+
+    for (const value of invalidValues) {
+      expect(parseAdminOAuthClientSearchFilters(value)).toBeUndefined();
+      expect(
+        normalizeAdminOAuthClientSearch({ search_filters: value }),
+      ).toEqual({});
+    }
+  });
+
+  it("canonicalizes valid field searches during route normalization", () => {
+    const search_filters = JSON.stringify([
+      { field: "allowed_scopes", values: [" email ", "EMAIL", "openid"] },
+      { field: "client", values: [" client,1 "] },
+    ]);
+
+    expect(normalizeAdminOAuthClientSearch({ search_filters })).toEqual({
+      search_filters:
+        '[{"field":"client","values":["client,1"]},{"field":"allowed_scopes","values":["email","openid"]}]',
+    });
+    expect(
+      normalizeAdminOAuthClientSearch({
+        search_filters: [
+          { field: "created_by", values: [" system "] },
+          { field: "client", values: ["portal"] },
+        ],
+      }),
+    ).toEqual({
+      search_filters:
+        '[{"field":"client","values":["portal"]},{"field":"created_by","values":["system"]}]',
+    });
+  });
+
+  it("upserts and removes one field-search group", () => {
+    const initial = encodeAdminOAuthClientSearchFilters([
+      { field: "client", values: ["Aevatar"] },
+      { field: "created_by", values: ["system"] },
+    ]);
+    const updated = updateAdminOAuthClientSearchFilters(initial, "client", [
+      "Console",
+      "console",
+      "Portal",
+    ]);
+
+    expect(parseAdminOAuthClientSearchFilters(updated)).toEqual([
+      { field: "client", values: ["Console", "Portal"] },
+      { field: "created_by", values: ["system"] },
+    ]);
+    expect(
+      updateAdminOAuthClientSearchFilters(updated, "client", undefined),
+    ).toBe('[{"field":"created_by","values":["system"]}]');
+    expect(
+      updateAdminOAuthClientSearchFilters(
+        '[{"field":"created_by","values":["system"]}]',
+        "created_by",
+        [],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("reads canonical field searches from table search state", () => {
+    expect(
+      getAdminOAuthClientSearchFilters({
+        search_filters:
+          '[{"field":"client_type","values":["public","confidential"]}]',
+      }),
+    ).toEqual([{ field: "client_type", values: ["public", "confidential"] }]);
+    expect(
+      getAdminOAuthClientSearchFilters({ search_filters: "invalid" }),
+    ).toEqual([]);
+  });
+
+  it("uses advertised search metadata and hides it for legacy backends", () => {
+    expect(getAdminOAuthClientSearchFields()).toEqual([]);
+
+    expect(
+      getAdminOAuthClientSearchFields({
+        client_types: [],
+        creator_types: [],
+        broker_filters: [],
+        statuses: [],
+        allowed_scopes: [],
+        sorts: [],
+        search_fields: [
+          { key: "created_by", label: "Provisioned by" },
+          { key: "client", label: "Application" },
+        ],
+      }),
+    ).toEqual([
+      { key: "client", label: "Application" },
+      { key: "created_by", label: "Provisioned by" },
+    ]);
+  });
+});

--- a/frontend/src/lib/admin-oauth-clients.ts
+++ b/frontend/src/lib/admin-oauth-clients.ts
@@ -1,0 +1,801 @@
+import type {
+  AdminOAuthClientBrokerFilter,
+  AdminOAuthClientCreatorType,
+  AdminOAuthClientFilterField,
+  AdminOAuthClientFilterKey,
+  AdminOAuthClientFilterOptions,
+  AdminOAuthClientSearchField,
+  AdminOAuthClientSearchFieldKey,
+  AdminOAuthClientSearchFilter,
+  AdminOAuthClientSearchState,
+  AdminOAuthClientSort,
+  AdminOAuthClientTypeFilter,
+} from "@/types/admin";
+import type { AppliedDataTableFilter } from "@/types/data-table";
+
+export const ADMIN_OAUTH_CLIENT_SCOPES = [
+  "openid",
+  "profile",
+  "email",
+  "roles",
+  "groups",
+  "offline_access",
+  "proxy",
+  "urn:nyxid:scope:broker_binding",
+] as const;
+
+const CLIENT_TYPES = ["public", "confidential", "other"] as const;
+const CREATOR_TYPES = [
+  "dynamic_registration",
+  "system",
+  "owned",
+  "ownerless",
+] as const;
+const BROKER_FILTERS = ["enabled", "disabled", "flag", "scope"] as const;
+const STATUS_FILTERS = ["true", "false"] as const;
+const MAX_MULTI_FILTER_VALUES = 32;
+const MAX_SEARCH_GROUPS = 5;
+const MAX_SEARCH_VALUES_PER_GROUP = 8;
+const MAX_SEARCH_VALUES = 32;
+const MAX_SEARCH_VALUE_LENGTH = 256;
+const SORTS = [
+  "-created_at",
+  "created_at",
+  "client_name",
+  "-client_name",
+  "client_type",
+  "-client_type",
+  "created_by",
+  "-created_by",
+  "broker",
+  "-broker",
+  "allowed_scopes",
+  "-allowed_scopes",
+  "-is_active",
+  "is_active",
+] as const;
+
+const FILTER_KEYS = [
+  "is_active",
+  "client_type",
+  "creator_type",
+  "broker",
+  "scope",
+  "created_at",
+] as const;
+
+export const ADMIN_OAUTH_CLIENT_SEARCH_FIELDS = [
+  { key: "client", label: "Client" },
+  { key: "client_type", label: "Client type" },
+  { key: "created_by", label: "Created by" },
+  { key: "allowed_scopes", label: "Allowed scopes" },
+] as const satisfies readonly AdminOAuthClientSearchField[];
+
+const SEARCH_FIELD_KEYS = ADMIN_OAUTH_CLIENT_SEARCH_FIELDS.map(
+  ({ key }) => key,
+);
+
+const CLIENT_TYPE_LABELS: Record<AdminOAuthClientTypeFilter, string> = {
+  public: "Public",
+  confidential: "Confidential",
+  other: "Other",
+};
+
+const CREATOR_TYPE_LABELS: Record<AdminOAuthClientCreatorType, string> = {
+  dynamic_registration: "Dynamic registration",
+  system: "System",
+  owned: "User / org",
+  ownerless: "Ownerless",
+};
+
+const BROKER_FILTER_LABELS: Record<AdminOAuthClientBrokerFilter, string> = {
+  enabled: "Enabled",
+  disabled: "Disabled",
+  flag: "Enabled by admin grant",
+  scope: "Enabled by broker scope",
+};
+
+const SCOPE_LABELS: Readonly<Record<string, string>> = {
+  openid: "OpenID",
+  profile: "Profile",
+  email: "Email",
+  roles: "Roles",
+  groups: "Groups",
+  offline_access: "Offline access",
+  proxy: "Proxy",
+  "urn:nyxid:scope:broker_binding": "Broker binding",
+};
+
+function option(value: string, label: string) {
+  return { value, label } as const;
+}
+
+function fallbackFilterFields(
+  filterOptions?: AdminOAuthClientFilterOptions,
+): readonly AdminOAuthClientFilterField[] {
+  const clientTypes = filterOptions?.client_types ?? CLIENT_TYPES;
+  const creatorTypes = filterOptions?.creator_types ?? CREATOR_TYPES;
+  const brokerFilters = filterOptions?.broker_filters ?? BROKER_FILTERS;
+  const statuses = filterOptions?.statuses ?? [true, false];
+  const allowedScopes =
+    filterOptions?.allowed_scopes ?? ADMIN_OAUTH_CLIENT_SCOPES;
+
+  return [
+    {
+      key: "is_active",
+      label: "Status",
+      value_type: "boolean",
+      operator: "is",
+      multiple: false,
+      options: statuses.map((value) =>
+        option(String(value), value ? "Active" : "Inactive"),
+      ),
+    },
+    {
+      key: "client_type",
+      label: "Client type",
+      value_type: "enum",
+      operator: "is",
+      multiple: false,
+      options: clientTypes.map((value) =>
+        option(value, CLIENT_TYPE_LABELS[value]),
+      ),
+    },
+    {
+      key: "creator_type",
+      label: "Creator",
+      value_type: "enum",
+      operator: "is",
+      multiple: false,
+      options: creatorTypes.map((value) =>
+        option(value, CREATOR_TYPE_LABELS[value]),
+      ),
+    },
+    {
+      key: "broker",
+      label: "Broker capability",
+      value_type: "enum",
+      operator: "is",
+      multiple: false,
+      options: brokerFilters.map((value) =>
+        option(value, BROKER_FILTER_LABELS[value]),
+      ),
+    },
+    {
+      key: "scope",
+      label: "Allowed scope",
+      value_type: "enum",
+      operator: "includes",
+      multiple: false,
+      options: allowedScopes.map((value) =>
+        option(value, SCOPE_LABELS[value] ?? value),
+      ),
+    },
+  ];
+}
+
+function isFilterKey(value: unknown): value is AdminOAuthClientFilterKey {
+  return (
+    typeof value === "string" &&
+    FILTER_KEYS.includes(value as AdminOAuthClientFilterKey)
+  );
+}
+
+/**
+ * Uses the server-described fields when available and fills any missing field
+ * from the legacy option arrays during rolling deployments.
+ */
+export function getAdminOAuthClientFilterFields(
+  filterOptions?: AdminOAuthClientFilterOptions,
+): readonly AdminOAuthClientFilterField[] {
+  const fallbacks = fallbackFilterFields(filterOptions);
+  const serverFields = filterOptions?.fields ?? [];
+  const seen = new Set<AdminOAuthClientFilterKey>();
+  const fields: AdminOAuthClientFilterField[] = [];
+
+  for (const field of serverFields) {
+    const isDateField =
+      field.key === "created_at" &&
+      field.value_type === "date" &&
+      field.operator === "between" &&
+      Array.isArray(field.options) &&
+      field.options.length === 0;
+    const isOptionField =
+      field.key !== "created_at" &&
+      (field.value_type === "enum" || field.value_type === "boolean") &&
+      (field.operator === "is" || field.operator === "includes") &&
+      Array.isArray(field.options) &&
+      field.options.length > 0;
+
+    if (
+      !isFilterKey(field.key) ||
+      seen.has(field.key) ||
+      (!isDateField && !isOptionField)
+    ) {
+      continue;
+    }
+
+    const options = field.options.filter(
+      (item) =>
+        typeof item.value === "string" &&
+        item.value !== "" &&
+        typeof item.label === "string" &&
+        item.label !== "",
+    );
+    if (!isDateField && options.length === 0) continue;
+
+    seen.add(field.key);
+    fields.push(
+      isDateField
+        ? {
+            ...field,
+            options,
+            date_modes: ["dates", "range"],
+            max_values: MAX_MULTI_FILTER_VALUES,
+          }
+        : { ...field, options },
+    );
+  }
+
+  for (const fallback of fallbacks) {
+    if (!seen.has(fallback.key)) fields.push(fallback);
+  }
+
+  return fields;
+}
+
+function isSearchFieldKey(
+  value: unknown,
+): value is AdminOAuthClientSearchFieldKey {
+  return (
+    typeof value === "string" &&
+    SEARCH_FIELD_KEYS.includes(value as AdminOAuthClientSearchFieldKey)
+  );
+}
+
+/**
+ * Returns server-advertised search fields in stable table order. Scoped
+ * search stays hidden for older backends that do not advertise support.
+ */
+export function getAdminOAuthClientSearchFields(
+  filterOptions?: AdminOAuthClientFilterOptions,
+): readonly AdminOAuthClientSearchField[] {
+  if (filterOptions?.search_fields === undefined) {
+    return [];
+  }
+
+  const fieldsByKey = new Map<
+    AdminOAuthClientSearchFieldKey,
+    AdminOAuthClientSearchField
+  >();
+  for (const field of filterOptions.search_fields) {
+    if (
+      isSearchFieldKey(field.key) &&
+      typeof field.label === "string" &&
+      field.label.trim() !== "" &&
+      !fieldsByKey.has(field.key)
+    ) {
+      fieldsByKey.set(field.key, { key: field.key, label: field.label.trim() });
+    }
+  }
+
+  return SEARCH_FIELD_KEYS.flatMap((key) => {
+    const field = fieldsByKey.get(key);
+    return field ? [field] : [];
+  });
+}
+
+function normalizeSearchValues(value: unknown): readonly string[] | undefined {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > MAX_SEARCH_VALUES_PER_GROUP
+  ) {
+    return undefined;
+  }
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const rawTerm of value) {
+    if (typeof rawTerm !== "string") return undefined;
+    const term = rawTerm.trim();
+    if (term === "" || [...term].length > MAX_SEARCH_VALUE_LENGTH) {
+      return undefined;
+    }
+    const identity = term.toLowerCase();
+    if (!seen.has(identity)) {
+      seen.add(identity);
+      normalized.push(term);
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeSearchFilterGroups(
+  value: unknown,
+): readonly AdminOAuthClientSearchFilter[] | undefined {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > MAX_SEARCH_GROUPS
+  ) {
+    return undefined;
+  }
+
+  const fields = new Set<AdminOAuthClientSearchFieldKey>();
+  const groups: AdminOAuthClientSearchFilter[] = [];
+  let totalValues = 0;
+
+  for (const rawGroup of value) {
+    if (
+      typeof rawGroup !== "object" ||
+      rawGroup === null ||
+      Array.isArray(rawGroup)
+    ) {
+      return undefined;
+    }
+    const group = rawGroup as Record<string, unknown>;
+    if (
+      Object.keys(group).some((key) => key !== "field" && key !== "values") ||
+      !isSearchFieldKey(group.field) ||
+      fields.has(group.field)
+    ) {
+      return undefined;
+    }
+    const values = normalizeSearchValues(group.values);
+    if (!values) return undefined;
+
+    totalValues += values.length;
+    if (totalValues > MAX_SEARCH_VALUES) return undefined;
+    fields.add(group.field);
+    groups.push({ field: group.field, values });
+  }
+
+  return groups.sort(
+    (left, right) =>
+      SEARCH_FIELD_KEYS.indexOf(left.field) -
+      SEARCH_FIELD_KEYS.indexOf(right.field),
+  );
+}
+
+/** Parses and canonicalizes field-scoped search URL state. */
+export function parseAdminOAuthClientSearchFilters(
+  raw: unknown,
+): readonly AdminOAuthClientSearchFilter[] | undefined {
+  if (Array.isArray(raw)) return normalizeSearchFilterGroups(raw);
+  if (typeof raw !== "string" || raw === "") return undefined;
+  try {
+    return normalizeSearchFilterGroups(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Encodes validated field groups as the canonical API/URL JSON value. */
+export function encodeAdminOAuthClientSearchFilters(
+  filters: readonly AdminOAuthClientSearchFilter[],
+): string | undefined {
+  const normalized = normalizeSearchFilterGroups(filters);
+  return normalized ? JSON.stringify(normalized) : undefined;
+}
+
+export function getAdminOAuthClientSearchFilters(
+  search: AdminOAuthClientSearchState,
+): readonly AdminOAuthClientSearchFilter[] {
+  return parseAdminOAuthClientSearchFilters(search.search_filters) ?? [];
+}
+
+/** Upserts or removes one field group and returns canonical URL state. */
+export function updateAdminOAuthClientSearchFilters(
+  current: unknown,
+  field: AdminOAuthClientSearchFieldKey,
+  values: readonly string[] | undefined,
+): string | undefined {
+  const filters = parseAdminOAuthClientSearchFilters(current) ?? [];
+  const remaining = filters.filter((filter) => filter.field !== field);
+  if (values === undefined || values.length === 0) {
+    return remaining.length > 0
+      ? encodeAdminOAuthClientSearchFilters(remaining)
+      : undefined;
+  }
+  return encodeAdminOAuthClientSearchFilters([...remaining, { field, values }]);
+}
+
+function getAdminOAuthClientFilterCsv(
+  search: AdminOAuthClientSearchState,
+  key: AdminOAuthClientFilterKey,
+): string | undefined {
+  switch (key) {
+    case "is_active":
+      return search.is_active === undefined
+        ? undefined
+        : String(search.is_active);
+    case "client_type":
+      return search.client_type;
+    case "creator_type":
+      return search.creator_type;
+    case "broker":
+      return search.broker;
+    case "scope":
+      return search.scope;
+    case "created_at":
+      return undefined;
+  }
+}
+
+export function getAdminOAuthClientFilterValues(
+  search: AdminOAuthClientSearchState,
+  key: AdminOAuthClientFilterKey,
+): readonly string[] {
+  if (key === "created_at") {
+    const createdDates = canonicalCalendarDateCsv(search.created_dates);
+    if (createdDates) return ["dates", ...createdDates.split(",")];
+    return search.created_from || search.created_to
+      ? ["range", search.created_from ?? "", search.created_to ?? ""]
+      : [];
+  }
+  return getAdminOAuthClientFilterCsv(search, key)?.split(",") ?? [];
+}
+
+export type AppliedAdminOAuthClientFilter =
+  AppliedDataTableFilter<AdminOAuthClientFilterKey>;
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+function formatCalendarDate(value: string): string {
+  const date = calendarDateObject(value);
+  return date ? DATE_FORMATTER.format(date) : value;
+}
+
+function appliedDateFilter(
+  field: AdminOAuthClientFilterField,
+  values: readonly string[],
+): AppliedAdminOAuthClientFilter | undefined {
+  const [mode, ...dateValues] = values;
+  if (mode === "dates") {
+    if (dateValues.length === 0) return undefined;
+    const valueLabels = dateValues.map(formatCalendarDate);
+    const hiddenValueCount = Math.max(0, valueLabels.length - 2);
+    return {
+      field,
+      values,
+      valueLabels,
+      operatorLabel: valueLabels.length === 1 ? "is on" : "is on any of",
+      valueSummary: `${valueLabels.slice(0, 2).join(", ")}${
+        hiddenValueCount > 0 ? ` +${String(hiddenValueCount)} more` : ""
+      }`,
+    };
+  }
+  if (mode !== "range") return undefined;
+
+  const [from = "", to = ""] = dateValues;
+  if (!from && !to) return undefined;
+
+  if (from && to && from === to) {
+    const date = formatCalendarDate(from);
+    return {
+      field,
+      values,
+      valueLabels: [date],
+      operatorLabel: "is on",
+      valueSummary: date,
+    };
+  }
+  if (from && to) {
+    const fromLabel = formatCalendarDate(from);
+    const toLabel = formatCalendarDate(to);
+    return {
+      field,
+      values,
+      valueLabels: [fromLabel, toLabel],
+      operatorLabel: "is between",
+      valueSummary: `${fromLabel} and ${toLabel}`,
+    };
+  }
+  if (from) {
+    const date = formatCalendarDate(from);
+    return {
+      field,
+      values,
+      valueLabels: [date],
+      operatorLabel: "is on or after",
+      valueSummary: date,
+    };
+  }
+
+  const date = formatCalendarDate(to);
+  return {
+    field,
+    values,
+    valueLabels: [date],
+    operatorLabel: "is on or before",
+    valueSummary: date,
+  };
+}
+
+export function getAppliedAdminOAuthClientFilters(
+  fields: readonly AdminOAuthClientFilterField[],
+  search: AdminOAuthClientSearchState,
+): readonly AppliedAdminOAuthClientFilter[] {
+  return fields.flatMap((field) => {
+    const values = getAdminOAuthClientFilterValues(search, field.key);
+    if (values.length === 0) return [];
+    if (field.key === "created_at") {
+      const applied = appliedDateFilter(field, values);
+      return applied ? [applied] : [];
+    }
+    return [
+      {
+        field,
+        values,
+        valueLabels: values.map(
+          (value) =>
+            field.options.find((item) => item.value === value)?.label ?? value,
+        ),
+      },
+    ];
+  });
+}
+
+export function adminOAuthClientFilterPatch(
+  key: AdminOAuthClientFilterKey,
+  values: readonly string[] | undefined,
+): Partial<AdminOAuthClientSearchState> | undefined {
+  if (values === undefined || values.length === 0) {
+    if (key === "created_at") {
+      return {
+        created_dates: undefined,
+        created_from: undefined,
+        created_to: undefined,
+      };
+    }
+    return { [key]: undefined };
+  }
+
+  const raw = values.join(",");
+  switch (key) {
+    case "is_active": {
+      const selection = canonicalKnownCsv(raw, STATUS_FILTERS);
+      if (selection === undefined) return undefined;
+      return {
+        is_active: selection.includes(",") ? selection : selection === "true",
+      };
+    }
+    case "client_type": {
+      const selection = canonicalKnownCsv(raw, CLIENT_TYPES);
+      return selection === undefined ? undefined : { client_type: selection };
+    }
+    case "creator_type": {
+      const selection = canonicalKnownCsv(raw, CREATOR_TYPES);
+      return selection === undefined ? undefined : { creator_type: selection };
+    }
+    case "broker": {
+      const selection = canonicalKnownCsv(raw, BROKER_FILTERS);
+      return selection === undefined ? undefined : { broker: selection };
+    }
+    case "scope": {
+      const selection = canonicalScopeCsv(raw);
+      return selection === undefined ? undefined : { scope: selection };
+    }
+    case "created_at": {
+      const [mode, ...dateValues] = values;
+      if (mode === "dates") {
+        if (dateValues.length === 0) {
+          return {
+            created_dates: undefined,
+            created_from: undefined,
+            created_to: undefined,
+          };
+        }
+        const createdDates = canonicalCalendarDateCsv(dateValues);
+        if (!createdDates) return undefined;
+        return {
+          created_dates: createdDates,
+          created_from: undefined,
+          created_to: undefined,
+        };
+      }
+      if (mode !== "range") return undefined;
+
+      const [rawFrom = "", rawTo = "", ...extra] = dateValues;
+      if (extra.length > 0) return undefined;
+      if (rawFrom === "" && rawTo === "") {
+        return {
+          created_dates: undefined,
+          created_from: undefined,
+          created_to: undefined,
+        };
+      }
+      const createdFrom = rawFrom === "" ? undefined : calendarDate(rawFrom);
+      const createdTo = rawTo === "" ? undefined : calendarDate(rawTo);
+      if (
+        (rawFrom !== "" && createdFrom === undefined) ||
+        (rawTo !== "" && createdTo === undefined) ||
+        (!createdFrom && !createdTo) ||
+        (createdFrom && createdTo && createdFrom > createdTo)
+      ) {
+        return undefined;
+      }
+      return {
+        created_dates: undefined,
+        created_from: createdFrom,
+        created_to: createdTo,
+      };
+    }
+  }
+}
+
+function calendarDateObject(value: unknown): Date | undefined {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return undefined;
+  }
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const parsed = new Date(0);
+  parsed.setUTCHours(0, 0, 0, 0);
+  parsed.setUTCFullYear(year, month - 1, day);
+  return parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+    ? parsed
+    : undefined;
+}
+
+function calendarDate(value: unknown): string | undefined {
+  return typeof value === "string" && calendarDateObject(value)
+    ? value
+    : undefined;
+}
+
+export function isAdminOAuthClientDateFilterValid(
+  values: readonly string[],
+): boolean {
+  return adminOAuthClientFilterPatch("created_at", values) !== undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function oneOf<T extends string>(
+  value: unknown,
+  options: readonly T[],
+): T | undefined {
+  return typeof value === "string" && options.includes(value as T)
+    ? (value as T)
+    : undefined;
+}
+
+function csvParts(value: unknown): readonly string[] | undefined {
+  const rawValues = Array.isArray(value) ? value : [value];
+  const parts: string[] = [];
+
+  for (const rawValue of rawValues) {
+    if (typeof rawValue === "boolean") {
+      parts.push(String(rawValue));
+      continue;
+    }
+    if (typeof rawValue !== "string") return undefined;
+
+    for (const rawPart of rawValue.split(",")) {
+      const part = rawPart.trim();
+      if (part === "") return undefined;
+      parts.push(part);
+    }
+  }
+
+  return parts.length > 0 && parts.length <= MAX_MULTI_FILTER_VALUES
+    ? parts
+    : undefined;
+}
+
+function canonicalKnownCsv<T extends string>(
+  value: unknown,
+  options: readonly T[],
+): string | undefined {
+  const parts = csvParts(value);
+  if (!parts || parts.some((part) => !options.includes(part as T))) {
+    return undefined;
+  }
+
+  const selected = new Set(parts);
+  return options.filter((option) => selected.has(option)).join(",");
+}
+
+function scopeToken(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const scope = value.trim();
+  return scope.length <= 256 && /^[\x21\x23-\x5b\x5d-\x7e]+$/.test(scope)
+    ? scope
+    : undefined;
+}
+
+function canonicalScopeCsv(value: unknown): string | undefined {
+  const parts = csvParts(value);
+  if (!parts) return undefined;
+
+  const scopes = parts.map(scopeToken);
+  if (scopes.some((scope) => scope === undefined)) return undefined;
+
+  const selected = new Set(scopes as string[]);
+  const known = ADMIN_OAUTH_CLIENT_SCOPES.filter((scope) =>
+    selected.delete(scope),
+  );
+  const future = [...selected].sort((left, right) => left.localeCompare(right));
+  return [...known, ...future].join(",");
+}
+
+function canonicalCalendarDateCsv(value: unknown): string | undefined {
+  const parts = csvParts(value);
+  if (!parts) return undefined;
+  const dates = parts.map(calendarDate);
+  if (dates.some((date) => date === undefined)) return undefined;
+  return [...new Set(dates as string[])].sort().join(",");
+}
+
+export function normalizeAdminOAuthClientSearch(
+  raw: Record<string, unknown>,
+): AdminOAuthClientSearchState {
+  const page = positiveInteger(raw.page);
+  const perPage = positiveInteger(raw.per_page);
+  const search = typeof raw.search === "string" ? raw.search.trim() : "";
+  const searchFilters = parseAdminOAuthClientSearchFilters(raw.search_filters);
+  const clientType = canonicalKnownCsv(raw.client_type, CLIENT_TYPES);
+  const creatorType = canonicalKnownCsv(raw.creator_type, CREATOR_TYPES);
+  const broker = canonicalKnownCsv(raw.broker, BROKER_FILTERS);
+  const isActiveCsv = canonicalKnownCsv(raw.is_active, STATUS_FILTERS);
+  const isActive =
+    isActiveCsv === undefined
+      ? undefined
+      : isActiveCsv.includes(",")
+        ? isActiveCsv
+        : isActiveCsv === "true";
+  const scope = canonicalScopeCsv(raw.scope);
+  const createdDates = canonicalCalendarDateCsv(raw.created_dates);
+  const createdFrom = calendarDate(raw.created_from);
+  const createdTo = calendarDate(raw.created_to);
+  const hasValidDateRange =
+    createdFrom === undefined ||
+    createdTo === undefined ||
+    createdFrom <= createdTo;
+  const sort = oneOf<AdminOAuthClientSort>(raw.sort, SORTS);
+
+  return {
+    ...(page !== undefined && page > 1 ? { page } : {}),
+    ...(perPage === 50 || perPage === 100 ? { per_page: perPage } : {}),
+    ...(search !== "" && [...search].length <= 256 ? { search } : {}),
+    ...(searchFilters !== undefined
+      ? { search_filters: JSON.stringify(searchFilters) }
+      : {}),
+    ...(clientType !== undefined ? { client_type: clientType } : {}),
+    ...(creatorType !== undefined ? { creator_type: creatorType } : {}),
+    ...(broker !== undefined ? { broker } : {}),
+    ...(isActive !== undefined ? { is_active: isActive } : {}),
+    ...(scope !== undefined ? { scope } : {}),
+    ...(createdDates !== undefined ? { created_dates: createdDates } : {}),
+    ...(createdDates === undefined &&
+    hasValidDateRange &&
+    createdFrom !== undefined
+      ? { created_from: createdFrom }
+      : {}),
+    ...(createdDates === undefined &&
+    hasValidDateRange &&
+    createdTo !== undefined
+      ? { created_to: createdTo }
+      : {}),
+    ...(sort !== undefined && sort !== "-created_at" ? { sort } : {}),
+  };
+}

--- a/frontend/src/pages/admin-oauth-clients.test.tsx
+++ b/frontend/src/pages/admin-oauth-clients.test.tsx
@@ -244,7 +244,6 @@ function resolveLastNavigationSearch(previous: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  window.localStorage.clear();
   for (const key of Object.keys(routeSearch)) delete routeSearch[key];
   mockUseAdminOAuthClients.mockReturnValue({
     data: clientsResponse,
@@ -948,40 +947,6 @@ describe("AdminOAuthClientsPage", () => {
     expect(
       table.querySelector('tbody td[data-column="client_name"]'),
     ).not.toHaveClass("sticky");
-  });
-
-  it("restores versioned column preferences only for the same user", async () => {
-    const user = userEvent.setup();
-    const { unmount } = render(<AdminOAuthClientsPage />);
-
-    const clientHandle = screen.getByRole("button", {
-      name: "Move Client column",
-    });
-    clientHandle.focus();
-    await user.keyboard("{End}");
-    await user.click(
-      screen.getByRole("button", { name: "Freeze columns through Type" }),
-    );
-    unmount();
-
-    const restored = render(<AdminOAuthClientsPage />);
-    expect(screen.getAllByRole("columnheader").at(-1)).toHaveAccessibleName(
-      "Client",
-    );
-    expect(screen.getByRole("columnheader", { name: "Type" })).toHaveAttribute(
-      "data-frozen",
-      "true",
-    );
-
-    useAuthStore.setState({ user: operatorUser() });
-    restored.unmount();
-    render(<AdminOAuthClientsPage />);
-    expect(screen.getAllByRole("columnheader").at(0)).toHaveAccessibleName(
-      "Client",
-    );
-    expect(
-      screen.getByRole("columnheader", { name: "Type" }),
-    ).not.toHaveAttribute("data-frozen");
   });
 
   it("marks retained rows as updating and prevents stale row mutations", () => {

--- a/frontend/src/pages/admin-oauth-clients.test.tsx
+++ b/frontend/src/pages/admin-oauth-clients.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuthStore } from "@/stores/auth-store";
@@ -9,11 +9,15 @@ import type {
 } from "@/types/admin";
 
 const {
+  mockNavigate,
+  mockRefetch,
+  mockUseAdminOAuthClients,
   mockUpdateClient,
   mockUpdateSettings,
   mockUseBrokerSettings,
   clientsResponse,
   brokerSettings,
+  routeSearch,
 } = vi.hoisted(() => {
   const clientsResponse: AdminOAuthClientListResponse = {
     clients: [
@@ -34,6 +38,119 @@ const {
         created_at: "2026-07-01T00:00:00Z",
       },
     ],
+    total: 1,
+    page: 1,
+    per_page: 25,
+    filter_options: {
+      client_types: ["public", "confidential", "other"],
+      creator_types: ["dynamic_registration", "system", "owned", "ownerless"],
+      broker_filters: ["enabled", "disabled", "flag", "scope"],
+      statuses: [true, false],
+      allowed_scopes: [
+        "openid",
+        "offline_access",
+        "urn:nyxid:scope:broker_binding",
+      ],
+      sorts: [
+        "-created_at",
+        "created_at",
+        "client_name",
+        "-client_name",
+        "client_type",
+        "-client_type",
+        "created_by",
+        "-created_by",
+        "broker",
+        "-broker",
+        "allowed_scopes",
+        "-allowed_scopes",
+        "-is_active",
+        "is_active",
+      ],
+      search_fields: [
+        { key: "client", label: "Client" },
+        { key: "client_type", label: "Client type" },
+        { key: "created_by", label: "Created by" },
+        { key: "allowed_scopes", label: "Allowed scopes" },
+      ],
+      fields: [
+        {
+          key: "is_active",
+          label: "Lifecycle status",
+          value_type: "boolean",
+          operator: "is",
+          multiple: true,
+          options: [
+            { value: "true", label: "Active" },
+            { value: "false", label: "Inactive" },
+          ],
+        },
+        {
+          key: "client_type",
+          label: "Client type",
+          value_type: "enum",
+          operator: "is",
+          multiple: true,
+          options: [
+            { value: "public", label: "Public" },
+            { value: "confidential", label: "Confidential" },
+            { value: "other", label: "Other" },
+          ],
+        },
+        {
+          key: "creator_type",
+          label: "Creator",
+          value_type: "enum",
+          operator: "is",
+          multiple: true,
+          options: [
+            {
+              value: "dynamic_registration",
+              label: "Dynamic registration",
+            },
+            { value: "system", label: "System" },
+            { value: "owned", label: "User / org" },
+            { value: "ownerless", label: "Ownerless" },
+          ],
+        },
+        {
+          key: "broker",
+          label: "Broker capability",
+          value_type: "enum",
+          operator: "is",
+          multiple: true,
+          options: [
+            { value: "enabled", label: "Enabled" },
+            { value: "disabled", label: "Disabled" },
+            { value: "flag", label: "Enabled by admin grant" },
+            { value: "scope", label: "Enabled by broker scope" },
+          ],
+        },
+        {
+          key: "scope",
+          label: "Allowed scope",
+          value_type: "enum",
+          operator: "includes",
+          multiple: true,
+          options: [
+            { value: "openid", label: "OpenID" },
+            { value: "offline_access", label: "Offline access" },
+            {
+              value: "urn:nyxid:scope:broker_binding",
+              label: "Broker binding (server label)",
+            },
+          ],
+        },
+        {
+          key: "created_at",
+          label: "Created",
+          value_type: "date",
+          operator: "between",
+          multiple: true,
+          options: [],
+        },
+      ],
+    },
   };
   const brokerSettings: BrokerSettingsResponse = {
     broker_require_sender_constraint: {
@@ -50,20 +167,25 @@ const {
     },
   };
   return {
+    mockNavigate: vi.fn(),
+    mockRefetch: vi.fn(),
+    mockUseAdminOAuthClients: vi.fn(),
     mockUpdateClient: vi.fn(),
     mockUpdateSettings: vi.fn(),
     mockUseBrokerSettings: vi.fn(),
     clientsResponse,
     brokerSettings,
+    routeSearch: {} as Record<string, unknown>,
   };
 });
 
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => routeSearch,
+}));
+
 vi.mock("@/hooks/use-admin-oauth-clients", () => ({
-  useAdminOAuthClients: () => ({
-    data: clientsResponse,
-    isLoading: false,
-    error: null,
-  }),
+  useAdminOAuthClients: mockUseAdminOAuthClients,
   useBrokerSettings: mockUseBrokerSettings,
   useUpdateAdminOAuthClient: () => ({
     mutateAsync: mockUpdateClient,
@@ -111,8 +233,27 @@ function operatorUser(): User {
   };
 }
 
+function resolveLastNavigationSearch(previous: Record<string, unknown> = {}) {
+  const navigation = mockNavigate.mock.calls.at(-1)?.[0] as {
+    readonly to: string;
+    readonly search: (current: Record<string, unknown>) => unknown;
+  };
+  expect(navigation.to).toBe("/admin/oauth-clients");
+  return navigation.search(previous);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
+  for (const key of Object.keys(routeSearch)) delete routeSearch[key];
+  mockUseAdminOAuthClients.mockReturnValue({
+    data: clientsResponse,
+    isLoading: false,
+    isFetching: false,
+    isPlaceholderData: false,
+    error: null,
+    refetch: mockRefetch,
+  });
   mockUpdateClient.mockResolvedValue(clientsResponse.clients[0]);
   mockUpdateSettings.mockResolvedValue(brokerSettings);
   mockUseBrokerSettings.mockReturnValue({
@@ -137,6 +278,753 @@ describe("AdminOAuthClientsPage", () => {
     expect(
       screen.getByText("urn:nyxid:scope:broker_binding"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Showing 1-1 of 1 clients")).toBeInTheDocument();
+    expect(screen.getByRole("table").parentElement).toHaveClass(
+      "overflow-auto",
+      "overscroll-x-none",
+    );
+    expect(mockUseAdminOAuthClients).toHaveBeenCalledWith({
+      page: 1,
+      per_page: 25,
+      search: undefined,
+      search_filters: undefined,
+      client_type: undefined,
+      creator_type: undefined,
+      broker: undefined,
+      is_active: undefined,
+      scope: undefined,
+      created_dates: undefined,
+      created_from: undefined,
+      created_to: undefined,
+      sort: "-created_at",
+    });
+  });
+
+  it("applies search through URL state and resets the page", async () => {
+    const user = userEvent.setup();
+    routeSearch.page = 4;
+    render(<AdminOAuthClientsPage />);
+
+    await user.type(
+      screen.getByLabelText("Search OAuth clients"),
+      " console {Enter}",
+    );
+
+    const navigation = mockNavigate.mock.calls.at(-1)?.[0] as {
+      readonly to: string;
+      readonly search: (previous: Record<string, unknown>) => unknown;
+    };
+    expect(navigation.to).toBe("/admin/oauth-clients");
+    expect(navigation.search({ page: 4 })).toEqual({ search: "console" });
+    expect(
+      screen.queryByRole("button", { name: "Apply search" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears an unsubmitted search draft across browser history changes", async () => {
+    const user = userEvent.setup();
+    routeSearch.search = "existing";
+    const { rerender } = render(<AdminOAuthClientsPage />);
+
+    const input = screen.getByLabelText("Search OAuth clients");
+    expect(input).toHaveValue("");
+    await user.type(input, "unsubmitted");
+
+    routeSearch.search = "history-value";
+    rerender(<AdminOAuthClientsPage />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Search OAuth clients")).toHaveValue(""),
+    );
+  });
+
+  it("applies typed search only after Enter or leaving the search control", async () => {
+    const user = userEvent.setup();
+    routeSearch.page = 3;
+    render(<AdminOAuthClientsPage />);
+    mockNavigate.mockClear();
+
+    const input = screen.getByLabelText("Search OAuth clients");
+    await user.type(input, "console");
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Filters" }));
+    expect(mockNavigate).toHaveBeenCalledOnce();
+    expect(input).not.toHaveFocus();
+    expect(resolveLastNavigationSearch({ page: 3 })).toEqual({
+      search: "console",
+    });
+  });
+
+  it("shows exactly one applied search filter and lets users edit or remove it", async () => {
+    const user = userEvent.setup();
+    routeSearch.search = "console";
+    routeSearch.sort = "client_name";
+    render(<AdminOAuthClientsPage />);
+
+    const searchFilterChip = screen.getByRole("button", {
+      name: "Edit All fields search: contains console",
+    });
+    expect(
+      screen.getAllByRole("button", {
+        name: "Edit All fields search: contains console",
+      }),
+    ).toHaveLength(1);
+    expect(searchFilterChip).toHaveTextContent('All fields contains "console"');
+    expect(
+      screen.getByRole("button", { name: "Filters, 1 applied" }),
+    ).toBeInTheDocument();
+
+    await user.click(searchFilterChip);
+    expect(screen.getByLabelText("Search OAuth clients")).toHaveFocus();
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove All fields search" }),
+    );
+    expect(
+      resolveLastNavigationSearch({
+        page: 2,
+        search: "console",
+        sort: "client_name",
+      }),
+    ).toEqual({ sort: "client_name" });
+  });
+
+  it("adds scoped search values on Enter and ORs values in one column", async () => {
+    const user = userEvent.setup();
+    routeSearch.page = 3;
+    routeSearch.search_filters = JSON.stringify([
+      { field: "client", values: ["console"] },
+    ]);
+    render(<AdminOAuthClientsPage />);
+    mockNavigate.mockClear();
+
+    await user.click(screen.getByRole("combobox", { name: "Search field" }));
+    await user.click(screen.getByRole("option", { name: "Client" }));
+    await user.type(screen.getByLabelText("Search OAuth clients"), "portal");
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.keyboard("{Enter}");
+
+    expect(
+      resolveLastNavigationSearch({
+        page: 3,
+        search_filters: JSON.stringify([
+          { field: "client", values: ["console"] },
+        ]),
+      }),
+    ).toEqual({
+      search_filters: JSON.stringify([
+        { field: "client", values: ["console", "portal"] },
+      ]),
+    });
+    expect(screen.getByLabelText("Search OAuth clients")).toHaveValue("");
+    expect(screen.getByLabelText("Search OAuth clients")).toHaveFocus();
+    expect(
+      screen.getByRole("combobox", { name: "Search field" }),
+    ).toHaveTextContent("In: All fields");
+  });
+
+  it("renders OR within a search column without inter-chip operators", async () => {
+    const user = userEvent.setup();
+    routeSearch.search_filters = JSON.stringify([
+      { field: "client", values: ["console", "portal"] },
+      { field: "created_by", values: ["dynamic"] },
+    ]);
+    render(<AdminOAuthClientsPage />);
+
+    expect(
+      screen.getByRole("group", {
+        name: "Client search, matches any term",
+      }),
+    ).toHaveTextContent(/Client contains.*"console".*OR.*"portal"/);
+    expect(
+      screen.getByRole("group", {
+        name: "Created by search, matches any term",
+      }),
+    ).toHaveTextContent(/Created by contains.*"dynamic"/);
+    expect(screen.getAllByText("OR")).toHaveLength(1);
+    expect(screen.queryByText("AND")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Filters, 2 applied" }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove Client search value: portal",
+      }),
+    );
+    expect(
+      resolveLastNavigationSearch({
+        search_filters: JSON.stringify([
+          { field: "client", values: ["console", "portal"] },
+          { field: "created_by", values: ["dynamic"] },
+        ]),
+      }),
+    ).toEqual({
+      search_filters: JSON.stringify([
+        { field: "client", values: ["console"] },
+        { field: "created_by", values: ["dynamic"] },
+      ]),
+    });
+  });
+
+  it("does not apply a draft when focus moves to the field dropdown", async () => {
+    const user = userEvent.setup();
+    render(<AdminOAuthClientsPage />);
+    const input = screen.getByLabelText("Search OAuth clients");
+    await user.type(input, "dynamic");
+
+    await user.click(screen.getByRole("combobox", { name: "Search field" }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("option", { name: "Created by" }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Filters" }));
+    expect(mockNavigate).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("combobox", { name: "Search field" }),
+    ).toHaveTextContent("In: Created by");
+  });
+
+  it("stages multiple metadata-backed values and applies them through URL state", async () => {
+    const user = userEvent.setup();
+    routeSearch.page = 4;
+    routeSearch.search = "aevatar";
+    routeSearch.sort = "client_name";
+    render(<AdminOAuthClientsPage />);
+    mockNavigate.mockClear();
+
+    await user.click(
+      screen.getByRole("button", { name: "Filters, 1 applied" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Lifecycle status" }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("checkbox", { name: "Active" }));
+
+    await user.click(screen.getByRole("button", { name: "Allowed scope" }));
+    const brokerBindingScope = screen.getByRole("checkbox", {
+      name: "Broker binding (server label)",
+    });
+    expect(brokerBindingScope).toBeInTheDocument();
+    await user.click(brokerBindingScope);
+
+    await user.click(screen.getByRole("button", { name: "Client type" }));
+    await user.click(screen.getByRole("checkbox", { name: "Public" }));
+    await user.click(screen.getByRole("checkbox", { name: "Confidential" }));
+
+    await user.click(screen.getByRole("button", { name: /^Lifecycle status/ }));
+    expect(screen.getByRole("checkbox", { name: "Active" })).toBeChecked();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+
+    expect(
+      resolveLastNavigationSearch({
+        page: 4,
+        search: "aevatar",
+        sort: "client_name",
+      }),
+    ).toEqual({
+      search: "aevatar",
+      client_type: "public,confidential",
+      is_active: true,
+      scope: "urn:nyxid:scope:broker_binding",
+      sort: "client_name",
+    });
+  });
+
+  it("aggregates multi-value chips and lets users edit and uncheck one option", async () => {
+    const user = userEvent.setup();
+    routeSearch.search = "aevatar";
+    routeSearch.is_active = "true,false";
+    routeSearch.client_type = "public,confidential,other";
+    routeSearch.scope = "openid,urn:nyxid:scope:broker_binding";
+    routeSearch.sort = "client_name";
+    render(<AdminOAuthClientsPage />);
+
+    expect(
+      screen.getByRole("button", {
+        name: /^Edit Lifecycle status filter:/,
+      }),
+    ).toHaveTextContent("Lifecycle status is any of Active, Inactive");
+    expect(
+      screen.getByRole("button", { name: /^Edit Client type filter:/ }),
+    ).toHaveTextContent("Client type is any of Public, Confidential +1 more");
+    expect(
+      screen.getByRole("button", { name: /^Edit Allowed scope filter:/ }),
+    ).toHaveTextContent(
+      "Allowed scope includes any of OpenID, Broker binding (server label)",
+    );
+    expect(
+      screen.getByRole("button", { name: "Filters, 4 applied" }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /^Edit Client type filter:/ }),
+    );
+    expect(screen.getByRole("checkbox", { name: "Public" })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Confidential" }),
+    ).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Other" })).toBeChecked();
+
+    await user.click(screen.getByRole("checkbox", { name: "Public" }));
+    expect(screen.getByRole("checkbox", { name: "Public" })).not.toBeChecked();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+
+    expect(
+      resolveLastNavigationSearch({
+        page: 3,
+        search: "aevatar",
+        is_active: "true,false",
+        client_type: "public,confidential,other",
+        scope: "openid,urn:nyxid:scope:broker_binding",
+        sort: "client_name",
+      }),
+    ).toEqual({
+      search: "aevatar",
+      is_active: "true,false",
+      client_type: "confidential,other",
+      scope: "openid,urn:nyxid:scope:broker_binding",
+      sort: "client_name",
+    });
+  });
+
+  it("removes one multi-value filter without changing search, sort, or other filters", async () => {
+    const user = userEvent.setup();
+    routeSearch.search = "aevatar";
+    routeSearch.is_active = "true,false";
+    routeSearch.client_type = "public,confidential";
+    routeSearch.sort = "client_name";
+    render(<AdminOAuthClientsPage />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Remove Lifecycle status filter",
+      }),
+    );
+
+    expect(
+      resolveLastNavigationSearch({
+        page: 3,
+        search: "aevatar",
+        is_active: "true,false",
+        client_type: "public,confidential",
+        sort: "client_name",
+      }),
+    ).toEqual({
+      search: "aevatar",
+      client_type: "public,confidential",
+      sort: "client_name",
+    });
+  });
+
+  it("restores date bounds without showing inter-chip operators", async () => {
+    const user = userEvent.setup();
+    routeSearch.search = "public";
+    routeSearch.client_type = "public";
+    routeSearch.created_from = "2026-07-01";
+    routeSearch.created_to = "2026-07-31";
+    render(<AdminOAuthClientsPage />);
+
+    expect(mockUseAdminOAuthClients).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: "public",
+        client_type: "public",
+        created_from: "2026-07-01",
+        created_to: "2026-07-31",
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: /^Edit Created filter:/ }),
+    ).toHaveTextContent("Created is between Jul 1, 2026 and Jul 31, 2026");
+    expect(screen.queryByText("AND")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove Created filter" }),
+    );
+    expect(
+      resolveLastNavigationSearch({
+        page: 2,
+        search: "public",
+        client_type: "public",
+        created_from: "2026-07-01",
+        created_to: "2026-07-31",
+      }),
+    ).toEqual({
+      search: "public",
+      client_type: "public",
+    });
+  });
+
+  it("restores and removes an exact multi-date filter", async () => {
+    const user = userEvent.setup();
+    routeSearch.created_dates = "2026-07-03,2026-07-08,2026-07-21";
+    render(<AdminOAuthClientsPage />);
+
+    expect(mockUseAdminOAuthClients).toHaveBeenCalledWith(
+      expect.objectContaining({
+        created_dates: "2026-07-03,2026-07-08,2026-07-21",
+        created_from: undefined,
+        created_to: undefined,
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: /^Edit Created filter:/ }),
+    ).toHaveTextContent(
+      "Created is on any of Jul 3, 2026, Jul 8, 2026 +1 more",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove Created filter" }),
+    );
+    expect(
+      resolveLastNavigationSearch({
+        page: 2,
+        created_dates: "2026-07-03,2026-07-08,2026-07-21",
+      }),
+    ).toEqual({});
+  });
+
+  it("clears search and structured filters together", async () => {
+    const user = userEvent.setup();
+    routeSearch.search = "console";
+    routeSearch.broker = "enabled,scope";
+    routeSearch.scope = "openid,urn:nyxid:scope:broker_binding";
+    routeSearch.created_from = "2026-07-01";
+    routeSearch.created_to = "2026-07-31";
+    routeSearch.sort = "-client_name";
+    render(<AdminOAuthClientsPage />);
+
+    await user.click(screen.getByRole("button", { name: "Clear filters" }));
+
+    expect(
+      resolveLastNavigationSearch({
+        page: 2,
+        search: "console",
+        broker: "enabled,scope",
+        scope: "openid,urn:nyxid:scope:broker_binding",
+        created_from: "2026-07-01",
+        created_to: "2026-07-31",
+        sort: "-client_name",
+      }),
+    ).toEqual({
+      sort: "-client_name",
+    });
+  });
+
+  it("sorts the complete dataset through each column header", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<AdminOAuthClientsPage />);
+
+    for (const label of [
+      "Client",
+      "Type",
+      "Created By",
+      "Broker",
+      "Status",
+      "Allowed Scopes",
+      "Created",
+    ]) {
+      expect(
+        screen.getByRole("button", {
+          name: new RegExp(`^Sort by ${label},`),
+        }),
+      ).toBeEnabled();
+    }
+
+    expect(
+      screen.getByRole("columnheader", { name: "Created" }),
+    ).toHaveAttribute("aria-sort", "descending");
+    expect(
+      screen.queryByLabelText("Sort OAuth clients"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Sort by Client, ascending" }),
+    );
+    expect(resolveLastNavigationSearch({ page: 5 })).toEqual({
+      sort: "client_name",
+    });
+
+    routeSearch.sort = "client_name";
+    rerender(<AdminOAuthClientsPage />);
+    await user.click(
+      screen.getByRole("button", { name: "Sort by Client, descending" }),
+    );
+    expect(resolveLastNavigationSearch({ sort: "client_name" })).toEqual({
+      sort: "-client_name",
+    });
+
+    routeSearch.sort = undefined;
+    rerender(<AdminOAuthClientsPage />);
+    await user.click(
+      screen.getByRole("button", { name: "Sort by Broker, descending" }),
+    );
+    expect(resolveLastNavigationSearch()).toEqual({ sort: "-broker" });
+  });
+
+  it("reorders headers and row cells from a dedicated drag handle", () => {
+    render(<AdminOAuthClientsPage />);
+
+    const expectedLabels = [
+      "Client",
+      "Type",
+      "Created By",
+      "Broker",
+      "Status",
+      "Allowed Scopes",
+      "Created",
+    ];
+    expect(
+      screen
+        .getAllByRole("columnheader")
+        .map((header) => header.getAttribute("aria-label")),
+    ).toEqual(expectedLabels);
+    for (const label of expectedLabels) {
+      expect(
+        screen.getByRole("button", { name: `Move ${label} column` }),
+      ).toBeInTheDocument();
+    }
+    expect(screen.getByRole("columnheader", { name: "Client" })).toHaveClass(
+      "p-0",
+      "hover:bg-accent",
+      "focus-within:bg-accent",
+    );
+
+    const source = screen.getByRole("button", {
+      name: "Move Client column",
+    });
+    expect(source).toHaveClass(
+      "w-7",
+      "opacity-0",
+      "group-hover/header:opacity-100",
+    );
+    const target = screen.getByRole("columnheader", { name: "Status" });
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 40,
+      top: 0,
+      right: 200,
+      bottom: 40,
+      left: 0,
+      toJSON: () => ({}),
+    });
+    let transferredColumn = "";
+    const dataTransfer = {
+      effectAllowed: "none",
+      dropEffect: "none",
+      setData: (_type: string, value: string) => {
+        transferredColumn = value;
+      },
+      getData: () => transferredColumn,
+    } as unknown as DataTransfer;
+
+    fireEvent.dragStart(source, { dataTransfer });
+    fireEvent.dragOver(target, { clientX: 160, dataTransfer });
+    expect(target).toHaveAttribute("data-drop-position", "after");
+    expect(screen.getByTestId("column-drop-indicator-is_active")).toHaveClass(
+      "inset-y-0",
+      "right-0",
+    );
+    fireEvent.drop(target, { clientX: 160, dataTransfer });
+
+    expect(
+      screen
+        .getAllByRole("columnheader")
+        .map((header) => header.getAttribute("aria-label")),
+    ).toEqual([
+      "Type",
+      "Created By",
+      "Broker",
+      "Status",
+      "Client",
+      "Allowed Scopes",
+      "Created",
+    ]);
+    const dataCells = screen
+      .getByRole("table")
+      .querySelectorAll<HTMLTableCellElement>("tbody td");
+    expect(dataCells[0]).toHaveTextContent("public");
+    expect(dataCells[4]).toHaveTextContent("Aevatar");
+    expect(
+      screen.getByText("Client column moved to position 5 of 7"),
+    ).toBeInTheDocument();
+  });
+
+  it("reorders columns from the keyboard without breaking header sorting", async () => {
+    const user = userEvent.setup();
+    render(<AdminOAuthClientsPage />);
+
+    const clientHandle = screen.getByRole("button", {
+      name: "Move Client column",
+    });
+    clientHandle.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(
+      screen
+        .getAllByRole("columnheader")
+        .slice(0, 2)
+        .map((header) => header.getAttribute("aria-label")),
+    ).toEqual(["Type", "Client"]);
+    expect(
+      screen.getByText("Client column moved to position 2 of 7"),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{End}");
+    expect(screen.getAllByRole("columnheader").at(-1)).toHaveAccessibleName(
+      "Client",
+    );
+    expect(
+      screen.getByText("Client column moved to position 7 of 7"),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Sort by Client, ascending" }),
+    );
+    expect(resolveLastNavigationSearch({ page: 3 })).toEqual({
+      sort: "client_name",
+    });
+  });
+
+  it("freezes through a column and recomputes sticky offsets after reordering", async () => {
+    const user = userEvent.setup();
+    render(<AdminOAuthClientsPage />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Freeze columns through Created By",
+      }),
+    );
+
+    const clientHeader = screen.getByRole("columnheader", { name: "Client" });
+    const typeHeader = screen.getByRole("columnheader", { name: "Type" });
+    const creatorHeader = screen.getByRole("columnheader", {
+      name: "Created By",
+    });
+    expect(clientHeader).toHaveAttribute("data-frozen", "true");
+    expect(clientHeader).toHaveClass("z-30", "bg-card");
+    expect(clientHeader).toHaveStyle({ left: "0px" });
+    expect(typeHeader).toHaveStyle({ left: "260px" });
+    expect(creatorHeader).toHaveStyle({ left: "400px" });
+    expect(creatorHeader).toHaveClass("border-r-2");
+    expect(
+      screen.getByRole("button", {
+        name: "Unfreeze columns through Created By",
+      }),
+    ).toHaveClass("opacity-100", "text-primary");
+
+    const table = screen.getByRole("table");
+    expect(
+      table.querySelector('tbody td[data-column="client_name"]'),
+    ).toHaveClass("sticky", "z-20", "bg-card");
+    expect(
+      table.querySelector('tbody td[data-column="created_by"]'),
+    ).toHaveClass("border-r-2");
+
+    const clientHandle = screen.getByRole("button", {
+      name: "Move Client column",
+    });
+    clientHandle.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(typeHeader).toHaveStyle({ left: "0px" });
+    expect(clientHeader).toHaveStyle({ left: "140px" });
+    expect(creatorHeader).toHaveStyle({ left: "400px" });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Unfreeze columns through Created By",
+      }),
+    );
+    expect(clientHeader).not.toHaveAttribute("data-frozen");
+    expect(typeHeader).not.toHaveAttribute("data-frozen");
+    expect(creatorHeader).not.toHaveAttribute("data-frozen");
+    expect(
+      table.querySelector('tbody td[data-column="client_name"]'),
+    ).not.toHaveClass("sticky");
+  });
+
+  it("restores versioned column preferences only for the same user", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<AdminOAuthClientsPage />);
+
+    const clientHandle = screen.getByRole("button", {
+      name: "Move Client column",
+    });
+    clientHandle.focus();
+    await user.keyboard("{End}");
+    await user.click(
+      screen.getByRole("button", { name: "Freeze columns through Type" }),
+    );
+    unmount();
+
+    const restored = render(<AdminOAuthClientsPage />);
+    expect(screen.getAllByRole("columnheader").at(-1)).toHaveAccessibleName(
+      "Client",
+    );
+    expect(screen.getByRole("columnheader", { name: "Type" })).toHaveAttribute(
+      "data-frozen",
+      "true",
+    );
+
+    useAuthStore.setState({ user: operatorUser() });
+    restored.unmount();
+    render(<AdminOAuthClientsPage />);
+    expect(screen.getAllByRole("columnheader").at(0)).toHaveAccessibleName(
+      "Client",
+    );
+    expect(
+      screen.getByRole("columnheader", { name: "Type" }),
+    ).not.toHaveAttribute("data-frozen");
+  });
+
+  it("marks retained rows as updating and prevents stale row mutations", () => {
+    routeSearch.page = 2;
+    mockUseAdminOAuthClients.mockReturnValue({
+      data: clientsResponse,
+      isLoading: false,
+      isFetching: true,
+      isPlaceholderData: true,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    render(<AdminOAuthClientsPage />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Updating results");
+    expect(screen.getByText("Showing 1-1 of 1 clients")).toBeInTheDocument();
+    expect(screen.getByText("Page 1 of 1")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", {
+        name: "Toggle broker capability for Aevatar (dcr-aevatar)",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("warns and retries when a cached-data refresh fails", async () => {
+    const user = userEvent.setup();
+    mockUseAdminOAuthClients.mockReturnValue({
+      data: clientsResponse,
+      isLoading: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      error: new Error("refresh failed"),
+      refetch: mockRefetch,
+    });
+
+    render(<AdminOAuthClientsPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Results may be out of date because the refresh failed.",
+    );
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(mockRefetch).toHaveBeenCalledOnce();
   });
 
   it("confirms and disables effective broker capability by removing the legacy scope trigger", async () => {
@@ -145,7 +1033,7 @@ describe("AdminOAuthClientsPage", () => {
 
     await user.click(
       screen.getByRole("switch", {
-        name: "Toggle broker capability for Aevatar",
+        name: "Toggle broker capability for Aevatar (dcr-aevatar)",
       }),
     );
 
@@ -172,12 +1060,12 @@ describe("AdminOAuthClientsPage", () => {
     expect(screen.getByText("Broker Rollout Policy")).toBeInTheDocument();
     expect(
       screen.getByRole("switch", {
-        name: "Toggle broker capability for Aevatar",
+        name: "Toggle broker capability for Aevatar (dcr-aevatar)",
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("switch", {
-        name: "Toggle active status for Aevatar",
+        name: "Toggle active status for Aevatar (dcr-aevatar)",
       }),
     ).toBeInTheDocument();
     expect(
@@ -193,7 +1081,9 @@ describe("AdminOAuthClientsPage", () => {
     expect(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
     expect(screen.getByText("Overridden")).toBeInTheDocument();
     expect(screen.getByText("Env default")).toBeInTheDocument();
-    expect(screen.getByText("Scope")).toBeInTheDocument();
+    expect(screen.getByText("Broker scope")).toBeInTheDocument();
+    expect(screen.getByText("Broker enabled")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getAllByText("Enabled").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Disabled").length).toBeGreaterThan(0);
     expect(mockUseBrokerSettings).toHaveBeenCalledWith(true);
@@ -205,7 +1095,9 @@ describe("AdminOAuthClientsPage", () => {
     render(<AdminOAuthClientsPage />);
 
     expect(screen.getByText("Aevatar")).toBeInTheDocument();
-    expect(screen.getByText("Scope")).toBeInTheDocument();
+    expect(screen.getByText("Broker scope")).toBeInTheDocument();
+    expect(screen.getByText("Broker enabled")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.queryByText("Broker Rollout Policy")).not.toBeInTheDocument();
     expect(screen.queryAllByRole("switch")).toHaveLength(0);
     expect(
@@ -226,5 +1118,62 @@ describe("AdminOAuthClientsPage", () => {
     expect(mockUpdateSettings).toHaveBeenCalledWith({
       broker_require_sender_constraint: null,
     });
+  });
+
+  it("summarizes long scope lists and reveals the complete list", async () => {
+    const user = userEvent.setup();
+    mockUseAdminOAuthClients.mockReturnValue({
+      data: {
+        ...clientsResponse,
+        clients: [
+          {
+            ...clientsResponse.clients[0],
+            allowed_scopes:
+              "openid profile email offline_access roles groups proxy",
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      isPlaceholderData: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+
+    render(<AdminOAuthClientsPage />);
+
+    expect(screen.getByText("openid")).toBeInTheDocument();
+    expect(screen.getByText("profile")).toBeInTheDocument();
+    expect(screen.getByText("email")).toBeInTheDocument();
+    expect(screen.queryByText("offline_access")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "View all 7 allowed scopes: openid, profile, email, offline_access, roles, groups, proxy",
+      }),
+    );
+
+    expect(screen.getByText("offline_access")).toBeInTheDocument();
+    expect(screen.getByText("roles")).toBeInTheDocument();
+    expect(screen.getByText("groups")).toBeInTheDocument();
+    expect(screen.getByText("proxy")).toBeInTheDocument();
+  });
+
+  it("lets keyboard and touch users reveal a single long scope", () => {
+    render(<AdminOAuthClientsPage />);
+
+    const scopeDisclosure = screen.getByRole("button", {
+      name: /^View all 2 allowed scopes:/,
+    });
+    scopeDisclosure.focus();
+    expect(scopeDisclosure).toHaveFocus();
+    fireEvent.click(scopeDisclosure);
+
+    expect(
+      screen.getByText("Allowed scopes", { selector: "p" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("urn:nyxid:scope:broker_binding")).toHaveLength(
+      2,
+    );
   });
 });

--- a/frontend/src/pages/admin-oauth-clients.tsx
+++ b/frontend/src/pages/admin-oauth-clients.tsx
@@ -204,12 +204,15 @@ const OAUTH_CLIENT_TABLE_WIDTH = OAUTH_CLIENT_COLUMNS.reduce(
   (width, column) => width + column.width,
   0,
 );
-const COLUMN_PREFERENCES_VERSION = 1;
 
 type ColumnPreferences = {
-  readonly version: typeof COLUMN_PREFERENCES_VERSION;
   readonly order: readonly OAuthClientSortField[];
   readonly frozenThrough: OAuthClientSortField | null;
+};
+
+const DEFAULT_COLUMN_PREFERENCES: ColumnPreferences = {
+  order: DEFAULT_COLUMN_ORDER,
+  frozenThrough: null,
 };
 
 type ColumnDropTarget = {
@@ -225,55 +228,6 @@ function getColumn(field: OAuthClientSortField): OAuthClientColumn {
 
 function isColumnField(value: unknown): value is OAuthClientSortField {
   return OAUTH_CLIENT_COLUMNS.some((column) => column.field === value);
-}
-
-function isCompleteColumnOrder(
-  value: unknown,
-): value is OAuthClientSortField[] {
-  return (
-    Array.isArray(value) &&
-    value.length === OAUTH_CLIENT_COLUMNS.length &&
-    value.every(isColumnField) &&
-    new Set(value).size === OAUTH_CLIENT_COLUMNS.length
-  );
-}
-
-function columnPreferencesKey(userId: string | undefined): string | null {
-  return userId
-    ? `nyxid:admin-oauth-clients:columns:v${String(COLUMN_PREFERENCES_VERSION)}:${userId}`
-    : null;
-}
-
-function readColumnPreferences(userId: string | undefined): ColumnPreferences {
-  const fallback: ColumnPreferences = {
-    version: COLUMN_PREFERENCES_VERSION,
-    order: DEFAULT_COLUMN_ORDER,
-    frozenThrough: null,
-  };
-  const key = columnPreferencesKey(userId);
-  if (!key || typeof window === "undefined") return fallback;
-
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(key) ?? "null") as {
-      version?: unknown;
-      order?: unknown;
-      frozenThrough?: unknown;
-    } | null;
-    if (
-      parsed?.version !== COLUMN_PREFERENCES_VERSION ||
-      !isCompleteColumnOrder(parsed.order) ||
-      (parsed.frozenThrough !== null && !isColumnField(parsed.frozenThrough))
-    ) {
-      return fallback;
-    }
-    return {
-      version: COLUMN_PREFERENCES_VERSION,
-      order: parsed.order,
-      frozenThrough: parsed.frozenThrough,
-    };
-  } catch {
-    return fallback;
-  }
 }
 
 function moveColumnToIndex(
@@ -530,8 +484,8 @@ export function AdminOAuthClientsPage() {
   }) as AdminOAuthClientSearchState;
   const currentUser = useAuthStore((s) => s.user);
   const canWrite = canAdminWrite(currentUser);
-  const [columnPreferences, setColumnPreferences] = useState(() =>
-    readColumnPreferences(currentUser?.id),
+  const [columnPreferences, setColumnPreferences] = useState(
+    DEFAULT_COLUMN_PREFERENCES,
   );
   const [draggingColumn, setDraggingColumn] =
     useState<OAuthClientSortField | null>(null);
@@ -644,16 +598,6 @@ export function AdminOAuthClientsPage() {
     }, 0);
     return () => window.clearTimeout(resetTimer);
   }, [routeSearch.search, routeSearch.search_filters]);
-
-  useEffect(() => {
-    const key = columnPreferencesKey(currentUser?.id);
-    if (!key || typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(key, JSON.stringify(columnPreferences));
-    } catch {
-      // Table preferences are non-critical when storage is unavailable.
-    }
-  }, [columnPreferences, currentUser?.id]);
 
   function clearSearchAndFilters() {
     updateListSearch({

--- a/frontend/src/pages/admin-oauth-clients.tsx
+++ b/frontend/src/pages/admin-oauth-clients.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
   useAdminOAuthClients,
   useBrokerSettings,
@@ -6,20 +7,39 @@ import {
   useUpdateBrokerSettings,
 } from "@/hooks/use-admin-oauth-clients";
 import { ApiError } from "@/lib/api-client";
-import { formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { canAdminWrite } from "@/types/api";
 import type {
   AdminOAuthClient,
+  AdminOAuthClientFilterKey,
+  AdminOAuthClientFilterSelections,
+  AdminOAuthClientListParams,
+  AdminOAuthClientSearchFieldKey,
+  AdminOAuthClientSearchState,
+  AdminOAuthClientSort,
   BrokerSettingsResponse,
   BrokerPolicyField,
   UpdateAdminOAuthClientRequest,
   UpdateBrokerSettingsRequest,
 } from "@/types/admin";
+import type { DataTableSearchApplyMode } from "@/types/data-table";
 import { useAuthStore } from "@/stores/auth-store";
 import { PageHeader } from "@/components/shared/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Card,
   CardContent,
@@ -44,8 +64,39 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { AlertTriangle, KeyRound, RotateCcw } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  GripVertical,
+  KeyRound,
+  Loader2,
+  Pin,
+  PinOff,
+  RotateCcw,
+} from "lucide-react";
 import { toast } from "sonner";
+import {
+  adminOAuthClientFilterPatch,
+  getAppliedAdminOAuthClientFilters,
+  getAdminOAuthClientFilterFields,
+  getAdminOAuthClientFilterValues,
+  getAdminOAuthClientSearchFields,
+  getAdminOAuthClientSearchFilters,
+  isAdminOAuthClientDateFilterValid,
+  normalizeAdminOAuthClientSearch,
+  parseAdminOAuthClientSearchFilters,
+  updateAdminOAuthClientSearchFilters,
+} from "@/lib/admin-oauth-clients";
+import {
+  DataTableControls,
+  DataTableFilterChips,
+  DataTableFilterPopover,
+  DataTableSearch,
+} from "@/components/data-table/data-table-controls";
 
 type ClientAction = {
   readonly client: AdminOAuthClient;
@@ -71,16 +122,459 @@ const SETTING_LABELS: Record<BrokerSettingKey, string> = {
 };
 
 const BROKER_BINDING_SCOPE = "urn:nyxid:scope:broker_binding";
+const DEFAULT_PER_PAGE = 25;
+const DEFAULT_SORT: AdminOAuthClientSort = "-created_at";
+
+const FALLBACK_SORTS: readonly AdminOAuthClientSort[] = [
+  "-created_at",
+  "created_at",
+  "client_name",
+  "-client_name",
+  "client_type",
+  "-client_type",
+  "created_by",
+  "-created_by",
+  "broker",
+  "-broker",
+  "allowed_scopes",
+  "-allowed_scopes",
+  "-is_active",
+  "is_active",
+];
+
+type OAuthClientSortField =
+  | "client_name"
+  | "client_type"
+  | "created_by"
+  | "broker"
+  | "is_active"
+  | "allowed_scopes"
+  | "created_at";
+
+type OAuthClientColumn = {
+  readonly field: OAuthClientSortField;
+  readonly label: string;
+  readonly width: number;
+  readonly cellClassName?: string;
+};
+
+const OAUTH_CLIENT_COLUMNS: readonly OAuthClientColumn[] = [
+  {
+    field: "client_name",
+    label: "Client",
+    width: 260,
+  },
+  {
+    field: "client_type",
+    label: "Type",
+    width: 140,
+  },
+  {
+    field: "created_by",
+    label: "Created By",
+    width: 200,
+    cellClassName: "font-mono text-[11px] text-muted-foreground",
+  },
+  {
+    field: "broker",
+    label: "Broker",
+    width: 280,
+  },
+  {
+    field: "is_active",
+    label: "Status",
+    width: 170,
+  },
+  {
+    field: "allowed_scopes",
+    label: "Allowed Scopes",
+    width: 320,
+    cellClassName: "max-w-[320px]",
+  },
+  {
+    field: "created_at",
+    label: "Created",
+    width: 190,
+    cellClassName: "whitespace-nowrap text-sm text-muted-foreground",
+  },
+];
+
+const DEFAULT_COLUMN_ORDER = OAUTH_CLIENT_COLUMNS.map((column) => column.field);
+const OAUTH_CLIENT_TABLE_WIDTH = OAUTH_CLIENT_COLUMNS.reduce(
+  (width, column) => width + column.width,
+  0,
+);
+const COLUMN_PREFERENCES_VERSION = 1;
+
+type ColumnPreferences = {
+  readonly version: typeof COLUMN_PREFERENCES_VERSION;
+  readonly order: readonly OAuthClientSortField[];
+  readonly frozenThrough: OAuthClientSortField | null;
+};
+
+type ColumnDropTarget = {
+  readonly field: OAuthClientSortField;
+  readonly position: "before" | "after";
+};
+
+function getColumn(field: OAuthClientSortField): OAuthClientColumn {
+  const column = OAUTH_CLIENT_COLUMNS.find((item) => item.field === field);
+  if (!column) throw new Error(`Unknown OAuth client column: ${field}`);
+  return column;
+}
+
+function isColumnField(value: unknown): value is OAuthClientSortField {
+  return OAUTH_CLIENT_COLUMNS.some((column) => column.field === value);
+}
+
+function isCompleteColumnOrder(
+  value: unknown,
+): value is OAuthClientSortField[] {
+  return (
+    Array.isArray(value) &&
+    value.length === OAUTH_CLIENT_COLUMNS.length &&
+    value.every(isColumnField) &&
+    new Set(value).size === OAUTH_CLIENT_COLUMNS.length
+  );
+}
+
+function columnPreferencesKey(userId: string | undefined): string | null {
+  return userId
+    ? `nyxid:admin-oauth-clients:columns:v${String(COLUMN_PREFERENCES_VERSION)}:${userId}`
+    : null;
+}
+
+function readColumnPreferences(userId: string | undefined): ColumnPreferences {
+  const fallback: ColumnPreferences = {
+    version: COLUMN_PREFERENCES_VERSION,
+    order: DEFAULT_COLUMN_ORDER,
+    frozenThrough: null,
+  };
+  const key = columnPreferencesKey(userId);
+  if (!key || typeof window === "undefined") return fallback;
+
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+      version?: unknown;
+      order?: unknown;
+      frozenThrough?: unknown;
+    } | null;
+    if (
+      parsed?.version !== COLUMN_PREFERENCES_VERSION ||
+      !isCompleteColumnOrder(parsed.order) ||
+      (parsed.frozenThrough !== null && !isColumnField(parsed.frozenThrough))
+    ) {
+      return fallback;
+    }
+    return {
+      version: COLUMN_PREFERENCES_VERSION,
+      order: parsed.order,
+      frozenThrough: parsed.frozenThrough,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function moveColumnToIndex(
+  order: readonly OAuthClientSortField[],
+  field: OAuthClientSortField,
+  targetIndex: number,
+): OAuthClientSortField[] {
+  const sourceIndex = order.indexOf(field);
+  if (sourceIndex < 0) return [...order];
+  const next = order.filter((item) => item !== field);
+  next.splice(Math.max(0, Math.min(targetIndex, next.length)), 0, field);
+  return next;
+}
+
+function reorderColumnsForDrop(
+  order: readonly OAuthClientSortField[],
+  source: OAuthClientSortField,
+  target: OAuthClientSortField,
+  position: ColumnDropTarget["position"],
+): OAuthClientSortField[] {
+  if (source === target) return [...order];
+  const withoutSource = order.filter((field) => field !== source);
+  const targetIndex = withoutSource.indexOf(target);
+  if (targetIndex < 0) return [...order];
+  const insertionIndex = targetIndex + (position === "after" ? 1 : 0);
+  withoutSource.splice(insertionIndex, 0, source);
+  return withoutSource;
+}
+
+function frozenColumnOffsets(
+  order: readonly OAuthClientSortField[],
+  frozenThrough: OAuthClientSortField | null,
+): ReadonlyMap<OAuthClientSortField, number> {
+  const offsets = new Map<OAuthClientSortField, number>();
+  if (!frozenThrough) return offsets;
+
+  let left = 0;
+  for (const field of order) {
+    offsets.set(field, left);
+    left += getColumn(field).width;
+    if (field === frozenThrough) break;
+  }
+  return offsets;
+}
+
+const DEFAULT_COLUMN_SORT: Record<OAuthClientSortField, AdminOAuthClientSort> =
+  {
+    client_name: "client_name",
+    client_type: "client_type",
+    created_by: "created_by",
+    broker: "-broker",
+    is_active: "-is_active",
+    allowed_scopes: "allowed_scopes",
+    created_at: "-created_at",
+  };
+
+type OAuthClientSearchEditTarget =
+  | { readonly kind: "all"; readonly value: string }
+  | {
+      readonly kind: "field";
+      readonly field: AdminOAuthClientSearchFieldKey;
+      readonly value: string;
+    };
+
+function sortDirection(
+  sort: AdminOAuthClientSort,
+  field: OAuthClientSortField,
+): "ascending" | "descending" | undefined {
+  if (sort === field) return "ascending";
+  if (sort === `-${field}`) return "descending";
+  return undefined;
+}
+
+function nextColumnSort(
+  sort: AdminOAuthClientSort,
+  field: OAuthClientSortField,
+): AdminOAuthClientSort {
+  const ascending = field as AdminOAuthClientSort;
+  const descending = `-${field}` as AdminOAuthClientSort;
+  if (sort === ascending) return descending;
+  if (sort === descending) return ascending;
+  return DEFAULT_COLUMN_SORT[field];
+}
+
+function ReorderableTableHead({
+  column,
+  sort,
+  disabled,
+  frozen,
+  lastFrozen,
+  stickyLeft,
+  dragging,
+  dropPosition,
+  onSort,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+  onMoveByKeyboard,
+  onToggleFreeze,
+}: {
+  readonly column: OAuthClientColumn;
+  readonly sort: AdminOAuthClientSort;
+  readonly disabled: boolean;
+  readonly frozen: boolean;
+  readonly lastFrozen: boolean;
+  readonly stickyLeft: number | undefined;
+  readonly dragging: boolean;
+  readonly dropPosition: ColumnDropTarget["position"] | undefined;
+  readonly onSort: (sort: AdminOAuthClientSort) => void;
+  readonly onDragStart: (
+    field: OAuthClientSortField,
+    event: React.DragEvent<HTMLButtonElement>,
+  ) => void;
+  readonly onDragOver: (
+    field: OAuthClientSortField,
+    event: React.DragEvent<HTMLTableCellElement>,
+  ) => void;
+  readonly onDrop: (
+    field: OAuthClientSortField,
+    event: React.DragEvent<HTMLTableCellElement>,
+  ) => void;
+  readonly onDragEnd: () => void;
+  readonly onMoveByKeyboard: (
+    field: OAuthClientSortField,
+    key: "ArrowLeft" | "ArrowRight" | "Home" | "End",
+  ) => void;
+  readonly onToggleFreeze: (field: OAuthClientSortField) => void;
+}) {
+  const { field, label } = column;
+  const direction = sortDirection(sort, field);
+  const Icon =
+    direction === "ascending"
+      ? ArrowUp
+      : direction === "descending"
+        ? ArrowDown
+        : ArrowUpDown;
+  const next = nextColumnSort(sort, field);
+  const nextDirection = next.startsWith("-") ? "descending" : "ascending";
+
+  return (
+    <TableHead
+      aria-label={label}
+      aria-sort={direction ?? "none"}
+      data-column={field}
+      data-dragging={dragging || undefined}
+      data-drop-position={dropPosition}
+      data-frozen={frozen || undefined}
+      style={frozen ? { left: stickyLeft } : undefined}
+      onDragOver={(event) => onDragOver(field, event)}
+      onDrop={(event) => onDrop(field, event)}
+      className={cn(
+        "group/header relative h-10 p-0 transition-colors hover:bg-accent focus-within:bg-accent",
+        dragging && "opacity-55",
+        frozen && "sticky z-30 bg-card",
+        lastFrozen &&
+          "border-r-2 border-border shadow-[3px_0_6px_-4px_rgba(0,0,0,0.35)]",
+        direction && "text-foreground",
+      )}
+    >
+      {direction && (
+        <span
+          className="pointer-events-none absolute inset-0 bg-primary/[0.07]"
+          aria-hidden="true"
+        />
+      )}
+      {dropPosition && (
+        <span
+          data-testid={`column-drop-indicator-${field}`}
+          className={cn(
+            "pointer-events-none absolute inset-y-0 z-30 w-0.5 bg-primary",
+            dropPosition === "before" ? "left-0" : "right-0",
+          )}
+          aria-hidden="true"
+        />
+      )}
+      <div className="flex h-full min-w-0 items-center">
+        <button
+          type="button"
+          draggable
+          aria-label={`Move ${label} column`}
+          title={`Move ${label} column`}
+          onDragStart={(event) => onDragStart(field, event)}
+          onDragEnd={onDragEnd}
+          onKeyDown={(event) => {
+            if (
+              event.key === "ArrowLeft" ||
+              event.key === "ArrowRight" ||
+              event.key === "Home" ||
+              event.key === "End"
+            ) {
+              event.preventDefault();
+              onMoveByKeyboard(field, event.key);
+            }
+          }}
+          className="flex h-full w-7 shrink-0 cursor-grab items-center justify-center text-muted-foreground opacity-0 outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring active:cursor-grabbing group-hover/header:opacity-100 group-focus-within/header:opacity-100"
+        >
+          <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className={cn(
+            "group/sort flex h-full min-w-0 flex-1 items-center gap-1.5 text-left text-[10px] font-semibold uppercase tracking-normal outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+            direction && "text-foreground",
+          )}
+          disabled={disabled}
+          aria-label={`Sort by ${label}, ${nextDirection}`}
+          title={`Sort by ${label}, ${nextDirection}`}
+          onClick={() => onSort(next)}
+        >
+          <span className="truncate">{label}</span>
+          <Icon
+            className={cn(
+              "h-3.5 w-3.5 shrink-0",
+              direction
+                ? "text-primary"
+                : "text-muted-foreground/55 group-hover/sort:text-muted-foreground",
+            )}
+            aria-hidden="true"
+          />
+        </button>
+        <button
+          type="button"
+          aria-label={
+            lastFrozen
+              ? `Unfreeze columns through ${label}`
+              : `Freeze columns through ${label}`
+          }
+          title={lastFrozen ? "Unfreeze columns" : "Freeze through this column"}
+          aria-pressed={lastFrozen}
+          onClick={() => onToggleFreeze(field)}
+          className={cn(
+            "flex h-full w-7 shrink-0 items-center justify-center outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring group-hover/header:opacity-100 group-focus-within/header:opacity-100",
+            lastFrozen
+              ? "text-primary opacity-100"
+              : "text-muted-foreground opacity-0",
+          )}
+        >
+          {lastFrozen ? (
+            <PinOff className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Pin className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    </TableHead>
+  );
+}
 
 export function AdminOAuthClientsPage() {
+  const navigate = useNavigate();
+  const routeSearch = useSearch({
+    strict: false,
+  }) as AdminOAuthClientSearchState;
   const currentUser = useAuthStore((s) => s.user);
   const canWrite = canAdminWrite(currentUser);
+  const [columnPreferences, setColumnPreferences] = useState(() =>
+    readColumnPreferences(currentUser?.id),
+  );
+  const [draggingColumn, setDraggingColumn] =
+    useState<OAuthClientSortField | null>(null);
+  const [columnDropTarget, setColumnDropTarget] =
+    useState<ColumnDropTarget | null>(null);
+  const [columnAnnouncement, setColumnAnnouncement] = useState("");
+  const draggingColumnRef = useRef<OAuthClientSortField | null>(null);
+  const appliedSearch = routeSearch.search ?? "";
+  const [searchDraft, setSearchDraft] = useState("");
+  const [selectedSearchField, setSelectedSearchField] =
+    useState<AdminOAuthClientSearchFieldKey | null>(null);
+  const [editingSearch, setEditingSearch] =
+    useState<OAuthClientSearchEditTarget | null>(null);
+  const previousSearchRouteRef = useRef(
+    `${routeSearch.search ?? ""}\u0000${routeSearch.search_filters ?? ""}`,
+  );
   const [pendingClientAction, setPendingClientAction] =
     useState<ClientAction | null>(null);
   const [pendingSettingAction, setPendingSettingAction] =
     useState<SettingAction | null>(null);
+  const [filterPopoverOpen, setFilterPopoverOpen] = useState(false);
+  const [selectedFilterKey, setSelectedFilterKey] =
+    useState<AdminOAuthClientFilterKey>("is_active");
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const { data, isLoading, error } = useAdminOAuthClients();
+  const listParams: AdminOAuthClientListParams = {
+    page: routeSearch.page ?? 1,
+    per_page: routeSearch.per_page ?? DEFAULT_PER_PAGE,
+    search: routeSearch.search,
+    search_filters: routeSearch.search_filters,
+    client_type: routeSearch.client_type,
+    creator_type: routeSearch.creator_type,
+    broker: routeSearch.broker,
+    is_active: routeSearch.is_active,
+    scope: routeSearch.scope,
+    created_dates: routeSearch.created_dates,
+    created_from: routeSearch.created_from,
+    created_to: routeSearch.created_to,
+    sort: routeSearch.sort ?? DEFAULT_SORT,
+  };
+
+  const { data, isLoading, isFetching, isPlaceholderData, error, refetch } =
+    useAdminOAuthClients(listParams);
   const {
     data: brokerSettings,
     isLoading: settingsLoading,
@@ -90,6 +584,374 @@ export function AdminOAuthClientsPage() {
   const updateSettings = useUpdateBrokerSettings();
 
   const clients = data?.clients ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / listParams.per_page));
+  const displayedPage = data?.page ?? listParams.page;
+  const displayedPerPage = data?.per_page ?? listParams.per_page;
+  const displayedTotalPages = Math.max(1, Math.ceil(total / displayedPerPage));
+  const filterOptions = data?.filter_options;
+  const filterFields = getAdminOAuthClientFilterFields(filterOptions);
+  const searchFields = getAdminOAuthClientSearchFields(filterOptions);
+  const appliedSearchFilters = getAdminOAuthClientSearchFilters(listParams);
+  const appliedStructuredFilters = getAppliedAdminOAuthClientFilters(
+    filterFields,
+    listParams,
+  );
+  const filterSelections: AdminOAuthClientFilterSelections = {};
+  for (const field of filterFields) {
+    filterSelections[field.key] = getAdminOAuthClientFilterValues(
+      listParams,
+      field.key,
+    );
+  }
+  const availableSorts = new Set(filterOptions?.sorts ?? FALLBACK_SORTS);
+  const hasActiveFilters = Boolean(
+    listParams.search ||
+    appliedSearchFilters.length > 0 ||
+    appliedStructuredFilters.length > 0,
+  );
+  const columnOrder = columnPreferences.order;
+  const frozenThrough = columnPreferences.frozenThrough;
+  const stickyOffsets = frozenColumnOffsets(columnOrder, frozenThrough);
+
+  const updateListSearch = useCallback(
+    (patch: Partial<AdminOAuthClientSearchState>, replace = false) => {
+      void navigate({
+        to: "/admin/oauth-clients",
+        search: (previous) =>
+          normalizeAdminOAuthClientSearch({ ...previous, ...patch }),
+        replace,
+      });
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    if (!isPlaceholderData && total > 0 && listParams.page > totalPages) {
+      updateListSearch({ page: totalPages }, true);
+    }
+  }, [isPlaceholderData, listParams.page, total, totalPages, updateListSearch]);
+
+  useEffect(() => {
+    const nextRoute = `${routeSearch.search ?? ""}\u0000${
+      routeSearch.search_filters ?? ""
+    }`;
+    if (nextRoute === previousSearchRouteRef.current) return;
+    previousSearchRouteRef.current = nextRoute;
+    const resetTimer = window.setTimeout(() => {
+      setSearchDraft("");
+      setEditingSearch(null);
+    }, 0);
+    return () => window.clearTimeout(resetTimer);
+  }, [routeSearch.search, routeSearch.search_filters]);
+
+  useEffect(() => {
+    const key = columnPreferencesKey(currentUser?.id);
+    if (!key || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(columnPreferences));
+    } catch {
+      // Table preferences are non-critical when storage is unavailable.
+    }
+  }, [columnPreferences, currentUser?.id]);
+
+  function clearSearchAndFilters() {
+    updateListSearch({
+      page: undefined,
+      search: undefined,
+      search_filters: undefined,
+      client_type: undefined,
+      creator_type: undefined,
+      broker: undefined,
+      is_active: undefined,
+      scope: undefined,
+      created_dates: undefined,
+      created_from: undefined,
+      created_to: undefined,
+    });
+  }
+
+  function focusSearchInput() {
+    window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+  }
+
+  function cancelSearchDraft() {
+    setSearchDraft("");
+    setEditingSearch(null);
+  }
+
+  function removeScopedSearchValue(
+    field: AdminOAuthClientSearchFieldKey,
+    value: string,
+    navigate = true,
+  ): string | undefined {
+    const current = parseAdminOAuthClientSearchFilters(
+      listParams.search_filters,
+    );
+    const values =
+      current
+        ?.find((group) => group.field === field)
+        ?.values.filter(
+          (item) => item.toLocaleLowerCase() !== value.toLocaleLowerCase(),
+        ) ?? [];
+    const next = updateAdminOAuthClientSearchFilters(
+      listParams.search_filters,
+      field,
+      values.length > 0 ? values : undefined,
+    );
+    if (navigate) {
+      updateListSearch({ page: undefined, search_filters: next });
+      if (
+        editingSearch?.kind === "field" &&
+        editingSearch.field === field &&
+        editingSearch.value.toLocaleLowerCase() === value.toLocaleLowerCase()
+      ) {
+        cancelSearchDraft();
+      }
+    }
+    return next;
+  }
+
+  function applySearchDraft(mode: DataTableSearchApplyMode) {
+    const term = searchDraft.trim();
+    if (!term) return;
+
+    let nextLegacySearch = listParams.search;
+    let nextScopedSearch = listParams.search_filters;
+    if (editingSearch?.kind === "all") {
+      nextLegacySearch = undefined;
+    } else if (editingSearch?.kind === "field") {
+      const current = parseAdminOAuthClientSearchFilters(nextScopedSearch);
+      const remaining =
+        current
+          ?.find((group) => group.field === editingSearch.field)
+          ?.values.filter(
+            (value) =>
+              value.toLocaleLowerCase() !==
+              editingSearch.value.toLocaleLowerCase(),
+          ) ?? [];
+      nextScopedSearch = updateAdminOAuthClientSearchFilters(
+        nextScopedSearch,
+        editingSearch.field,
+        remaining.length > 0 ? remaining : undefined,
+      );
+    }
+
+    if (selectedSearchField === null) {
+      nextLegacySearch = term;
+    } else {
+      const current =
+        parseAdminOAuthClientSearchFilters(nextScopedSearch) ?? [];
+      const values =
+        current.find((group) => group.field === selectedSearchField)?.values ??
+        [];
+      const duplicate = values.some(
+        (value) => value.toLocaleLowerCase() === term.toLocaleLowerCase(),
+      );
+      const nextValues = duplicate ? values : [...values, term];
+      const encoded = updateAdminOAuthClientSearchFilters(
+        nextScopedSearch,
+        selectedSearchField,
+        nextValues,
+      );
+      if (!encoded) {
+        toast.error("Search supports up to 8 values per field and 32 overall");
+        return;
+      }
+      nextScopedSearch = encoded;
+    }
+
+    updateListSearch({
+      page: undefined,
+      search: nextLegacySearch,
+      search_filters: nextScopedSearch,
+    });
+    cancelSearchDraft();
+    if (mode === "submit") {
+      setSelectedSearchField(null);
+      focusSearchInput();
+    }
+  }
+
+  function editLegacySearch() {
+    setSelectedSearchField(null);
+    setSearchDraft(appliedSearch);
+    setEditingSearch({ kind: "all", value: appliedSearch });
+    focusSearchInput();
+  }
+
+  function editScopedSearchValue(
+    field: AdminOAuthClientSearchFieldKey,
+    value: string,
+  ) {
+    setSelectedSearchField(field);
+    setSearchDraft(value);
+    setEditingSearch({ kind: "field", field, value });
+    focusSearchInput();
+  }
+
+  function applyStructuredFilters(
+    selections: AdminOAuthClientFilterSelections,
+  ) {
+    const patch: Partial<AdminOAuthClientSearchState> = { page: undefined };
+    for (const field of filterFields) {
+      const fieldPatch = adminOAuthClientFilterPatch(
+        field.key,
+        selections[field.key],
+      );
+      if (!fieldPatch) return;
+      Object.assign(patch, fieldPatch);
+    }
+    updateListSearch(patch);
+  }
+
+  function removeStructuredFilter(key: AdminOAuthClientFilterKey) {
+    const patch = adminOAuthClientFilterPatch(key, undefined);
+    if (patch) updateListSearch({ page: undefined, ...patch });
+  }
+
+  function editStructuredFilter(key: AdminOAuthClientFilterKey) {
+    setSelectedFilterKey(key);
+    setFilterPopoverOpen(true);
+  }
+
+  function updateSort(sort: AdminOAuthClientSort) {
+    updateListSearch({
+      page: undefined,
+      sort: sort === DEFAULT_SORT ? undefined : sort,
+    });
+  }
+
+  function canSortColumn(field: OAuthClientSortField) {
+    return (
+      availableSorts.has(field as AdminOAuthClientSort) &&
+      availableSorts.has(`-${field}` as AdminOAuthClientSort)
+    );
+  }
+
+  function announceColumnPosition(
+    field: OAuthClientSortField,
+    order: readonly OAuthClientSortField[],
+  ) {
+    setColumnAnnouncement(
+      `${getColumn(field).label} column moved to position ${String(
+        order.indexOf(field) + 1,
+      )} of ${String(order.length)}`,
+    );
+  }
+
+  function updateColumnOrder(
+    nextOrder: readonly OAuthClientSortField[],
+    movedField: OAuthClientSortField,
+  ) {
+    setColumnPreferences((previous) => ({
+      ...previous,
+      order: nextOrder,
+    }));
+    announceColumnPosition(movedField, nextOrder);
+  }
+
+  function handleColumnDragStart(
+    field: OAuthClientSortField,
+    event: React.DragEvent<HTMLButtonElement>,
+  ) {
+    draggingColumnRef.current = field;
+    setDraggingColumn(field);
+    setColumnDropTarget(null);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", field);
+  }
+
+  function dropPositionForEvent(
+    event: React.DragEvent<HTMLTableCellElement>,
+  ): ColumnDropTarget["position"] {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    return event.clientX < bounds.left + bounds.width / 2 ? "before" : "after";
+  }
+
+  function handleColumnDragOver(
+    field: OAuthClientSortField,
+    event: React.DragEvent<HTMLTableCellElement>,
+  ) {
+    const source = draggingColumnRef.current;
+    if (!source || source === field) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const nextTarget: ColumnDropTarget = {
+      field,
+      position: dropPositionForEvent(event),
+    };
+    setColumnDropTarget((current) =>
+      current?.field === nextTarget.field &&
+      current.position === nextTarget.position
+        ? current
+        : nextTarget,
+    );
+  }
+
+  function clearColumnDragState() {
+    draggingColumnRef.current = null;
+    setDraggingColumn(null);
+    setColumnDropTarget(null);
+  }
+
+  function handleColumnDrop(
+    field: OAuthClientSortField,
+    event: React.DragEvent<HTMLTableCellElement>,
+  ) {
+    const transferredField = event.dataTransfer.getData("text/plain");
+    const source =
+      draggingColumnRef.current ??
+      (isColumnField(transferredField) ? transferredField : null);
+    if (!source || source === field) {
+      clearColumnDragState();
+      return;
+    }
+
+    event.preventDefault();
+    const position =
+      columnDropTarget?.field === field
+        ? columnDropTarget.position
+        : dropPositionForEvent(event);
+    const nextOrder = reorderColumnsForDrop(
+      columnOrder,
+      source,
+      field,
+      position,
+    );
+    updateColumnOrder(nextOrder, source);
+    clearColumnDragState();
+  }
+
+  function handleColumnKeyboardMove(
+    field: OAuthClientSortField,
+    key: "ArrowLeft" | "ArrowRight" | "Home" | "End",
+  ) {
+    const sourceIndex = columnOrder.indexOf(field);
+    const targetIndex =
+      key === "Home"
+        ? 0
+        : key === "End"
+          ? columnOrder.length - 1
+          : key === "ArrowLeft"
+            ? Math.max(0, sourceIndex - 1)
+            : Math.min(columnOrder.length - 1, sourceIndex + 1);
+    if (sourceIndex < 0 || sourceIndex === targetIndex) return;
+    updateColumnOrder(
+      moveColumnToIndex(columnOrder, field, targetIndex),
+      field,
+    );
+  }
+
+  function toggleFrozenColumns(field: OAuthClientSortField) {
+    setColumnPreferences((previous) => ({
+      ...previous,
+      frozenThrough: previous.frozenThrough === field ? null : field,
+    }));
+  }
 
   function stageBrokerCapability(client: AdminOAuthClient, enabled: boolean) {
     const removingLegacyScope =
@@ -184,6 +1046,91 @@ export function AdminOAuthClientsPage() {
     }
   }
 
+  function renderOAuthClientCell(
+    client: AdminOAuthClient,
+    field: OAuthClientSortField,
+  ): React.ReactNode {
+    switch (field) {
+      case "client_name":
+        return (
+          <div className="min-w-0 space-y-1">
+            <p className="truncate text-sm font-medium text-foreground">
+              {client.client_name}
+            </p>
+            <p className="truncate font-mono text-[11px] text-muted-foreground">
+              {client.id}
+            </p>
+          </div>
+        );
+      case "client_type":
+        return <Badge variant="secondary">{client.client_type}</Badge>;
+      case "created_by":
+        return (
+          <span className="break-all">{client.created_by ?? "ownerless"}</span>
+        );
+      case "broker":
+        return canWrite ? (
+          <div className="flex items-center gap-2.5">
+            <Switch
+              aria-label={`Toggle broker capability for ${client.client_name} (${client.id})`}
+              checked={client.broker_capability_effective}
+              disabled={
+                isFetching ||
+                (updateClient.isPending &&
+                  updateClient.variables?.clientId === client.id)
+              }
+              onCheckedChange={(checked) =>
+                stageBrokerCapability(client, checked)
+              }
+            />
+            <span className="whitespace-nowrap text-[11px] font-medium text-foreground">
+              {client.broker_capability_effective
+                ? "Broker enabled"
+                : "No broker"}
+            </span>
+            <BrokerSourceBadge source={client.broker_capability_source} />
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <ClientStateBadge
+              active={client.broker_capability_effective}
+              activeLabel="Broker enabled"
+              inactiveLabel="No broker"
+            />
+            <BrokerSourceBadge source={client.broker_capability_source} />
+          </div>
+        );
+      case "is_active":
+        return canWrite ? (
+          <div className="flex items-center gap-2.5">
+            <Switch
+              aria-label={`Toggle active status for ${client.client_name} (${client.id})`}
+              checked={client.is_active}
+              disabled={
+                isFetching ||
+                (updateClient.isPending &&
+                  updateClient.variables?.clientId === client.id)
+              }
+              onCheckedChange={(checked) => stageActive(client, checked)}
+            />
+            <span className="whitespace-nowrap text-[11px] font-medium text-foreground">
+              {client.is_active ? "Active" : "Inactive"}
+            </span>
+          </div>
+        ) : (
+          <ClientStateBadge
+            active={client.is_active}
+            activeLabel="Active"
+            inactiveLabel="Inactive"
+          />
+        );
+      case "allowed_scopes":
+        return <ScopeList scopes={client.allowed_scopes} />;
+      case "created_at":
+        return formatDate(client.created_at);
+    }
+  }
+
   return (
     <div className="space-y-8">
       <PageHeader
@@ -201,119 +1148,323 @@ export function AdminOAuthClientsPage() {
         />
       )}
 
-      {isLoading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton
-              key={`oauth-client-skel-${String(i)}`}
-              className="h-12 w-full"
+      <section
+        className="m-0 overflow-hidden rounded-lg border border-border/60 bg-card"
+        aria-label="OAuth clients"
+      >
+        <DataTableControls
+          search={
+            <DataTableSearch
+              fields={searchFields}
+              value={searchDraft}
+              selectedField={selectedSearchField}
+              inputRef={searchInputRef}
+              ariaLabel="Search OAuth clients"
+              onValueChange={setSearchDraft}
+              onFieldChange={setSelectedSearchField}
+              onApply={applySearchDraft}
+              onCancel={cancelSearchDraft}
             />
-          ))}
-        </div>
-      ) : error ? (
-        <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-12 text-center">
-          <AlertTriangle className="h-8 w-8 text-destructive" />
-          <p className="text-sm font-medium text-destructive">
-            Failed to load OAuth clients
-          </p>
-        </div>
-      ) : clients.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-border/50 bg-card px-4 py-14 text-center">
-          <KeyRound className="h-10 w-10 text-muted-foreground" />
-          <div>
-            <p className="text-sm font-medium text-foreground">
-              No OAuth clients
-            </p>
-            <p className="text-xs text-muted-foreground">
-              Registered clients will appear here.
-            </p>
+          }
+          filter={
+            <DataTableFilterPopover
+              fields={filterFields}
+              values={filterSelections}
+              open={filterPopoverOpen}
+              selectedKey={selectedFilterKey}
+              activeCount={
+                appliedStructuredFilters.length +
+                appliedSearchFilters.length +
+                (appliedSearch ? 1 : 0)
+              }
+              validateValues={(field, values) =>
+                field.value_type !== "date" ||
+                isAdminOAuthClientDateFilterValid(values)
+              }
+              onOpenChange={setFilterPopoverOpen}
+              onSelectField={setSelectedFilterKey}
+              onApply={applyStructuredFilters}
+            />
+          }
+          status={
+            isFetching && !isLoading ? (
+              <div
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-1.5 text-xs text-muted-foreground"
+              >
+                <Loader2
+                  className="h-3.5 w-3.5 animate-spin"
+                  aria-hidden="true"
+                />
+                <span>Updating results</span>
+              </div>
+            ) : null
+          }
+          chips={
+            <DataTableFilterChips
+              search={appliedSearch}
+              searchFields={searchFields}
+              searchFilters={appliedSearchFilters}
+              filters={appliedStructuredFilters}
+              onEditSearch={editLegacySearch}
+              onRemoveSearch={() =>
+                updateListSearch({ page: undefined, search: undefined })
+              }
+              onEditSearchValue={editScopedSearchValue}
+              onRemoveSearchValue={removeScopedSearchValue}
+              onEdit={editStructuredFilter}
+              onRemove={removeStructuredFilter}
+              onClear={clearSearchAndFilters}
+            />
+          }
+        />
+
+        {error && data && (
+          <div
+            role="alert"
+            className="flex flex-col gap-3 border-b border-destructive/25 bg-destructive/5 px-3 py-2.5 text-sm sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="flex items-center gap-2 text-destructive">
+              <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>
+                Results may be out of date because the refresh failed.
+              </span>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isFetching}
+              onClick={() => void refetch()}
+            >
+              Retry
+            </Button>
           </div>
-        </div>
-      ) : (
-        <div className="overflow-x-auto rounded-xl border border-border/50 bg-card">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Client</TableHead>
-                <TableHead>Type</TableHead>
-                <TableHead>Created By</TableHead>
-                <TableHead>Broker</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Allowed Scopes</TableHead>
-                <TableHead>Created</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {clients.map((client) => (
-                <TableRow key={client.id}>
-                  <TableCell className="min-w-[220px]">
-                    <div className="space-y-1">
-                      <p className="text-sm font-medium text-foreground">
-                        {client.client_name}
-                      </p>
-                      <p className="font-mono text-[11px] text-muted-foreground">
-                        {client.id}
-                      </p>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="secondary">{client.client_type}</Badge>
-                  </TableCell>
-                  <TableCell className="min-w-[170px]">
-                    <span className="font-mono text-[11px] text-muted-foreground">
-                      {client.created_by ?? "ownerless"}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    {canWrite ? (
-                      <div className="flex items-center gap-2">
-                        <Switch
-                          aria-label={`Toggle broker capability for ${client.client_name}`}
-                          checked={client.broker_capability_effective}
-                          disabled={updateClient.isPending}
-                          onCheckedChange={(checked) =>
-                            stageBrokerCapability(client, checked)
+        )}
+
+        {isLoading || (isPlaceholderData && clients.length === 0) ? (
+          <div
+            className="space-y-2 p-3"
+            role="status"
+            aria-live="polite"
+            aria-label={
+              isLoading ? "Loading OAuth clients" : "Updating OAuth clients"
+            }
+          >
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton
+                key={`oauth-client-skel-${String(i)}`}
+                className="h-12 w-full"
+              />
+            ))}
+          </div>
+        ) : error && !data ? (
+          <div
+            role="alert"
+            className="flex min-h-56 flex-col items-center justify-center gap-2 bg-destructive/5 px-4 py-12 text-center"
+          >
+            <AlertTriangle
+              className="h-8 w-8 text-destructive"
+              aria-hidden="true"
+            />
+            <p className="text-sm font-medium text-destructive">
+              Failed to load OAuth clients
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : clients.length === 0 ? (
+          <div className="flex min-h-56 flex-col items-center justify-center gap-3 px-4 py-14 text-center">
+            <KeyRound className="h-10 w-10 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {hasActiveFilters
+                  ? "No clients match these filters"
+                  : "No OAuth clients"}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {hasActiveFilters
+                  ? "Adjust or clear the current filters."
+                  : "Registered clients will appear here."}
+              </p>
+              {hasActiveFilters && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
+                  onClick={clearSearchAndFilters}
+                >
+                  Clear search and filters
+                </Button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <>
+            <div
+              className={`transition-opacity motion-reduce:transition-none ${
+                isPlaceholderData ? "opacity-60" : ""
+              }`}
+              aria-busy={isFetching}
+            >
+              <p className="sr-only" aria-live="polite" aria-atomic="true">
+                {columnAnnouncement}
+              </p>
+              <Table
+                containerClassName="overscroll-x-none"
+                className="table-fixed [&_td]:py-1.5"
+                style={{ minWidth: OAUTH_CLIENT_TABLE_WIDTH }}
+              >
+                <colgroup>
+                  {columnOrder.map((field) => (
+                    <col
+                      key={field}
+                      style={{ width: getColumn(field).width }}
+                    />
+                  ))}
+                </colgroup>
+                <TableHeader>
+                  <TableRow>
+                    {columnOrder.map((field) => {
+                      const column = getColumn(field);
+                      return (
+                        <ReorderableTableHead
+                          key={field}
+                          column={column}
+                          sort={listParams.sort}
+                          disabled={!canSortColumn(field)}
+                          frozen={stickyOffsets.has(field)}
+                          lastFrozen={frozenThrough === field}
+                          stickyLeft={stickyOffsets.get(field)}
+                          dragging={draggingColumn === field}
+                          dropPosition={
+                            columnDropTarget?.field === field
+                              ? columnDropTarget.position
+                              : undefined
                           }
+                          onSort={updateSort}
+                          onDragStart={handleColumnDragStart}
+                          onDragOver={handleColumnDragOver}
+                          onDrop={handleColumnDrop}
+                          onDragEnd={clearColumnDragState}
+                          onMoveByKeyboard={handleColumnKeyboardMove}
+                          onToggleFreeze={toggleFrozenColumns}
                         />
-                        <BrokerSourceBadge
-                          source={client.broker_capability_source}
-                        />
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <BoolBadge value={client.broker_capability_effective} />
-                        <BrokerSourceBadge
-                          source={client.broker_capability_source}
-                        />
-                      </div>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    {canWrite ? (
-                      <Switch
-                        aria-label={`Toggle active status for ${client.client_name}`}
-                        checked={client.is_active}
-                        disabled={updateClient.isPending}
-                        onCheckedChange={(checked) =>
-                          stageActive(client, checked)
-                        }
-                      />
-                    ) : (
-                      <BoolBadge value={client.is_active} />
-                    )}
-                  </TableCell>
-                  <TableCell className="min-w-[260px] max-w-[360px]">
-                    <ScopeList scopes={client.allowed_scopes} />
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
-                    {formatDate(client.created_at)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+                      );
+                    })}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {clients.map((client) => (
+                    <TableRow
+                      key={client.id}
+                      className="group/row hover:bg-muted/45"
+                    >
+                      {columnOrder.map((field) => {
+                        const column = getColumn(field);
+                        const frozen = stickyOffsets.has(field);
+                        return (
+                          <TableCell
+                            key={field}
+                            data-column={field}
+                            data-frozen={frozen || undefined}
+                            style={
+                              frozen
+                                ? { left: stickyOffsets.get(field) }
+                                : undefined
+                            }
+                            className={cn(
+                              column.cellClassName,
+                              frozen &&
+                                "sticky z-20 bg-card group-hover/row:bg-muted",
+                              frozenThrough === field &&
+                                "border-r-2 border-border shadow-[3px_0_6px_-4px_rgba(0,0,0,0.35)]",
+                            )}
+                          >
+                            {renderOAuthClientCell(client, field)}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex flex-col gap-3 border-t border-border/60 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-[11px] text-text-tertiary">
+                Showing {String((displayedPage - 1) * displayedPerPage + 1)}-
+                {String(Math.min(displayedPage * displayedPerPage, total))} of{" "}
+                {String(total)} clients
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Select
+                  value={String(listParams.per_page)}
+                  disabled={isFetching}
+                  onValueChange={(value) =>
+                    updateListSearch({
+                      page: undefined,
+                      per_page:
+                        Number(value) === DEFAULT_PER_PAGE
+                          ? undefined
+                          : (Number(value) as 50 | 100),
+                    })
+                  }
+                >
+                  <SelectTrigger
+                    aria-label="Rows per page"
+                    className="w-[112px]"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="25">25 rows</SelectItem>
+                    <SelectItem value="50">50 rows</SelectItem>
+                    <SelectItem value="100">100 rows</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-11 w-11 md:h-8 md:w-8"
+                  disabled={listParams.page <= 1 || isFetching}
+                  onClick={() =>
+                    updateListSearch({ page: Math.max(1, listParams.page - 1) })
+                  }
+                  aria-label="Previous page"
+                >
+                  <ChevronLeft />
+                </Button>
+                <span className="min-w-[84px] text-center text-[11px] text-text-tertiary">
+                  Page {String(displayedPage)} of {String(displayedTotalPages)}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-11 w-11 md:h-8 md:w-8"
+                  disabled={listParams.page >= totalPages || isFetching}
+                  onClick={() =>
+                    updateListSearch({ page: listParams.page + 1 })
+                  }
+                  aria-label="Next page"
+                >
+                  <ChevronRight />
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
 
       <Dialog
         open={canWrite && pendingClientAction !== null}
@@ -515,7 +1666,23 @@ function BrokerSourceBadge({
   if (source === "none") return null;
   return (
     <Badge variant="secondary" className="whitespace-nowrap">
-      {source === "flag" ? "Flag" : "Scope"}
+      {source === "flag" ? "Admin grant" : "Broker scope"}
+    </Badge>
+  );
+}
+
+function ClientStateBadge({
+  active,
+  activeLabel,
+  inactiveLabel,
+}: {
+  readonly active: boolean;
+  readonly activeLabel: string;
+  readonly inactiveLabel: string;
+}) {
+  return (
+    <Badge variant={active ? "success" : "secondary"}>
+      {active ? activeLabel : inactiveLabel}
     </Badge>
   );
 }
@@ -533,18 +1700,50 @@ function ScopeList({ scopes }: { readonly scopes: string }) {
   if (items.length === 0) {
     return <span className="text-sm text-muted-foreground">None</span>;
   }
+  const visibleItems = items.slice(0, 3);
+  const hiddenItems = items.slice(3);
+
   return (
-    <div className="flex flex-wrap gap-1.5">
-      {items.map((scope) => (
-        <Badge
-          key={scope}
-          variant="secondary"
-          className="font-mono text-[10px]"
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex max-w-full items-center gap-1.5 rounded-md text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`View all ${String(items.length)} allowed scopes: ${items.join(", ")}`}
+          title={items.join("\n")}
         >
-          {scope}
-        </Badge>
-      ))}
-    </div>
+          {visibleItems.map((scope) => (
+            <span
+              key={scope}
+              className="inline-flex max-w-[112px] truncate rounded-md bg-muted px-2 py-0.5 font-mono text-[10px] font-medium text-muted-foreground"
+            >
+              {scope}
+            </span>
+          ))}
+          {hiddenItems.length > 0 && (
+            <span className="inline-flex h-6 shrink-0 items-center rounded-md border border-border/80 bg-muted px-2 text-[10px] font-medium text-muted-foreground">
+              +{String(hiddenItems.length)} more
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 rounded-lg p-3">
+        <p className="mb-2 text-xs font-semibold text-foreground">
+          Allowed scopes
+        </p>
+        <div className="flex max-h-56 flex-wrap gap-1.5 overflow-y-auto">
+          {items.map((scope) => (
+            <Badge
+              key={scope}
+              variant="secondary"
+              className="max-w-full break-all font-mono text-[10px]"
+            >
+              {scope}
+            </Badge>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -16,6 +16,7 @@ import { BillingRouteGuard } from "@/components/billing-route-guard";
 import { useAuthStore } from "@/stores/auth-store";
 import { hasAdminRead } from "@/types/api";
 import { shouldRedirectFromBilling } from "@/lib/billing-availability";
+import { normalizeAdminOAuthClientSearch } from "@/lib/admin-oauth-clients";
 
 import {
   LandingPage,
@@ -728,6 +729,7 @@ const adminOAuthClientsRoute = createRoute({
   path: "oauth-clients",
   getParentRoute: () => adminLayout,
   component: AdminOAuthClientsPage,
+  validateSearch: normalizeAdminOAuthClientSearch,
 });
 
 const adminNodesRoute = createRoute({

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -1,4 +1,13 @@
 import type { PlatformRole } from "./api";
+import type {
+  DataTableFilterField,
+  DataTableFilterOperator,
+  DataTableFilterOption,
+  DataTableFilterSelections,
+  DataTableFilterValueType,
+  DataTableSearchField,
+  DataTableSearchGroup,
+} from "./data-table";
 
 export interface AdminUser {
   readonly id: string;
@@ -148,8 +157,111 @@ export interface AdminOAuthClient {
   readonly created_at: string;
 }
 
+export type AdminOAuthClientTypeFilter = "public" | "confidential" | "other";
+export type AdminOAuthClientCreatorType =
+  | "dynamic_registration"
+  | "system"
+  | "owned"
+  | "ownerless";
+export type AdminOAuthClientBrokerFilter =
+  | "enabled"
+  | "disabled"
+  | "flag"
+  | "scope";
+export type AdminOAuthClientSort =
+  | "-created_at"
+  | "created_at"
+  | "client_name"
+  | "-client_name"
+  | "client_type"
+  | "-client_type"
+  | "created_by"
+  | "-created_by"
+  | "broker"
+  | "-broker"
+  | "allowed_scopes"
+  | "-allowed_scopes"
+  | "-is_active"
+  | "is_active";
+
+export type AdminOAuthClientFilterKey =
+  | "is_active"
+  | "client_type"
+  | "creator_type"
+  | "broker"
+  | "scope"
+  | "created_at";
+
+export type AdminOAuthClientFilterSelections =
+  DataTableFilterSelections<AdminOAuthClientFilterKey>;
+export type AdminOAuthClientFilterValueType = DataTableFilterValueType;
+export type AdminOAuthClientFilterOperator = DataTableFilterOperator;
+export type AdminOAuthClientFilterOption = DataTableFilterOption;
+export type AdminOAuthClientFilterField =
+  DataTableFilterField<AdminOAuthClientFilterKey>;
+
+export type AdminOAuthClientSearchFieldKey =
+  | "client"
+  | "client_type"
+  | "created_by"
+  | "allowed_scopes";
+
+export type AdminOAuthClientSearchField =
+  DataTableSearchField<AdminOAuthClientSearchFieldKey>;
+export type AdminOAuthClientSearchFilter =
+  DataTableSearchGroup<AdminOAuthClientSearchFieldKey>;
+
+export interface AdminOAuthClientFilterOptions {
+  readonly client_types: readonly AdminOAuthClientTypeFilter[];
+  readonly creator_types: readonly AdminOAuthClientCreatorType[];
+  readonly broker_filters: readonly AdminOAuthClientBrokerFilter[];
+  readonly statuses: readonly boolean[];
+  readonly allowed_scopes: readonly string[];
+  readonly sorts: readonly AdminOAuthClientSort[];
+  /** Optional while older backend instances remain in a rolling deployment. */
+  readonly fields?: readonly AdminOAuthClientFilterField[];
+  /** Optional while older backend instances remain in a rolling deployment. */
+  readonly search_fields?: readonly AdminOAuthClientSearchField[];
+}
+
 export interface AdminOAuthClientListResponse {
   readonly clients: readonly AdminOAuthClient[];
+  readonly total: number;
+  readonly page: number;
+  readonly per_page: number;
+  readonly filter_options: AdminOAuthClientFilterOptions;
+}
+
+export interface AdminOAuthClientListParams {
+  readonly page: number;
+  readonly per_page: 25 | 50 | 100;
+  readonly search?: string;
+  readonly search_filters?: string;
+  readonly client_type?: string;
+  readonly creator_type?: string;
+  readonly broker?: string;
+  readonly is_active?: boolean | string;
+  readonly scope?: string;
+  readonly created_dates?: string;
+  readonly created_from?: string;
+  readonly created_to?: string;
+  readonly sort: AdminOAuthClientSort;
+}
+
+export interface AdminOAuthClientSearchState {
+  readonly page?: number;
+  readonly per_page?: 25 | 50 | 100;
+  readonly search?: string;
+  readonly search_filters?: string;
+  readonly client_type?: string;
+  readonly creator_type?: string;
+  readonly broker?: string;
+  readonly is_active?: boolean | string;
+  readonly scope?: string;
+  readonly created_dates?: string;
+  readonly created_from?: string;
+  readonly created_to?: string;
+  readonly sort?: AdminOAuthClientSort;
 }
 
 export interface UpdateAdminOAuthClientRequest {

--- a/frontend/src/types/data-table.ts
+++ b/frontend/src/types/data-table.ts
@@ -1,0 +1,42 @@
+export interface DataTableSearchField<Key extends string> {
+  readonly key: Key;
+  readonly label: string;
+}
+
+export interface DataTableSearchGroup<Key extends string> {
+  readonly field: Key;
+  readonly values: readonly string[];
+}
+
+export type DataTableFilterValueType = "enum" | "boolean" | "date";
+export type DataTableFilterOperator = "is" | "includes" | "between";
+
+export interface DataTableFilterOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+export interface DataTableFilterField<Key extends string> {
+  readonly key: Key;
+  readonly label: string;
+  readonly value_type: DataTableFilterValueType;
+  readonly operator: DataTableFilterOperator;
+  readonly multiple?: boolean;
+  readonly options: readonly DataTableFilterOption[];
+  readonly max_values?: number;
+  readonly date_modes?: readonly ("dates" | "range")[];
+}
+
+export type DataTableFilterSelections<Key extends string> = Partial<
+  Record<Key, readonly string[]>
+>;
+
+export interface AppliedDataTableFilter<Key extends string> {
+  readonly field: DataTableFilterField<Key>;
+  readonly values: readonly string[];
+  readonly valueLabels: readonly string[];
+  readonly operatorLabel?: string;
+  readonly valueSummary?: string;
+}
+
+export type DataTableSearchApplyMode = "submit" | "blur";


### PR DESCRIPTION
## Summary

- add server-side pagination, allowlisted sorting, scoped search, multi-value filters, exact-date/range filtering, and supporting MongoDB indexes for the admin OAuth-client table
- add reusable, typed frontend data-table search/filter/chip controls while keeping OAuth query encoding in a domain adapter
- add column drag/reorder/freeze interactions, contained horizontal scrolling, clearer status/broker presentation, compact scope summaries, and cohesive table controls

## Compatibility

- preserve the existing no-query GET /api/v1/admin/oauth-clients contract: all rows, created_at descending, and exact top-level response shape { clients: [...] }
- opt into the paginated response only when a recognized table query parameter is supplied; unknown parameters retain legacy behavior
- keep client-secret omission and admin/operator authorization unchanged

## Verification

- frontend: 150 test files and 1,650 tests passed
- frontend lint and both production builds passed
- frontend line coverage: 50.32 percent
- backend: 4,617 tests passed, including database-backed legacy and paginated response tests
- cargo fmt, workspace/package Clippy with warnings denied, RCI backend boundary check, and git diff check passed
- live local API: 65-row legacy shape, 25-row paginated shape, unknown-query fallback, scoped search, exact multi-date filtering, and localhost CORS verified