### PR TITLE
Support in-place broker grant review

### DIFF
--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -88,6 +88,12 @@ pub enum AppError {
     #[error("Invalid target: {0}")]
     InvalidTarget(String),
 
+    #[error("Required service is not connected: {service_name} ({service_slug})")]
+    RequiredServiceNotConnected {
+        service_slug: String,
+        service_name: String,
+    },
+
     #[error("Role not found: {0}")]
     RoleNotFound(String),
 
@@ -411,7 +417,8 @@ impl AppError {
             | Self::InvalidDpopProof(_)
             | Self::InvalidRedirectUri
             | Self::InvalidScope(_)
-            | Self::InvalidTarget(_) => StatusCode::BAD_REQUEST,
+            | Self::InvalidTarget(_)
+            | Self::RequiredServiceNotConnected { .. } => StatusCode::BAD_REQUEST,
             Self::RoleNotFound(_) | Self::GroupNotFound(_) | Self::ConsentNotFound => {
                 StatusCode::NOT_FOUND
             }
@@ -542,6 +549,7 @@ impl AppError {
             Self::InvalidScope(_) => 3002,
             Self::InvalidTarget(_) => 3005,
             Self::InvalidDpopProof(_) => 3006,
+            Self::RequiredServiceNotConnected { .. } => 3007,
             Self::RoleNotFound(_) => 4000,
             Self::GroupNotFound(_) => 4001,
             Self::ConsentNotFound => 4002,
@@ -652,7 +660,7 @@ impl AppError {
             Self::PkceVerificationFailed | Self::InvalidRedirectUri => "invalid_grant",
             Self::InvalidDpopProof(_) => "invalid_dpop_proof",
             Self::InvalidScope(_) => "invalid_scope",
-            Self::InvalidTarget(_) => "invalid_target",
+            Self::InvalidTarget(_) | Self::RequiredServiceNotConnected { .. } => "invalid_target",
             Self::Unauthorized(_)
             | Self::AuthenticationFailed(_)
             | Self::ServiceAccountNotFound(_)
@@ -704,6 +712,7 @@ impl AppError {
             Self::InvalidRedirectUri => "invalid_redirect_uri",
             Self::InvalidScope(_) => "invalid_scope",
             Self::InvalidTarget(_) => "invalid_target",
+            Self::RequiredServiceNotConnected { .. } => "required_service_not_connected",
             Self::RoleNotFound(_) => "role_not_found",
             Self::GroupNotFound(_) => "group_not_found",
             Self::ConsentNotFound => "consent_not_found",

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -2411,6 +2411,7 @@ mod operator_route_tests {
                 code_challenge_method: None,
                 nonce: None,
                 external_subject: None,
+                binding_grant_id: None,
                 resource_uris: Vec::new(),
                 allowed_service_ids: Vec::new(),
                 allow_all_services: true,

--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -678,12 +678,8 @@ pub async fn authorize(
     let params = match resolve_pushed_authorize_params(&state, params).await {
         Ok(params) => params,
         Err(err) if is_browser_mode => {
-            let error_url = format!(
-                "{}/error?code={}&message={}",
-                state.config.frontend_url,
-                urlencoding::encode(err.error_key()),
-                urlencoding::encode(&err.to_string()),
-            );
+            let error_url =
+                build_frontend_authorization_error_url(&state.config.frontend_url, &err);
             return Ok(redirect_302(&error_url));
         }
         Err(err) => return Err(err),
@@ -726,12 +722,7 @@ pub async fn authorize(
                 error = %err,
                 "OAuth authorize failed, redirecting to error page"
             );
-            let error_url = format!(
-                "{}/error?code={}&message={}",
-                state.config.frontend_url,
-                urlencoding::encode(err.error_key()),
-                urlencoding::encode(&err.to_string()),
-            );
+            let error_url = build_frontend_authorization_error_url(&state.config.frontend_url, err);
             Ok(redirect_302(&error_url))
         }
         Err(err) => Err(err),
@@ -1407,6 +1398,29 @@ fn build_callback_error_url(params: &AuthorizeQuery, error: &str, description: &
     if let Some(ref state_param) = params.state {
         url.push_str(&format!("&state={}", urlencoding::encode(state_param)));
     }
+    url
+}
+
+fn build_frontend_authorization_error_url(frontend_url: &str, err: &AppError) -> String {
+    let mut url = format!(
+        "{}/error?code={}&message={}",
+        frontend_url.trim_end_matches('/'),
+        urlencoding::encode(err.error_key()),
+        urlencoding::encode(&err.to_string()),
+    );
+
+    if let AppError::RequiredServiceNotConnected {
+        service_slug,
+        service_name,
+    } = err
+    {
+        url.push_str(&format!(
+            "&service_slug={}&service_name={}",
+            urlencoding::encode(service_slug),
+            urlencoding::encode(service_name),
+        ));
+    }
+
     url
 }
 
@@ -3127,6 +3141,7 @@ mod tests {
     use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
     use mongodb::bson::doc;
     use serde::Serialize;
+    use sha2::{Digest, Sha256};
     use uuid::Uuid;
 
     use crate::crypto::jwt;
@@ -4330,6 +4345,187 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn broker_resource_flow_authorize_consent_code_and_binding_exchange_is_end_to_end() {
+        let Some(db) = connect_test_database("oauth_broker_resource_e2e").await else {
+            return;
+        };
+        let state = test_app_state(db.clone());
+        let client_id = "aevatar-broker-resource-e2e";
+        let user_id = Uuid::new_v4().to_string();
+        let scope = format!("openid profile offline_access proxy {BROKER_BINDING_SCOPE}");
+        let redirect_uri = "https://app.example/callback";
+        let verifier = "aevatar-nyxid-broker-resource-e2e-verifier-0123456789";
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(verifier.as_bytes()));
+        let external_subject = ExternalSubjectRef {
+            platform: "lark".to_string(),
+            tenant: Some("tenant-e2e".to_string()),
+            external_user_id: "sender-e2e".to_string(),
+        };
+
+        insert_person_user(&db, &user_id).await;
+        insert_public_client(&db, client_id, &scope).await;
+        let services = [
+            insert_user_service(&db, &user_id, "aevatar").await,
+            insert_user_service(&db, &user_id, "chrono-llm-public").await,
+            insert_user_service(&db, &user_id, "ornn-api").await,
+        ];
+        let resources = services
+            .iter()
+            .map(|service| resource_uri(&service.slug))
+            .collect::<Vec<_>>();
+        let service_ids = services
+            .iter()
+            .map(|service| service.id.clone())
+            .collect::<Vec<_>>();
+        let params = AuthorizeQuery {
+            response_type: "code".to_string(),
+            client_id: client_id.to_string(),
+            redirect_uri: redirect_uri.to_string(),
+            scope: Some(scope.clone()),
+            state: Some("aevatar-state-e2e".to_string()),
+            code_challenge: Some(challenge.clone()),
+            code_challenge_method: Some("S256".to_string()),
+            nonce: Some("nonce-e2e".to_string()),
+            external_subject_platform: Some(external_subject.platform.clone()),
+            external_subject_tenant: external_subject.tenant.clone(),
+            external_subject_external_user_id: Some(external_subject.external_user_id.clone()),
+            binding_grant_id: None,
+            prompt: Some("consent".to_string()),
+            request_uri: None,
+            resource: resources.clone(),
+        };
+
+        let consent_redirect = authorize_inner(
+            &state,
+            OptionalAuthUser(Some(crate::test_utils::test_auth_user(&user_id))),
+            &params,
+            true,
+            Some(&external_subject),
+        )
+        .await
+        .expect("authorize redirects to consent");
+        assert_eq!(consent_redirect.status(), StatusCode::FOUND);
+        let consent_url = consent_redirect
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .expect("consent redirect location");
+        let parsed_consent_url = url::Url::parse(consent_url).expect("parse consent URL");
+        let consent_request = parsed_consent_url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "consent_request").then(|| value.into_owned()))
+            .expect("signed consent request");
+        let required_ids = parsed_consent_url
+            .query_pairs()
+            .filter_map(|(key, value)| (key == "required_service_ids").then(|| value.into_owned()))
+            .collect::<Vec<_>>();
+        assert_eq!(required_ids, service_ids);
+
+        let code_redirect = authorize_decision(
+            State(state.clone()),
+            OptionalAuthUser(Some(crate::test_utils::test_auth_user(&user_id))),
+            TelemetryContext::default(),
+            Form(ConsentDecisionForm {
+                response_type: params.response_type.clone(),
+                client_id: params.client_id.clone(),
+                redirect_uri: params.redirect_uri.clone(),
+                scope: params.scope.clone(),
+                state: params.state.clone(),
+                code_challenge: params.code_challenge.clone(),
+                code_challenge_method: params.code_challenge_method.clone(),
+                nonce: params.nonce.clone(),
+                external_subject_platform: params.external_subject_platform.clone(),
+                external_subject_tenant: params.external_subject_tenant.clone(),
+                external_subject_external_user_id: params.external_subject_external_user_id.clone(),
+                binding_grant_id: None,
+                prompt: params.prompt.clone(),
+                allow_all_services: false,
+                allowed_service_ids: service_ids.clone(),
+                consent_request: Some(consent_request),
+                resource: resources.clone(),
+                decision: "allow".to_string(),
+            }),
+        )
+        .await
+        .expect("approve required resources");
+        assert_eq!(code_redirect.status(), StatusCode::FOUND);
+        let callback_url = code_redirect
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .expect("authorization code callback");
+        let code = url::Url::parse(callback_url)
+            .expect("parse callback URL")
+            .query_pairs()
+            .find_map(|(key, value)| (key == "code").then(|| value.into_owned()))
+            .expect("authorization code");
+
+        let Json(code_exchange) = token_inner(
+            &state,
+            &TelemetryContext::default(),
+            &HeaderMap::new(),
+            TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some(code),
+                redirect_uri: Some(redirect_uri.to_string()),
+                client_id: Some(client_id.to_string()),
+                client_secret: None,
+                code_verifier: Some(verifier.to_string()),
+                refresh_token: None,
+                subject_token: None,
+                subject_token_type: None,
+                scope: None,
+                provider: None,
+                resource: resources.clone(),
+            },
+        )
+        .await
+        .expect("exchange authorization code");
+        assert_eq!(
+            code_exchange.resource.as_deref(),
+            Some(resources.as_slice())
+        );
+        let binding_id = code_exchange.binding_id.expect("new binding id");
+
+        let Json(binding_exchange) = token_inner(
+            &state,
+            &TelemetryContext::default(),
+            &HeaderMap::new(),
+            TokenRequest {
+                grant_type: "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
+                code: None,
+                redirect_uri: None,
+                client_id: Some(client_id.to_string()),
+                client_secret: None,
+                code_verifier: None,
+                refresh_token: None,
+                subject_token: Some(binding_id),
+                subject_token_type: Some(
+                    oauth_broker_service::BROKER_SUBJECT_TOKEN_TYPE.to_string(),
+                ),
+                scope: Some("proxy".to_string()),
+                provider: None,
+                resource: resources.clone(),
+            },
+        )
+        .await
+        .expect("exchange binding");
+        let claims = jwt::verify_token(
+            &state.jwt_keys,
+            &state.config,
+            &binding_exchange.access_token,
+        )
+        .expect("verify binding access token");
+        assert_eq!(claims.resources.as_deref(), Some(resources.as_slice()));
+        assert_eq!(
+            claims.allowed_service_ids.as_deref(),
+            Some(service_ids.as_slice())
+        );
+        assert_eq!(claims.allow_all_services, Some(false));
+    }
+
+    #[tokio::test]
     async fn broker_authorization_code_strict_unpinned_reject_leaves_no_refresh_token() {
         let Some(db) = connect_test_database("oauth_broker_strict_unpinned_no_refresh").await
         else {
@@ -5252,5 +5448,35 @@ mod tests {
         );
         assert!(!none.contains("preselect_service_ids"));
         assert!(!none.contains("unmatched_defaults"));
+    }
+
+    #[test]
+    fn frontend_authorization_error_url_carries_actionable_service_identity() {
+        let url = build_frontend_authorization_error_url(
+            "https://app.example/",
+            &AppError::RequiredServiceNotConnected {
+                service_slug: "chrono-llm-public".to_string(),
+                service_name: "Chrono Public LLM".to_string(),
+            },
+        );
+        let parsed = url::Url::parse(&url).expect("parse frontend error URL");
+        let query = parsed
+            .query_pairs()
+            .into_owned()
+            .collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(parsed.path(), "/error");
+        assert_eq!(
+            query.get("code").map(String::as_str),
+            Some("required_service_not_connected")
+        );
+        assert_eq!(
+            query.get("service_slug").map(String::as_str),
+            Some("chrono-llm-public")
+        );
+        assert_eq!(
+            query.get("service_name").map(String::as_str),
+            Some("Chrono Public LLM")
+        );
     }
 }

--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -54,6 +54,10 @@ pub struct AuthorizeQuery {
     pub external_subject_platform: Option<String>,
     pub external_subject_tenant: Option<String>,
     pub external_subject_external_user_id: Option<String>,
+    /// SHA-256 identifier of an existing broker binding whose service grant
+    /// the authenticated owner is reviewing. The raw binding credential is
+    /// never sent through the browser.
+    pub binding_grant_id: Option<String>,
     /// OIDC prompt parameter: "none", "login", "consent", or space-separated combo.
     pub prompt: Option<String>,
     pub request_uri: Option<String>,
@@ -74,6 +78,7 @@ pub struct ConsentDecisionForm {
     pub external_subject_platform: Option<String>,
     pub external_subject_tenant: Option<String>,
     pub external_subject_external_user_id: Option<String>,
+    pub binding_grant_id: Option<String>,
     pub prompt: Option<String>,
     #[serde(default = "default_allow_all_services_form")]
     pub allow_all_services: bool,
@@ -127,6 +132,8 @@ pub struct TokenResponse {
     pub resource: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binding_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binding_updated: Option<bool>,
     /// RFC 8693: Indicates the type of the issued token (only for token exchange grant).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub issued_token_type: Option<String>,
@@ -262,6 +269,7 @@ pub struct PushedAuthorizationRequestForm {
     pub external_subject_platform: Option<String>,
     pub external_subject_tenant: Option<String>,
     pub external_subject_external_user_id: Option<String>,
+    pub binding_grant_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -304,6 +312,7 @@ struct ConsentRequestClaims {
     external_subject_platform: Option<String>,
     external_subject_tenant: Option<String>,
     external_subject_external_user_id: Option<String>,
+    binding_grant_id: Option<String>,
     prompt: Option<String>,
     resource: Vec<String>,
 }
@@ -489,6 +498,30 @@ fn consent_requires_prompt(
     })
 }
 
+async fn resolve_binding_grant_review(
+    state: &AppState,
+    params: &AuthorizeQuery,
+    user_id: &str,
+    external_subject: Option<&ExternalSubjectRef>,
+) -> AppResult<Option<oauth_broker_service::BindingGrantSnapshot>> {
+    let Some(binding_hash) = params.binding_grant_id.as_deref() else {
+        return Ok(None);
+    };
+    let external_subject = external_subject.ok_or_else(|| {
+        AppError::InvalidTarget("binding grant review requires an external subject".to_string())
+    })?;
+
+    oauth_broker_service::resolve_binding_grant(
+        &state.db,
+        &params.client_id,
+        user_id,
+        external_subject,
+        binding_hash,
+    )
+    .await
+    .map(Some)
+}
+
 fn params_from_consent_form(form: &ConsentDecisionForm) -> AuthorizeQuery {
     AuthorizeQuery {
         response_type: form.response_type.clone(),
@@ -502,6 +535,7 @@ fn params_from_consent_form(form: &ConsentDecisionForm) -> AuthorizeQuery {
         external_subject_platform: form.external_subject_platform.clone(),
         external_subject_tenant: form.external_subject_tenant.clone(),
         external_subject_external_user_id: form.external_subject_external_user_id.clone(),
+        binding_grant_id: form.binding_grant_id.clone(),
         prompt: form.prompt.clone(),
         resource: form.resource.clone(),
         request_uri: None,
@@ -539,6 +573,7 @@ fn sign_consent_request(
         external_subject_platform: params.external_subject_platform.clone(),
         external_subject_tenant: params.external_subject_tenant.clone(),
         external_subject_external_user_id: params.external_subject_external_user_id.clone(),
+        binding_grant_id: params.binding_grant_id.clone(),
         prompt: params.prompt.clone(),
         resource: params.resource.clone(),
     };
@@ -579,6 +614,7 @@ fn verify_consent_request(
         external_subject_platform: claims.external_subject_platform,
         external_subject_tenant: claims.external_subject_tenant,
         external_subject_external_user_id: claims.external_subject_external_user_id,
+        binding_grant_id: claims.binding_grant_id,
         prompt: claims.prompt,
         resource: claims.resource,
         request_uri: None,
@@ -734,7 +770,6 @@ pub async fn authorize_decision(
             .ok_or_else(|| AppError::BadRequest("Missing consent request".to_string()))?,
         &user_id_str,
     )?;
-
     let external_subject = validate_external_subject_params(
         params.external_subject_platform.as_deref(),
         params.external_subject_tenant.as_deref(),
@@ -756,6 +791,11 @@ pub async fn authorize_decision(
         return Err(AppError::BadRequest("Invalid consent decision".to_string()));
     }
 
+    // Re-resolve the reviewed binding after the consent round-trip. The
+    // signed consent request carries only its hash; current ownership and
+    // active grant state remain authoritative in the database.
+    resolve_binding_grant_review(&state, &params, &user_id_str, external_subject.as_ref()).await?;
+
     if !selected_resources_are_subset(&params.resource, &form.resource) {
         return Err(AppError::InvalidTarget(
             "selected resource was not in the original authorization request".to_string(),
@@ -765,7 +805,22 @@ pub async fn authorize_decision(
     let consent_allowed_service_ids = if form.allow_all_services {
         None
     } else {
-        let selected_service_ids = normalize_allowed_service_ids(form.allowed_service_ids);
+        let mut selected_service_ids = normalize_allowed_service_ids(form.allowed_service_ids);
+        let required_service_ids = oauth_resource_service::resolve_resource_service_ids_for_user(
+            &state.db,
+            &state.config,
+            &user_id_str,
+            &params.resource,
+        )
+        .await?;
+        for service_id in required_service_ids {
+            if !selected_service_ids
+                .iter()
+                .any(|selected| selected == &service_id)
+            {
+                selected_service_ids.push(service_id);
+            }
+        }
         validate_allowed_service_ids(&state.db, &user_id_str, &selected_service_ids).await?;
         Some(selected_service_ids)
     };
@@ -909,10 +964,13 @@ async fn authorize_inner(
                     non_empty_resources(&params.resource),
                 )
                 .await?;
+                let binding_grant =
+                    resolve_binding_grant_review(state, params, &user_id_str, external_subject)
+                        .await?;
 
-                let needs_consent =
-                    consent_requires_prompt(consent.as_ref(), resolved_resources.as_ref())
-                        || force_consent;
+                let needs_consent = binding_grant.is_some()
+                    || consent_requires_prompt(consent.as_ref(), resolved_resources.as_ref())
+                    || force_consent;
 
                 if needs_consent {
                     // prompt=none + needs consent → error, not redirect
@@ -925,8 +983,10 @@ async fn authorize_inner(
                         return Ok(redirect_302(&redirect_url));
                     }
 
-                    let default_service_hints =
+                    let mut default_service_hints =
                         resolve_app_default_service_hints(state, &client, &user_id_str).await?;
+                    default_service_hints
+                        .include_flow_grants(resolved_resources.as_ref(), binding_grant.as_ref());
                     let consent_url = build_consent_url(
                         &state.config.frontend_url,
                         params,
@@ -987,10 +1047,17 @@ async fn authorize_inner(
             non_empty_resources(&params.resource),
         )
         .await?;
+        let binding_grant =
+            resolve_binding_grant_review(state, params, &user_id_str, external_subject).await?;
 
-        if consent_requires_prompt(consent.as_ref(), resolved_resources.as_ref()) || force_consent {
-            let default_service_hints =
+        if binding_grant.is_some()
+            || consent_requires_prompt(consent.as_ref(), resolved_resources.as_ref())
+            || force_consent
+        {
+            let mut default_service_hints =
                 resolve_app_default_service_hints(state, &client, &user_id_str).await?;
+            default_service_hints
+                .include_flow_grants(resolved_resources.as_ref(), binding_grant.as_ref());
             let consent_url = build_consent_url(
                 &state.config.frontend_url,
                 params,
@@ -1190,6 +1257,7 @@ fn has_non_par_authorize_params(params: &AuthorizeQuery) -> bool {
         || params.external_subject_platform.is_some()
         || params.external_subject_tenant.is_some()
         || params.external_subject_external_user_id.is_some()
+        || params.binding_grant_id.is_some()
         || params.prompt.is_some()
         || !params.resource.is_empty()
 }
@@ -1235,6 +1303,7 @@ async fn resolve_pushed_authorize_params(
         external_subject_platform,
         external_subject_tenant,
         external_subject_external_user_id,
+        binding_grant_id: record.binding_grant_id,
         prompt: record.prompt,
         resource: record.resources,
         request_uri: None,
@@ -1301,6 +1370,12 @@ fn build_authorize_url(base_url: &str, params: &AuthorizeQuery) -> String {
         url.push_str(&format!(
             "&external_subject_external_user_id={}",
             urlencoding::encode(external_user_id)
+        ));
+    }
+    if let Some(ref binding_grant_id) = params.binding_grant_id {
+        url.push_str(&format!(
+            "&binding_grant_id={}",
+            urlencoding::encode(binding_grant_id)
         ));
     }
     if let Some(ref prompt) = params.prompt {
@@ -1377,6 +1452,30 @@ struct AppDefaultServiceHints {
     /// Human-readable names of declared catalog services the user has no
     /// matching service for -- shown as unmatched on the consent screen.
     unmatched_names: Vec<String>,
+    /// Services resolved from RFC 8707 resource parameters. These are required
+    /// by the app and cannot be removed independently of denying the request.
+    required_service_ids: Vec<String>,
+    /// Service grant currently held by the reviewed broker binding.
+    current_binding_service_ids: Vec<String>,
+    current_binding_allow_all_services: bool,
+    binding_review: bool,
+}
+
+impl AppDefaultServiceHints {
+    fn include_flow_grants(
+        &mut self,
+        resolved_resources: Option<&oauth_resource_service::ResolvedOAuthResources>,
+        binding_grant: Option<&oauth_broker_service::BindingGrantSnapshot>,
+    ) {
+        self.required_service_ids = resolved_resources
+            .map(|resolved| resolved.service_ids.clone())
+            .unwrap_or_default();
+        if let Some(binding_grant) = binding_grant {
+            self.binding_review = true;
+            self.current_binding_service_ids = binding_grant.allowed_service_ids.clone();
+            self.current_binding_allow_all_services = binding_grant.allow_all_services;
+        }
+    }
 }
 
 /// Resolve `client.default_service_catalog_slugs` against the consenting
@@ -1439,6 +1538,7 @@ async fn resolve_app_default_service_hints(
     Ok(AppDefaultServiceHints {
         preselect_service_ids: user_services.into_iter().map(|s| s.id).collect(),
         unmatched_names,
+        ..AppDefaultServiceHints::default()
     })
 }
 
@@ -1500,6 +1600,12 @@ fn build_consent_url(
             urlencoding::encode(external_user_id)
         ));
     }
+    if let Some(ref binding_grant_id) = params.binding_grant_id {
+        url.push_str(&format!(
+            "&binding_grant_id={}",
+            urlencoding::encode(binding_grant_id)
+        ));
+    }
     if let Some(ref prompt) = params.prompt {
         url.push_str(&format!("&prompt={}", urlencoding::encode(prompt)));
     }
@@ -1517,6 +1623,24 @@ fn build_consent_url(
             "&unmatched_defaults={}",
             urlencoding::encode(name)
         ));
+    }
+    for service_id in &default_service_hints.required_service_ids {
+        url.push_str(&format!(
+            "&required_service_ids={}",
+            urlencoding::encode(service_id)
+        ));
+    }
+    for service_id in &default_service_hints.current_binding_service_ids {
+        url.push_str(&format!(
+            "&current_binding_service_ids={}",
+            urlencoding::encode(service_id)
+        ));
+    }
+    if default_service_hints.current_binding_allow_all_services {
+        url.push_str("&current_binding_allow_all_services=true");
+    }
+    if default_service_hints.binding_review {
+        url.push_str("&binding_review=true");
     }
     if let Some(consent_request) = consent_request {
         url.push_str(&format!(
@@ -1580,6 +1704,7 @@ async fn issue_authorization_code(
         params.code_challenge_method.as_deref(),
         params.nonce.as_deref(),
         external_subject,
+        params.binding_grant_id.as_deref(),
         &resource_uris,
         &allowed_service_ids,
         // AuthorizationCode stores the allow-all flag, while this path
@@ -1669,6 +1794,14 @@ pub async fn pushed_authorization_request(
         body.external_subject_tenant.as_deref(),
         body.external_subject_external_user_id.as_deref(),
     )?;
+    if let Some(binding_grant_id) = body.binding_grant_id.as_deref() {
+        if external_subject.is_none() || !oauth_broker_service::is_binding_hash(binding_grant_id) {
+            return Err(AppError::InvalidTarget(
+                "binding grant review requires a valid external subject and binding hash"
+                    .to_string(),
+            ));
+        }
+    }
     for resource in &body.resource {
         oauth_resource_service::validate_resource_uri(resource)?;
     }
@@ -1686,6 +1819,7 @@ pub async fn pushed_authorization_request(
         body.prompt.as_deref(),
         &body.resource,
         external_subject,
+        body.binding_grant_id.as_deref(),
     )
     .await?;
 
@@ -1826,26 +1960,45 @@ async fn token_inner(
                         refresh_token_jti: exchanged.refresh_token_jti.clone(),
                     }
                 };
-                let (binding_id, _binding_hash) = oauth_broker_service::create_binding(
-                    &state.db,
-                    &state.encryption_keys,
-                    client_id_str,
-                    &exchanged.user_id,
-                    &binding_refresh.refresh_token,
-                    &binding_refresh.refresh_token_jti,
-                    &granted_scopes,
-                    exchanged.external_subject.as_ref(),
-                    sender_constraint.clone(),
-                    broker_require_sender_constraint,
-                )
-                .await?;
-
-                let binding_hash =
-                    crate::models::oauth_broker_binding::hash_binding_id(&binding_id);
+                let (binding_id, binding_hash, binding_updated) =
+                    if let Some(binding_hash) = exchanged.binding_grant_id.as_deref() {
+                        oauth_broker_service::update_binding_grant(
+                            &state.db,
+                            &state.encryption_keys,
+                            client_id_str,
+                            &exchanged.user_id,
+                            binding_hash,
+                            &binding_refresh.refresh_token,
+                            &binding_refresh.refresh_token_jti,
+                            &granted_scopes,
+                            exchanged.external_subject.as_ref(),
+                        )
+                        .await?;
+                        (None, binding_hash.to_string(), true)
+                    } else {
+                        let (binding_id, binding_hash) = oauth_broker_service::create_binding(
+                            &state.db,
+                            &state.encryption_keys,
+                            client_id_str,
+                            &exchanged.user_id,
+                            &binding_refresh.refresh_token,
+                            &binding_refresh.refresh_token_jti,
+                            &granted_scopes,
+                            exchanged.external_subject.as_ref(),
+                            sender_constraint.clone(),
+                            broker_require_sender_constraint,
+                        )
+                        .await?;
+                        (Some(binding_id), binding_hash, false)
+                    };
                 audit_service::log_async(
                     state.db.clone(),
                     Some(exchanged.user_id.clone()),
-                    "oauth_broker_binding_issued".to_string(),
+                    if binding_updated {
+                        "oauth_broker_binding_grant_updated".to_string()
+                    } else {
+                        "oauth_broker_binding_issued".to_string()
+                    },
                     Some(serde_json::json!({
                         "client_id": client_id_str,
                         "binding_hash": oauth_broker_service::binding_hash_prefix(&binding_hash),
@@ -1872,7 +2025,8 @@ async fn token_inner(
                     id_token: exchanged.id_token,
                     scope: Some(exchanged.granted_scope),
                     resource: response_resources(exchanged.resource_uris),
-                    binding_id: Some(binding_id),
+                    binding_id,
+                    binding_updated: binding_updated.then_some(true),
                     issued_token_type: None,
                 }));
             }
@@ -1886,6 +2040,7 @@ async fn token_inner(
                 scope: Some(exchanged.granted_scope),
                 resource: response_resources(exchanged.resource_uris),
                 binding_id: None,
+                binding_updated: None,
                 issued_token_type: None,
             }))
         }
@@ -1913,6 +2068,7 @@ async fn token_inner(
                 scope: None,
                 resource: response_resources(tokens.resource_uris),
                 binding_id: None,
+                binding_updated: None,
                 issued_token_type: None,
             }))
         }
@@ -1981,6 +2137,7 @@ async fn token_inner(
                     scope: Some(result.scope),
                     resource: None,
                     binding_id: None,
+                    binding_updated: None,
                     issued_token_type: Some(
                         "urn:ietf:params:oauth:token-type:access_token".to_string(),
                     ),
@@ -2039,6 +2196,7 @@ async fn token_inner(
                     scope: Some(result.scope),
                     resource: None,
                     binding_id: None,
+                    binding_updated: None,
                     issued_token_type: Some(result.issued_token_type),
                 }))
             } else if subject_token_type == oauth_broker_service::BROKER_SUBJECT_TOKEN_TYPE {
@@ -2113,6 +2271,7 @@ async fn token_inner(
                     scope: Some(result.granted_scope),
                     resource: None,
                     binding_id: None,
+                    binding_updated: None,
                     issued_token_type: Some(result.issued_token_type),
                 }))
             } else {
@@ -2168,6 +2327,7 @@ async fn token_inner(
                         scope: Some(response.scope),
                         resource: None,
                         binding_id: None,
+                        binding_updated: None,
                         issued_token_type: None,
                     }))
                 }
@@ -3165,6 +3325,7 @@ mod tests {
                 code_challenge_method: None,
                 nonce: Some("nonce-1".to_string()),
                 external_subject: None,
+                binding_grant_id: None,
                 resource_uris: Vec::new(),
                 allowed_service_ids: Vec::new(),
                 allow_all_services: true,
@@ -3388,6 +3549,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: Vec::new(),
@@ -3448,6 +3610,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: vec![resource_uri("svc-b")],
@@ -3517,6 +3680,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: vec![resource_uri("svc-a")],
@@ -3586,6 +3750,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: Some("none".to_string()),
             request_uri: None,
             resource: vec![resource_uri("svc-b")],
@@ -3642,6 +3807,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: Vec::new(),
@@ -3698,6 +3864,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: Some("none".to_string()),
             request_uri: None,
             resource: Vec::new(),
@@ -3749,6 +3916,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: Vec::new(),
@@ -3802,6 +3970,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: vec![resource_uri("svc-a")],
@@ -3860,6 +4029,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: Vec::new(),
@@ -3883,6 +4053,7 @@ mod tests {
                 external_subject_platform: None,
                 external_subject_tenant: None,
                 external_subject_external_user_id: None,
+                binding_grant_id: None,
                 prompt: None,
                 allow_all_services: false,
                 allowed_service_ids: Vec::new(),
@@ -4657,6 +4828,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: vec![requested_resource],
@@ -4680,6 +4852,7 @@ mod tests {
                 external_subject_platform: None,
                 external_subject_tenant: None,
                 external_subject_external_user_id: None,
+                binding_grant_id: None,
                 prompt: None,
                 allow_all_services: true,
                 allowed_service_ids: Vec::new(),
@@ -5048,6 +5221,7 @@ mod tests {
             external_subject_platform: None,
             external_subject_tenant: None,
             external_subject_external_user_id: None,
+            binding_grant_id: None,
             prompt: None,
             request_uri: None,
             resource: vec![],
@@ -5055,6 +5229,7 @@ mod tests {
         let hints = AppDefaultServiceHints {
             preselect_service_ids: vec!["svc-1".to_string(), "svc-2".to_string()],
             unmatched_names: vec!["Lark Bot".to_string()],
+            ..AppDefaultServiceHints::default()
         };
         let url = build_consent_url(
             "https://app.example",

--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -1794,13 +1794,12 @@ pub async fn pushed_authorization_request(
         body.external_subject_tenant.as_deref(),
         body.external_subject_external_user_id.as_deref(),
     )?;
-    if let Some(binding_grant_id) = body.binding_grant_id.as_deref() {
-        if external_subject.is_none() || !oauth_broker_service::is_binding_hash(binding_grant_id) {
-            return Err(AppError::InvalidTarget(
-                "binding grant review requires a valid external subject and binding hash"
-                    .to_string(),
-            ));
-        }
+    if let Some(binding_grant_id) = body.binding_grant_id.as_deref()
+        && (external_subject.is_none() || !oauth_broker_service::is_binding_hash(binding_grant_id))
+    {
+        return Err(AppError::InvalidTarget(
+            "binding grant review requires a valid external subject and binding hash".to_string(),
+        ));
     }
     for resource in &body.resource {
         oauth_resource_service::validate_resource_uri(resource)?;

--- a/backend/src/models/authorization_code.rs
+++ b/backend/src/models/authorization_code.rs
@@ -27,6 +27,10 @@ pub struct AuthorizationCode {
     pub nonce: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_subject: Option<ExternalSubjectRef>,
+    /// Existing broker binding grant to update after this code is exchanged.
+    /// This is the SHA-256 binding identifier, never the raw binding credential.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_grant_id: Option<String>,
     #[serde(default)]
     pub resource_uris: Vec<String>,
     #[serde(default)]
@@ -132,6 +136,7 @@ mod tests {
                 tenant: Some("t1".to_string()),
                 external_user_id: "u1".to_string(),
             }),
+            binding_grant_id: Some("a".repeat(64)),
             resource_uris: vec!["https://nyx.example/api/v1/proxy/s/openai".to_string()],
             allowed_service_ids: vec!["svc-1".to_string()],
             allow_all_services: false,
@@ -145,6 +150,7 @@ mod tests {
         assert_eq!(code.scope, restored.scope);
         assert_eq!(code.code_challenge, restored.code_challenge);
         assert_eq!(code.external_subject, restored.external_subject);
+        assert_eq!(code.binding_grant_id, restored.binding_grant_id);
         assert_eq!(code.resource_uris, restored.resource_uris);
         assert_eq!(code.allowed_service_ids, restored.allowed_service_ids);
         assert_eq!(code.allow_all_services, restored.allow_all_services);
@@ -163,6 +169,7 @@ mod tests {
             code_challenge_method: None,
             nonce: None,
             external_subject: None,
+            binding_grant_id: None,
             resource_uris: Vec::new(),
             allowed_service_ids: Vec::new(),
             allow_all_services: true,

--- a/backend/src/models/pushed_authorization_request.rs
+++ b/backend/src/models/pushed_authorization_request.rs
@@ -38,6 +38,9 @@ pub struct PushedAuthorizationRequest {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_subject: Option<ExternalSubjectRef>,
+    /// Existing broker binding grant to review/update, identified by hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_grant_id: Option<String>,
     #[serde(default)]
     pub resources: Vec<String>,
 

--- a/backend/src/services/oauth_broker_service.rs
+++ b/backend/src/services/oauth_broker_service.rs
@@ -80,6 +80,77 @@ pub struct BindingExchangeResult {
 
 const MAX_BROKER_ROTATION_RETRIES: usize = 3;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BindingGrantSnapshot {
+    pub binding_hash: String,
+    pub allowed_service_ids: Vec<String>,
+    pub allow_all_services: bool,
+}
+
+pub fn is_binding_hash(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+/// Resolve the service grant currently held by one browser-reviewed broker
+/// binding. The hash is only an address: ownership is re-validated against the
+/// authenticated NyxID user, OAuth client, and exact external subject before
+/// any grant details are returned.
+pub async fn resolve_binding_grant(
+    db: &mongodb::Database,
+    client_id: &str,
+    user_id: &str,
+    external_subject: &ExternalSubjectRef,
+    binding_hash: &str,
+) -> AppResult<BindingGrantSnapshot> {
+    if !is_binding_hash(binding_hash) {
+        return Err(AppError::InvalidTarget(
+            "binding grant is unavailable for review".to_string(),
+        ));
+    }
+
+    let binding = db
+        .collection::<OauthBrokerBinding>(OAUTH_BROKER_BINDINGS)
+        .find_one(doc! {
+            "_id": binding_hash,
+            "client_id": client_id,
+            "user_id": user_id,
+            "revoked": false,
+        })
+        .await?
+        .ok_or_else(|| {
+            AppError::InvalidTarget("binding grant is unavailable for review".to_string())
+        })?;
+
+    if binding.external_subject.as_ref() != Some(external_subject) {
+        return Err(AppError::InvalidTarget(
+            "binding grant is unavailable for review".to_string(),
+        ));
+    }
+
+    let refresh = db
+        .collection::<RefreshToken>(REFRESH_TOKENS)
+        .find_one(doc! {
+            "jti": &binding.refresh_token_jti,
+            "client_id": client_id,
+            "user_id": user_id,
+            "revoked": false,
+        })
+        .await?
+        .filter(|token| token.expires_at > Utc::now())
+        .ok_or_else(|| {
+            AppError::InvalidTarget("binding grant is unavailable for review".to_string())
+        })?;
+
+    Ok(BindingGrantSnapshot {
+        binding_hash: binding.id,
+        allowed_service_ids: refresh.allowed_service_ids,
+        allow_all_services: refresh.allow_all_services,
+    })
+}
+
 /// Build persisted confirmation material from the sender proofs presented on a
 /// token request. DPoP takes precedence over mTLS, matching token minting.
 pub fn sender_constraint_from_proofs(
@@ -204,6 +275,124 @@ pub async fn create_binding(
         .await?;
 
     Ok((raw_binding_id, binding_hash))
+}
+
+/// Replace the service grant behind an existing binding while preserving its
+/// opaque raw binding credential. The update is optimistic against the active
+/// refresh-token pointer so concurrent broker exchanges either finish first or
+/// retry against the newly rotated binding state.
+#[allow(clippy::too_many_arguments)]
+pub async fn update_binding_grant(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    client_id: &str,
+    user_id: &str,
+    binding_hash: &str,
+    refresh_token: &str,
+    refresh_token_jti: &str,
+    scopes: &[String],
+    external_subject: Option<&ExternalSubjectRef>,
+) -> AppResult<()> {
+    if !is_binding_hash(binding_hash) {
+        return Err(AppError::InvalidTarget(
+            "binding grant is unavailable for update".to_string(),
+        ));
+    }
+
+    let replacement_refresh = db
+        .collection::<RefreshToken>(REFRESH_TOKENS)
+        .find_one(doc! {
+            "jti": refresh_token_jti,
+            "client_id": client_id,
+            "user_id": user_id,
+            "revoked": false,
+        })
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal("replacement refresh token was not persisted".to_string())
+        })?;
+    let encrypted_refresh = encryption_keys
+        .encrypt_with_aad(refresh_token.as_bytes(), binding_hash.as_bytes())
+        .await
+        .map_err(|error| AppError::Internal(format!("broker binding encrypt failed: {error}")))?;
+
+    for _ in 0..MAX_BROKER_ROTATION_RETRIES {
+        let binding = db
+            .collection::<OauthBrokerBinding>(OAUTH_BROKER_BINDINGS)
+            .find_one(doc! {
+                "_id": binding_hash,
+                "client_id": client_id,
+                "user_id": user_id,
+                "revoked": false,
+            })
+            .await?
+            .ok_or_else(|| {
+                AppError::InvalidTarget("binding grant is unavailable for update".to_string())
+            })?;
+
+        if binding.external_subject.as_ref() != external_subject {
+            return Err(AppError::InvalidTarget(
+                "binding grant is unavailable for update".to_string(),
+            ));
+        }
+        if binding.refresh_token_jti == refresh_token_jti {
+            return Ok(());
+        }
+
+        let previous_refresh_jti = binding.refresh_token_jti.clone();
+        let now = Utc::now();
+        let updated = db
+            .collection::<OauthBrokerBinding>(OAUTH_BROKER_BINDINGS)
+            .find_one_and_update(
+                doc! {
+                    "_id": binding_hash,
+                    "client_id": client_id,
+                    "user_id": user_id,
+                    "revoked": false,
+                    "refresh_token_jti": &previous_refresh_jti,
+                    "rotation_version": binding.rotation_version,
+                },
+                doc! { "$set": {
+                    "refresh_token_encrypted": Binary {
+                        subtype: BinarySubtype::Generic,
+                        bytes: encrypted_refresh.clone(),
+                    },
+                    "refresh_token_jti": refresh_token_jti,
+                    "scopes": scopes,
+                    "rotation_version": i64::from(binding.rotation_version) + 1,
+                }},
+            )
+            .await?;
+
+        if updated.is_none() {
+            continue;
+        }
+
+        db.collection::<RefreshToken>(REFRESH_TOKENS)
+            .update_one(
+                doc! { "jti": &previous_refresh_jti, "revoked": false },
+                doc! { "$set": {
+                    "revoked": true,
+                    "replaced_by": &replacement_refresh.id,
+                    "revoked_at": bson::DateTime::from_chrono(now),
+                }},
+            )
+            .await?;
+        return Ok(());
+    }
+
+    db.collection::<RefreshToken>(REFRESH_TOKENS)
+        .update_one(
+            doc! { "jti": refresh_token_jti, "revoked": false },
+            doc! { "$set": {
+                "revoked": true,
+                "revoked_at": bson::DateTime::from_chrono(Utc::now()),
+            }},
+        )
+        .await?;
+    Err(AppError::Conflict(
+        "binding grant changed while authorization was completing".to_string(),
+    ))
 }
 
 /// Fetch a binding's metadata for the owning client. Returns NotFound on
@@ -1269,6 +1458,27 @@ mod tests {
         refresh
     }
 
+    async fn insert_refresh_token_with_grant(
+        db: &mongodb::Database,
+        jti: &str,
+        client_id: &str,
+        user_id: &str,
+        allowed_service_ids: &[&str],
+        allow_all_services: bool,
+    ) -> RefreshToken {
+        let mut refresh = refresh_token_doc(jti, client_id, user_id, false);
+        refresh.allowed_service_ids = allowed_service_ids
+            .iter()
+            .map(|service_id| (*service_id).to_string())
+            .collect();
+        refresh.allow_all_services = allow_all_services;
+        db.collection::<RefreshToken>(REFRESH_TOKENS)
+            .insert_one(&refresh)
+            .await
+            .expect("insert refresh token with grant");
+        refresh
+    }
+
     async fn insert_refresh_token_jwt(
         db: &mongodb::Database,
         jwt_keys: &JwtKeys,
@@ -1556,6 +1766,338 @@ mod tests {
             .await
             .expect("decrypt refresh token");
         assert_eq!(decrypted, b"test-refresh-token-123");
+    }
+
+    #[tokio::test]
+    async fn resolve_binding_grant_returns_active_refresh_service_grant() {
+        let Some(db) = connect_test_database("broker_resolve_grant").await else {
+            return;
+        };
+        let encryption_keys = test_encryption_keys();
+        let raw_binding_id = generate_binding_id();
+        let binding_hash = hash_binding_id(&raw_binding_id);
+        let external_subject = ExternalSubjectRef {
+            platform: "lark".to_string(),
+            tenant: Some("tenant-1".to_string()),
+            external_user_id: "external-user-1".to_string(),
+        };
+
+        insert_refresh_token_with_grant(
+            &db,
+            "grant-current",
+            "client-1",
+            "user-1",
+            &["svc-a", "svc-b"],
+            false,
+        )
+        .await;
+        insert_binding_with_external_subject(
+            &db,
+            &encryption_keys,
+            BindingSeed {
+                raw_binding_id: &raw_binding_id,
+                client_id: "client-1",
+                user_id: "user-1",
+                refresh_token_jti: "grant-current",
+                refresh_token: "refresh-current",
+                scopes: vec!["openid".to_string(), "proxy".to_string()],
+                created_at: Utc::now(),
+                revoked: false,
+                revoke_reason: None,
+            },
+            Some(external_subject.clone()),
+        )
+        .await;
+
+        let snapshot =
+            resolve_binding_grant(&db, "client-1", "user-1", &external_subject, &binding_hash)
+                .await
+                .expect("resolve binding grant");
+
+        assert_eq!(snapshot.binding_hash, binding_hash);
+        assert_eq!(snapshot.allowed_service_ids, vec!["svc-a", "svc-b"]);
+        assert!(!snapshot.allow_all_services);
+    }
+
+    #[tokio::test]
+    async fn resolve_binding_grant_rejects_owner_client_and_external_subject_mismatches() {
+        let Some(db) = connect_test_database("broker_resolve_grant_owner").await else {
+            return;
+        };
+        let encryption_keys = test_encryption_keys();
+        let raw_binding_id = generate_binding_id();
+        let binding_hash = hash_binding_id(&raw_binding_id);
+        let external_subject = ExternalSubjectRef {
+            platform: "lark".to_string(),
+            tenant: Some("tenant-1".to_string()),
+            external_user_id: "external-user-1".to_string(),
+        };
+
+        insert_refresh_token_with_grant(
+            &db,
+            "grant-owned",
+            "client-1",
+            "user-1",
+            &["svc-a"],
+            false,
+        )
+        .await;
+        insert_binding_with_external_subject(
+            &db,
+            &encryption_keys,
+            BindingSeed {
+                raw_binding_id: &raw_binding_id,
+                client_id: "client-1",
+                user_id: "user-1",
+                refresh_token_jti: "grant-owned",
+                refresh_token: "refresh-owned",
+                scopes: vec!["openid".to_string()],
+                created_at: Utc::now(),
+                revoked: false,
+                revoke_reason: None,
+            },
+            Some(external_subject.clone()),
+        )
+        .await;
+
+        let wrong_client =
+            resolve_binding_grant(&db, "client-2", "user-1", &external_subject, &binding_hash)
+                .await;
+        let wrong_user =
+            resolve_binding_grant(&db, "client-1", "user-2", &external_subject, &binding_hash)
+                .await;
+        let wrong_subject = resolve_binding_grant(
+            &db,
+            "client-1",
+            "user-1",
+            &ExternalSubjectRef {
+                platform: "lark".to_string(),
+                tenant: Some("tenant-1".to_string()),
+                external_user_id: "external-user-2".to_string(),
+            },
+            &binding_hash,
+        )
+        .await;
+
+        assert!(matches!(wrong_client, Err(AppError::InvalidTarget(_))));
+        assert!(matches!(wrong_user, Err(AppError::InvalidTarget(_))));
+        assert!(matches!(wrong_subject, Err(AppError::InvalidTarget(_))));
+    }
+
+    #[tokio::test]
+    async fn update_binding_grant_rotates_refresh_in_place() {
+        let Some(db) = connect_test_database("broker_update_grant").await else {
+            return;
+        };
+        let encryption_keys = test_encryption_keys();
+        let raw_binding_id = generate_binding_id();
+        let binding_hash = hash_binding_id(&raw_binding_id);
+        let external_subject = ExternalSubjectRef {
+            platform: "lark".to_string(),
+            tenant: Some("tenant-1".to_string()),
+            external_user_id: "external-user-1".to_string(),
+        };
+
+        insert_refresh_token_with_grant(
+            &db,
+            "grant-old",
+            "client-1",
+            "user-1",
+            &["svc-old"],
+            false,
+        )
+        .await;
+        insert_binding_with_external_subject(
+            &db,
+            &encryption_keys,
+            BindingSeed {
+                raw_binding_id: &raw_binding_id,
+                client_id: "client-1",
+                user_id: "user-1",
+                refresh_token_jti: "grant-old",
+                refresh_token: "refresh-old",
+                scopes: vec!["openid".to_string()],
+                created_at: Utc::now(),
+                revoked: false,
+                revoke_reason: None,
+            },
+            Some(external_subject.clone()),
+        )
+        .await;
+        let replacement = insert_refresh_token_with_grant(
+            &db,
+            "grant-new",
+            "client-1",
+            "user-1",
+            &["svc-new", "svc-required"],
+            false,
+        )
+        .await;
+
+        update_binding_grant(
+            &db,
+            &encryption_keys,
+            "client-1",
+            "user-1",
+            &binding_hash,
+            "refresh-new",
+            "grant-new",
+            &["openid".to_string(), "proxy".to_string()],
+            Some(&external_subject),
+        )
+        .await
+        .expect("update binding grant");
+
+        let binding = load_binding(&db, &binding_hash).await;
+        assert_eq!(binding.id, binding_hash);
+        assert_eq!(binding.refresh_token_jti, "grant-new");
+        assert_eq!(binding.rotation_version, 1);
+        assert_eq!(binding.scopes, vec!["openid", "proxy"]);
+        let decrypted = encryption_keys
+            .decrypt_with_aad(
+                binding
+                    .refresh_token_encrypted
+                    .as_ref()
+                    .expect("encrypted replacement refresh token"),
+                binding.id.as_bytes(),
+            )
+            .await
+            .expect("decrypt replacement refresh token");
+        assert_eq!(decrypted, b"refresh-new");
+
+        let previous = load_refresh_by_jti(&db, "grant-old").await;
+        assert!(previous.revoked);
+        assert_eq!(
+            previous.replaced_by.as_deref(),
+            Some(replacement.id.as_str())
+        );
+        assert!(!load_refresh_by_jti(&db, "grant-new").await.revoked);
+
+        let snapshot =
+            resolve_binding_grant(&db, "client-1", "user-1", &external_subject, &binding.id)
+                .await
+                .expect("resolve updated grant");
+        assert_eq!(
+            snapshot.allowed_service_ids,
+            vec!["svc-new", "svc-required"]
+        );
+        assert!(!snapshot.allow_all_services);
+    }
+
+    #[tokio::test]
+    async fn concurrent_binding_grant_updates_preserve_one_active_refresh_chain() {
+        let Some(db) = connect_test_database("broker_update_grant_concurrent").await else {
+            return;
+        };
+        let encryption_keys = test_encryption_keys();
+        let raw_binding_id = generate_binding_id();
+        let binding_hash = hash_binding_id(&raw_binding_id);
+        let external_subject = ExternalSubjectRef {
+            platform: "lark".to_string(),
+            tenant: Some("tenant-1".to_string()),
+            external_user_id: "external-user-1".to_string(),
+        };
+
+        insert_refresh_token_with_grant(
+            &db,
+            "grant-base",
+            "client-1",
+            "user-1",
+            &["svc-base"],
+            false,
+        )
+        .await;
+        insert_binding_with_external_subject(
+            &db,
+            &encryption_keys,
+            BindingSeed {
+                raw_binding_id: &raw_binding_id,
+                client_id: "client-1",
+                user_id: "user-1",
+                refresh_token_jti: "grant-base",
+                refresh_token: "refresh-base",
+                scopes: vec!["openid".to_string()],
+                created_at: Utc::now(),
+                revoked: false,
+                revoke_reason: None,
+            },
+            Some(external_subject.clone()),
+        )
+        .await;
+        insert_refresh_token_with_grant(&db, "grant-a", "client-1", "user-1", &["svc-a"], false)
+            .await;
+        insert_refresh_token_with_grant(&db, "grant-b", "client-1", "user-1", &["svc-b"], false)
+            .await;
+        let scopes_a = vec!["openid".to_string(), "scope-a".to_string()];
+        let scopes_b = vec!["openid".to_string(), "scope-b".to_string()];
+
+        let (result_a, result_b) = tokio::join!(
+            update_binding_grant(
+                &db,
+                &encryption_keys,
+                "client-1",
+                "user-1",
+                &binding_hash,
+                "refresh-a",
+                "grant-a",
+                &scopes_a,
+                Some(&external_subject),
+            ),
+            update_binding_grant(
+                &db,
+                &encryption_keys,
+                "client-1",
+                "user-1",
+                &binding_hash,
+                "refresh-b",
+                "grant-b",
+                &scopes_b,
+                Some(&external_subject),
+            ),
+        );
+        result_a.expect("first concurrent grant update");
+        result_b.expect("second concurrent grant update");
+
+        let binding = load_binding(&db, &binding_hash).await;
+        assert_eq!(binding.rotation_version, 2);
+        assert!(binding.refresh_token_jti == "grant-a" || binding.refresh_token_jti == "grant-b");
+        let base = load_refresh_by_jti(&db, "grant-base").await;
+        let refresh_a = load_refresh_by_jti(&db, "grant-a").await;
+        let refresh_b = load_refresh_by_jti(&db, "grant-b").await;
+        assert!(base.revoked);
+        assert_eq!(
+            [refresh_a.revoked, refresh_b.revoked]
+                .into_iter()
+                .filter(|revoked| !revoked)
+                .count(),
+            1
+        );
+
+        let (expected_secret, expected_services) = if binding.refresh_token_jti == "grant-a" {
+            assert!(!refresh_a.revoked);
+            assert!(refresh_b.revoked);
+            (b"refresh-a".as_slice(), vec!["svc-a"])
+        } else {
+            assert!(refresh_a.revoked);
+            assert!(!refresh_b.revoked);
+            (b"refresh-b".as_slice(), vec!["svc-b"])
+        };
+        let decrypted = encryption_keys
+            .decrypt_with_aad(
+                binding
+                    .refresh_token_encrypted
+                    .as_ref()
+                    .expect("encrypted final refresh token"),
+                binding.id.as_bytes(),
+            )
+            .await
+            .expect("decrypt final refresh token");
+        assert_eq!(decrypted, expected_secret);
+        let snapshot =
+            resolve_binding_grant(&db, "client-1", "user-1", &external_subject, &binding.id)
+                .await
+                .expect("resolve concurrent winner");
+        assert_eq!(snapshot.allowed_service_ids, expected_services);
     }
 
     #[tokio::test]

--- a/backend/src/services/oauth_client_service.rs
+++ b/backend/src/services/oauth_client_service.rs
@@ -2984,6 +2984,7 @@ mod tests {
                     code_challenge_method: None,
                     nonce: None,
                     external_subject: None,
+                    binding_grant_id: None,
                     resource_uris: Vec::new(),
                     allowed_service_ids: Vec::new(),
                     allow_all_services: true,

--- a/backend/src/services/oauth_resource_service.rs
+++ b/backend/src/services/oauth_resource_service.rs
@@ -2,7 +2,7 @@ use crate::config::AppConfig;
 use crate::errors::{AppError, AppResult};
 use crate::models::org_membership::OrgMembership;
 use crate::models::user_service::UserService;
-use crate::services::{org_role_scope_service, org_service, user_service_service};
+use crate::services::{catalog_service, org_role_scope_service, org_service, user_service_service};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedOAuthResources {
@@ -271,7 +271,22 @@ async fn resolve_single_resource(
         return Ok(service);
     }
 
-    resolve_org_service_by_slug(db, actor_user_id, slug).await
+    match resolve_org_service_by_slug(db, actor_user_id, slug).await {
+        Ok(service) => Ok(service),
+        Err(AppError::InvalidTarget(_)) => {
+            match catalog_service::get_downstream_service_by_slug(db, slug, actor_user_id).await {
+                Ok(catalog_service) => Err(AppError::RequiredServiceNotConnected {
+                    service_slug: catalog_service.slug,
+                    service_name: catalog_service.name,
+                }),
+                Err(AppError::NotFound(_)) => Err(AppError::InvalidTarget(
+                    "resource is unknown or not owned by the user".to_string(),
+                )),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err),
+    }
 }
 
 async fn resolve_org_service_by_slug(
@@ -312,6 +327,7 @@ async fn resolve_org_service_by_slug(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     #[test]
     fn validates_absolute_resource_without_fragment() {
@@ -338,6 +354,44 @@ mod tests {
         assert!(matches!(
             filter_resource_narrowing(&expanded, &granted),
             Err(AppError::InvalidTarget(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn known_catalog_resource_without_user_service_is_actionable() {
+        let Some(db) = crate::test_utils::connect_test_database("oauth_missing_resource").await
+        else {
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db.clone());
+        let suffix = Uuid::new_v4().to_string();
+        let mut catalog = crate::models::downstream_service::test_helpers::dummy_service();
+        catalog.id = Uuid::new_v4().to_string();
+        catalog.slug = format!("required-{suffix}");
+        catalog.name = "Required Test Service".to_string();
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_one(&catalog)
+        .await
+        .expect("insert catalog service");
+
+        let resource = user_service_resource_uri(&state.config, &catalog.slug);
+        let error = resolve_requested_resources(
+            &db,
+            &state.config,
+            &Uuid::new_v4().to_string(),
+            Some(&[resource]),
+        )
+        .await
+        .expect_err("missing user service must stop authorization");
+
+        assert!(matches!(
+            error,
+            AppError::RequiredServiceNotConnected {
+                service_slug,
+                service_name,
+            } if service_slug == catalog.slug && service_name == catalog.name
         ));
     }
 }

--- a/backend/src/services/oauth_service.rs
+++ b/backend/src/services/oauth_service.rs
@@ -92,6 +92,7 @@ pub async fn create_authorization_code(
     code_challenge_method: Option<&str>,
     nonce: Option<&str>,
     external_subject: Option<&ExternalSubjectRef>,
+    binding_grant_id: Option<&str>,
     resource_uris: &[String],
     allowed_service_ids: &[String],
     allow_all_services: bool,
@@ -111,6 +112,7 @@ pub async fn create_authorization_code(
         code_challenge_method: code_challenge_method.map(String::from),
         nonce: nonce.map(String::from),
         external_subject: external_subject.cloned(),
+        binding_grant_id: binding_grant_id.map(String::from),
         resource_uris: resource_uris.to_vec(),
         allowed_service_ids: allowed_service_ids.to_vec(),
         allow_all_services,
@@ -195,6 +197,7 @@ pub struct ExchangedTokens {
     pub granted_scope: String,
     pub user_id: String,
     pub external_subject: Option<ExternalSubjectRef>,
+    pub binding_grant_id: Option<String>,
     pub broker_capability_enabled: bool,
     pub resource_uris: Vec<String>,
     // Populated by the token exchange for the granted per-service access, but not
@@ -482,6 +485,7 @@ pub async fn exchange_authorization_code(
         granted_scope,
         user_id: stored.user_id,
         external_subject: stored.external_subject,
+        binding_grant_id: stored.binding_grant_id,
         broker_capability_enabled,
         resource_uris: token_resource_scope.resource_uris,
         allowed_service_ids: token_resource_scope.allowed_service_ids,
@@ -728,6 +732,7 @@ mod tests {
             Some("S256"),
             Some("nonce-1"),
             Some(&external),
+            Some(&"a".repeat(64)),
             &["https://nyx.example/api/v1/proxy/s/openai".to_string()],
             &["svc-1".to_string()],
             false,
@@ -751,6 +756,7 @@ mod tests {
         assert_eq!(stored.code_challenge_method.as_deref(), Some("S256"));
         assert_eq!(stored.nonce.as_deref(), Some("nonce-1"));
         assert_eq!(stored.external_subject, Some(external));
+        assert_eq!(stored.binding_grant_id, Some("a".repeat(64)));
         assert_eq!(
             stored.resource_uris,
             vec!["https://nyx.example/api/v1/proxy/s/openai".to_string()]
@@ -784,6 +790,7 @@ mod tests {
                 code_challenge_method: None,
                 nonce: None,
                 external_subject: None,
+                binding_grant_id: None,
                 resource_uris: Vec::new(),
                 allowed_service_ids: Vec::new(),
                 allow_all_services: false,
@@ -882,6 +889,7 @@ mod tests {
                 code_challenge_method: None,
                 nonce: None,
                 external_subject: None,
+                binding_grant_id: None,
                 resource_uris: Vec::new(),
                 allowed_service_ids: vec![service_a_id.clone()],
                 allow_all_services: false,
@@ -983,6 +991,7 @@ mod tests {
                 code_challenge_method: None,
                 nonce: None,
                 external_subject: None,
+                binding_grant_id: None,
                 resource_uris: Vec::new(),
                 allowed_service_ids: vec![service_a_id],
                 allow_all_services: false,
@@ -1049,6 +1058,7 @@ mod tests {
                 code_challenge_method: None,
                 nonce: None,
                 external_subject: None,
+                binding_grant_id: None,
                 resource_uris: Vec::new(),
                 allowed_service_ids: Vec::new(),
                 allow_all_services: true,

--- a/backend/src/services/par_service.rs
+++ b/backend/src/services/par_service.rs
@@ -27,6 +27,7 @@ pub async fn create_request(
     prompt: Option<&str>,
     resources: &[String],
     external_subject: Option<ExternalSubjectRef>,
+    binding_grant_id: Option<&str>,
 ) -> AppResult<(String, i64)> {
     let request_uri = generate_request_uri();
     let id = hash_request_uri(&request_uri);
@@ -45,6 +46,7 @@ pub async fn create_request(
         nonce: nonce.map(String::from),
         prompt: prompt.map(String::from),
         external_subject,
+        binding_grant_id: binding_grant_id.map(String::from),
         resources: resources.to_vec(),
         expires_at,
         created_at: now,
@@ -96,6 +98,7 @@ mod tests {
             nonce: None,
             prompt: None,
             external_subject: None,
+            binding_grant_id: None,
             resources: Vec::new(),
             expires_at: now - Duration::seconds(1),
             created_at: now - Duration::seconds(PAR_TTL_SECS + 1),
@@ -124,6 +127,7 @@ mod tests {
             Some("nonce-1"),
             None,
             &[],
+            None,
             None,
         )
         .await
@@ -166,6 +170,7 @@ mod tests {
             Some("consent"),
             &["https://nyx.example/api/v1/proxy/s/openai".to_string()],
             Some(external_subject.clone()),
+            Some(&"a".repeat(64)),
         )
         .await
         .expect("create PAR");
@@ -187,6 +192,7 @@ mod tests {
             vec!["https://nyx.example/api/v1/proxy/s/openai".to_string()]
         );
         assert_eq!(record.external_subject, Some(external_subject));
+        assert_eq!(record.binding_grant_id, Some("a".repeat(64)));
     }
 
     #[tokio::test]
@@ -219,6 +225,7 @@ mod tests {
             None,
             &[],
             None,
+            None,
         )
         .await
         .expect("create PAR");
@@ -244,6 +251,7 @@ mod tests {
             None,
             None,
             &[],
+            None,
             None,
         )
         .await

--- a/docs/site/shared/concepts/oauth-oidc.md
+++ b/docs/site/shared/concepts/oauth-oidc.md
@@ -44,6 +44,14 @@ The flow:
 
 Redirect URI types supported: standard HTTPS URLs, loopback redirects (`http://127.0.0.1:*`, `http://localhost:*`), and private-use URI schemes (e.g. `cursor://`, `vscode://`).
 
+## Reviewing a broker binding's service access
+
+Broker-capable applications can let a signed-in user review the service grant behind an existing binding without replacing its opaque binding credential. The application starts a normal Authorization Code + PKCE request with `prompt=consent`, the required RFC 8707 `resource` values, the exact external subject, and `binding_grant_id=SHA-256(binding_id)`. The raw `binding_id` must never be placed in a browser-visible URL or form.
+
+NyxID accepts the review only when the binding belongs to the authenticated user, OAuth client, and exact external subject. The consent page then distinguishes services already authorized by the binding, services required by the application, and optional services the user can add or remove. Required resources cannot be deselected individually; the user can deny the whole request instead.
+
+When the user confirms the review, NyxID rotates the refresh grant behind the same binding with optimistic concurrency. The token response contains `binding_updated: true` and no replacement `binding_id`. This keeps the application's stored binding handle stable while NyxID remains the source of truth for service authorization.
+
 ## Token types
 
 All tokens are RS256-signed JWTs using a 4096-bit RSA key pair.

--- a/frontend/src/pages/oauth-consent.test.tsx
+++ b/frontend/src/pages/oauth-consent.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { vi } from "vitest";
@@ -303,24 +303,19 @@ describe("OAuthConsentPage", () => {
     );
   });
 
-  it("submits only the selected requested resources", () => {
+  it("keeps every requested resource backend-authoritative", () => {
     const resourceA = "https://nyx.example/api/v1/proxy/s/openai";
     const resourceB = "https://nyx.example/api/v1/proxy/s/anthropic";
     setSearch({ ...VALID, resource: [resourceA, resourceB] });
 
     render(<OAuthConsentPage />);
 
-    expect(hiddenInput("resource_selection_present")?.value).toBe("true");
     expect(hiddenInputs("resource").map((input) => input.value)).toEqual([
       resourceA,
       resourceB,
     ]);
-
-    fireEvent.click(screen.getByRole("checkbox", { name: resourceB }));
-
-    expect(hiddenInputs("resource").map((input) => input.value)).toEqual([
-      resourceA,
-    ]);
+    expect(screen.queryByRole("checkbox", { name: resourceA })).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: resourceB })).toBeNull();
   });
 
   it("renders an Unknown redirect host for an unparseable redirect_uri", () => {
@@ -486,5 +481,103 @@ describe("OAuthConsentPage", () => {
         "svc-openai",
       ]);
     });
+  });
+
+  it("opens a Lark binding review with the current service grant visible", () => {
+    setSearch({
+      ...VALID,
+      external_subject_platform: "lark",
+      external_subject_external_user_id: "ou-user-1",
+      binding_grant_id: "a".repeat(64),
+      binding_review: "true",
+      current_binding_service_ids: ["svc-openai"],
+    });
+
+    render(<OAuthConsentPage />);
+
+    expect(screen.getByText("Review Lark bot access")).toBeInTheDocument();
+    expect(screen.getByText("My OpenAI")).toBeInTheDocument();
+    expect(screen.getByText("Authorized now")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Update access" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(hiddenInput("binding_grant_id")?.value).toBe("a".repeat(64));
+    expect(
+      hiddenInputs("allowed_service_ids").map((input) => input.value),
+    ).toEqual(["svc-openai"]);
+  });
+
+  it("keeps app-required services selected and lets the user add optional access", async () => {
+    const user = userEvent.setup();
+    state.userServices.push(
+      {
+        id: "svc-ornn",
+        label: "Ornn Skills",
+        slug: "ornn-api",
+        catalog_service_name: "Ornn",
+        resource_uri: "https://nyx.example/api/v1/proxy/s/ornn-api",
+        auth_method: "bearer",
+        is_active: true,
+        credential_source: { type: "personal" },
+      },
+      {
+        id: "svc-optional",
+        label: "Optional Service",
+        slug: "optional-service",
+        catalog_service_name: null,
+        resource_uri: "https://nyx.example/api/v1/proxy/s/optional-service",
+        auth_method: "bearer",
+        is_active: true,
+        credential_source: { type: "personal" },
+      },
+    );
+    setSearch({
+      ...VALID,
+      external_subject_platform: "lark",
+      external_subject_external_user_id: "ou-user-1",
+      binding_grant_id: "b".repeat(64),
+      binding_review: "true",
+      current_binding_service_ids: ["svc-openai"],
+      required_service_ids: ["svc-openai", "svc-org", "svc-ornn"],
+    });
+
+    render(<OAuthConsentPage />);
+
+    for (const name of [/My OpenAI/i, /Org Service/i, /Ornn Skills/i]) {
+      const required = screen.getByRole("checkbox", { name });
+      expect(required).toBeChecked();
+      expect(required).toBeDisabled();
+    }
+
+    await user.click(
+      screen.getByRole("checkbox", { name: /Optional Service/i }),
+    );
+
+    expect(screen.getByText("New")).toBeInTheDocument();
+    expect(
+      hiddenInputs("allowed_service_ids").map((input) => input.value),
+    ).toEqual(["svc-openai", "svc-org", "svc-ornn", "svc-optional"]);
+  });
+
+  it("lets a binding review remove an optional current service", async () => {
+    const user = userEvent.setup();
+    setSearch({
+      ...VALID,
+      external_subject_platform: "lark",
+      external_subject_external_user_id: "ou-user-1",
+      binding_grant_id: "c".repeat(64),
+      binding_review: "true",
+      current_binding_service_ids: ["svc-org"],
+      required_service_ids: ["svc-openai"],
+    });
+
+    render(<OAuthConsentPage />);
+
+    await user.click(screen.getByRole("checkbox", { name: /Org Service/i }));
+
+    expect(
+      hiddenInputs("allowed_service_ids").map((input) => input.value),
+    ).toEqual(["svc-openai"]);
   });
 });

--- a/frontend/src/pages/oauth-consent.tsx
+++ b/frontend/src/pages/oauth-consent.tsx
@@ -68,10 +68,28 @@ export function OAuthConsentPage() {
   useApplyTheme();
   const { data: userServices, isLoading: userServicesLoading } =
     useUserServices();
-  // The consent page renders once per authorize redirect; the query string
-  // never changes within a mount, so URL-derived values are memoized to keep
-  // referential stability for the memos below.
-  const search = useMemo(() => new URLSearchParams(window.location.search), []);
+  // The consent page renders once per authorize redirect; capture every
+  // repeated query value in one immutable snapshot so downstream memos keep
+  // stable array identities across local state updates.
+  const [authorizeQuery] = useState(() => {
+    const search = new URLSearchParams(window.location.search);
+    return {
+      search,
+      resources: search.getAll("resource"),
+      preselectServiceIds: search.getAll("preselect_service_ids"),
+      unmatchedDefaults: search.getAll("unmatched_defaults"),
+      requiredServiceIds: search.getAll("required_service_ids"),
+      currentBindingServiceIds: search.getAll("current_binding_service_ids"),
+    };
+  });
+  const {
+    search,
+    resources,
+    preselectServiceIds,
+    unmatchedDefaults,
+    requiredServiceIds,
+    currentBindingServiceIds,
+  } = authorizeQuery;
 
   const responseType = readParam(search, "response_type");
   const clientId = readParam(search, "client_id");
@@ -89,26 +107,9 @@ export function OAuthConsentPage() {
     search.get("external_subject_external_user_id") ?? "";
   const bindingGrantId = search.get("binding_grant_id") ?? "";
   const consentRequest = search.get("consent_request") ?? "";
-  const resources = useMemo(() => search.getAll("resource"), [search]);
   // Server-resolved hints: the app's declared default services matched to
   // this user (pre-selected), and declared services the user has no match
   // for (informational only).
-  const preselectServiceIds = useMemo(
-    () => search.getAll("preselect_service_ids"),
-    [search],
-  );
-  const unmatchedDefaults = useMemo(
-    () => search.getAll("unmatched_defaults"),
-    [search],
-  );
-  const requiredServiceIds = useMemo(
-    () => search.getAll("required_service_ids"),
-    [search],
-  );
-  const currentBindingServiceIds = useMemo(
-    () => search.getAll("current_binding_service_ids"),
-    [search],
-  );
   const bindingReview =
     search.get("binding_review") === "true" && Boolean(bindingGrantId);
   const currentBindingAllowsAllServices =

--- a/frontend/src/pages/oauth-consent.tsx
+++ b/frontend/src/pages/oauth-consent.tsx
@@ -87,6 +87,7 @@ export function OAuthConsentPage() {
   const externalSubjectTenant = search.get("external_subject_tenant") ?? "";
   const externalSubjectExternalUserId =
     search.get("external_subject_external_user_id") ?? "";
+  const bindingGrantId = search.get("binding_grant_id") ?? "";
   const consentRequest = search.get("consent_request") ?? "";
   const resources = useMemo(() => search.getAll("resource"), [search]);
   // Server-resolved hints: the app's declared default services matched to
@@ -100,14 +101,37 @@ export function OAuthConsentPage() {
     () => search.getAll("unmatched_defaults"),
     [search],
   );
-  const [allowAllServices, setAllowAllServices] = useState(false);
-  const [customize, setCustomize] = useState(false);
-  const [selectedServiceIds, setSelectedServiceIds] =
-    useState<readonly string[]>(preselectServiceIds);
+  const requiredServiceIds = useMemo(
+    () => search.getAll("required_service_ids"),
+    [search],
+  );
+  const currentBindingServiceIds = useMemo(
+    () => search.getAll("current_binding_service_ids"),
+    [search],
+  );
+  const bindingReview =
+    search.get("binding_review") === "true" && Boolean(bindingGrantId);
+  const currentBindingAllowsAllServices =
+    search.get("current_binding_allow_all_services") === "true";
+  const isLarkBinding = externalSubjectPlatform.toLowerCase() === "lark";
+  const [allowAllServices, setAllowAllServices] = useState(
+    bindingReview && currentBindingAllowsAllServices,
+  );
+  const [customize, setCustomize] = useState(bindingReview);
+  const [selectedServiceIds, setSelectedServiceIds] = useState<
+    readonly string[]
+  >(() =>
+    Array.from(
+      new Set([
+        ...preselectServiceIds,
+        ...currentBindingServiceIds,
+        ...requiredServiceIds,
+      ]),
+    ),
+  );
   const [deselectedServiceIds, setDeselectedServiceIds] = useState<
     readonly string[]
   >([]);
-  const [selectedResources, setSelectedResources] = useState(resources);
 
   const missing =
     !responseType ||
@@ -141,17 +165,29 @@ export function OAuthConsentPage() {
     [userServices],
   );
   const resourceSelectedServiceIds = useMemo(() => {
-    const requested = new Set(selectedResources);
+    const requested = new Set(resources);
     return selectableServices
       .filter((service) => requested.has(service.resource_uri))
       .map((service) => service.id);
-  }, [selectableServices, selectedResources]);
+  }, [resources, selectableServices]);
   const effectiveSelectedServiceIds = useMemo(
     () =>
       Array.from(
-        new Set([...resourceSelectedServiceIds, ...selectedServiceIds]),
-      ).filter((id) => !deselectedServiceIds.includes(id)),
-    [deselectedServiceIds, resourceSelectedServiceIds, selectedServiceIds],
+        new Set([
+          ...requiredServiceIds,
+          ...resourceSelectedServiceIds,
+          ...selectedServiceIds,
+        ]),
+      ).filter(
+        (id) =>
+          requiredServiceIds.includes(id) || !deselectedServiceIds.includes(id),
+      ),
+    [
+      deselectedServiceIds,
+      requiredServiceIds,
+      resourceSelectedServiceIds,
+      selectedServiceIds,
+    ],
   );
   const serviceAccess = oauthConsentServiceAccessSchema.parse({
     allow_all_services: allowAllServices,
@@ -171,18 +207,34 @@ export function OAuthConsentPage() {
           orgName: service ? serviceOrgName(service) : null,
           requestedByApp:
             preselectServiceIds.includes(id) ||
-            resourceSelectedServiceIds.includes(id),
+            resourceSelectedServiceIds.includes(id) ||
+            requiredServiceIds.includes(id),
+          requiredByApp:
+            resourceSelectedServiceIds.includes(id) ||
+            requiredServiceIds.includes(id),
+          currentlyAuthorized:
+            currentBindingAllowsAllServices ||
+            currentBindingServiceIds.includes(id),
+          newlySelected:
+            bindingReview &&
+            !currentBindingAllowsAllServices &&
+            !currentBindingServiceIds.includes(id),
         };
       }),
     [
       effectiveSelectedServiceIds,
       preselectServiceIds,
+      requiredServiceIds,
       resourceSelectedServiceIds,
       selectableServices,
+      bindingReview,
+      currentBindingAllowsAllServices,
+      currentBindingServiceIds,
     ],
   );
 
   function toggleService(serviceId: string, checked: boolean) {
+    if (!checked && requiredServiceIds.includes(serviceId)) return;
     setSelectedServiceIds((current) => {
       if (checked) {
         return current.includes(serviceId) ? current : [...current, serviceId];
@@ -195,14 +247,6 @@ export function OAuthConsentPage() {
       }
       return current.includes(serviceId) ? current : [...current, serviceId];
     });
-  }
-
-  function toggleResource(resource: string) {
-    setSelectedResources((current) =>
-      current.includes(resource)
-        ? current.filter((item) => item !== resource)
-        : [...current, resource],
-    );
   }
 
   if (missing) {
@@ -240,10 +284,32 @@ export function OAuthConsentPage() {
           <div className="flex items-center">
             <NyxidLogo className="h-7 w-auto" />
           </div>
-          <CardTitle>Authorize Application</CardTitle>
+          <CardTitle>
+            {bindingReview
+              ? isLarkBinding
+                ? "Review Lark bot access"
+                : "Review application access"
+              : isLarkBinding
+                ? "Authorize Lark bot"
+                : "Authorize application"}
+          </CardTitle>
           <CardDescription>
-            <span className="font-medium text-foreground">{clientName}</span>{" "}
-            wants to access your account via OAuth.
+            {bindingReview ? (
+              <>
+                Review the NyxID services available to{" "}
+                <span className="font-medium text-foreground">
+                  {clientName}
+                </span>
+                .
+              </>
+            ) : (
+              <>
+                <span className="font-medium text-foreground">
+                  {clientName}
+                </span>{" "}
+                wants to access your account via OAuth.
+              </>
+            )}
           </CardDescription>
         </CardHeader>
 
@@ -279,32 +345,6 @@ export function OAuthConsentPage() {
               ))}
             </div>
           </div>
-
-          {resources.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-xs uppercase tracking-wide text-text-tertiary">
-                Requested resources
-              </p>
-              <div className="space-y-2">
-                {resources.map((resource) => (
-                  <label
-                    key={resource}
-                    className="flex items-start gap-3 rounded-lg border border-border bg-muted/50 px-3 py-2"
-                  >
-                    <Checkbox
-                      className="mt-0.5"
-                      aria-label={resource}
-                      checked={selectedResources.includes(resource)}
-                      onCheckedChange={() => toggleResource(resource)}
-                    />
-                    <p className="break-all text-xs text-foreground">
-                      {resource}
-                    </p>
-                  </label>
-                ))}
-              </div>
-            </div>
-          )}
 
           <div className="space-y-2">
             <p className="text-xs uppercase tracking-wide text-text-tertiary">
@@ -354,9 +394,13 @@ export function OAuthConsentPage() {
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   {serviceAccess.allow_all_services
-                    ? "This app will be able to use all of your available services through the proxy."
+                    ? bindingReview && currentBindingAllowsAllServices
+                      ? "This binding currently authorizes all available services."
+                      : "This app will be able to use all of your available services through the proxy."
                     : summaryServices.length > 0
-                      ? "This app will be able to use these services through the proxy:"
+                      ? bindingReview
+                        ? "Review the current grant and select any additional services."
+                        : "This app will be able to use these services through the proxy:"
                       : "No service access requested. This app only signs you in."}
                 </p>
               </div>
@@ -400,14 +444,29 @@ export function OAuthConsentPage() {
                           </div>
                         )}
                       </div>
-                      {item.requestedByApp && (
-                        <Badge
-                          variant="secondary"
-                          className="shrink-0 text-[10px]"
-                        >
-                          Requested by app
-                        </Badge>
-                      )}
+                      <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                        {item.currentlyAuthorized && bindingReview && (
+                          <Badge variant="secondary" className="text-[10px]">
+                            Authorized now
+                          </Badge>
+                        )}
+                        {item.requiredByApp ? (
+                          <Badge variant="secondary" className="text-[10px]">
+                            Required by app
+                          </Badge>
+                        ) : (
+                          item.requestedByApp && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              Requested by app
+                            </Badge>
+                          )
+                        )}
+                        {item.newlySelected && (
+                          <Badge variant="accent" className="text-[10px]">
+                            New
+                          </Badge>
+                        )}
+                      </div>
                     </div>
                   ))}
                   {unmatchedDefaults.map((name) => (
@@ -458,6 +517,7 @@ export function OAuthConsentPage() {
                               checked={effectiveSelectedServiceIds.includes(
                                 service.id,
                               )}
+                              disabled={requiredServiceIds.includes(service.id)}
                               onCheckedChange={(checked) =>
                                 toggleService(service.id, checked === true)
                               }
@@ -489,6 +549,44 @@ export function OAuthConsentPage() {
                                   </span>
                                 </div>
                               )}
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {bindingReview &&
+                                  (currentBindingAllowsAllServices ||
+                                    currentBindingServiceIds.includes(
+                                      service.id,
+                                    )) && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-[10px]"
+                                    >
+                                      Authorized now
+                                    </Badge>
+                                  )}
+                                {requiredServiceIds.includes(service.id) && (
+                                  <Badge
+                                    variant="secondary"
+                                    className="text-[10px]"
+                                  >
+                                    Required by app
+                                  </Badge>
+                                )}
+                                {bindingReview &&
+                                  effectiveSelectedServiceIds.includes(
+                                    service.id,
+                                  ) &&
+                                  !currentBindingAllowsAllServices &&
+                                  !currentBindingServiceIds.includes(
+                                    service.id,
+                                  ) &&
+                                  !requiredServiceIds.includes(service.id) && (
+                                    <Badge
+                                      variant="accent"
+                                      className="text-[10px]"
+                                    >
+                                      New
+                                    </Badge>
+                                  )}
+                              </div>
                             </div>
                           </div>
                         );
@@ -572,6 +670,13 @@ export function OAuthConsentPage() {
                 value={externalSubjectExternalUserId}
               />
             )}
+            {bindingGrantId && (
+              <input
+                type="hidden"
+                name="binding_grant_id"
+                value={bindingGrantId}
+              />
+            )}
             <input
               type="hidden"
               name="allow_all_services"
@@ -586,14 +691,7 @@ export function OAuthConsentPage() {
                   value={serviceId}
                 />
               ))}
-            {resources.length > 0 && (
-              <input
-                type="hidden"
-                name="resource_selection_present"
-                value="true"
-              />
-            )}
-            {selectedResources.map((resource) => (
+            {resources.map((resource) => (
               <input
                 key={resource}
                 type="hidden"
@@ -608,7 +706,7 @@ export function OAuthConsentPage() {
               name="decision"
               value="deny"
             >
-              Deny
+              {bindingReview ? "Cancel" : "Deny"}
             </Button>
             <Button
               variant="primary"
@@ -616,7 +714,7 @@ export function OAuthConsentPage() {
               name="decision"
               value="allow"
             >
-              Allow
+              {bindingReview ? "Update access" : "Allow"}
             </Button>
           </form>
         </CardContent>

--- a/frontend/src/pages/oauth-error.test.tsx
+++ b/frontend/src/pages/oauth-error.test.tsx
@@ -64,6 +64,41 @@ describe("OAuthErrorPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("links a missing required service to the existing connection flow", async () => {
+    const user = userEvent.setup();
+    const backSpy = vi
+      .spyOn(window.history, "back")
+      .mockImplementation(() => undefined);
+    setSearch(
+      "?code=required_service_not_connected" +
+        "&message=Required%20service%20is%20not%20connected" +
+        "&service_slug=chrono-llm-public" +
+        "&service_name=Chrono%20Public%20LLM",
+    );
+
+    render(<OAuthErrorPage />);
+
+    expect(screen.getByText("Connect a Required Service")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Public LLM")).toBeInTheDocument();
+    expect(screen.getByText("chrono-llm-public")).toBeInTheDocument();
+    expect(
+      screen.getByText(/is required by this app but is not connected/),
+    ).toBeInTheDocument();
+
+    const connect = screen.getByRole("link", { name: /Connect service/ });
+    expect(connect).toHaveAttribute(
+      "href",
+      "/keys?tab=services&slug=chrono-llm-public",
+    );
+    expect(connect).toHaveAttribute("target", "_blank");
+
+    await user.click(
+      screen.getByRole("button", { name: /Retry authorization/ }),
+    );
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    backSpy.mockRestore();
+  });
+
   it("Go Back calls window.history.back()", async () => {
     const user = userEvent.setup();
     setSearch("?code=login_required");
@@ -95,6 +130,7 @@ describe("OAuthErrorPage", () => {
       pkce_verification_failed: "PKCE Verification Failed",
       consent_required: "Consent Required",
       login_required: "Login Required",
+      required_service_not_connected: "Connect a Required Service",
     };
     for (const [code, label] of Object.entries(cases)) {
       setSearch(`?code=${code}`);

--- a/frontend/src/pages/oauth-error.tsx
+++ b/frontend/src/pages/oauth-error.tsx
@@ -1,9 +1,10 @@
 import { useNavigate } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ShieldAlert } from "lucide-react";
+import { ExternalLink, RotateCcw, ShieldAlert } from "lucide-react";
 import { useApplyTheme } from "@/hooks/use-theme";
 import { NyxidLogo } from "@/components/brand/nyxid-logo";
+import { ServiceIcon } from "@/components/service-icon";
 
 const ERROR_LABELS: Record<string, string> = {
   invalid_request: "Invalid Request",
@@ -14,6 +15,7 @@ const ERROR_LABELS: Record<string, string> = {
   invalid_scope: "Invalid Scope",
   consent_required: "Consent Required",
   login_required: "Login Required",
+  required_service_not_connected: "Connect a Required Service",
 };
 
 export function OAuthErrorPage() {
@@ -24,8 +26,13 @@ export function OAuthErrorPage() {
   const message =
     search.get("message") ??
     "An unexpected error occurred during authorization.";
+  const serviceSlug = search.get("service_slug")?.trim() ?? "";
+  const serviceName = search.get("service_name")?.trim() || serviceSlug;
+  const isMissingRequiredService =
+    code === "required_service_not_connected" && serviceSlug.length > 0;
 
   const title = ERROR_LABELS[code] ?? "Authorization Error";
+  const connectServiceUrl = `/keys?tab=services&slug=${encodeURIComponent(serviceSlug)}`;
 
   return (
     <div
@@ -42,25 +49,69 @@ export function OAuthErrorPage() {
 
         <Card className="w-full">
           <CardHeader className="space-y-3">
-            <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-red-500/10">
-              <ShieldAlert className="h-4 w-4 text-red-400" />
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-red-500/10">
+              {isMissingRequiredService ? (
+                <ServiceIcon slug={serviceSlug} size="xs" />
+              ) : (
+                <ShieldAlert className="h-4 w-4 text-red-400" />
+              )}
             </div>
             <CardTitle>{title}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <p className="text-[12px] leading-relaxed text-muted-foreground">
-              {message}
+              {isMissingRequiredService
+                ? `${serviceName} is required by this app but is not connected to your NyxID account. Connect it, then retry authorization.`
+                : message}
             </p>
+            {isMissingRequiredService && (
+              <div className="flex items-center gap-3 rounded-lg border border-border bg-muted px-3 py-3">
+                <ServiceIcon slug={serviceSlug} size="md" />
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium text-foreground">
+                    {serviceName}
+                  </p>
+                  <p className="truncate text-[11px] text-text-tertiary">
+                    {serviceSlug}
+                  </p>
+                </div>
+              </div>
+            )}
             <div className="rounded-lg border border-border bg-muted px-3 py-2">
               <p className="text-[11px] text-text-tertiary">Error code</p>
               <p className="text-xs text-foreground">{code}</p>
             </div>
-            <div className="flex justify-end gap-3 pt-2">
-              <Button variant="outline" onClick={() => window.history.back()}>
-                Go Back
-              </Button>
-              <Button onClick={() => void navigate({ to: "/dashboard" })}>Home</Button>
-            </div>
+            {isMissingRequiredService ? (
+              <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">
+                <Button
+                  variant="outline"
+                  onClick={() => window.history.back()}
+                  className="w-full sm:w-auto"
+                >
+                  <RotateCcw />
+                  Retry authorization
+                </Button>
+                <Button asChild variant="primary" className="w-full sm:w-auto">
+                  <a
+                    href={connectServiceUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Connect service
+                    <ExternalLink />
+                  </a>
+                </Button>
+              </div>
+            ) : (
+              <div className="flex justify-end gap-3 pt-2">
+                <Button variant="outline" onClick={() => window.history.back()}>
+                  Go Back
+                </Button>
+                <Button onClick={() => void navigate({ to: "/dashboard" })}>
+                  Home
+                </Button>
+              </div>
+            )}
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Problem

Aevatar Lark bindings need to review and expand an existing NyxID service grant without replacing the opaque binding credential. Historical bindings may contain only the `aevatar` service while runtime calls also require the configured LLM and Ornn services.

Tracks https://github.com/aevatarAI/aevatar/issues/2754.

## Solution

- Carry `binding_grant_id=SHA-256(binding_id)` through authorize, PAR, signed consent, authorization code, and token exchange.
- Revalidate the authenticated user, OAuth client, and exact external subject against the active binding.
- Display current, required, new, and optional service access in the existing OAuth consent picker.
- Keep required services selected while allowing optional grants to be added or removed.
- Optimistically rotate the refresh grant behind the existing binding and return `binding_updated=true` without issuing a replacement `binding_id`.
- Document the browser-safe in-place review protocol.

## Verification

- `cargo check -p nyxid`
- broker grant tests: 4 passed
- OAuth consent tests: 26 passed
- frontend TypeScript check passed
- `git diff --check`

Browser screenshot checks remain pending because the in-app browser runtime fails to initialize with `Cannot redefine property: process`.