### PR TITLE
feat(feature-flags): platform-admin feature-flag API + wired admin page

### DIFF
--- a/backend/src/handlers/admin_feature_flags.rs
+++ b/backend/src/handlers/admin_feature_flags.rs
@@ -11,7 +11,7 @@ use utoipa::ToSchema;
 
 use crate::AppState;
 use crate::errors::{AppError, AppResult};
-use crate::handlers::admin_helpers::require_admin;
+use crate::handlers::admin_helpers::{require_admin, require_admin_or_operator};
 use crate::models::feature_flag_override::{FeatureFlagOverride, FlagTargetKind};
 use crate::mw::auth::AuthUser;
 use crate::services::{audit_service, feature_flag_service};
@@ -98,7 +98,7 @@ pub async fn list_feature_flags(
     State(state): State<AppState>,
     auth_user: AuthUser,
 ) -> AppResult<Json<AdminFeatureFlagListResponse>> {
-    require_admin(&state, &auth_user).await?;
+    require_admin_or_operator(&state, &auth_user, "admin.feature_flags.list").await?;
     let overrides = feature_flag_service::list_platform_overrides(&state.db).await?;
     let mut flags = Vec::with_capacity(feature_flag_service::FEATURE_FLAGS.len());
 
@@ -220,19 +220,22 @@ mod tests {
     use axum::extract::{Path, Query, State};
     use uuid::Uuid;
 
-    async fn setup(prefix: &str) -> Option<(AppState, String, String)> {
+    async fn setup(prefix: &str) -> Option<(AppState, String, String, String)> {
         let db = connect_test_database(prefix).await?;
         role_service::seed_system_roles(&db).await.ok()?;
         let role_ids = role_service::get_platform_role_ids(&db).await.ok()?;
         let admin_id = Uuid::new_v4().to_string();
+        let operator_id = Uuid::new_v4().to_string();
         let target_id = Uuid::new_v4().to_string();
         let mut admin = test_user(&admin_id, UserType::Person);
         admin.role_ids.push(role_ids.admin);
+        let mut operator = test_user(&operator_id, UserType::Person);
+        operator.role_ids.push(role_ids.operator);
         db.collection(USERS)
-            .insert_many([admin, test_user(&target_id, UserType::Person)])
+            .insert_many([admin, operator, test_user(&target_id, UserType::Person)])
             .await
             .ok()?;
-        Some((test_app_state(db), admin_id, target_id))
+        Some((test_app_state(db), admin_id, operator_id, target_id))
     }
 
     #[test]
@@ -245,7 +248,9 @@ mod tests {
 
     #[tokio::test]
     async fn set_list_clear_round_trip_and_unknown_rejection() {
-        let Some((state, admin_id, target_id)) = setup("admin_feature_flags_flow").await else {
+        let Some((state, admin_id, _operator_id, target_id)) =
+            setup("admin_feature_flags_flow").await
+        else {
             eprintln!("skipping admin feature flag handler test: no local MongoDB available");
             return;
         };
@@ -311,5 +316,77 @@ mod tests {
         .await
         .expect_err("unknown flag rejected");
         assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn admin_operator_read_write_split_is_enforced() {
+        let Some((state, admin_id, operator_id, _target_id)) =
+            setup("admin_feature_flags_access_split").await
+        else {
+            eprintln!("skipping admin feature flag access test: no local MongoDB available");
+            return;
+        };
+        let flag_key = "example_ui".to_string();
+        let operator = test_auth_user(&operator_id);
+        let admin = test_auth_user(&admin_id);
+
+        let _ = list_feature_flags(State(state.clone()), operator.clone())
+            .await
+            .expect("operator GET should succeed");
+
+        let operator_put = set_feature_flag(
+            State(state.clone()),
+            operator.clone(),
+            Path(flag_key.clone()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::Global,
+                target_key: None,
+                enabled: true,
+            }),
+        )
+        .await
+        .expect_err("operator PUT should be forbidden");
+        assert!(matches!(operator_put, AppError::Forbidden(_)));
+
+        let operator_delete = clear_feature_flag(
+            State(state.clone()),
+            operator,
+            Path(flag_key.clone()),
+            Query(ClearAdminFeatureFlagQuery {
+                target_kind: AdminFlagTargetKind::Global,
+                target_key: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("operator DELETE should be forbidden");
+        assert!(matches!(operator_delete, AppError::Forbidden(_)));
+
+        let _ = list_feature_flags(State(state.clone()), admin.clone())
+            .await
+            .expect("admin GET should succeed");
+        let _ = set_feature_flag(
+            State(state.clone()),
+            admin.clone(),
+            Path(flag_key.clone()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::Global,
+                target_key: None,
+                enabled: true,
+            }),
+        )
+        .await
+        .expect("admin PUT should succeed");
+        clear_feature_flag(
+            State(state),
+            admin,
+            Path(flag_key),
+            Query(ClearAdminFeatureFlagQuery {
+                target_kind: AdminFlagTargetKind::Global,
+                target_key: None,
+            }),
+        )
+        .await
+        .expect("admin DELETE should succeed");
     }
 }

--- a/backend/src/handlers/admin_feature_flags.rs
+++ b/backend/src/handlers/admin_feature_flags.rs
@@ -20,20 +20,29 @@ use feature_flag_service::FlagTarget;
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AdminUserFeatureFlagOverride {
     pub user_id: String,
+    pub user_email: Option<String>,
+    pub user_display_name: Option<String>,
     pub enabled: bool,
     pub updated_at: String,
     pub updated_by: String,
 }
 
-impl TryFrom<FeatureFlagOverride> for AdminUserFeatureFlagOverride {
-    type Error = AppError;
-
-    fn try_from(row: FeatureFlagOverride) -> Result<Self, Self::Error> {
+impl AdminUserFeatureFlagOverride {
+    fn from_row(
+        row: FeatureFlagOverride,
+        users: &std::collections::HashMap<
+            String,
+            feature_flag_service::PlatformOverrideUserDisplay,
+        >,
+    ) -> AppResult<Self> {
         let user_id = row.target_key.ok_or_else(|| {
             AppError::Internal("platform user override is missing its target key".to_string())
         })?;
+        let user = users.get(&user_id);
         Ok(Self {
             user_id,
+            user_email: user.map(|item| item.email.clone()),
+            user_display_name: user.and_then(|item| item.display_name.clone()),
             enabled: row.enabled,
             updated_at: row.updated_at.to_rfc3339(),
             updated_by: row.updated_by,
@@ -100,6 +109,7 @@ pub async fn list_feature_flags(
 ) -> AppResult<Json<AdminFeatureFlagListResponse>> {
     require_admin_or_operator(&state, &auth_user, "admin.feature_flags.list").await?;
     let overrides = feature_flag_service::list_platform_overrides(&state.db).await?;
+    let users = feature_flag_service::fetch_platform_override_users(&state.db, &overrides).await?;
     let mut flags = Vec::with_capacity(feature_flag_service::FEATURE_FLAGS.len());
 
     for def in feature_flag_service::FEATURE_FLAGS {
@@ -111,7 +121,7 @@ pub async fn list_feature_flags(
             .iter()
             .filter(|row| row.flag_key == def.key && row.target_kind == FlagTargetKind::User)
             .cloned()
-            .map(TryInto::try_into)
+            .map(|row| AdminUserFeatureFlagOverride::from_row(row, &users))
             .collect::<AppResult<Vec<_>>>()?;
         flags.push(AdminFeatureFlagItem {
             key: def.key.to_string(),
@@ -276,6 +286,30 @@ mod tests {
         let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
         assert_eq!(item.user_overrides.len(), 1);
         assert_eq!(item.user_overrides[0].user_id, target_id);
+        let expected_email = format!("{target_id}@example.com");
+        assert_eq!(
+            item.user_overrides[0].user_email.as_deref(),
+            Some(expected_email.as_str())
+        );
+        assert_eq!(
+            item.user_overrides[0].user_display_name.as_deref(),
+            Some("Test User")
+        );
+
+        state
+            .db
+            .collection::<crate::models::user::User>(USERS)
+            .delete_one(mongodb::bson::doc! { "_id": &target_id })
+            .await
+            .expect("delete target user");
+        let Json(list) = list_feature_flags(State(state.clone()), auth.clone())
+            .await
+            .expect("list flags after target deletion");
+        let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
+        assert_eq!(item.user_overrides.len(), 1);
+        assert_eq!(item.user_overrides[0].user_id, target_id);
+        assert!(item.user_overrides[0].user_email.is_none());
+        assert!(item.user_overrides[0].user_display_name.is_none());
 
         let missing_user_error = set_feature_flag(
             State(state.clone()),

--- a/backend/src/handlers/admin_feature_flags.rs
+++ b/backend/src/handlers/admin_feature_flags.rs
@@ -1,0 +1,315 @@
+//! Platform-admin feature-flag management handlers.
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::AppState;
+use crate::errors::{AppError, AppResult};
+use crate::handlers::admin_helpers::require_admin;
+use crate::models::feature_flag_override::{FeatureFlagOverride, FlagTargetKind};
+use crate::mw::auth::AuthUser;
+use crate::services::{audit_service, feature_flag_service};
+use feature_flag_service::FlagTarget;
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AdminUserFeatureFlagOverride {
+    pub user_id: String,
+    pub enabled: bool,
+    pub updated_at: String,
+    pub updated_by: String,
+}
+
+impl TryFrom<FeatureFlagOverride> for AdminUserFeatureFlagOverride {
+    type Error = AppError;
+
+    fn try_from(row: FeatureFlagOverride) -> Result<Self, Self::Error> {
+        let user_id = row.target_key.ok_or_else(|| {
+            AppError::Internal("platform user override is missing its target key".to_string())
+        })?;
+        Ok(Self {
+            user_id,
+            enabled: row.enabled,
+            updated_at: row.updated_at.to_rfc3339(),
+            updated_by: row.updated_by,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AdminFeatureFlagItem {
+    pub key: String,
+    pub description: String,
+    pub default_enabled: bool,
+    pub org_manageable: bool,
+    pub global_override: Option<bool>,
+    pub user_overrides: Vec<AdminUserFeatureFlagOverride>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AdminFeatureFlagListResponse {
+    pub flags: Vec<AdminFeatureFlagItem>,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdminFlagTargetKind {
+    Global,
+    Org,
+    Role,
+    User,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetAdminFeatureFlagRequest {
+    pub target_kind: AdminFlagTargetKind,
+    #[serde(default)]
+    pub target_key: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ClearAdminFeatureFlagQuery {
+    pub target_kind: AdminFlagTargetKind,
+    #[serde(default)]
+    pub target_key: Option<String>,
+}
+
+fn parse_target(kind: AdminFlagTargetKind, key: Option<&str>) -> AppResult<FlagTarget> {
+    match kind {
+        AdminFlagTargetKind::Global if key.is_none() => Ok(FlagTarget::Global),
+        AdminFlagTargetKind::Global => Err(AppError::BadRequest(
+            "global target requires target_key to be null".to_string(),
+        )),
+        AdminFlagTargetKind::User => FlagTarget::from_parts(FlagTargetKind::User, key),
+        AdminFlagTargetKind::Org | AdminFlagTargetKind::Role => Err(AppError::BadRequest(
+            "org and role targets require an org; use the org feature-flag API".to_string(),
+        )),
+    }
+}
+
+/// GET /api/v1/admin/feature-flags
+pub async fn list_feature_flags(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AppResult<Json<AdminFeatureFlagListResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let overrides = feature_flag_service::list_platform_overrides(&state.db).await?;
+    let mut flags = Vec::with_capacity(feature_flag_service::FEATURE_FLAGS.len());
+
+    for def in feature_flag_service::FEATURE_FLAGS {
+        let global_override = overrides
+            .iter()
+            .find(|row| row.flag_key == def.key && row.target_kind == FlagTargetKind::Global)
+            .map(|row| row.enabled);
+        let user_overrides = overrides
+            .iter()
+            .filter(|row| row.flag_key == def.key && row.target_kind == FlagTargetKind::User)
+            .cloned()
+            .map(TryInto::try_into)
+            .collect::<AppResult<Vec<_>>>()?;
+        flags.push(AdminFeatureFlagItem {
+            key: def.key.to_string(),
+            description: def.description.to_string(),
+            default_enabled: def.default_enabled,
+            org_manageable: def.org_manageable,
+            global_override,
+            user_overrides,
+        });
+    }
+
+    Ok(Json(AdminFeatureFlagListResponse { flags }))
+}
+
+/// PUT /api/v1/admin/feature-flags/{flag_key}
+pub async fn set_feature_flag(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(flag_key): Path<String>,
+    Json(body): Json<SetAdminFeatureFlagRequest>,
+) -> AppResult<Json<AdminUserFeatureFlagOverrideOrGlobal>> {
+    require_admin(&state, &auth_user).await?;
+    let target = parse_target(body.target_kind, body.target_key.as_deref())?;
+    let actor = auth_user.user_id.to_string();
+    let row = feature_flag_service::set_platform_override(
+        &state.db,
+        &flag_key,
+        &target,
+        body.enabled,
+        &actor,
+    )
+    .await?;
+
+    audit_service::log_for_user(
+        state.db.clone(),
+        &auth_user,
+        "admin_feature_flag_override_set",
+        Some(serde_json::json!({
+            "flag_key": flag_key,
+            "target_kind": row.target_kind.as_str(),
+            "target_key": row.target_key,
+            "enabled": row.enabled,
+        })),
+    );
+
+    Ok(Json(row.into()))
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AdminUserFeatureFlagOverrideOrGlobal {
+    pub target_kind: String,
+    pub target_key: Option<String>,
+    pub enabled: bool,
+    pub updated_at: String,
+    pub updated_by: String,
+}
+
+impl From<FeatureFlagOverride> for AdminUserFeatureFlagOverrideOrGlobal {
+    fn from(row: FeatureFlagOverride) -> Self {
+        Self {
+            target_kind: row.target_kind.as_str().to_string(),
+            target_key: row.target_key,
+            enabled: row.enabled,
+            updated_at: row.updated_at.to_rfc3339(),
+            updated_by: row.updated_by,
+        }
+    }
+}
+
+/// DELETE /api/v1/admin/feature-flags/{flag_key}
+pub async fn clear_feature_flag(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(flag_key): Path<String>,
+    Query(query): Query<ClearAdminFeatureFlagQuery>,
+) -> AppResult<impl IntoResponse> {
+    require_admin(&state, &auth_user).await?;
+    feature_flag_service::find_flag(&flag_key)
+        .ok_or_else(|| AppError::BadRequest(format!("unknown feature flag '{flag_key}'")))?;
+    let target = parse_target(query.target_kind, query.target_key.as_deref())?;
+    let removed =
+        feature_flag_service::clear_platform_override(&state.db, &flag_key, &target).await?;
+
+    if let Some(row) = removed {
+        audit_service::log_for_user(
+            state.db.clone(),
+            &auth_user,
+            "admin_feature_flag_override_cleared",
+            Some(serde_json::json!({
+                "flag_key": flag_key,
+                "target_kind": query.target_kind,
+                "target_key": query.target_key,
+                "enabled": row.enabled,
+            })),
+        );
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::user::{COLLECTION_NAME as USERS, UserType};
+    use crate::services::role_service;
+    use crate::test_utils::{connect_test_database, test_app_state, test_auth_user, test_user};
+    use axum::extract::{Path, Query, State};
+    use uuid::Uuid;
+
+    async fn setup(prefix: &str) -> Option<(AppState, String, String)> {
+        let db = connect_test_database(prefix).await?;
+        role_service::seed_system_roles(&db).await.ok()?;
+        let role_ids = role_service::get_platform_role_ids(&db).await.ok()?;
+        let admin_id = Uuid::new_v4().to_string();
+        let target_id = Uuid::new_v4().to_string();
+        let mut admin = test_user(&admin_id, UserType::Person);
+        admin.role_ids.push(role_ids.admin);
+        db.collection(USERS)
+            .insert_many([admin, test_user(&target_id, UserType::Person)])
+            .await
+            .ok()?;
+        Some((test_app_state(db), admin_id, target_id))
+    }
+
+    #[test]
+    fn target_validation_rejects_invalid_platform_scopes() {
+        assert!(parse_target(AdminFlagTargetKind::Global, Some("x")).is_err());
+        assert!(parse_target(AdminFlagTargetKind::User, None).is_err());
+        assert!(parse_target(AdminFlagTargetKind::Org, None).is_err());
+        assert!(parse_target(AdminFlagTargetKind::Role, Some("admin")).is_err());
+    }
+
+    #[tokio::test]
+    async fn set_list_clear_round_trip_and_unknown_rejection() {
+        let Some((state, admin_id, target_id)) = setup("admin_feature_flags_flow").await else {
+            eprintln!("skipping admin feature flag handler test: no local MongoDB available");
+            return;
+        };
+        let auth = test_auth_user(&admin_id);
+        let flag_key = "example_ui".to_string();
+
+        let _ = set_feature_flag(
+            State(state.clone()),
+            auth.clone(),
+            Path(flag_key.clone()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::User,
+                target_key: Some(target_id.clone()),
+                enabled: true,
+            }),
+        )
+        .await
+        .expect("set user override");
+
+        let Json(list) = list_feature_flags(State(state.clone()), auth.clone())
+            .await
+            .expect("list flags");
+        let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
+        assert_eq!(item.user_overrides.len(), 1);
+        assert_eq!(item.user_overrides[0].user_id, target_id);
+
+        let missing_user_error = set_feature_flag(
+            State(state.clone()),
+            auth.clone(),
+            Path(flag_key.clone()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::User,
+                target_key: Some(Uuid::new_v4().to_string()),
+                enabled: true,
+            }),
+        )
+        .await
+        .expect_err("missing target user rejected");
+        assert!(matches!(missing_user_error, AppError::NotFound(_)));
+
+        clear_feature_flag(
+            State(state.clone()),
+            auth.clone(),
+            Path(flag_key),
+            Query(ClearAdminFeatureFlagQuery {
+                target_kind: AdminFlagTargetKind::User,
+                target_key: Some(target_id),
+            }),
+        )
+        .await
+        .expect("clear user override");
+
+        let err = set_feature_flag(
+            State(state),
+            auth,
+            Path("unknown".to_string()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::Global,
+                target_key: None,
+                enabled: true,
+            }),
+        )
+        .await
+        .expect_err("unknown flag rejected");
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod admin_anonymous_endpoints;
+pub mod admin_feature_flags;
 pub mod admin_groups;
 pub mod admin_helpers;
 pub mod admin_nodes;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -337,6 +337,15 @@ pub fn build_router(
 
     let admin_routes = Router::new()
         .route(
+            "/feature-flags",
+            get(handlers::admin_feature_flags::list_feature_flags),
+        )
+        .route(
+            "/feature-flags/{flag_key}",
+            put(handlers::admin_feature_flags::set_feature_flag)
+                .delete(handlers::admin_feature_flags::clear_feature_flag),
+        )
+        .route(
             "/users",
             get(handlers::admin::list_users).post(handlers::admin::create_user),
         )

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 use crate::errors::{AppError, AppResult};
 use crate::models::feature_flag_override::{COLLECTION_NAME, FeatureFlagOverride, FlagTargetKind};
 use crate::models::org_membership::OrgRole;
+use crate::models::user::{COLLECTION_NAME as USERS, User};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Registry (source of truth — declared in code)
@@ -395,9 +396,6 @@ pub async fn clear_override(
 /// personal `User` targets are valid — org/role scopes require an org, and are
 /// rejected here. No `org_manageable` gate: platform admins own these.
 ///
-// Write path for the forthcoming platform-admin `/admin/feature-flags` surface;
-// exercised by tests today. `allow(dead_code)` until those endpoints land.
-#[allow(dead_code)]
 pub async fn set_platform_override(
     db: &mongodb::Database,
     flag_key: &str,
@@ -411,6 +409,16 @@ pub async fn set_platform_override(
         return Err(AppError::BadRequest(
             "org and role targets require an org; use the org feature-flag API".to_string(),
         ));
+    }
+    if let FlagTarget::User(user_id) = target {
+        let exists = db
+            .collection::<User>(USERS)
+            .find_one(doc! { "_id": user_id })
+            .await?
+            .is_some();
+        if !exists {
+            return Err(AppError::NotFound("User not found".to_string()));
+        }
     }
 
     let now = bson::DateTime::from_chrono(Utc::now());
@@ -458,27 +466,26 @@ pub async fn set_platform_override(
     Ok(row)
 }
 
-/// Clear a platform-level override. Returns whether a row was removed.
-#[allow(dead_code)]
+/// Clear a platform-level override. Returns the removed row when present.
 pub async fn clear_platform_override(
     db: &mongodb::Database,
     flag_key: &str,
     target: &FlagTarget,
-) -> AppResult<bool> {
+) -> AppResult<Option<FeatureFlagOverride>> {
     let target_key = match target.key() {
         Some(k) => bson::Bson::String(k),
         None => bson::Bson::Null,
     };
-    let res = db
+    let row = db
         .collection::<FeatureFlagOverride>(COLLECTION_NAME)
-        .delete_one(doc! {
+        .find_one_and_delete(doc! {
             "org_user_id": bson::Bson::Null,
             "flag_key": flag_key,
             "target_kind": target.kind().as_str(),
             "target_key": target_key,
         })
         .await?;
-    Ok(res.deleted_count > 0)
+    Ok(row)
 }
 
 /// Cascade helper: drop every override for an org (used when the org is deleted).
@@ -492,7 +499,8 @@ pub async fn delete_all_for_org(db: &mongodb::Database, org_user_id: &str) -> Ap
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::connect_test_database;
+    use crate::models::user::UserType;
+    use crate::test_utils::{connect_test_database, test_user};
 
     fn override_row(
         org: Option<&str>,
@@ -748,6 +756,10 @@ mod tests {
         };
         let user = Uuid::new_v4().to_string();
         let actor = Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_one(test_user(&user, UserType::Person))
+            .await
+            .expect("insert target user");
 
         // A user with zero orgs starts with the code default (off).
         assert!(
@@ -797,6 +809,7 @@ mod tests {
             clear_platform_override(&db, "example_ui", &FlagTarget::Global)
                 .await
                 .expect("clear global")
+                .is_some()
         );
     }
 }

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -14,6 +14,8 @@
 //! role / user is a runtime write, no deploy. Mirror new keys in
 //! `frontend/src/lib/feature-flags.ts`.
 
+use std::collections::{HashMap, HashSet};
+
 use chrono::Utc;
 use futures::TryStreamExt;
 use mongodb::bson::{self, doc};
@@ -277,6 +279,57 @@ pub async fn list_platform_overrides(
         .try_collect()
         .await?;
     Ok(rows)
+}
+
+/// Safe user fields used to enrich platform-admin feature-flag responses.
+#[derive(Clone, Debug)]
+pub struct PlatformOverrideUserDisplay {
+    pub email: String,
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PlatformOverrideUserProjection {
+    #[serde(rename = "_id")]
+    id: String,
+    email: String,
+    #[serde(default)]
+    display_name: Option<String>,
+}
+
+/// Resolve every user referenced by platform overrides in one projected query.
+/// Deleted users are absent and become null display fields in the response.
+pub async fn fetch_platform_override_users(
+    db: &mongodb::Database,
+    overrides: &[FeatureFlagOverride],
+) -> AppResult<HashMap<String, PlatformOverrideUserDisplay>> {
+    let user_ids: HashSet<&str> = overrides
+        .iter()
+        .filter(|row| row.target_kind == FlagTargetKind::User)
+        .filter_map(|row| row.target_key.as_deref())
+        .collect();
+    if user_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let cursor = db
+        .collection::<PlatformOverrideUserProjection>(USERS)
+        .find(doc! { "_id": { "$in": user_ids.into_iter().collect::<Vec<_>>() } })
+        .projection(doc! { "_id": 1, "email": 1, "display_name": 1 })
+        .await?;
+    let users: Vec<PlatformOverrideUserProjection> = cursor.try_collect().await?;
+    Ok(users
+        .into_iter()
+        .map(|user| {
+            (
+                user.id,
+                PlatformOverrideUserDisplay {
+                    email: user.email,
+                    display_name: user.display_name,
+                },
+            )
+        })
+        .collect())
 }
 
 /// A registry flag paired with the org's current overrides for it. Powers the

--- a/frontend/src/hooks/use-admin-feature-flags.test.tsx
+++ b/frontend/src/hooks/use-admin-feature-flags.test.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useAdminFeatureFlags,
+  useClearAdminFeatureFlag,
+  useSetAdminFeatureFlag,
+} from "./use-admin-feature-flags";
+
+const { mockGet, mockPut, mockDelete } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  api: { get: mockGet, put: mockPut, delete: mockDelete },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("admin feature-flag hooks", () => {
+  it("lists platform feature flags", async () => {
+    mockGet.mockResolvedValue({ flags: [] });
+    const { result } = renderHook(() => useAdminFeatureFlags(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith("/admin/feature-flags");
+  });
+
+  it("sets an encoded flag key", async () => {
+    mockPut.mockResolvedValue({});
+    const { result } = renderHook(() => useSetAdminFeatureFlag(), {
+      wrapper: createWrapper(),
+    });
+    await result.current.mutateAsync({
+      flagKey: "experimental:ai-assistant",
+      body: { target_kind: "global", target_key: null, enabled: true },
+    });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/admin/feature-flags/experimental%3Aai-assistant",
+      { target_kind: "global", target_key: null, enabled: true },
+    );
+  });
+
+  it("clears a user override with query parameters", async () => {
+    mockDelete.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useClearAdminFeatureFlag(), {
+      wrapper: createWrapper(),
+    });
+    await result.current.mutateAsync({
+      flagKey: "example_ui",
+      targetKind: "user",
+      targetKey: "user-1",
+    });
+    expect(mockDelete).toHaveBeenCalledWith(
+      "/admin/feature-flags/example_ui?target_kind=user&target_key=user-1",
+    );
+  });
+});

--- a/frontend/src/hooks/use-admin-feature-flags.ts
+++ b/frontend/src/hooks/use-admin-feature-flags.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type {
+  AdminFeatureFlagListResponse,
+  AdminFeatureFlagTargetKind,
+  SetAdminFeatureFlagRequest,
+} from "@/schemas/admin-feature-flags";
+
+const QUERY_KEY = ["admin", "feature-flags"] as const;
+
+export function useAdminFeatureFlags() {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: (): Promise<AdminFeatureFlagListResponse> =>
+      api.get<AdminFeatureFlagListResponse>("/admin/feature-flags"),
+  });
+}
+
+export function useSetAdminFeatureFlag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      flagKey,
+      body,
+    }: {
+      flagKey: string;
+      body: SetAdminFeatureFlagRequest;
+    }): Promise<unknown> =>
+      api.put(`/admin/feature-flags/${encodeURIComponent(flagKey)}`, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] });
+      void queryClient.invalidateQueries({ queryKey: ["user"] });
+    },
+  });
+}
+
+export function useClearAdminFeatureFlag() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      flagKey,
+      targetKind,
+      targetKey,
+    }: {
+      flagKey: string;
+      targetKind: AdminFeatureFlagTargetKind;
+      targetKey?: string | null;
+    }): Promise<void> => {
+      const params = new URLSearchParams({ target_kind: targetKind });
+      if (targetKey != null) params.set("target_key", targetKey);
+      return api.delete<void>(
+        `/admin/feature-flags/${encodeURIComponent(flagKey)}?${params.toString()}`,
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: ["orgs"] });
+      void queryClient.invalidateQueries({ queryKey: ["user"] });
+    },
+  });
+}

--- a/frontend/src/pages/admin-feature-flags.test.tsx
+++ b/frontend/src/pages/admin-feature-flags.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminFeatureFlagsPage } from "./admin-feature-flags";
 
-const { mockUseFlags, mockUseUsers } = vi.hoisted(() => ({
+const { mockUseFlags, mockUseUser, mockUseUsers } = vi.hoisted(() => ({
   mockUseFlags: vi.fn(),
+  mockUseUser: vi.fn(),
   mockUseUsers: vi.fn(),
 }));
 
@@ -14,14 +15,16 @@ vi.mock("@/hooks/use-admin-feature-flags", () => ({
 }));
 
 vi.mock("@/hooks/use-admin", () => ({
+  useAdminUser: mockUseUser,
   useAdminUsers: mockUseUsers,
 }));
 
 beforeEach(() => {
   mockUseUsers.mockReturnValue({
-    data: { users: [], total: 0, page: 1, per_page: 100 },
+    data: { users: [], total: 201, page: 1, per_page: 20 },
     isLoading: false,
   });
+  mockUseUser.mockReturnValue({ data: undefined, isLoading: false });
 });
 
 describe("AdminFeatureFlagsPage", () => {
@@ -60,6 +63,42 @@ describe("AdminFeatureFlagsPage", () => {
     expect(screen.getByText("No feature flags")).toBeInTheDocument();
   });
 
+  it("resolves an existing override label independently of search results", () => {
+    mockUseUser.mockImplementation((userId: string) => ({
+      data:
+        userId === "user-outside-page"
+          ? { id: userId, email: "existing@example.com" }
+          : undefined,
+      isLoading: false,
+    }));
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          {
+            key: "experimental:ai-assistant",
+            description: "AI Assistant chat surface.",
+            default_enabled: false,
+            org_manageable: true,
+            global_override: null,
+            user_overrides: [
+              {
+                user_id: "user-outside-page",
+                enabled: true,
+                updated_at: "2026-07-17T00:00:00Z",
+                updated_by: "admin-1",
+              },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    expect(screen.getByText("existing@example.com")).toBeInTheDocument();
+  });
+
   it("shows loading and error states", () => {
     mockUseFlags.mockReturnValue({ data: undefined, isLoading: true, error: null });
     const { rerender } = render(<AdminFeatureFlagsPage />);
@@ -72,5 +111,49 @@ describe("AdminFeatureFlagsPage", () => {
     });
     rerender(<AdminFeatureFlagsPage />);
     expect(screen.getByText("Failed to load feature flags")).toBeInTheDocument();
+  });
+
+  it("finds a user beyond the unsearched first page with server search", async () => {
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          {
+            key: "experimental:ai-assistant",
+            description: "AI Assistant chat surface.",
+            default_enabled: false,
+            org_manageable: true,
+            global_override: null,
+            user_overrides: [],
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockUseUsers.mockImplementation(
+      (_page: number, _perPage: number, search?: string) => ({
+        data:
+          search === "late@example.com"
+            ? {
+                users: [{ id: "user-201", email: "late@example.com" }],
+                total: 1,
+                page: 1,
+                per_page: 20,
+              }
+            : { users: [], total: 201, page: 1, per_page: 20 },
+        isLoading: false,
+      }),
+    );
+
+    render(<AdminFeatureFlagsPage />);
+    fireEvent.click(screen.getByText("experimental:ai-assistant"));
+    fireEvent.change(screen.getByLabelText("Search users by email"), {
+      target: { value: "late@example.com" },
+    });
+
+    await waitFor(() =>
+      expect(mockUseUsers).toHaveBeenCalledWith(1, 20, "late@example.com"),
+    );
+    expect(await screen.findByText("late@example.com")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/admin-feature-flags.test.tsx
+++ b/frontend/src/pages/admin-feature-flags.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AdminFeatureFlagsPage } from "./admin-feature-flags";
+
+const { mockUseFlags, mockUseUsers } = vi.hoisted(() => ({
+  mockUseFlags: vi.fn(),
+  mockUseUsers: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-admin-feature-flags", () => ({
+  useAdminFeatureFlags: mockUseFlags,
+  useSetAdminFeatureFlag: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useClearAdminFeatureFlag: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/use-admin", () => ({
+  useAdminUsers: mockUseUsers,
+}));
+
+beforeEach(() => {
+  mockUseUsers.mockReturnValue({
+    data: { users: [], total: 0, page: 1, per_page: 100 },
+    isLoading: false,
+  });
+});
+
+describe("AdminFeatureFlagsPage", () => {
+  it("renders registry flags returned by the API", () => {
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          {
+            key: "experimental:ai-assistant",
+            description: "AI Assistant chat surface.",
+            default_enabled: false,
+            org_manageable: true,
+            global_override: true,
+            user_overrides: [],
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    expect(screen.getByText("experimental:ai-assistant")).toBeInTheDocument();
+    expect(screen.getByText("Default: Disabled")).toBeInTheDocument();
+    expect(screen.queryByText("No feature flags")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state only for an empty registry response", () => {
+    mockUseFlags.mockReturnValue({
+      data: { flags: [] },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    expect(screen.getByText("No feature flags")).toBeInTheDocument();
+  });
+
+  it("shows loading and error states", () => {
+    mockUseFlags.mockReturnValue({ data: undefined, isLoading: true, error: null });
+    const { rerender } = render(<AdminFeatureFlagsPage />);
+    expect(screen.getByLabelText("Loading feature flags")).toBeInTheDocument();
+
+    mockUseFlags.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("failed"),
+    });
+    rerender(<AdminFeatureFlagsPage />);
+    expect(screen.getByText("Failed to load feature flags")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin-feature-flags.test.tsx
+++ b/frontend/src/pages/admin-feature-flags.test.tsx
@@ -2,9 +2,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminFeatureFlagsPage } from "./admin-feature-flags";
 
-const { mockUseFlags, mockUseUser, mockUseUsers } = vi.hoisted(() => ({
+const { mockUseFlags, mockUseUsers } = vi.hoisted(() => ({
   mockUseFlags: vi.fn(),
-  mockUseUser: vi.fn(),
   mockUseUsers: vi.fn(),
 }));
 
@@ -15,7 +14,6 @@ vi.mock("@/hooks/use-admin-feature-flags", () => ({
 }));
 
 vi.mock("@/hooks/use-admin", () => ({
-  useAdminUser: mockUseUser,
   useAdminUsers: mockUseUsers,
 }));
 
@@ -24,7 +22,6 @@ beforeEach(() => {
     data: { users: [], total: 201, page: 1, per_page: 20 },
     isLoading: false,
   });
-  mockUseUser.mockReturnValue({ data: undefined, isLoading: false });
 });
 
 describe("AdminFeatureFlagsPage", () => {
@@ -64,13 +61,6 @@ describe("AdminFeatureFlagsPage", () => {
   });
 
   it("resolves an existing override label independently of search results", () => {
-    mockUseUser.mockImplementation((userId: string) => ({
-      data:
-        userId === "user-outside-page"
-          ? { id: userId, email: "existing@example.com" }
-          : undefined,
-      isLoading: false,
-    }));
     mockUseFlags.mockReturnValue({
       data: {
         flags: [
@@ -83,6 +73,8 @@ describe("AdminFeatureFlagsPage", () => {
             user_overrides: [
               {
                 user_id: "user-outside-page",
+                user_email: "existing@example.com",
+                user_display_name: null,
                 enabled: true,
                 updated_at: "2026-07-17T00:00:00Z",
                 updated_by: "admin-1",

--- a/frontend/src/pages/admin-feature-flags.tsx
+++ b/frontend/src/pages/admin-feature-flags.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { ChevronDown, Search } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
@@ -16,7 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { useAdminUsers } from "@/hooks/use-admin";
+import { useAdminUser, useAdminUsers } from "@/hooks/use-admin";
 import {
   useAdminFeatureFlags,
   useClearAdminFeatureFlag,
@@ -47,17 +47,11 @@ const draftKey = (flag: string, type: ScopeType, id: string) =>
 
 export function AdminFeatureFlagsPage() {
   const { data, isLoading, error } = useAdminFeatureFlags();
-  const { data: usersData, isLoading: usersLoading } = useAdminUsers(1, 100);
   const setOverride = useSetAdminFeatureFlag();
   const clearOverride = useClearAdminFeatureFlag();
   const [drafts, setDrafts] = useState<Record<string, ScopeState>>({});
   const [search, setSearch] = useState("");
   const [openKeys, setOpenKeys] = useState<string[]>([]);
-  const userOptions = (usersData?.users ?? []).map((user) => ({
-    id: user.id,
-    label: user.email,
-  }));
-  const userLabels = new Map(userOptions.map((user) => [user.id, user.label]));
   const flags: FlagRow[] = (data?.flags ?? []).map((flag) => ({
     key: flag.key,
     description: flag.description,
@@ -72,7 +66,7 @@ export function AdminFeatureFlagsPage() {
     orgs: [],
     users: flag.user_overrides.map((override) => ({
       id: override.user_id,
-      label: userLabels.get(override.user_id) ?? override.user_id,
+      label: override.user_id,
       state: override.enabled ? "enabled" : "disabled",
     })),
   }));
@@ -216,8 +210,6 @@ export function AdminFeatureFlagsPage() {
               stage={(type, id, s) => stage(flag.key, type, id, s)}
               stagedUsers={stagedIds(drafts, flag.key, "user")}
               stagedOrgs={stagedIds(drafts, flag.key, "org")}
-              userOptions={userOptions}
-              usersLoading={usersLoading}
             />
           ))}
         </div>
@@ -236,8 +228,6 @@ function FlagCard({
   stage,
   stagedOrgs,
   stagedUsers,
-  userOptions,
-  usersLoading,
 }: {
   readonly flag: FlagRow;
   readonly open: boolean;
@@ -248,43 +238,47 @@ function FlagCard({
   readonly stage: (type: ScopeType, id: string, s: ScopeState) => void;
   readonly stagedOrgs: readonly string[];
   readonly stagedUsers: readonly string[];
-  readonly userOptions: readonly { id: string; label: string }[];
-  readonly usersLoading: boolean;
 }) {
   const [addOrg, setAddOrg] = useState("");
-  const [addUser, setAddUser] = useState("");
 
   const orgIds = uniq([...flag.orgs.map((o) => o.id), ...stagedOrgs]);
   const userIds = uniq([...flag.users.map((u) => u.id), ...stagedUsers]);
-  const labelFor = (type: ScopeType, id: string) =>
-    type === "user"
-      ? userOptions.find((candidate) => candidate.id === id)?.label ?? id
-      : id;
-
-  const addableUsers = userOptions.filter((user) => !userIds.includes(user.id));
+  const labelFor = (_type: ScopeType, id: string) => id;
 
   // Collapsed summary pills: Global + configured orgs/users (non-inherit).
-  const pills: { id: string; label: string; state: ScopeState; pending: boolean }[] =
-    [
-      {
-        id: "global",
-        label: "Global",
-        state: stateFor("global", ""),
-        pending: isPending("global", ""),
-      },
-      ...orgIds.map((id) => ({
-        id: `org-${id}`,
-        label: labelFor("org", id),
-        state: stateFor("org", id),
-        pending: isPending("org", id),
-      })),
-      ...userIds.map((id) => ({
-        id: `user-${id}`,
-        label: labelFor("user", id),
-        state: stateFor("user", id),
-        pending: isPending("user", id),
-      })),
-    ].filter((p) => p.id === "global" || p.state !== "inherit");
+  const pills: {
+    id: string;
+    label: string;
+    scope: ScopeType;
+    targetId: string;
+    state: ScopeState;
+    pending: boolean;
+  }[] = [
+    {
+      id: "global",
+      label: "Global",
+      scope: "global" as const,
+      targetId: "",
+      state: stateFor("global", ""),
+      pending: isPending("global", ""),
+    },
+    ...orgIds.map((id) => ({
+      id: `org-${id}`,
+      label: labelFor("org", id),
+      scope: "org" as const,
+      targetId: id,
+      state: stateFor("org", id),
+      pending: isPending("org", id),
+    })),
+    ...userIds.map((id) => ({
+      id: `user-${id}`,
+      label: id,
+      scope: "user" as const,
+      targetId: id,
+      state: stateFor("user", id),
+      pending: isPending("user", id),
+    })),
+  ].filter((pill) => pill.id === "global" || pill.state !== "inherit");
   const shownPills = pills.slice(0, 6);
   const extraPills = pills.length - shownPills.length;
 
@@ -310,20 +304,8 @@ function FlagCard({
           </p>
           {!open && (
             <div className="flex flex-wrap items-center gap-1 pt-0.5">
-              {shownPills.map((p) => (
-                <Badge
-                  key={p.id}
-                  variant={p.state === "enabled" ? "success" : "secondary"}
-                  className={cn(
-                    "flex max-w-[180px] gap-1 text-[11px] font-normal",
-                    p.state === "inherit" && !p.pending && "opacity-60",
-                    p.pending && "ring-1 ring-primary/70",
-                  )}
-                  title={`${p.label} · ${word(p.state)}`}
-                >
-                  <span className="min-w-0 truncate">{p.label}</span>
-                  <span className="shrink-0">· {word(p.state)}</span>
-                </Badge>
+              {shownPills.map((pill) => (
+                <SummaryPill key={pill.id} pill={pill} />
               ))}
               {extraPills > 0 && (
                 <Badge
@@ -380,25 +362,16 @@ function FlagCard({
           </Group>
 
           <Group label="By user">
-            <AddPicker
-              value={addUser}
-              placeholder={
-                usersLoading
-                  ? "Loading users…"
-                  : addableUsers.length === 0
-                  ? "All users added"
-                  : "Add user…"
-              }
-              options={addableUsers}
+            <UserSearchPicker
+              excludedIds={userIds}
               onPick={(id) => {
-                setAddUser("");
                 stage("user", id, "enabled");
               }}
             />
             {userIds.map((id) => (
-              <ScopeRow
+              <UserScopeRow
                 key={id}
-                label={labelFor("user", id)}
+                userId={id}
                 state={stateFor("user", id)}
                 pending={isPending("user", id)}
                 onChange={(s) => stage("user", id, s)}
@@ -408,6 +381,130 @@ function FlagCard({
         </div>
       )}
     </Card>
+  );
+}
+
+interface SummaryPillValue {
+  readonly label: string;
+  readonly scope: ScopeType;
+  readonly targetId: string;
+  readonly state: ScopeState;
+  readonly pending: boolean;
+}
+
+function SummaryPill({ pill }: { readonly pill: SummaryPillValue }) {
+  const { data: user } = useAdminUser(
+    pill.scope === "user" ? pill.targetId : "",
+  );
+  const label = user?.email ?? pill.label;
+  return (
+    <Badge
+      variant={pill.state === "enabled" ? "success" : "secondary"}
+      className={cn(
+        "flex max-w-[180px] gap-1 text-[11px] font-normal",
+        pill.state === "inherit" && !pill.pending && "opacity-60",
+        pill.pending && "ring-1 ring-primary/70",
+      )}
+      title={`${label} · ${word(pill.state)}`}
+    >
+      <span className="min-w-0 truncate">{label}</span>
+      <span className="shrink-0">· {word(pill.state)}</span>
+    </Badge>
+  );
+}
+
+function UserSearchPicker({
+  excludedIds,
+  onPick,
+}: {
+  readonly excludedIds: readonly string[];
+  readonly onPick: (id: string) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const normalizedSearch = search.trim();
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedSearch(normalizedSearch), 300);
+    return () => window.clearTimeout(timer);
+  }, [normalizedSearch]);
+
+  const { data, isLoading } = useAdminUsers(
+    1,
+    20,
+    debouncedSearch || undefined,
+  );
+  const waitingForSearch = normalizedSearch !== debouncedSearch;
+  const results = debouncedSearch && !waitingForSearch
+    ? (data?.users ?? []).filter((user) => !excludedIds.includes(user.id))
+    : [];
+
+  return (
+    <div className="space-y-2 border-b border-border/40 px-3 py-2 last:border-b-0">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search users by email…"
+          aria-label="Search users by email"
+          className="h-8 pl-8 text-[12px]"
+        />
+      </div>
+      {normalizedSearch && (
+        <div className="max-h-40 overflow-y-auto rounded-md border border-border/60">
+          {isLoading || waitingForSearch ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground">Searching…</p>
+          ) : results.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground">
+              No users match this search.
+            </p>
+          ) : (
+            results.map((user) => (
+              <button
+                key={user.id}
+                type="button"
+                onClick={() => {
+                  onPick(user.id);
+                  setSearch("");
+                  setDebouncedSearch("");
+                }}
+                className="block w-full border-b border-border/40 px-3 py-2 text-left text-xs last:border-b-0 hover:bg-muted/50"
+              >
+                <span className="block truncate font-medium">{user.email}</span>
+                <span className="block truncate text-muted-foreground">
+                  {user.id}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UserScopeRow({
+  userId,
+  state,
+  pending,
+  onChange,
+}: {
+  readonly userId: string;
+  readonly state: ScopeState;
+  readonly pending: boolean;
+  readonly onChange: (state: ScopeState) => void;
+}) {
+  const { data: user } = useAdminUser(userId);
+  return (
+    <div title={user ? undefined : userId}>
+      <ScopeRow
+        label={user?.email ?? userId}
+        state={state}
+        pending={pending}
+        onChange={onChange}
+      />
+    </div>
   );
 }
 

--- a/frontend/src/pages/admin-feature-flags.tsx
+++ b/frontend/src/pages/admin-feature-flags.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
   SelectContent,
@@ -15,16 +16,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-
-/**
- * PROTOTYPE — platform-admin, flag-centric feature-flag management.
- *
- * This is the proposed single home for feature flags (see design discussion):
- * flags are configured here across every scope of the resolution ladder —
- * Global → per-org → per-user — instead of under a single org's page. Data is
- * local mock state so the layout/flow can be reviewed before the backend
- * (global + org-less scopes, /admin endpoints) is built.
- */
+import { useAdminUsers } from "@/hooks/use-admin";
+import {
+  useAdminFeatureFlags,
+  useClearAdminFeatureFlag,
+  useSetAdminFeatureFlag,
+} from "@/hooks/use-admin-feature-flags";
 
 type ScopeState = "inherit" | "enabled" | "disabled";
 type FlagKind = "experiment" | "entitlement" | "ops";
@@ -44,36 +41,41 @@ interface FlagRow {
   users: Assignment[];
 }
 
-// ── Mock catalogs (prototype only) ──────────────────────────────────────────
-const ALL_ORGS = [
-  { id: "org-acme", label: "Acme" },
-  { id: "org-globex", label: "Globex" },
-  { id: "org-initech", label: "Initech" },
-  { id: "org-umbrella", label: "Umbrella" },
-  { id: "org-wonka", label: "Wonka Industries" },
-] as const;
-const ALL_USERS = [
-  { id: "u-alice", label: "alice@acme.io" },
-  { id: "u-bob", label: "bob@globex.com" },
-  { id: "u-carol", label: "carol@initech.dev" },
-  { id: "u-dave", label: "dave@personal.me" },
-] as const;
-
-// No flags loaded yet — the page renders its empty state. Populate this list
-// (or wire the backend) to visualize the flag-centric layout.
-const INITIAL_FLAGS: FlagRow[] = [];
-
 type ScopeType = "global" | "org" | "user";
 const draftKey = (flag: string, type: ScopeType, id: string) =>
   `${flag}\u001f${type}\u001f${id}`;
 
 export function AdminFeatureFlagsPage() {
-  const [flags, setFlags] = useState<FlagRow[]>(() =>
-    structuredCloneFlags(INITIAL_FLAGS),
-  );
+  const { data, isLoading, error } = useAdminFeatureFlags();
+  const { data: usersData, isLoading: usersLoading } = useAdminUsers(1, 100);
+  const setOverride = useSetAdminFeatureFlag();
+  const clearOverride = useClearAdminFeatureFlag();
   const [drafts, setDrafts] = useState<Record<string, ScopeState>>({});
   const [search, setSearch] = useState("");
   const [openKeys, setOpenKeys] = useState<string[]>([]);
+  const userOptions = (usersData?.users ?? []).map((user) => ({
+    id: user.id,
+    label: user.email,
+  }));
+  const userLabels = new Map(userOptions.map((user) => [user.id, user.label]));
+  const flags: FlagRow[] = (data?.flags ?? []).map((flag) => ({
+    key: flag.key,
+    description: flag.description,
+    kind: flag.key.startsWith("experimental:") ? "experiment" : "ops",
+    defaultEnabled: flag.default_enabled,
+    global:
+      flag.global_override == null
+        ? "inherit"
+        : flag.global_override
+          ? "enabled"
+          : "disabled",
+    orgs: [],
+    users: flag.user_overrides.map((override) => ({
+      id: override.user_id,
+      label: userLabels.get(override.user_id) ?? override.user_id,
+      state: override.enabled ? "enabled" : "disabled",
+    })),
+  }));
 
   const flagByKey = (key: string) => flags.find((f) => f.key === key);
   const persisted = (flag: string, type: ScopeType, id: string): ScopeState => {
@@ -94,34 +96,34 @@ export function AdminFeatureFlagsPage() {
   });
   const pendingCount = pending.length;
 
-  function applyChanges() {
-    setFlags((prev) => {
-      const next = structuredCloneFlags(prev);
-      for (const [k, state] of pending) {
-        const [flag, type, id] = k.split("\u001f");
-        const f = next.find((x) => x.key === flag);
-        if (!f) continue;
-        if (type === "global") {
-          f.global = state;
-        } else {
-          const list = type === "org" ? f.orgs : f.users;
-          const existing = list.find((a) => a.id === id);
-          if (existing) {
-            existing.state = state;
+  async function applyChanges() {
+    try {
+      await Promise.all(
+        pending.map(async ([key, scopeState]) => {
+          const [flagKey = "", type = "global", id = ""] = key.split("\u001f");
+          const targetKind = type === "user" ? "user" : "global";
+          const targetKey = targetKind === "user" ? id : null;
+          if (scopeState === "inherit") {
+            await clearOverride.mutateAsync({ flagKey, targetKind, targetKey });
           } else {
-            const cat = (type === "org" ? ALL_ORGS : ALL_USERS).find(
-              (c) => c.id === id,
-            );
-            if (cat) list.push({ id: cat.id, label: cat.label, state });
+            await setOverride.mutateAsync({
+              flagKey,
+              body: {
+                target_kind: targetKind,
+                target_key: targetKey,
+                enabled: scopeState === "enabled",
+              },
+            });
           }
-        }
-      }
-      return next;
-    });
-    setDrafts({});
-    toast.success(
-      `${pendingCount} change${pendingCount === 1 ? "" : "s"} applied (prototype)`,
-    );
+        }),
+      );
+      setDrafts({});
+      toast.success(
+        `${pendingCount} change${pendingCount === 1 ? "" : "s"} applied`,
+      );
+    } catch {
+      toast.error("Failed to apply feature flag changes");
+    }
   }
 
   const q = search.trim().toLowerCase();
@@ -176,7 +178,18 @@ export function AdminFeatureFlagsPage() {
         />
       </div>
 
-      {flags.length === 0 ? (
+      {isLoading ? (
+        <div className="space-y-2" aria-label="Loading feature flags">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : error ? (
+        <FlagsEmptyState
+          title="Failed to load feature flags"
+          subtitle="Please try again later."
+        />
+      ) : flags.length === 0 ? (
         <FlagsEmptyState
           title="No feature flags"
           subtitle="Flags are declared in code. None have been defined yet."
@@ -203,6 +216,8 @@ export function AdminFeatureFlagsPage() {
               stage={(type, id, s) => stage(flag.key, type, id, s)}
               stagedUsers={stagedIds(drafts, flag.key, "user")}
               stagedOrgs={stagedIds(drafts, flag.key, "org")}
+              userOptions={userOptions}
+              usersLoading={usersLoading}
             />
           ))}
         </div>
@@ -221,6 +236,8 @@ function FlagCard({
   stage,
   stagedOrgs,
   stagedUsers,
+  userOptions,
+  usersLoading,
 }: {
   readonly flag: FlagRow;
   readonly open: boolean;
@@ -231,6 +248,8 @@ function FlagCard({
   readonly stage: (type: ScopeType, id: string, s: ScopeState) => void;
   readonly stagedOrgs: readonly string[];
   readonly stagedUsers: readonly string[];
+  readonly userOptions: readonly { id: string; label: string }[];
+  readonly usersLoading: boolean;
 }) {
   const [addOrg, setAddOrg] = useState("");
   const [addUser, setAddUser] = useState("");
@@ -238,11 +257,11 @@ function FlagCard({
   const orgIds = uniq([...flag.orgs.map((o) => o.id), ...stagedOrgs]);
   const userIds = uniq([...flag.users.map((u) => u.id), ...stagedUsers]);
   const labelFor = (type: ScopeType, id: string) =>
-    (type === "org" ? ALL_ORGS : ALL_USERS).find((c) => c.id === id)?.label ??
-    id;
+    type === "user"
+      ? userOptions.find((candidate) => candidate.id === id)?.label ?? id
+      : id;
 
-  const addableOrgs = ALL_ORGS.filter((o) => !orgIds.includes(o.id));
-  const addableUsers = ALL_USERS.filter((u) => !userIds.includes(u.id));
+  const addableUsers = userOptions.filter((user) => !userIds.includes(user.id));
 
   // Collapsed summary pills: Global + configured orgs/users (non-inherit).
   const pills: { id: string; label: string; state: ScopeState; pending: boolean }[] =
@@ -344,16 +363,10 @@ function FlagCard({
           <Group label="By organization">
             <AddPicker
               value={addOrg}
-              placeholder={
-                addableOrgs.length === 0
-                  ? "All organizations added"
-                  : "Add organization…"
-              }
-              options={addableOrgs}
-              onPick={(id) => {
-                setAddOrg("");
-                stage("org", id, "enabled");
-              }}
+              placeholder="Manage overrides from the organization page"
+              options={[]}
+              onPick={setAddOrg}
+              disabledReason="Organization-scoped overrides are managed from each organization page."
             />
             {orgIds.map((id) => (
               <ScopeRow
@@ -370,7 +383,9 @@ function FlagCard({
             <AddPicker
               value={addUser}
               placeholder={
-                addableUsers.length === 0
+                usersLoading
+                  ? "Loading users…"
+                  : addableUsers.length === 0
                   ? "All users added"
                   : "Add user…"
               }
@@ -438,18 +453,23 @@ function AddPicker({
   placeholder,
   options,
   onPick,
+  disabledReason,
 }: {
   readonly value: string;
   readonly placeholder: string;
   readonly options: readonly { id: string; label: string }[];
   readonly onPick: (id: string) => void;
+  readonly disabledReason?: string;
 }) {
   return (
-    <div className="border-b border-border/40 px-3 py-2 last:border-b-0">
+    <div
+      className="border-b border-border/40 px-3 py-2 last:border-b-0"
+      title={disabledReason}
+    >
       <Select
         value={value}
         onValueChange={onPick}
-        disabled={options.length === 0}
+        disabled={Boolean(disabledReason) || options.length === 0}
       >
         <SelectTrigger className="h-8 w-full text-[12px]">
           <SelectValue placeholder={placeholder} />
@@ -533,11 +553,4 @@ function stagedIds(
     .map((k) => k.split("\u001f"))
     .filter((p) => p[0] === flag && p[1] === type && p[2])
     .map((p) => p[2] as string);
-}
-function structuredCloneFlags(rows: FlagRow[]): FlagRow[] {
-  return rows.map((f) => ({
-    ...f,
-    orgs: f.orgs.map((o) => ({ ...o })),
-    users: f.users.map((u) => ({ ...u })),
-  }));
 }

--- a/frontend/src/pages/admin-feature-flags.tsx
+++ b/frontend/src/pages/admin-feature-flags.tsx
@@ -16,7 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { useAdminUser, useAdminUsers } from "@/hooks/use-admin";
+import { useAdminUsers } from "@/hooks/use-admin";
 import {
   useAdminFeatureFlags,
   useClearAdminFeatureFlag,
@@ -29,6 +29,7 @@ type FlagKind = "experiment" | "entitlement" | "ops";
 interface Assignment {
   readonly id: string;
   readonly label: string;
+  readonly missingUser?: boolean;
   state: ScopeState;
 }
 interface FlagRow {
@@ -66,7 +67,9 @@ export function AdminFeatureFlagsPage() {
     orgs: [],
     users: flag.user_overrides.map((override) => ({
       id: override.user_id,
-      label: override.user_id,
+      label: userOverrideLabel(override),
+      missingUser:
+        override.user_email == null && override.user_display_name == null,
       state: override.enabled ? "enabled" : "disabled",
     })),
   }));
@@ -240,41 +243,41 @@ function FlagCard({
   readonly stagedUsers: readonly string[];
 }) {
   const [addOrg, setAddOrg] = useState("");
+  const [stagedUserLabels, setStagedUserLabels] = useState<
+    Record<string, string>
+  >({});
 
   const orgIds = uniq([...flag.orgs.map((o) => o.id), ...stagedOrgs]);
   const userIds = uniq([...flag.users.map((u) => u.id), ...stagedUsers]);
-  const labelFor = (_type: ScopeType, id: string) => id;
+  const labelFor = (type: ScopeType, id: string) =>
+    type === "user"
+      ? flag.users.find((user) => user.id === id)?.label ??
+        stagedUserLabels[id] ??
+        id
+      : id;
 
   // Collapsed summary pills: Global + configured orgs/users (non-inherit).
   const pills: {
     id: string;
     label: string;
-    scope: ScopeType;
-    targetId: string;
     state: ScopeState;
     pending: boolean;
   }[] = [
     {
       id: "global",
       label: "Global",
-      scope: "global" as const,
-      targetId: "",
       state: stateFor("global", ""),
       pending: isPending("global", ""),
     },
     ...orgIds.map((id) => ({
       id: `org-${id}`,
       label: labelFor("org", id),
-      scope: "org" as const,
-      targetId: id,
       state: stateFor("org", id),
       pending: isPending("org", id),
     })),
     ...userIds.map((id) => ({
       id: `user-${id}`,
-      label: id,
-      scope: "user" as const,
-      targetId: id,
+      label: labelFor("user", id),
       state: stateFor("user", id),
       pending: isPending("user", id),
     })),
@@ -364,19 +367,31 @@ function FlagCard({
           <Group label="By user">
             <UserSearchPicker
               excludedIds={userIds}
-              onPick={(id) => {
-                stage("user", id, "enabled");
+              onPick={(user) => {
+                setStagedUserLabels((labels) => ({
+                  ...labels,
+                  [user.id]: user.label,
+                }));
+                stage("user", user.id, "enabled");
               }}
             />
-            {userIds.map((id) => (
-              <UserScopeRow
-                key={id}
-                userId={id}
-                state={stateFor("user", id)}
-                pending={isPending("user", id)}
-                onChange={(s) => stage("user", id, s)}
-              />
-            ))}
+            {userIds.map((id) => {
+              const assignment = flag.users.find((user) => user.id === id);
+              const label = labelFor("user", id);
+              return (
+                <div
+                  key={id}
+                  title={assignment?.missingUser ? id : undefined}
+                >
+                  <ScopeRow
+                    label={label}
+                    state={stateFor("user", id)}
+                    pending={isPending("user", id)}
+                    onChange={(state) => stage("user", id, state)}
+                  />
+                </div>
+              );
+            })}
           </Group>
         </div>
       )}
@@ -386,17 +401,11 @@ function FlagCard({
 
 interface SummaryPillValue {
   readonly label: string;
-  readonly scope: ScopeType;
-  readonly targetId: string;
   readonly state: ScopeState;
   readonly pending: boolean;
 }
 
 function SummaryPill({ pill }: { readonly pill: SummaryPillValue }) {
-  const { data: user } = useAdminUser(
-    pill.scope === "user" ? pill.targetId : "",
-  );
-  const label = user?.email ?? pill.label;
   return (
     <Badge
       variant={pill.state === "enabled" ? "success" : "secondary"}
@@ -405,9 +414,9 @@ function SummaryPill({ pill }: { readonly pill: SummaryPillValue }) {
         pill.state === "inherit" && !pill.pending && "opacity-60",
         pill.pending && "ring-1 ring-primary/70",
       )}
-      title={`${label} · ${word(pill.state)}`}
+      title={`${pill.label} · ${word(pill.state)}`}
     >
-      <span className="min-w-0 truncate">{label}</span>
+      <span className="min-w-0 truncate">{pill.label}</span>
       <span className="shrink-0">· {word(pill.state)}</span>
     </Badge>
   );
@@ -418,7 +427,7 @@ function UserSearchPicker({
   onPick,
 }: {
   readonly excludedIds: readonly string[];
-  readonly onPick: (id: string) => void;
+  readonly onPick: (user: { id: string; label: string }) => void;
 }) {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -465,7 +474,7 @@ function UserSearchPicker({
                 key={user.id}
                 type="button"
                 onClick={() => {
-                  onPick(user.id);
+                  onPick({ id: user.id, label: user.email });
                   setSearch("");
                   setDebouncedSearch("");
                 }}
@@ -480,30 +489,6 @@ function UserSearchPicker({
           )}
         </div>
       )}
-    </div>
-  );
-}
-
-function UserScopeRow({
-  userId,
-  state,
-  pending,
-  onChange,
-}: {
-  readonly userId: string;
-  readonly state: ScopeState;
-  readonly pending: boolean;
-  readonly onChange: (state: ScopeState) => void;
-}) {
-  const { data: user } = useAdminUser(userId);
-  return (
-    <div title={user ? undefined : userId}>
-      <ScopeRow
-        label={user?.email ?? userId}
-        state={state}
-        pending={pending}
-        onChange={onChange}
-      />
     </div>
   );
 }
@@ -650,4 +635,16 @@ function stagedIds(
     .map((k) => k.split("\u001f"))
     .filter((p) => p[0] === flag && p[1] === type && p[2])
     .map((p) => p[2] as string);
+}
+
+function userOverrideLabel(override: {
+  readonly user_id: string;
+  readonly user_email: string | null;
+  readonly user_display_name: string | null;
+}): string {
+  const displayName = override.user_display_name?.trim();
+  if (displayName && override.user_email) {
+    return `${displayName} (${override.user_email})`;
+  }
+  return displayName || override.user_email || override.user_id;
 }

--- a/frontend/src/schemas/admin-feature-flags.ts
+++ b/frontend/src/schemas/admin-feature-flags.ts
@@ -7,6 +7,8 @@ export type AdminFeatureFlagTargetKind = z.infer<
 
 export const adminUserFeatureFlagOverrideSchema = z.object({
   user_id: z.string(),
+  user_email: z.string().nullable(),
+  user_display_name: z.string().nullable(),
   enabled: z.boolean(),
   updated_at: z.string(),
   updated_by: z.string(),

--- a/frontend/src/schemas/admin-feature-flags.ts
+++ b/frontend/src/schemas/admin-feature-flags.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const adminFeatureFlagTargetKindSchema = z.enum(["global", "user"]);
+export type AdminFeatureFlagTargetKind = z.infer<
+  typeof adminFeatureFlagTargetKindSchema
+>;
+
+export const adminUserFeatureFlagOverrideSchema = z.object({
+  user_id: z.string(),
+  enabled: z.boolean(),
+  updated_at: z.string(),
+  updated_by: z.string(),
+});
+
+export const adminFeatureFlagSchema = z.object({
+  key: z.string(),
+  description: z.string(),
+  default_enabled: z.boolean(),
+  org_manageable: z.boolean(),
+  global_override: z.boolean().nullable(),
+  user_overrides: z.array(adminUserFeatureFlagOverrideSchema),
+});
+export type AdminFeatureFlag = z.infer<typeof adminFeatureFlagSchema>;
+
+export const adminFeatureFlagListResponseSchema = z.object({
+  flags: z.array(adminFeatureFlagSchema),
+});
+export type AdminFeatureFlagListResponse = z.infer<
+  typeof adminFeatureFlagListResponseSchema
+>;
+
+export const setAdminFeatureFlagRequestSchema = z.object({
+  target_kind: adminFeatureFlagTargetKindSchema,
+  target_key: z.string().nullable(),
+  enabled: z.boolean(),
+});
+export type SetAdminFeatureFlagRequest = z.infer<
+  typeof setAdminFeatureFlagRequestSchema
+>;


### PR DESCRIPTION
## Summary

Wires the `/admin/feature-flags` page (previously a UI prototype on local mock state) to a real platform-admin API. Closes the gap where the only ways to manage platform-level flag rollout were org-scoped routes or manual `feature_flag_overrides` Mongo rows.

**New endpoints** (admin router, human-only group):
- `GET /api/v1/admin/feature-flags` — code registry joined with platform-level (global + per-user) override rows; user overrides enriched server-side (email/display name) via a single batched `$in` query with a narrow projection. Operators get read-only access (`require_admin_or_operator`), per the platform contract.
- `PUT /api/v1/admin/feature-flags/{flag_key}` — upsert global/user override (admin-only; `org`/`role` targets rejected: org-scoped concerns; user existence validated)
- `DELETE /api/v1/admin/feature-flags/{flag_key}?target_kind=&target_key=` — idempotent clear (204), admin-only, mirroring the org handler precedent

Backend reuses the pre-staged `set_platform_override`/`clear_platform_override` service functions from #1171 (previously `#[allow(dead_code)]`), adds unknown-flag rejection and metadata-only chained audit events (`admin_feature_flag_override_set` / `_cleared`, plus the standard operator-read marker).

**Frontend:** `admin-feature-flags.tsx` mock state replaced with TanStack Query (`use-admin-feature-flags.ts` + Zod schema); debounced server-side-search user picker (no page-size cap); override labels from the enriched list payload (no per-row lookups); loading/error/empty states; org-scope controls disabled with a pointer to the org page (org rows stay managed there).

## Rollout impact

None by itself — no flag defaults change. This makes `experimental:ai-assistant` (and future flags) operable from the admin UI: global killswitch + per-user enablement without Mongo shell access.

## Verification — cleared for merge ✅

Implemented by Sol-AdminFlags (codex gpt-5.6-sol); adversarially reviewed by an independent agent, Terra-Verify (codex gpt-5.6-terra), across three rounds, with all gates re-run independently each round (`cargo test`, clippy `-D warnings`, fmt, frontend build + 1,826 tests, wizard-bundle freshness — all passing):

- **Round 1 (ITERATE)**: caught operators being locked out of the read view (contract: read-only admin access) and a user picker silently capped at 100 users → fixed in `88565b9b` with a 6-way handler-level access-matrix test and a search-driven picker.
- **Round 2 (ITERATE)**: caught an unbounded N+1 (per-override admin-user lookups) → fixed in `7268da06` with single-query batched server-side enrichment (projection restricted to `_id`/`email`/`display_name`; sensitive fields never retrieved).
- **Round 3: SHIP** — no blocking findings; verified the batch is one query, the projection can't leak, and the new tests fail on the pre-fix implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)