### PR TITLE
feat(admin): persist the OAuth table column layout

### DIFF
--- a/frontend/src/lib/data-table-preferences.test.ts
+++ b/frontend/src/lib/data-table-preferences.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isDefaultColumnLayout,
+  loadColumnPreferences,
+  sanitizeColumnPreferences,
+  saveColumnPreferences,
+  type DataTableColumnPreferences,
+} from "./data-table-preferences";
+
+type Field = "name" | "type" | "created";
+
+const BOUNDS = { min: 96, max: 640 };
+
+const DEFAULTS: DataTableColumnPreferences<Field> = {
+  order: ["name", "type", "created"],
+  frozenThrough: null,
+  widths: { name: 260, type: 140, created: 190 },
+};
+
+const KEY = "nyxid.table.test.columns.v1";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("sanitizeColumnPreferences", () => {
+  it("keeps a valid stored layout", () => {
+    expect(
+      sanitizeColumnPreferences(
+        {
+          order: ["type", "name", "created"],
+          frozenThrough: "name",
+          widths: { name: 320, type: 140, created: 190 },
+        },
+        DEFAULTS,
+        BOUNDS,
+      ),
+    ).toEqual({
+      order: ["type", "name", "created"],
+      frozenThrough: "name",
+      widths: { name: 320, type: 140, created: 190 },
+    });
+  });
+
+  it("falls back to the defaults for anything that is not a layout", () => {
+    for (const raw of [null, undefined, 7, "{}", [], true]) {
+      expect(sanitizeColumnPreferences(raw, DEFAULTS, BOUNDS)).toEqual(
+        DEFAULTS,
+      );
+    }
+  });
+
+  it("drops columns it no longer knows and re-adds ones it never saw", () => {
+    // Written by an older build: `type` did not exist yet, `legacy` since gone.
+    const sanitized = sanitizeColumnPreferences(
+      { order: ["created", "legacy", "name"], frozenThrough: "legacy" },
+      DEFAULTS,
+      BOUNDS,
+    );
+
+    expect(sanitized.order).toEqual(["created", "name", "type"]);
+    // A freeze point that survived only as a dropped column must not stick.
+    expect(sanitized.frozenThrough).toBeNull();
+  });
+
+  it("ignores duplicate columns in a stored order", () => {
+    expect(
+      sanitizeColumnPreferences(
+        { order: ["name", "name", "type"] },
+        DEFAULTS,
+        BOUNDS,
+      ).order,
+    ).toEqual(["name", "type", "created"]);
+  });
+
+  it("rejects widths outside the current bounds instead of clamping them", () => {
+    const sanitized = sanitizeColumnPreferences(
+      { widths: { name: 5000, type: 1, created: 240.6 } },
+      DEFAULTS,
+      BOUNDS,
+    );
+
+    // Out-of-bounds values came from different rules, so the default is the
+    // honest answer -- clamping would silently invent a width the user never set.
+    expect(sanitized.widths).toEqual({ name: 260, type: 140, created: 241 });
+  });
+
+  it("ignores widths that are not finite numbers", () => {
+    expect(
+      sanitizeColumnPreferences(
+        { widths: { name: "320", type: Number.NaN, created: null } },
+        DEFAULTS,
+        BOUNDS,
+      ).widths,
+    ).toEqual(DEFAULTS.widths);
+  });
+});
+
+describe("load / save", () => {
+  it("round-trips a layout through storage", () => {
+    const layout: DataTableColumnPreferences<Field> = {
+      order: ["type", "name", "created"],
+      frozenThrough: "type",
+      widths: { name: 300, type: 140, created: 190 },
+    };
+
+    saveColumnPreferences(KEY, layout, DEFAULTS);
+    expect(loadColumnPreferences(KEY, DEFAULTS, BOUNDS)).toEqual(layout);
+  });
+
+  it("clears the row once the table is back to its defaults", () => {
+    saveColumnPreferences(
+      KEY,
+      { ...DEFAULTS, frozenThrough: "name" },
+      DEFAULTS,
+    );
+    expect(localStorage.getItem(KEY)).not.toBeNull();
+
+    saveColumnPreferences(KEY, DEFAULTS, DEFAULTS);
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(loadColumnPreferences(KEY, DEFAULTS, BOUNDS)).toEqual(DEFAULTS);
+  });
+
+  it("returns the defaults for a corrupt row rather than throwing", () => {
+    localStorage.setItem(KEY, "{not json");
+    expect(loadColumnPreferences(KEY, DEFAULTS, BOUNDS)).toEqual(DEFAULTS);
+  });
+
+  it("survives storage being unavailable", () => {
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+    expect(loadColumnPreferences(KEY, DEFAULTS, BOUNDS)).toEqual(DEFAULTS);
+    expect(() => {
+      saveColumnPreferences(
+        KEY,
+        { ...DEFAULTS, frozenThrough: "name" },
+        DEFAULTS,
+      );
+    }).not.toThrow();
+
+    getItem.mockRestore();
+    setItem.mockRestore();
+  });
+});
+
+describe("isDefaultColumnLayout", () => {
+  it("detects each way a layout can differ", () => {
+    expect(isDefaultColumnLayout(DEFAULTS, DEFAULTS)).toBe(true);
+    expect(
+      isDefaultColumnLayout({ ...DEFAULTS, frozenThrough: "name" }, DEFAULTS),
+    ).toBe(false);
+    expect(
+      isDefaultColumnLayout(
+        { ...DEFAULTS, order: ["type", "name", "created"] },
+        DEFAULTS,
+      ),
+    ).toBe(false);
+    expect(
+      isDefaultColumnLayout(
+        { ...DEFAULTS, widths: { ...DEFAULTS.widths, name: 300 } },
+        DEFAULTS,
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/data-table-preferences.ts
+++ b/frontend/src/lib/data-table-preferences.ts
@@ -1,0 +1,134 @@
+/**
+ * Per-table column layout (order, freeze point, widths) persisted to
+ * localStorage so a user's arrangement survives a reload.
+ *
+ * Everything read back is sanitized against the table's current columns: the
+ * stored payload outlives the code that wrote it, so a column that has since
+ * been renamed, added, or removed -- or a width from an older set of bounds,
+ * or a hand-edited value -- must degrade to the default rather than render a
+ * broken table.
+ */
+
+export interface DataTableColumnPreferences<Field extends string> {
+  readonly order: readonly Field[];
+  readonly frozenThrough: Field | null;
+  readonly widths: Readonly<Record<Field, number>>;
+}
+
+export interface ColumnWidthBounds {
+  readonly min: number;
+  readonly max: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reconcile a stored order with the columns that exist now: keep the stored
+ * positions of the columns we still know and drop the ones we don't. A column
+ * the stored payload never saw goes to the end -- the user has never placed it,
+ * and dropping it into its default index would push it between two columns they
+ * did place.
+ */
+function sanitizeOrder<Field extends string>(
+  raw: unknown,
+  defaults: readonly Field[],
+): readonly Field[] {
+  if (!Array.isArray(raw)) return defaults;
+  const known = new Set<Field>(defaults);
+  const order: Field[] = [];
+  for (const field of raw) {
+    if (typeof field !== "string") continue;
+    const candidate = field as Field;
+    if (!known.has(candidate) || order.includes(candidate)) continue;
+    order.push(candidate);
+  }
+  if (order.length === 0) return defaults;
+  return [...order, ...defaults.filter((field) => !order.includes(field))];
+}
+
+function sanitizeWidths<Field extends string>(
+  raw: unknown,
+  defaults: Readonly<Record<Field, number>>,
+  bounds: ColumnWidthBounds,
+): Readonly<Record<Field, number>> {
+  if (!isRecord(raw)) return defaults;
+  const widths: Record<string, number> = { ...defaults };
+  for (const field of Object.keys(defaults)) {
+    const width = raw[field];
+    if (typeof width !== "number" || !Number.isFinite(width)) continue;
+    if (width < bounds.min || width > bounds.max) continue;
+    widths[field] = Math.round(width);
+  }
+  return widths as Record<Field, number>;
+}
+
+export function sanitizeColumnPreferences<Field extends string>(
+  raw: unknown,
+  defaults: DataTableColumnPreferences<Field>,
+  bounds: ColumnWidthBounds,
+): DataTableColumnPreferences<Field> {
+  if (!isRecord(raw)) return defaults;
+  const order = sanitizeOrder(raw.order, defaults.order);
+  const frozenThrough =
+    typeof raw.frozenThrough === "string" &&
+    order.includes(raw.frozenThrough as Field)
+      ? (raw.frozenThrough as Field)
+      : null;
+  return {
+    order,
+    frozenThrough,
+    widths: sanitizeWidths(raw.widths, defaults.widths, bounds),
+  };
+}
+
+export function loadColumnPreferences<Field extends string>(
+  key: string,
+  defaults: DataTableColumnPreferences<Field>,
+  bounds: ColumnWidthBounds,
+): DataTableColumnPreferences<Field> {
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (!stored) return defaults;
+    return sanitizeColumnPreferences(JSON.parse(stored), defaults, bounds);
+  } catch {
+    // Corrupt JSON, or storage unavailable (private mode, blocked cookies).
+    return defaults;
+  }
+}
+
+export function saveColumnPreferences<Field extends string>(
+  key: string,
+  preferences: DataTableColumnPreferences<Field>,
+  defaults: DataTableColumnPreferences<Field>,
+): void {
+  try {
+    // Nothing to remember once the table is back to its defaults; clearing the
+    // row also means a future change to the defaults reaches existing users.
+    if (isDefaultColumnLayout(preferences, defaults)) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+    window.localStorage.setItem(key, JSON.stringify(preferences));
+  } catch {
+    // A layout preference is never worth failing a render over.
+  }
+}
+
+export function isDefaultColumnLayout<Field extends string>(
+  preferences: DataTableColumnPreferences<Field>,
+  defaults: DataTableColumnPreferences<Field>,
+): boolean {
+  return (
+    preferences.frozenThrough === defaults.frozenThrough &&
+    preferences.order.length === defaults.order.length &&
+    preferences.order.every(
+      (field, index) => field === defaults.order[index],
+    ) &&
+    Object.keys(defaults.widths).every(
+      (field) =>
+        preferences.widths[field as Field] === defaults.widths[field as Field],
+    )
+  );
+}

--- a/frontend/src/pages/admin-oauth-clients.test.tsx
+++ b/frontend/src/pages/admin-oauth-clients.test.tsx
@@ -246,6 +246,9 @@ function resolveLastNavigationSearch(previous: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The column layout persists, so a test that reorders or resizes would
+  // otherwise seed the layout of every test that runs after it.
+  localStorage.clear();
   for (const key of Object.keys(routeSearch)) delete routeSearch[key];
   mockUseAdminOAuthClients.mockReturnValue({
     data: clientsResponse,
@@ -1082,6 +1085,128 @@ describe("AdminOAuthClientsPage", () => {
     expect(
       stickyColumnLeft(["client_name", "client_type"], "client_type"),
     ).toBe("calc(var(--col-w-client_name))");
+  });
+
+  it("persists a resize, a reorder and a freeze across a remount", () => {
+    const { unmount } = render(<AdminOAuthClientsPage />);
+
+    const handle = screen.getByRole("separator", {
+      name: "Resize Client column",
+    });
+    fireEvent.pointerDown(handle, { button: 0, clientX: 260 });
+    fireEvent.pointerMove(window, { clientX: 340 });
+    fireEvent.pointerUp(window, { clientX: 340 });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Freeze columns through Type" }),
+    );
+    const clientGrip = screen.getByRole("button", {
+      name: "Move Client column",
+    });
+    clientGrip.focus();
+    fireEvent.keyDown(clientGrip, { key: "ArrowRight" });
+
+    expect(
+      JSON.parse(
+        localStorage.getItem("nyxid.table.admin-oauth-clients.columns.v1") ??
+          "{}",
+      ),
+    ).toMatchObject({
+      order: [
+        "client_type",
+        "client_name",
+        "created_by",
+        "broker",
+        "is_active",
+        "allowed_scopes",
+        "created_at",
+      ],
+      frozenThrough: "client_type",
+      widths: expect.objectContaining({ client_name: 340 }),
+    });
+
+    unmount();
+    render(<AdminOAuthClientsPage />);
+
+    const table = screen.getByRole("table");
+    expect(table.style.getPropertyValue("--col-w-client_name")).toBe("340px");
+    expect(
+      [...table.querySelectorAll("thead th")].map((th) =>
+        th.getAttribute("data-column"),
+      ),
+    ).toEqual([
+      "client_type",
+      "client_name",
+      "created_by",
+      "broker",
+      "is_active",
+      "allowed_scopes",
+      "created_at",
+    ]);
+    expect(screen.getByRole("columnheader", { name: "Type" })).toHaveAttribute(
+      "data-frozen-edge",
+      "true",
+    );
+  });
+
+  it("restores the defaults from the reset control and forgets the stored layout", () => {
+    render(<AdminOAuthClientsPage />);
+
+    expect(
+      screen.queryByRole("button", { name: /Reset columns/ }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Freeze columns through Type" }),
+    );
+    expect(
+      localStorage.getItem("nyxid.table.admin-oauth-clients.columns.v1"),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Reset columns/ }));
+
+    expect(
+      screen.getByRole("columnheader", { name: "Type" }),
+    ).not.toHaveAttribute("data-frozen");
+    expect(
+      screen.queryByRole("button", { name: /Reset columns/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      localStorage.getItem("nyxid.table.admin-oauth-clients.columns.v1"),
+    ).toBeNull();
+  });
+
+  it("ignores a stored layout that no longer matches the table", () => {
+    localStorage.setItem(
+      "nyxid.table.admin-oauth-clients.columns.v1",
+      JSON.stringify({
+        order: ["client_secret", "client_name"],
+        frozenThrough: "client_secret",
+        widths: { client_name: 9000 },
+      }),
+    );
+
+    render(<AdminOAuthClientsPage />);
+
+    const table = screen.getByRole("table");
+    // A column that no longer exists cannot survive as a freeze point, and a
+    // width from other bounds falls back rather than rendering a broken table.
+    expect(table.style.getPropertyValue("--col-w-client_name")).toBe("260px");
+    expect(
+      screen.getByRole("columnheader", { name: "Client" }),
+    ).not.toHaveAttribute("data-frozen");
+    expect(
+      [...table.querySelectorAll("thead th")].map((th) =>
+        th.getAttribute("data-column"),
+      ),
+    ).toEqual([
+      "client_name",
+      "client_type",
+      "created_by",
+      "broker",
+      "is_active",
+      "allowed_scopes",
+      "created_at",
+    ]);
   });
 
   it("sends a filter's custom text as a contains search beside its checked options", async () => {

--- a/frontend/src/pages/admin-oauth-clients.tsx
+++ b/frontend/src/pages/admin-oauth-clients.tsx
@@ -24,6 +24,7 @@ import type {
   UpdateBrokerSettingsRequest,
 } from "@/types/admin";
 import type { DataTableSearchApplyMode } from "@/types/data-table";
+import type { DataTableColumnPreferences } from "@/lib/data-table-preferences";
 import { useAuthStore } from "@/stores/auth-store";
 import { PageHeader } from "@/components/shared/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -110,6 +111,11 @@ import {
   stickyColumnLeft,
   sumOfColumnWidths,
 } from "@/lib/data-table-columns";
+import {
+  isDefaultColumnLayout,
+  loadColumnPreferences,
+  saveColumnPreferences,
+} from "@/lib/data-table-preferences";
 
 type ClientAction = {
   readonly client: AdminOAuthClient;
@@ -223,17 +229,18 @@ const DEFAULT_COLUMN_WIDTHS = Object.fromEntries(
   OAUTH_CLIENT_COLUMNS.map((column) => [column.field, column.defaultWidth]),
 ) as ColumnWidths;
 
-type ColumnPreferences = {
-  readonly order: readonly OAuthClientSortField[];
-  readonly frozenThrough: OAuthClientSortField | null;
-  readonly widths: ColumnWidths;
-};
+type ColumnPreferences = DataTableColumnPreferences<OAuthClientSortField>;
 
 const DEFAULT_COLUMN_PREFERENCES: ColumnPreferences = {
   order: DEFAULT_COLUMN_ORDER,
   frozenThrough: null,
   widths: DEFAULT_COLUMN_WIDTHS,
 };
+
+const COLUMN_WIDTH_BOUNDS = { min: MIN_COLUMN_WIDTH, max: MAX_COLUMN_WIDTH };
+
+/** Bump the version suffix when a change makes stored layouts unreadable. */
+const COLUMN_PREFERENCES_KEY = "nyxid.table.admin-oauth-clients.columns.v1";
 
 type ColumnDropTarget = {
   readonly field: OAuthClientSortField;
@@ -561,8 +568,12 @@ export function AdminOAuthClientsPage() {
   }) as AdminOAuthClientSearchState;
   const currentUser = useAuthStore((s) => s.user);
   const canWrite = canAdminWrite(currentUser);
-  const [columnPreferences, setColumnPreferences] = useState(
-    DEFAULT_COLUMN_PREFERENCES,
+  const [columnPreferences, setColumnPreferences] = useState(() =>
+    loadColumnPreferences(
+      COLUMN_PREFERENCES_KEY,
+      DEFAULT_COLUMN_PREFERENCES,
+      COLUMN_WIDTH_BOUNDS,
+    ),
   );
   const [draggingColumn, setDraggingColumn] =
     useState<OAuthClientSortField | null>(null);
@@ -1065,6 +1076,19 @@ export function AdminOAuthClientsPage() {
   // Drop a drag still in flight if the table unmounts under it.
   useEffect(() => () => detachResizeRef.current?.(), []);
 
+  useEffect(() => {
+    saveColumnPreferences(
+      COLUMN_PREFERENCES_KEY,
+      columnPreferences,
+      DEFAULT_COLUMN_PREFERENCES,
+    );
+  }, [columnPreferences]);
+
+  function resetColumnLayout() {
+    setColumnPreferences(DEFAULT_COLUMN_PREFERENCES);
+    setColumnAnnouncement("Column layout reset");
+  }
+
   function handleResizeKeyboard(
     field: OAuthClientSortField,
     key: "ArrowLeft" | "ArrowRight" | "Home",
@@ -1560,6 +1584,23 @@ export function AdminOAuthClientsPage() {
                 {String(total)} clients
               </p>
               <div className="flex flex-wrap items-center gap-2">
+                {!isDefaultColumnLayout(
+                  columnPreferences,
+                  DEFAULT_COLUMN_PREFERENCES,
+                ) && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={resetColumnLayout}
+                  >
+                    <RotateCcw
+                      className="mr-2 h-3.5 w-3.5"
+                      aria-hidden="true"
+                    />
+                    Reset columns
+                  </Button>
+                )}
                 <Select
                   value={String(listParams.per_page)}
                   disabled={isFetching}


### PR DESCRIPTION
Follow-up to #1143. **Stacked on `frozen-pane-line-grid-view`** — review/merge that one first; this diff is only the persistence work. Retarget to `main` once #1143 lands.

## Why

Column width, order and freeze point were in-memory only, so any arrangement you set up was gone on the next reload. That is fine for a transient sort, but a column layout is a preference — you set it once and expect it to be there.

## What

Persist the layout per table to `localStorage`.

The interesting half is reading it back, not writing it. The stored payload outlives the code that wrote it, so everything is sanitized against the columns that exist *now*:

- a column since **removed** is dropped, and cannot survive as a freeze point (a frozen-through pointing at a dead column would freeze nothing and strand the divider);
- a column it **never saw** is appended at the end rather than dropped into its default index, which would push a brand-new column between two the user deliberately placed;
- a width outside the **current bounds** falls back to the default instead of being clamped — clamping would silently invent a width nobody chose;
- **corrupt JSON or unavailable storage** (private mode, blocked cookies, quota) degrades to the defaults. A layout preference is never worth failing a render over.

Storing the layout also means a bad one is now *sticky*, so the footer grows a **Reset columns** control whenever the layout differs from the default. It restores the defaults and deletes the stored row — which also means a future change to the default widths reaches users who never customised anything.

The storage key is versioned (`nyxid.table.admin-oauth-clients.columns.v1`) and the module is generic, so the next table can reuse it.

## Testing

- `npm run test` — 1689 passed / 152 files. New unit tests cover the hostile-payload cases (unknown columns, duplicates, dead freeze point, out-of-bounds and non-finite widths, corrupt JSON, throwing storage); page tests cover round-tripping a resize + reorder + freeze across a remount, the reset control, and ignoring a stale layout.
- Added `localStorage.clear()` to the page suite's `beforeEach` — with the layout now persisted, a test that resizes would otherwise seed every test after it.
- Build and lint clean; wizard bundle regenerated for the CI freshness gate.
- Verified in a real browser against this branch's backend: resized Client to 340px and froze through Type, **hard-reloaded** — both came back — then Reset columns restored the defaults and cleared the stored row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)