### PR TITLE
[codex] Persist DCR consent defaults

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -887,6 +887,9 @@ pub struct CreateOAuthClientRequest {
     /// OIDC scopes this client is allowed to request.
     /// Defaults to `["openid", "profile", "email"]` when omitted; `[]` canonicalizes to `["openid"]`.
     pub allowed_scopes: Option<Vec<String>>,
+    /// Catalog services preselected on the consent screen. This is a hint,
+    /// not an authorization grant; the user may change the selection.
+    pub default_service_catalog_slugs: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -896,6 +899,7 @@ pub struct UpdateOAuthClientRequest {
     pub redirect_uris: Option<Vec<String>>,
     pub allowed_scopes: Option<Vec<String>>,
     pub client_name: Option<String>,
+    pub default_service_catalog_slugs: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -944,6 +948,7 @@ pub struct OAuthClientResponse {
     pub redirect_uris: Vec<String>,
     pub allowed_scopes: String,
     pub delegation_scopes: String,
+    pub default_service_catalog_slugs: Vec<String>,
     pub broker_capability_enabled: bool,
     pub broker_capability_effective: bool,
     pub broker_capability_source: BrokerCapabilitySource,
@@ -1094,6 +1099,7 @@ fn oauth_client_response(
         redirect_uris: client.redirect_uris,
         allowed_scopes: client.allowed_scopes,
         delegation_scopes: client.delegation_scopes,
+        default_service_catalog_slugs: client.default_service_catalog_slugs,
         broker_capability_enabled: client.broker_capability_enabled,
         broker_capability_effective,
         broker_capability_source,
@@ -1327,6 +1333,12 @@ pub async fn create_oauth_client(
             Some(secret) => Some(state.encryption_keys.encrypt(secret.as_bytes()).await?),
             None => None,
         };
+    let default_service_catalog_slugs = match body.default_service_catalog_slugs.as_deref() {
+        Some(slugs) => {
+            oauth_client_service::validate_default_service_catalog_slugs(&state.db, slugs).await?
+        }
+        None => Vec::new(),
+    };
 
     let (client, raw_secret) = oauth_client_service::create_client(
         &state.db,
@@ -1339,7 +1351,7 @@ pub async fn create_oauth_client(
         body.broker_capability_enabled.unwrap_or(false),
         revocation_webhook_url,
         revocation_webhook_secret_encrypted,
-        &[],
+        &default_service_catalog_slugs,
     )
     .await?;
 
@@ -1461,6 +1473,12 @@ pub async fn update_oauth_client(
         .as_deref()
         .map(oauth_client_service::validate_allowed_scopes_list)
         .transpose()?;
+    let default_service_catalog_slugs = match body.default_service_catalog_slugs.as_deref() {
+        Some(slugs) => Some(
+            oauth_client_service::validate_default_service_catalog_slugs(&state.db, slugs).await?,
+        ),
+        None => None,
+    };
 
     let changed_fields = oauth_client_update_changed_fields(&body);
     let updated = oauth_client_service::admin_update_client(
@@ -1470,6 +1488,7 @@ pub async fn update_oauth_client(
             client_name,
             redirect_uris: redirect_uris.as_deref(),
             allowed_scopes: allowed_scopes.as_deref(),
+            default_service_catalog_slugs: default_service_catalog_slugs.as_deref(),
             broker_capability_enabled: body.broker_capability_enabled,
             is_active: body.is_active,
         },
@@ -1512,6 +1531,9 @@ fn oauth_client_update_changed_fields(body: &UpdateOAuthClientRequest) -> Vec<&'
     }
     if body.client_name.is_some() {
         changed.push("client_name");
+    }
+    if body.default_service_catalog_slugs.is_some() {
+        changed.push("default_service_catalog_slugs");
     }
     changed
 }
@@ -2276,6 +2298,20 @@ mod operator_route_tests {
         );
     }
 
+    #[test]
+    fn oauth_client_update_audit_includes_default_service_catalog_slugs() {
+        let changed = oauth_client_update_changed_fields(&UpdateOAuthClientRequest {
+            broker_capability_enabled: None,
+            is_active: None,
+            redirect_uris: None,
+            allowed_scopes: None,
+            client_name: None,
+            default_service_catalog_slugs: Some(vec!["aevatar".to_string()]),
+        });
+
+        assert_eq!(changed, vec!["default_service_catalog_slugs"]);
+    }
+
     #[tokio::test]
     async fn operator_lists_paginated_oauth_clients_with_metadata_and_no_secret() {
         let Some(db) = connect_test_database("admin_oauth_client_list_operator").await else {
@@ -2398,6 +2434,15 @@ mod operator_route_tests {
             .insert_one(test_oauth_client(client_id))
             .await
             .expect("insert dcr client");
+        let mut catalog_service = crate::models::downstream_service::test_helpers::dummy_service();
+        catalog_service.id = "catalog-aevatar".to_string();
+        catalog_service.slug = "aevatar".to_string();
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_one(&catalog_service)
+        .await
+        .expect("insert catalog service");
         let now = chrono::Utc::now();
         db.collection::<AuthorizationCode>(AUTH_CODES)
             .insert_one(AuthorizationCode {
@@ -2440,6 +2485,10 @@ mod operator_route_tests {
                     "urn:nyxid:scope:broker_binding".to_string(),
                 ]),
                 client_name: Some("Aevatar Broker".to_string()),
+                default_service_catalog_slugs: Some(vec![
+                    " aevatar ".to_string(),
+                    "aevatar".to_string(),
+                ]),
             }),
         )
         .await
@@ -2460,6 +2509,10 @@ mod operator_route_tests {
         assert_eq!(
             response.0.allowed_scopes,
             "openid urn:nyxid:scope:broker_binding"
+        );
+        assert_eq!(
+            response.0.default_service_catalog_slugs,
+            vec!["aevatar".to_string()]
         );
         let pending_codes = db
             .collection::<AuthorizationCode>(AUTH_CODES)
@@ -2500,6 +2553,7 @@ mod operator_route_tests {
                     redirect_uris: None,
                     allowed_scopes: None,
                     client_name: None,
+                    default_service_catalog_slugs: None,
                 }),
             )
             .await
@@ -2535,6 +2589,7 @@ mod operator_route_tests {
                 redirect_uris: None,
                 allowed_scopes: Some(vec!["admin".to_string()]),
                 client_name: None,
+                default_service_catalog_slugs: None,
             }),
         )
         .await
@@ -2542,7 +2597,7 @@ mod operator_route_tests {
         assert!(matches!(scope_err, AppError::ValidationError(_)));
 
         let uri_err = update_oauth_client(
-            State(state),
+            State(state.clone()),
             test_auth_user(&admin_id),
             Path(client_id.to_string()),
             Json(UpdateOAuthClientRequest {
@@ -2551,11 +2606,29 @@ mod operator_route_tests {
                 redirect_uris: Some(vec!["javascript:alert(1)".to_string()]),
                 allowed_scopes: None,
                 client_name: None,
+                default_service_catalog_slugs: None,
             }),
         )
         .await
         .expect_err("invalid redirect_uri must be rejected");
         assert!(matches!(uri_err, AppError::ValidationError(_)));
+
+        let default_service_err = update_oauth_client(
+            State(state),
+            test_auth_user(&admin_id),
+            Path(client_id.to_string()),
+            Json(UpdateOAuthClientRequest {
+                broker_capability_enabled: None,
+                is_active: None,
+                redirect_uris: None,
+                allowed_scopes: None,
+                client_name: None,
+                default_service_catalog_slugs: Some(vec!["missing-service".to_string()]),
+            }),
+        )
+        .await
+        .expect_err("unknown default service must be rejected");
+        assert!(matches!(default_service_err, AppError::ValidationError(_)));
     }
 
     #[test]
@@ -2730,6 +2803,7 @@ mod operator_route_tests {
             Json(crate::handlers::oauth::RegisterClientRequest {
                 client_name: Some("Allowed Before Override".to_string()),
                 redirect_uris: Some(vec!["http://localhost:8080/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),
@@ -2756,6 +2830,7 @@ mod operator_route_tests {
             Json(crate::handlers::oauth::RegisterClientRequest {
                 client_name: Some("Rejected After Override".to_string()),
                 redirect_uris: Some(vec!["http://localhost:8081/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),

--- a/backend/src/handlers/developer_apps.rs
+++ b/backend/src/handlers/developer_apps.rs
@@ -3,7 +3,6 @@ use axum::{
     extract::{Path, State},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 use crate::AppState;
 use crate::errors::{AppError, AppResult};
@@ -168,49 +167,6 @@ fn to_response(c: OauthClient, secret: Option<String>) -> DeveloperOAuthClientRe
     }
 }
 
-/// Maximum catalog slugs an app may declare as consent defaults.
-const MAX_DEFAULT_SERVICE_SLUGS: usize = 25;
-
-/// Trim, de-duplicate, and verify each declared catalog slug against the
-/// active service catalog. Unknown slugs are rejected so app owners catch
-/// typos at save time instead of silently pre-selecting nothing.
-async fn validate_default_service_catalog_slugs(
-    state: &AppState,
-    slugs: &[String],
-) -> AppResult<Vec<String>> {
-    let mut seen = HashSet::new();
-    let mut validated = Vec::new();
-    for raw in slugs {
-        let slug = raw.trim();
-        if slug.is_empty() {
-            continue;
-        }
-        if !seen.insert(slug.to_string()) {
-            continue;
-        }
-        let exists = state
-            .db
-            .collection::<crate::models::downstream_service::DownstreamService>(
-                crate::models::downstream_service::COLLECTION_NAME,
-            )
-            .find_one(doc! { "slug": slug, "is_active": true })
-            .await?
-            .is_some();
-        if !exists {
-            return Err(AppError::ValidationError(format!(
-                "Unknown catalog service slug: {slug}"
-            )));
-        }
-        validated.push(slug.to_string());
-    }
-    if validated.len() > MAX_DEFAULT_SERVICE_SLUGS {
-        return Err(AppError::ValidationError(format!(
-            "At most {MAX_DEFAULT_SERVICE_SLUGS} default services may be declared"
-        )));
-    }
-    Ok(validated)
-}
-
 fn validate_redirect_uris(redirect_uris: &[String]) -> AppResult<Vec<String>> {
     oauth_client_service::validate_redirect_uris(redirect_uris)
 }
@@ -303,7 +259,9 @@ pub async fn create_my_oauth_client(
             None => None,
         };
     let default_service_catalog_slugs = match body.default_service_catalog_slugs.as_deref() {
-        Some(slugs) => validate_default_service_catalog_slugs(&state, slugs).await?,
+        Some(slugs) => {
+            oauth_client_service::validate_default_service_catalog_slugs(&state.db, slugs).await?
+        }
         None => Vec::new(),
     };
 
@@ -420,7 +378,9 @@ pub async fn update_my_oauth_client(
             None => None,
         };
     let validated_default_slugs = match body.default_service_catalog_slugs.as_deref() {
-        Some(slugs) => Some(validate_default_service_catalog_slugs(&state, slugs).await?),
+        Some(slugs) => Some(
+            oauth_client_service::validate_default_service_catalog_slugs(&state.db, slugs).await?,
+        ),
         None => None,
     };
 

--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -2740,6 +2740,10 @@ pub async fn revoke(
 pub struct RegisterClientRequest {
     pub client_name: Option<String>,
     pub redirect_uris: Option<Vec<String>>,
+    /// NyxID extension: catalog services preselected on the consent screen.
+    /// These remain user-editable hints and do not grant service access.
+    #[serde(default)]
+    pub default_service_catalog_slugs: Vec<String>,
     // RFC 7591 fields parsed but not yet acted on. Kept so serde accepts
     // conformant requests; remove if/when we start branching on them.
     #[allow(dead_code)]
@@ -2759,6 +2763,7 @@ pub struct RegisterClientResponse {
     pub response_types: Vec<String>,
     pub token_endpoint_auth_method: String,
     pub scope: String,
+    pub default_service_catalog_slugs: Vec<String>,
     pub client_id_issued_at: i64,
 }
 
@@ -2810,6 +2815,13 @@ pub async fn register_client(
         ));
     }
 
+    let default_service_catalog_slugs =
+        oauth_client_service::validate_default_service_catalog_slugs(
+            &state.db,
+            &body.default_service_catalog_slugs,
+        )
+        .await?;
+
     let (client, _secret) = oauth_client_service::create_client(
         &state.db,
         &client_name,
@@ -2821,7 +2833,7 @@ pub async fn register_client(
         false,
         None,
         None,
-        &[],
+        &default_service_catalog_slugs,
     )
     .await?;
 
@@ -2844,6 +2856,7 @@ pub async fn register_client(
             response_types: vec!["code".to_string()],
             token_endpoint_auth_method: "none".to_string(),
             scope: client.allowed_scopes,
+            default_service_catalog_slugs: client.default_service_catalog_slugs,
             client_id_issued_at: client.created_at.timestamp(),
         }),
     ))
@@ -3927,6 +3940,7 @@ mod tests {
             Json(RegisterClientRequest {
                 client_name: Some("Aevatar".to_string()),
                 redirect_uris: Some(vec!["http://localhost/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),
@@ -3957,6 +3971,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_client_validates_and_persists_default_service_catalog_slugs() {
+        let Some(db) = connect_test_database("oauth_dcr_default_services").await else {
+            return;
+        };
+        let mut aevatar = crate::models::downstream_service::test_helpers::dummy_service();
+        aevatar.id = "catalog-aevatar".to_string();
+        aevatar.slug = "aevatar".to_string();
+        let mut ornn = crate::models::downstream_service::test_helpers::dummy_service();
+        ornn.id = "catalog-ornn".to_string();
+        ornn.slug = "ornn-api".to_string();
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_many([&aevatar, &ornn])
+        .await
+        .expect("insert catalog services");
+        let state = test_app_state(db.clone());
+
+        let (status, Json(response)) = register_client(
+            State(state.clone()),
+            Json(RegisterClientRequest {
+                client_name: Some("Aevatar".to_string()),
+                redirect_uris: Some(vec!["http://localhost/callback".to_string()]),
+                default_service_catalog_slugs: vec![
+                    " aevatar ".to_string(),
+                    "ornn-api".to_string(),
+                    "aevatar".to_string(),
+                ],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: Some("none".to_string()),
+                scope: None,
+            }),
+        )
+        .await
+        .expect("register client with consent defaults");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            response.default_service_catalog_slugs,
+            vec!["aevatar".to_string(), "ornn-api".to_string()]
+        );
+        let stored = db
+            .collection::<OauthClient>(OAUTH_CLIENTS)
+            .find_one(doc! { "_id": &response.client_id })
+            .await
+            .expect("query client")
+            .expect("client exists");
+        assert_eq!(
+            stored.default_service_catalog_slugs,
+            response.default_service_catalog_slugs
+        );
+
+        let error = register_client(
+            State(state),
+            Json(RegisterClientRequest {
+                client_name: Some("Invalid defaults".to_string()),
+                redirect_uris: Some(vec!["http://localhost/callback-2".to_string()]),
+                default_service_catalog_slugs: vec!["missing-service".to_string()],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: Some("none".to_string()),
+                scope: None,
+            }),
+        )
+        .await
+        .expect_err("unknown catalog slugs must be rejected");
+        assert!(
+            matches!(error, AppError::ValidationError(message) if message.contains("missing-service"))
+        );
+    }
+
+    #[tokio::test]
     async fn register_client_rejects_broker_scope_when_admin_capability_required() {
         let Some(db) = connect_test_database("oauth_dcr_broker_scope_strict").await else {
             return;
@@ -3970,6 +4057,7 @@ mod tests {
             Json(RegisterClientRequest {
                 client_name: Some("Aevatar".to_string()),
                 redirect_uris: Some(vec!["http://localhost/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),
@@ -3994,6 +4082,7 @@ mod tests {
             Json(RegisterClientRequest {
                 client_name: Some("Aevatar".to_string()),
                 redirect_uris: Some(vec!["http://localhost/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),
@@ -4284,6 +4373,7 @@ mod tests {
             Json(RegisterClientRequest {
                 client_name: Some("Bad Scope".to_string()),
                 redirect_uris: Some(vec!["http://localhost/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),
@@ -4307,6 +4397,7 @@ mod tests {
             Json(RegisterClientRequest {
                 client_name: Some("Default Scope".to_string()),
                 redirect_uris: Some(vec!["http://localhost/callback".to_string()]),
+                default_service_catalog_slugs: Vec::new(),
                 grant_types: None,
                 response_types: None,
                 token_endpoint_auth_method: Some("none".to_string()),

--- a/backend/src/services/oauth_client_service.rs
+++ b/backend/src/services/oauth_client_service.rs
@@ -10,6 +10,9 @@ use crate::crypto::token::{generate_random_token, hash_token};
 use crate::errors::{AppError, AppResult};
 use crate::models::authorization_code::COLLECTION_NAME as AUTH_CODES;
 use crate::models::consent::COLLECTION_NAME as CONSENTS;
+use crate::models::downstream_service::{
+    COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
+};
 use crate::models::oauth_client::{COLLECTION_NAME as OAUTH_CLIENTS, OauthClient};
 use crate::models::refresh_token::COLLECTION_NAME as REFRESH_TOKENS;
 
@@ -45,6 +48,58 @@ pub const DEFAULT_ALLOWED_SCOPES: &str = "openid profile email";
 /// still gated by what the client requests at `/oauth/authorize` and what the
 /// user consents to.
 pub const DEFAULT_MCP_ALLOWED_SCOPES: &str = "openid profile email roles groups proxy";
+
+/// Maximum catalog slugs an OAuth client may declare as consent defaults.
+pub const MAX_DEFAULT_SERVICE_CATALOG_SLUGS: usize = 25;
+
+/// Trim, de-duplicate, and verify declared consent defaults against the active
+/// service catalog. Unknown slugs are rejected at the write boundary so a
+/// client cannot silently provision defaults that the consent screen can
+/// never resolve.
+pub async fn validate_default_service_catalog_slugs(
+    db: &mongodb::Database,
+    slugs: &[String],
+) -> AppResult<Vec<String>> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for raw in slugs {
+        let slug = raw.trim();
+        if !slug.is_empty() && seen.insert(slug.to_string()) {
+            normalized.push(slug.to_string());
+        }
+    }
+
+    if normalized.len() > MAX_DEFAULT_SERVICE_CATALOG_SLUGS {
+        return Err(AppError::ValidationError(format!(
+            "At most {MAX_DEFAULT_SERVICE_CATALOG_SLUGS} default services may be declared"
+        )));
+    }
+    if normalized.is_empty() {
+        return Ok(normalized);
+    }
+
+    let active_slugs: HashSet<String> = db
+        .collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+        .find(doc! {
+            "slug": { "$in": &normalized },
+            "is_active": true,
+        })
+        .await?
+        .map_ok(|service| service.slug)
+        .try_collect()
+        .await?;
+
+    if let Some(unknown) = normalized
+        .iter()
+        .find(|slug| !active_slugs.contains(slug.as_str()))
+    {
+        return Err(AppError::ValidationError(format!(
+            "Unknown catalog service slug: {unknown}"
+        )));
+    }
+
+    Ok(normalized)
+}
 
 pub const ADMIN_CLIENT_TYPE_FILTERS: &[&str] = &["public", "confidential", "other"];
 pub const ADMIN_CREATOR_TYPE_FILTERS: &[&str] =
@@ -1228,6 +1283,7 @@ pub struct AdminUpdateClient<'a> {
     pub client_name: Option<&'a str>,
     pub redirect_uris: Option<&'a [String]>,
     pub allowed_scopes: Option<&'a str>,
+    pub default_service_catalog_slugs: Option<&'a [String]>,
     pub broker_capability_enabled: Option<bool>,
     pub is_active: Option<bool>,
 }
@@ -1262,6 +1318,17 @@ pub async fn admin_update_client(
 
     if let Some(scopes) = update.allowed_scopes {
         set_doc.insert("allowed_scopes", scopes);
+    }
+
+    if let Some(slugs) = update.default_service_catalog_slugs {
+        set_doc.insert(
+            "default_service_catalog_slugs",
+            bson::to_bson(slugs).map_err(|e| {
+                AppError::Internal(format!(
+                    "Failed to convert default_service_catalog_slugs to bson: {e}"
+                ))
+            })?,
+        );
     }
 
     if let Some(enabled) = update.broker_capability_enabled {

--- a/skills/nyxid/references/oauth-consent.md
+++ b/skills/nyxid/references/oauth-consent.md
@@ -51,7 +51,11 @@ Current management surfaces:
 
 - Web UI: Developer Apps -> app detail -> `Default Services` uses the include-all catalog picker.
 - API: `POST /api/v1/developer/oauth-clients` and `PATCH /api/v1/developer/oauth-clients/{client_id}` accept `default_service_catalog_slugs`.
+- Dynamic Client Registration: `POST /oauth/register` accepts and returns `default_service_catalog_slugs`. NyxID validates the slugs before creating the ownerless client.
+- Admin API: `POST /api/v1/admin/oauth-clients` and `PATCH /api/v1/admin/oauth-clients/{client_id}` accept `default_service_catalog_slugs`; admin responses include the persisted list. This is the repair path for ownerless DCR clients created before the field was supported.
 - CLI: ordinary `nyxid developer-app create/update` exists, but default-service flags are not available yet. CLI parity is tracked separately in issue #1126.
+
+Existing DCR clients are not backfilled automatically. Re-register the client with the desired defaults or patch the existing client once through the admin API after deploying support.
 
 ## RFC 8707 resource indicators
 


### PR DESCRIPTION
## Problem

OAuth clients created through `POST /oauth/register` could not persist consent-screen defaults. The DCR request ignored `default_service_catalog_slugs`, and the admin API could not repair ownerless DCR clients, so Aevatar's consent page opened without its expected services selected.

## Solution

- accept, validate, persist, and echo `default_service_catalog_slugs` in Dynamic Client Registration
- reuse one active-catalog validator across DCR, Developer Apps, and Admin writes
- expose the field through Admin create, update, and response DTOs, including audit `changed_fields`
- document the DCR contract and the repair path for existing clients

The defaults remain user-editable consent hints. They do not grant service access.

## Coordination And Deployment

1. Aevatar frontend PR [#2793](https://github.com/aevatarAI/aevatar/pull/2793) already removed browser-supplied OAuth `resource` defaults.
2. Deploy this NyxID PR first.
3. Deploy companion Aevatar PR [aevatarAI/aevatar#2805](https://github.com/aevatarAI/aevatar/pull/2805) second. It verifies the DCR response before committing actor state, then re-registers legacy clients whose defaults are empty.

Existing DCR clients are not mutated automatically by NyxID. They can be patched through Admin, or replaced when the Aevatar deployment detects drift.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nyxid default_service_catalog_slugs` (3 passed)
- `cargo clippy -p nyxid --all-targets -- -A clippy::collapsible-else-if -D warnings`

Strict repository-wide Clippy remains blocked by the pre-existing `clippy::collapsible_else_if` warning at `backend/src/handlers/node_ws.rs:444`; this PR does not touch that path.
