### PR TITLE
fix(feature-flags): align empty state with app conventions

### DIFF
--- a/frontend/src/components/orgs/org-feature-flags-panel.tsx
+++ b/frontend/src/components/orgs/org-feature-flags-panel.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useState } from "react";
 import { ChevronDown, Search } from "lucide-react";
+import { PowerButtonIcon } from "@/components/icons/empty-state";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -21,7 +22,6 @@ import {
   useSetOrgFeatureFlag,
 } from "@/hooks/use-org-feature-flags";
 import { useOrgMembers } from "@/hooks/use-org-members";
-import { SwitchIcon } from "@/components/icons/empty-state";
 import type {
   FeatureFlagItem,
   FlagTargetKind,
@@ -232,13 +232,13 @@ export function OrgFeatureFlagsPanel({ orgId }: { readonly orgId: string }) {
       </div>
 
       {flags.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
-          <SwitchIcon className="h-40 w-40 text-muted-foreground" />
+        <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
+          <PowerButtonIcon className="h-64 w-64 text-muted-foreground" />
           <div className="space-y-1">
-            <p className="text-[13px] font-medium text-foreground">
+            <p className="text-[12px] font-medium text-muted-foreground">
               No feature flags
             </p>
-            <p className="max-w-sm text-xs text-muted-foreground">
+            <p className="text-xs text-muted-foreground">
               No features are available for this organization yet.
             </p>
           </div>

--- a/frontend/src/pages/admin-feature-flags.tsx
+++ b/frontend/src/pages/admin-feature-flags.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useState } from "react";
 import { ChevronDown, Search } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
-import { SwitchIcon } from "@/components/icons/empty-state";
+import { PowerButtonIcon } from "@/components/icons/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -148,11 +148,6 @@ export function AdminFeatureFlagsPage() {
         title="Feature Flags"
         description="Platform-wide feature rollout. Configure each flag globally, per organization, and per user."
       />
-
-      <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-[12px] text-foreground">
-        Prototype — mock data, not wired to the backend yet. For visualizing the
-        flag-centric admin surface.
-      </div>
 
       {pendingCount > 0 && (
         <div className="sticky top-2 z-10 flex items-center justify-between gap-3 rounded-lg border border-primary/40 bg-primary/10 px-3 py-2 shadow-sm backdrop-blur">
@@ -409,11 +404,11 @@ function FlagsEmptyState({
   readonly subtitle: string;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
-      <SwitchIcon className="h-40 w-40 text-muted-foreground" />
+    <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
+      <PowerButtonIcon className="h-64 w-64 text-muted-foreground" />
       <div className="space-y-1">
-        <p className="text-[13px] font-medium text-foreground">{title}</p>
-        <p className="max-w-sm text-xs text-muted-foreground">{subtitle}</p>
+        <p className="text-[12px] font-medium text-muted-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Swap `SwitchIcon` (electrical light-switch cartoon) → `PowerButtonIcon` from the same isometric line-art set — better on/off metaphor for feature flags.
- Match the empty-state token stack used by the *No Developer Apps* pattern (`developer-apps.tsx:418-430`): `h-64 w-64` icon, `gap-1 py-12` container, muted-foreground title + subtitle.
- Drop the *Prototype — mock data, not wired to the backend yet* banner from `admin-feature-flags.tsx` now that the surface is wired to the backend (#1171).

Both surfaces touched:
- `frontend/src/pages/admin-feature-flags.tsx` (platform-admin page)
- `frontend/src/components/orgs/org-feature-flags-panel.tsx` (org detail panel)

## Test plan

- [ ] Navigate to `/admin/feature-flags` with no flags defined → verify isometric PowerButton illustration + "No feature flags" copy (no prototype banner).
- [ ] Navigate to an org's Feature Flags tab with no overrides → same empty-state shape.
- [ ] `npm run build` / `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)