### PR TITLE
feat(feature-flags): let platform admins manage org-scoped overrides

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -26,6 +26,9 @@ pub struct UserListQuery {
     pub page: Option<u64>,
     pub per_page: Option<u64>,
     pub search: Option<String>,
+    /// Optional account-type filter: `"person"` or `"org"`. Unset lists all
+    /// accounts (legacy behavior).
+    pub user_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -48,6 +51,8 @@ pub struct AdminUserItem {
     pub id: String,
     pub email: String,
     pub display_name: Option<String>,
+    /// Org accounts only; `None` for person accounts.
+    pub slug: Option<String>,
     pub avatar_url: Option<String>,
     pub email_verified: bool,
     pub is_active: bool,
@@ -216,6 +221,7 @@ fn user_to_admin_item(u: User, platform_role: PlatformRole) -> AdminUserItem {
         id: u.id,
         email: u.email,
         display_name: u.display_name,
+        slug: u.slug,
         avatar_url: u.avatar_url,
         email_verified: u.email_verified,
         is_active: u.is_active,
@@ -312,13 +318,34 @@ pub async fn list_users(
     let per_page = query.per_page.unwrap_or(50).min(100);
     let offset = (page - 1) * per_page;
 
-    let filter = match query.search.as_deref() {
-        Some(s) if !s.is_empty() => {
-            let escaped = regex::escape(s);
-            doc! { "email": { "$regex": &escaped, "$options": "i" } }
+    let mut filter = match query.user_type.as_deref() {
+        None => doc! {},
+        Some("org") => doc! { "user_type": "org" },
+        // Legacy person rows predate the field; match its absence too.
+        Some("person") => doc! { "user_type": { "$ne": "org" } },
+        Some(other) => {
+            return Err(AppError::BadRequest(format!(
+                "invalid user_type filter '{other}'; expected person or org"
+            )));
         }
-        _ => doc! {},
     };
+    if let Some(s) = query.search.as_deref().filter(|s| !s.is_empty()) {
+        let escaped = regex::escape(s);
+        let pattern = doc! { "$regex": &escaped, "$options": "i" };
+        if query.user_type.as_deref() == Some("org") {
+            // Orgs are found by name/slug; their emails are auto-generated.
+            filter.insert(
+                "$or",
+                vec![
+                    doc! { "email": pattern.clone() },
+                    doc! { "display_name": pattern.clone() },
+                    doc! { "slug": pattern },
+                ],
+            );
+        } else {
+            filter.insert("email", pattern);
+        }
+    }
 
     let total = state
         .db
@@ -1781,6 +1808,7 @@ mod tests {
             id: "id-1".to_string(),
             email: "test@example.com".to_string(),
             display_name: Some("Display".to_string()),
+            slug: None,
             avatar_url: None,
             email_verified: true,
             is_active: true,
@@ -2032,6 +2060,7 @@ mod operator_route_tests {
                 page: None,
                 per_page: None,
                 search: None,
+                user_type: None,
             }),
         )
         .await

--- a/backend/src/handlers/admin_feature_flags.rs
+++ b/backend/src/handlers/admin_feature_flags.rs
@@ -51,12 +51,43 @@ impl AdminUserFeatureFlagOverride {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
+pub struct AdminOrgFeatureFlagOverride {
+    pub org_id: String,
+    pub org_display_name: Option<String>,
+    pub org_slug: Option<String>,
+    pub enabled: bool,
+    pub updated_at: String,
+    pub updated_by: String,
+}
+
+impl AdminOrgFeatureFlagOverride {
+    fn from_row(
+        row: FeatureFlagOverride,
+        orgs: &std::collections::HashMap<String, feature_flag_service::PlatformOverrideOrgDisplay>,
+    ) -> AppResult<Self> {
+        let org_id = row.org_user_id.ok_or_else(|| {
+            AppError::Internal("org-scope override is missing its org id".to_string())
+        })?;
+        let org = orgs.get(&org_id);
+        Ok(Self {
+            org_display_name: org.and_then(|item| item.display_name.clone()),
+            org_slug: org.and_then(|item| item.slug.clone()),
+            org_id,
+            enabled: row.enabled,
+            updated_at: row.updated_at.to_rfc3339(),
+            updated_by: row.updated_by,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
 pub struct AdminFeatureFlagItem {
     pub key: String,
     pub description: String,
     pub default_enabled: bool,
     pub org_manageable: bool,
     pub global_override: Option<bool>,
+    pub org_overrides: Vec<AdminOrgFeatureFlagOverride>,
     pub user_overrides: Vec<AdminUserFeatureFlagOverride>,
 }
 
@@ -89,15 +120,41 @@ pub struct ClearAdminFeatureFlagQuery {
     pub target_key: Option<String>,
 }
 
-fn parse_target(kind: AdminFlagTargetKind, key: Option<&str>) -> AppResult<FlagTarget> {
+/// A parsed admin-API target: a platform-level row (`org_user_id = null`) or
+/// an org-wide row for one org (wire `target_key` = that org's user id).
+#[derive(Debug)]
+enum AdminTarget {
+    Platform(FlagTarget),
+    OrgWide { org_user_id: String },
+}
+
+fn parse_target(kind: AdminFlagTargetKind, key: Option<&str>) -> AppResult<AdminTarget> {
     match kind {
-        AdminFlagTargetKind::Global if key.is_none() => Ok(FlagTarget::Global),
+        AdminFlagTargetKind::Global if key.is_none() => {
+            Ok(AdminTarget::Platform(FlagTarget::Global))
+        }
         AdminFlagTargetKind::Global => Err(AppError::BadRequest(
             "global target requires target_key to be null".to_string(),
         )),
-        AdminFlagTargetKind::User => FlagTarget::from_parts(FlagTargetKind::User, key),
-        AdminFlagTargetKind::Org | AdminFlagTargetKind::Role => Err(AppError::BadRequest(
-            "org and role targets require an org; use the org feature-flag API".to_string(),
+        AdminFlagTargetKind::User => Ok(AdminTarget::Platform(FlagTarget::from_parts(
+            FlagTargetKind::User,
+            key,
+        )?)),
+        AdminFlagTargetKind::Org => {
+            let org_id = key
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    AppError::BadRequest(
+                        "org target requires target_key to be the org's user id".to_string(),
+                    )
+                })?;
+            Ok(AdminTarget::OrgWide {
+                org_user_id: org_id.to_string(),
+            })
+        }
+        AdminFlagTargetKind::Role => Err(AppError::BadRequest(
+            "role targets are org-scoped; use the org feature-flag API".to_string(),
         )),
     }
 }
@@ -109,7 +166,9 @@ pub async fn list_feature_flags(
 ) -> AppResult<Json<AdminFeatureFlagListResponse>> {
     require_admin_or_operator(&state, &auth_user, "admin.feature_flags.list").await?;
     let overrides = feature_flag_service::list_platform_overrides(&state.db).await?;
+    let org_rows = feature_flag_service::list_all_org_scope_overrides(&state.db).await?;
     let users = feature_flag_service::fetch_platform_override_users(&state.db, &overrides).await?;
+    let orgs = feature_flag_service::fetch_override_org_display(&state.db, &org_rows).await?;
     let mut flags = Vec::with_capacity(feature_flag_service::FEATURE_FLAGS.len());
 
     for def in feature_flag_service::FEATURE_FLAGS {
@@ -117,6 +176,12 @@ pub async fn list_feature_flags(
             .iter()
             .find(|row| row.flag_key == def.key && row.target_kind == FlagTargetKind::Global)
             .map(|row| row.enabled);
+        let org_overrides = org_rows
+            .iter()
+            .filter(|row| row.flag_key == def.key)
+            .cloned()
+            .map(|row| AdminOrgFeatureFlagOverride::from_row(row, &orgs))
+            .collect::<AppResult<Vec<_>>>()?;
         let user_overrides = overrides
             .iter()
             .filter(|row| row.flag_key == def.key && row.target_kind == FlagTargetKind::User)
@@ -129,6 +194,7 @@ pub async fn list_feature_flags(
             default_enabled: def.default_enabled,
             org_manageable: def.org_manageable,
             global_override,
+            org_overrides,
             user_overrides,
         });
     }
@@ -144,16 +210,29 @@ pub async fn set_feature_flag(
     Json(body): Json<SetAdminFeatureFlagRequest>,
 ) -> AppResult<Json<AdminUserFeatureFlagOverrideOrGlobal>> {
     require_admin(&state, &auth_user).await?;
-    let target = parse_target(body.target_kind, body.target_key.as_deref())?;
     let actor = auth_user.user_id.to_string();
-    let row = feature_flag_service::set_platform_override(
-        &state.db,
-        &flag_key,
-        &target,
-        body.enabled,
-        &actor,
-    )
-    .await?;
+    let row = match parse_target(body.target_kind, body.target_key.as_deref())? {
+        AdminTarget::Platform(target) => {
+            feature_flag_service::set_platform_override(
+                &state.db,
+                &flag_key,
+                &target,
+                body.enabled,
+                &actor,
+            )
+            .await?
+        }
+        AdminTarget::OrgWide { org_user_id } => {
+            feature_flag_service::set_platform_org_override(
+                &state.db,
+                &org_user_id,
+                &flag_key,
+                body.enabled,
+                &actor,
+            )
+            .await?
+        }
+    };
 
     audit_service::log_for_user(
         state.db.clone(),
@@ -163,6 +242,7 @@ pub async fn set_feature_flag(
             "flag_key": flag_key,
             "target_kind": row.target_kind.as_str(),
             "target_key": row.target_key,
+            "org_user_id": row.org_user_id,
             "enabled": row.enabled,
         })),
     );
@@ -183,7 +263,10 @@ impl From<FeatureFlagOverride> for AdminUserFeatureFlagOverrideOrGlobal {
     fn from(row: FeatureFlagOverride) -> Self {
         Self {
             target_kind: row.target_kind.as_str().to_string(),
-            target_key: row.target_key,
+            // Org-wide rows store the org in `org_user_id` with a null
+            // `target_key`; echo the org id back so the response mirrors the
+            // request's wire shape.
+            target_key: row.target_key.or(row.org_user_id),
             enabled: row.enabled,
             updated_at: row.updated_at.to_rfc3339(),
             updated_by: row.updated_by,
@@ -201,9 +284,15 @@ pub async fn clear_feature_flag(
     require_admin(&state, &auth_user).await?;
     feature_flag_service::find_flag(&flag_key)
         .ok_or_else(|| AppError::BadRequest(format!("unknown feature flag '{flag_key}'")))?;
-    let target = parse_target(query.target_kind, query.target_key.as_deref())?;
-    let removed =
-        feature_flag_service::clear_platform_override(&state.db, &flag_key, &target).await?;
+    let removed = match parse_target(query.target_kind, query.target_key.as_deref())? {
+        AdminTarget::Platform(target) => {
+            feature_flag_service::clear_platform_override(&state.db, &flag_key, &target).await?
+        }
+        AdminTarget::OrgWide { org_user_id } => {
+            feature_flag_service::clear_platform_org_override(&state.db, &org_user_id, &flag_key)
+                .await?
+        }
+    };
 
     if let Some(row) = removed {
         audit_service::log_for_user(
@@ -214,6 +303,7 @@ pub async fn clear_feature_flag(
                 "flag_key": flag_key,
                 "target_kind": query.target_kind,
                 "target_key": query.target_key,
+                "org_user_id": row.org_user_id,
                 "enabled": row.enabled,
             })),
         );
@@ -253,7 +343,12 @@ mod tests {
         assert!(parse_target(AdminFlagTargetKind::Global, Some("x")).is_err());
         assert!(parse_target(AdminFlagTargetKind::User, None).is_err());
         assert!(parse_target(AdminFlagTargetKind::Org, None).is_err());
+        assert!(parse_target(AdminFlagTargetKind::Org, Some("  ")).is_err());
         assert!(parse_target(AdminFlagTargetKind::Role, Some("admin")).is_err());
+        assert!(matches!(
+            parse_target(AdminFlagTargetKind::Org, Some("org-1")),
+            Ok(AdminTarget::OrgWide { org_user_id }) if org_user_id == "org-1"
+        ));
     }
 
     #[tokio::test]
@@ -350,6 +445,95 @@ mod tests {
         .await
         .expect_err("unknown flag rejected");
         assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[tokio::test]
+    async fn org_override_round_trip_and_validation() {
+        let Some((state, admin_id, _operator_id, target_id)) =
+            setup("admin_feature_flags_org_flow").await
+        else {
+            eprintln!("skipping admin feature flag org test: no local MongoDB available");
+            return;
+        };
+        let auth = test_auth_user(&admin_id);
+        let flag_key = "staff_only_ui".to_string();
+        let org_id = Uuid::new_v4().to_string();
+        state
+            .db
+            .collection(USERS)
+            .insert_one(test_user(&org_id, UserType::Org))
+            .await
+            .expect("insert org user");
+
+        // Set an org-wide override (on a staff-only flag: no org_manageable
+        // gate on the platform path). The response echoes the org id.
+        let Json(row) = set_feature_flag(
+            State(state.clone()),
+            auth.clone(),
+            Path(flag_key.clone()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::Org,
+                target_key: Some(org_id.clone()),
+                enabled: true,
+            }),
+        )
+        .await
+        .expect("set org override");
+        assert_eq!(row.target_kind, "org");
+        assert_eq!(row.target_key.as_deref(), Some(org_id.as_str()));
+        assert!(row.enabled);
+
+        // The admin list shows the enriched org override; the org's own
+        // override set picks up the identical row.
+        let Json(list) = list_feature_flags(State(state.clone()), auth.clone())
+            .await
+            .expect("list flags");
+        let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
+        assert_eq!(item.org_overrides.len(), 1);
+        assert_eq!(item.org_overrides[0].org_id, org_id);
+        assert_eq!(
+            item.org_overrides[0].org_display_name.as_deref(),
+            Some("Test Org")
+        );
+        let org_rows = crate::services::feature_flag_service::list_overrides(&state.db, &org_id)
+            .await
+            .expect("org rows");
+        assert_eq!(org_rows.len(), 1);
+
+        // Nonexistent org and person accounts are rejected as not-an-org.
+        for bad_org in [Uuid::new_v4().to_string(), target_id] {
+            let err = set_feature_flag(
+                State(state.clone()),
+                auth.clone(),
+                Path(flag_key.clone()),
+                Json(SetAdminFeatureFlagRequest {
+                    target_kind: AdminFlagTargetKind::Org,
+                    target_key: Some(bad_org),
+                    enabled: true,
+                }),
+            )
+            .await
+            .expect_err("non-org target rejected");
+            assert!(matches!(err, AppError::NotFound(_)));
+        }
+
+        // Clear removes the row from both views.
+        clear_feature_flag(
+            State(state.clone()),
+            auth.clone(),
+            Path(flag_key.clone()),
+            Query(ClearAdminFeatureFlagQuery {
+                target_kind: AdminFlagTargetKind::Org,
+                target_key: Some(org_id.clone()),
+            }),
+        )
+        .await
+        .expect("clear org override");
+        let Json(list) = list_feature_flags(State(state), auth)
+            .await
+            .expect("list after clear");
+        let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
+        assert!(item.org_overrides.is_empty());
     }
 
     #[tokio::test]

--- a/backend/src/models/feature_flag_override.rs
+++ b/backend/src/models/feature_flag_override.rs
@@ -63,7 +63,8 @@ pub struct FeatureFlagOverride {
     pub created_at: DateTime<Utc>,
     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
     pub updated_at: DateTime<Utc>,
-    /// member_user_id of the org admin who last wrote this override.
+    /// User id of the admin who last wrote this override — an org admin on the
+    /// org self-serve path, or a platform admin via the admin feature-flag API.
     pub updated_by: String,
 }
 

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -66,6 +66,12 @@ pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
         default_enabled: false,
         org_manageable: true,
     },
+    FeatureFlagDef {
+        key: "staff_only_ui",
+        description: "Test-only staff-managed flag.",
+        default_enabled: false,
+        org_manageable: false,
+    },
 ];
 
 /// Look up a flag definition by key. `None` for unknown keys.
@@ -359,8 +365,9 @@ pub async fn list_for_admin(
         .collect())
 }
 
-/// Upsert an override. Rejects unknown flag keys (400) and non-org-manageable
-/// flags (403). Idempotent per `(org, flag, target_kind, target_key)`.
+/// Upsert an override on the org self-serve path. Rejects unknown flag keys
+/// (400) and non-org-manageable flags (403). Idempotent per
+/// `(org, flag, target_kind, target_key)`.
 pub async fn set_override(
     db: &mongodb::Database,
     org_user_id: &str,
@@ -376,7 +383,19 @@ pub async fn set_override(
             "feature flag '{flag_key}' is not org-manageable"
         )));
     }
+    upsert_override_row(db, org_user_id, flag_key, target, enabled, actor_id).await
+}
 
+/// The shared org-row upsert behind [`set_override`] (org admins) and
+/// [`set_platform_org_override`] (platform staff). Gates live on the callers.
+async fn upsert_override_row(
+    db: &mongodb::Database,
+    org_user_id: &str,
+    flag_key: &str,
+    target: &FlagTarget,
+    enabled: bool,
+    actor_id: &str,
+) -> AppResult<FeatureFlagOverride> {
     let now = bson::DateTime::from_chrono(Utc::now());
     let target_key = match target.key() {
         Some(k) => bson::Bson::String(k),
@@ -422,13 +441,22 @@ pub async fn set_override(
     Ok(row)
 }
 
-/// Delete one override. Returns whether a row was removed (idempotent clear).
+/// Delete one override on the org self-serve path. Returns whether a row was
+/// removed (idempotent clear). Same gates as [`set_override`] so org admins
+/// can't remove staff-set rows on flags they may not manage.
 pub async fn clear_override(
     db: &mongodb::Database,
     org_user_id: &str,
     flag_key: &str,
     target: &FlagTarget,
 ) -> AppResult<bool> {
+    let def = find_flag(flag_key)
+        .ok_or_else(|| AppError::BadRequest(format!("unknown feature flag '{flag_key}'")))?;
+    if !def.org_manageable {
+        return Err(AppError::Forbidden(format!(
+            "feature flag '{flag_key}' is not org-manageable"
+        )));
+    }
     let target_key = match target.key() {
         Some(k) => bson::Bson::String(k),
         None => bson::Bson::Null,
@@ -539,6 +567,133 @@ pub async fn clear_platform_override(
         })
         .await?;
     Ok(row)
+}
+
+/// Upsert an org-wide override on behalf of platform staff. Unlike
+/// [`set_override`] there is no `org_manageable` gate — platform admins own the
+/// full registry — but the target must be an existing org account (404
+/// otherwise). The written row is identical to one an org admin writes, so
+/// resolution and the org's own flags page pick it up unchanged.
+pub async fn set_platform_org_override(
+    db: &mongodb::Database,
+    org_user_id: &str,
+    flag_key: &str,
+    enabled: bool,
+    actor_id: &str,
+) -> AppResult<FeatureFlagOverride> {
+    find_flag(flag_key)
+        .ok_or_else(|| AppError::BadRequest(format!("unknown feature flag '{flag_key}'")))?;
+    ensure_org_exists(db, org_user_id).await?;
+    upsert_override_row(
+        db,
+        org_user_id,
+        flag_key,
+        &FlagTarget::Org,
+        enabled,
+        actor_id,
+    )
+    .await
+}
+
+/// Clear an org-wide override on behalf of platform staff. Returns the removed
+/// row when present (idempotent otherwise). No `org_manageable` gate.
+pub async fn clear_platform_org_override(
+    db: &mongodb::Database,
+    org_user_id: &str,
+    flag_key: &str,
+) -> AppResult<Option<FeatureFlagOverride>> {
+    let row = db
+        .collection::<FeatureFlagOverride>(COLLECTION_NAME)
+        .find_one_and_delete(doc! {
+            "org_user_id": org_user_id,
+            "flag_key": flag_key,
+            "target_kind": FlagTargetKind::Org.as_str(),
+            "target_key": bson::Bson::Null,
+        })
+        .await?;
+    Ok(row)
+}
+
+async fn ensure_org_exists(db: &mongodb::Database, org_user_id: &str) -> AppResult<()> {
+    let is_org = db
+        .collection::<User>(USERS)
+        .find_one(doc! { "_id": org_user_id })
+        .await?
+        .map(|user| user.user_type.is_org())
+        .unwrap_or(false);
+    if !is_org {
+        return Err(AppError::NotFound("Organization not found".to_string()));
+    }
+    Ok(())
+}
+
+/// Every org-wide (`target_kind = "org"`) override row across all orgs. Powers
+/// the platform-admin list view only — resolution reads a single org's rows
+/// via `list_overrides`, so this must never feed the resolver.
+pub async fn list_all_org_scope_overrides(
+    db: &mongodb::Database,
+) -> AppResult<Vec<FeatureFlagOverride>> {
+    let rows: Vec<FeatureFlagOverride> = db
+        .collection::<FeatureFlagOverride>(COLLECTION_NAME)
+        .find(doc! {
+            "target_kind": FlagTargetKind::Org.as_str(),
+            "org_user_id": { "$ne": bson::Bson::Null },
+        })
+        .await?
+        .try_collect()
+        .await?;
+    Ok(rows)
+}
+
+/// Safe org fields used to enrich platform-admin feature-flag responses.
+#[derive(Clone, Debug)]
+pub struct PlatformOverrideOrgDisplay {
+    pub display_name: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PlatformOverrideOrgProjection {
+    #[serde(rename = "_id")]
+    id: String,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    slug: Option<String>,
+}
+
+/// Resolve every org referenced by org-scope overrides in one projected query.
+/// Deleted orgs are absent and become null display fields in the response.
+pub async fn fetch_override_org_display(
+    db: &mongodb::Database,
+    overrides: &[FeatureFlagOverride],
+) -> AppResult<HashMap<String, PlatformOverrideOrgDisplay>> {
+    let org_ids: HashSet<&str> = overrides
+        .iter()
+        .filter_map(|row| row.org_user_id.as_deref())
+        .collect();
+    if org_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let cursor = db
+        .collection::<PlatformOverrideOrgProjection>(USERS)
+        .find(doc! { "_id": { "$in": org_ids.into_iter().collect::<Vec<_>>() } })
+        .projection(doc! { "_id": 1, "display_name": 1, "slug": 1 })
+        .await?;
+    let orgs: Vec<PlatformOverrideOrgProjection> = cursor.try_collect().await?;
+    Ok(orgs
+        .into_iter()
+        .map(|org| {
+            (
+                org.id,
+                PlatformOverrideOrgDisplay {
+                    display_name: org.display_name,
+                    slug: org.slug,
+                },
+            )
+        })
+        .collect())
 }
 
 /// Cascade helper: drop every override for an org (used when the org is deleted).
@@ -864,5 +1019,88 @@ mod tests {
                 .expect("clear global")
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn org_manageable_gates_org_path_but_not_platform_staff() {
+        let Some(db) = connect_test_database("feature_flag_staff_only").await else {
+            eprintln!("skipping feature flag service test: no local MongoDB available");
+            return;
+        };
+        let org = Uuid::new_v4().to_string();
+        let actor = Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_one(test_user(&org, UserType::Org))
+            .await
+            .expect("insert org user");
+
+        // Org self-serve path: staff-only flags are neither settable nor
+        // clearable (an org admin must not remove a staff-set row).
+        assert!(matches!(
+            set_override(&db, &org, "staff_only_ui", &FlagTarget::Org, true, &actor).await,
+            Err(AppError::Forbidden(_))
+        ));
+        assert!(matches!(
+            clear_override(&db, &org, "staff_only_ui", &FlagTarget::Org).await,
+            Err(AppError::Forbidden(_))
+        ));
+        assert!(matches!(
+            clear_override(&db, &org, "nope", &FlagTarget::Org).await,
+            Err(AppError::BadRequest(_))
+        ));
+
+        // Platform staff path: no org_manageable gate; the row lands in the
+        // org's own override set and the cross-org admin listing.
+        let row = set_platform_org_override(&db, &org, "staff_only_ui", true, &actor)
+            .await
+            .expect("staff sets org override");
+        assert_eq!(row.org_user_id.as_deref(), Some(org.as_str()));
+        assert_eq!(row.target_kind, FlagTargetKind::Org);
+        assert!(row.target_key.is_none());
+
+        let org_rows = list_overrides(&db, &org).await.expect("org rows");
+        assert_eq!(org_rows.len(), 1);
+        let all = list_all_org_scope_overrides(&db)
+            .await
+            .expect("all org-scope rows");
+        assert!(all.iter().any(|r| r.id == row.id));
+
+        let display = fetch_override_org_display(&db, &all)
+            .await
+            .expect("org display");
+        assert_eq!(
+            display.get(&org).and_then(|o| o.display_name.as_deref()),
+            Some("Test Org")
+        );
+
+        let removed = clear_platform_org_override(&db, &org, "staff_only_ui")
+            .await
+            .expect("staff clears org override");
+        assert_eq!(removed.map(|r| r.id), Some(row.id));
+    }
+
+    #[tokio::test]
+    async fn set_platform_org_override_requires_existing_org() {
+        let Some(db) = connect_test_database("feature_flag_org_validation").await else {
+            eprintln!("skipping feature flag service test: no local MongoDB available");
+            return;
+        };
+        let actor = Uuid::new_v4().to_string();
+        let person = Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_one(test_user(&person, UserType::Person))
+            .await
+            .expect("insert person user");
+
+        // Unknown id and a person account both 404 as "not an org".
+        assert!(matches!(
+            set_platform_org_override(&db, &Uuid::new_v4().to_string(), "example_ui", true, &actor)
+                .await,
+            Err(AppError::NotFound(_))
+        ));
+        assert!(matches!(
+            set_platform_org_override(&db, &person, "example_ui", true, &actor).await,
+            Err(AppError::NotFound(_))
+        ));
     }
 }

--- a/frontend/src/hooks/use-admin.ts
+++ b/frontend/src/hooks/use-admin.ts
@@ -16,15 +16,21 @@ import type {
 } from "@/types/admin";
 import type { PlatformRole } from "@/types/api";
 
-export function useAdminUsers(page: number, perPage: number, search?: string) {
+export function useAdminUsers(
+  page: number,
+  perPage: number,
+  search?: string,
+  userType?: "person" | "org",
+) {
   return useQuery({
-    queryKey: ["admin", "users", page, perPage, search],
+    queryKey: ["admin", "users", page, perPage, search, userType],
     queryFn: async (): Promise<AdminUserListResponse> => {
       const params = new URLSearchParams({
         page: String(page),
         per_page: String(perPage),
       });
       if (search) params.set("search", search);
+      if (userType) params.set("user_type", userType);
       return api.get<AdminUserListResponse>(
         `/admin/users?${params.toString()}`,
       );

--- a/frontend/src/pages/admin-feature-flags.test.tsx
+++ b/frontend/src/pages/admin-feature-flags.test.tsx
@@ -2,23 +2,51 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AdminFeatureFlagsPage } from "./admin-feature-flags";
 
-const { mockUseFlags, mockUseUsers } = vi.hoisted(() => ({
-  mockUseFlags: vi.fn(),
-  mockUseUsers: vi.fn(),
-}));
+const { mockUseFlags, mockUseUsers, mockSetFlag, mockClearFlag } = vi.hoisted(
+  () => ({
+    mockUseFlags: vi.fn(),
+    mockUseUsers: vi.fn(),
+    mockSetFlag: vi.fn(),
+    mockClearFlag: vi.fn(),
+  }),
+);
 
 vi.mock("@/hooks/use-admin-feature-flags", () => ({
   useAdminFeatureFlags: mockUseFlags,
-  useSetAdminFeatureFlag: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useClearAdminFeatureFlag: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useSetAdminFeatureFlag: () => ({ mutateAsync: mockSetFlag, isPending: false }),
+  useClearAdminFeatureFlag: () => ({
+    mutateAsync: mockClearFlag,
+    isPending: false,
+  }),
 }));
 
 vi.mock("@/hooks/use-admin", () => ({
   useAdminUsers: mockUseUsers,
 }));
 
+function flagFixture(
+  overrides: Partial<{
+    global_override: boolean | null;
+    org_overrides: unknown[];
+    user_overrides: unknown[];
+  }> = {},
+) {
+  return {
+    key: "experimental:ai-assistant",
+    description: "AI Assistant chat surface.",
+    default_enabled: false,
+    org_manageable: true,
+    global_override: null,
+    org_overrides: [],
+    user_overrides: [],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
-  mockUseUsers.mockReturnValue({
+  mockSetFlag.mockReset().mockResolvedValue(undefined);
+  mockClearFlag.mockReset().mockResolvedValue(undefined);
+  mockUseUsers.mockReset().mockReturnValue({
     data: { users: [], total: 201, page: 1, per_page: 20 },
     isLoading: false,
   });
@@ -27,18 +55,7 @@ beforeEach(() => {
 describe("AdminFeatureFlagsPage", () => {
   it("renders registry flags returned by the API", () => {
     mockUseFlags.mockReturnValue({
-      data: {
-        flags: [
-          {
-            key: "experimental:ai-assistant",
-            description: "AI Assistant chat surface.",
-            default_enabled: false,
-            org_manageable: true,
-            global_override: true,
-            user_overrides: [],
-          },
-        ],
-      },
+      data: { flags: [flagFixture({ global_override: true })] },
       isLoading: false,
       error: null,
     });
@@ -64,12 +81,7 @@ describe("AdminFeatureFlagsPage", () => {
     mockUseFlags.mockReturnValue({
       data: {
         flags: [
-          {
-            key: "experimental:ai-assistant",
-            description: "AI Assistant chat surface.",
-            default_enabled: false,
-            org_manageable: true,
-            global_override: null,
+          flagFixture({
             user_overrides: [
               {
                 user_id: "user-outside-page",
@@ -80,7 +92,7 @@ describe("AdminFeatureFlagsPage", () => {
                 updated_by: "admin-1",
               },
             ],
-          },
+          }),
         ],
       },
       isLoading: false,
@@ -89,6 +101,32 @@ describe("AdminFeatureFlagsPage", () => {
 
     render(<AdminFeatureFlagsPage />);
     expect(screen.getByText("existing@example.com")).toBeInTheDocument();
+  });
+
+  it("renders org overrides with their display name and slug", () => {
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          flagFixture({
+            org_overrides: [
+              {
+                org_id: "org-1",
+                org_display_name: "Acme Corp",
+                org_slug: "acme",
+                enabled: true,
+                updated_at: "2026-07-17T00:00:00Z",
+                updated_by: "admin-1",
+              },
+            ],
+          }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    expect(screen.getByText("Acme Corp (acme)")).toBeInTheDocument();
   });
 
   it("shows loading and error states", () => {
@@ -107,25 +145,14 @@ describe("AdminFeatureFlagsPage", () => {
 
   it("finds a user beyond the unsearched first page with server search", async () => {
     mockUseFlags.mockReturnValue({
-      data: {
-        flags: [
-          {
-            key: "experimental:ai-assistant",
-            description: "AI Assistant chat surface.",
-            default_enabled: false,
-            org_manageable: true,
-            global_override: null,
-            user_overrides: [],
-          },
-        ],
-      },
+      data: { flags: [flagFixture()] },
       isLoading: false,
       error: null,
     });
     mockUseUsers.mockImplementation(
-      (_page: number, _perPage: number, search?: string) => ({
+      (_page: number, _perPage: number, search?: string, kind?: string) => ({
         data:
-          search === "late@example.com"
+          kind === "person" && search === "late@example.com"
             ? {
                 users: [{ id: "user-201", email: "late@example.com" }],
                 total: 1,
@@ -144,8 +171,65 @@ describe("AdminFeatureFlagsPage", () => {
     });
 
     await waitFor(() =>
-      expect(mockUseUsers).toHaveBeenCalledWith(1, 20, "late@example.com"),
+      expect(mockUseUsers).toHaveBeenCalledWith(
+        1,
+        20,
+        "late@example.com",
+        "person",
+      ),
     );
     expect(await screen.findByText("late@example.com")).toBeInTheDocument();
+  });
+
+  it("stages an org from the org search and applies an org-scoped override", async () => {
+    mockUseFlags.mockReturnValue({
+      data: { flags: [flagFixture()] },
+      isLoading: false,
+      error: null,
+    });
+    mockUseUsers.mockImplementation(
+      (_page: number, _perPage: number, search?: string, kind?: string) => ({
+        data:
+          kind === "org" && search === "acme"
+            ? {
+                users: [
+                  {
+                    id: "org-9",
+                    email: "org-acme@nyxid.local",
+                    display_name: "Acme Corp",
+                    slug: "acme",
+                  },
+                ],
+                total: 1,
+                page: 1,
+                per_page: 20,
+              }
+            : { users: [], total: 0, page: 1, per_page: 20 },
+        isLoading: false,
+      }),
+    );
+
+    render(<AdminFeatureFlagsPage />);
+    fireEvent.click(screen.getByText("experimental:ai-assistant"));
+    fireEvent.change(screen.getByLabelText("Search organizations by name"), {
+      target: { value: "acme" },
+    });
+    fireEvent.click(await screen.findByText("Acme Corp"));
+
+    // The pick stages an enabled org override; applying must send an
+    // org-scoped write, never a global one (regression: NyxID killswitch).
+    fireEvent.click(screen.getByText("Apply changes"));
+    await waitFor(() =>
+      expect(mockSetFlag).toHaveBeenCalledWith({
+        flagKey: "experimental:ai-assistant",
+        body: {
+          target_kind: "org",
+          target_key: "org-9",
+          enabled: true,
+        },
+      }),
+    );
+    expect(mockSetFlag).toHaveBeenCalledTimes(1);
+    expect(mockClearFlag).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/admin-feature-flags.tsx
+++ b/frontend/src/pages/admin-feature-flags.tsx
@@ -29,7 +29,8 @@ type FlagKind = "experiment" | "entitlement" | "ops";
 interface Assignment {
   readonly id: string;
   readonly label: string;
-  readonly missingUser?: boolean;
+  /** True when the referenced account no longer resolves (deleted). */
+  readonly missingAccount?: boolean;
   state: ScopeState;
 }
 interface FlagRow {
@@ -64,11 +65,17 @@ export function AdminFeatureFlagsPage() {
         : flag.global_override
           ? "enabled"
           : "disabled",
-    orgs: [],
+    orgs: (flag.org_overrides ?? []).map((override) => ({
+      id: override.org_id,
+      label: orgOverrideLabel(override),
+      missingAccount:
+        override.org_display_name == null && override.org_slug == null,
+      state: override.enabled ? "enabled" : "disabled",
+    })),
     users: flag.user_overrides.map((override) => ({
       id: override.user_id,
       label: userOverrideLabel(override),
-      missingUser:
+      missingAccount:
         override.user_email == null && override.user_display_name == null,
       state: override.enabled ? "enabled" : "disabled",
     })),
@@ -98,8 +105,9 @@ export function AdminFeatureFlagsPage() {
       await Promise.all(
         pending.map(async ([key, scopeState]) => {
           const [flagKey = "", type = "global", id = ""] = key.split("\u001f");
-          const targetKind = type === "user" ? "user" : "global";
-          const targetKey = targetKind === "user" ? id : null;
+          const targetKind =
+            type === "user" ? "user" : type === "org" ? "org" : "global";
+          const targetKey = targetKind === "global" ? null : id;
           if (scopeState === "inherit") {
             await clearOverride.mutateAsync({ flagKey, targetKind, targetKey });
           } else {
@@ -242,7 +250,9 @@ function FlagCard({
   readonly stagedOrgs: readonly string[];
   readonly stagedUsers: readonly string[];
 }) {
-  const [addOrg, setAddOrg] = useState("");
+  const [stagedOrgLabels, setStagedOrgLabels] = useState<
+    Record<string, string>
+  >({});
   const [stagedUserLabels, setStagedUserLabels] = useState<
     Record<string, string>
   >({});
@@ -254,7 +264,11 @@ function FlagCard({
       ? flag.users.find((user) => user.id === id)?.label ??
         stagedUserLabels[id] ??
         id
-      : id;
+      : type === "org"
+        ? flag.orgs.find((org) => org.id === id)?.label ??
+          stagedOrgLabels[id] ??
+          id
+        : id;
 
   // Collapsed summary pills: Global + configured orgs/users (non-inherit).
   const pills: {
@@ -346,26 +360,38 @@ function FlagCard({
           </Group>
 
           <Group label="By organization">
-            <AddPicker
-              value={addOrg}
-              placeholder="Manage overrides from the organization page"
-              options={[]}
-              onPick={setAddOrg}
-              disabledReason="Organization-scoped overrides are managed from each organization page."
+            <AccountSearchPicker
+              kind="org"
+              excludedIds={orgIds}
+              onPick={(org) => {
+                setStagedOrgLabels((labels) => ({
+                  ...labels,
+                  [org.id]: org.label,
+                }));
+                stage("org", org.id, "enabled");
+              }}
             />
-            {orgIds.map((id) => (
-              <ScopeRow
-                key={id}
-                label={labelFor("org", id)}
-                state={stateFor("org", id)}
-                pending={isPending("org", id)}
-                onChange={(s) => stage("org", id, s)}
-              />
-            ))}
+            {orgIds.map((id) => {
+              const assignment = flag.orgs.find((org) => org.id === id);
+              return (
+                <div
+                  key={id}
+                  title={assignment?.missingAccount ? id : undefined}
+                >
+                  <ScopeRow
+                    label={labelFor("org", id)}
+                    state={stateFor("org", id)}
+                    pending={isPending("org", id)}
+                    onChange={(s) => stage("org", id, s)}
+                  />
+                </div>
+              );
+            })}
           </Group>
 
           <Group label="By user">
-            <UserSearchPicker
+            <AccountSearchPicker
+              kind="person"
               excludedIds={userIds}
               onPick={(user) => {
                 setStagedUserLabels((labels) => ({
@@ -381,7 +407,7 @@ function FlagCard({
               return (
                 <div
                   key={id}
-                  title={assignment?.missingUser ? id : undefined}
+                  title={assignment?.missingAccount ? id : undefined}
                 >
                   <ScopeRow
                     label={label}
@@ -422,12 +448,14 @@ function SummaryPill({ pill }: { readonly pill: SummaryPillValue }) {
   );
 }
 
-function UserSearchPicker({
+function AccountSearchPicker({
+  kind,
   excludedIds,
   onPick,
 }: {
+  readonly kind: "person" | "org";
   readonly excludedIds: readonly string[];
-  readonly onPick: (user: { id: string; label: string }) => void;
+  readonly onPick: (picked: { id: string; label: string }) => void;
 }) {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -442,11 +470,13 @@ function UserSearchPicker({
     1,
     20,
     debouncedSearch || undefined,
+    kind,
   );
   const waitingForSearch = normalizedSearch !== debouncedSearch;
   const results = debouncedSearch && !waitingForSearch
-    ? (data?.users ?? []).filter((user) => !excludedIds.includes(user.id))
+    ? (data?.users ?? []).filter((account) => !excludedIds.includes(account.id))
     : [];
+  const isOrg = kind === "org";
 
   return (
     <div className="space-y-2 border-b border-border/40 px-3 py-2 last:border-b-0">
@@ -455,8 +485,12 @@ function UserSearchPicker({
         <Input
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search users by email…"
-          aria-label="Search users by email"
+          placeholder={
+            isOrg ? "Search organizations by name…" : "Search users by email…"
+          }
+          aria-label={
+            isOrg ? "Search organizations by name" : "Search users by email"
+          }
           className="h-8 pl-8 text-[12px]"
         />
       </div>
@@ -466,26 +500,34 @@ function UserSearchPicker({
             <p className="px-3 py-2 text-xs text-muted-foreground">Searching…</p>
           ) : results.length === 0 ? (
             <p className="px-3 py-2 text-xs text-muted-foreground">
-              No users match this search.
+              {isOrg
+                ? "No organizations match this search."
+                : "No users match this search."}
             </p>
           ) : (
-            results.map((user) => (
-              <button
-                key={user.id}
-                type="button"
-                onClick={() => {
-                  onPick({ id: user.id, label: user.email });
-                  setSearch("");
-                  setDebouncedSearch("");
-                }}
-                className="block w-full border-b border-border/40 px-3 py-2 text-left text-xs last:border-b-0 hover:bg-muted/50"
-              >
-                <span className="block truncate font-medium">{user.email}</span>
-                <span className="block truncate text-muted-foreground">
-                  {user.id}
-                </span>
-              </button>
-            ))
+            results.map((account) => {
+              const label = isOrg
+                ? (account.display_name ?? account.slug ?? account.id)
+                : account.email;
+              const secondary = isOrg ? (account.slug ?? account.id) : account.id;
+              return (
+                <button
+                  key={account.id}
+                  type="button"
+                  onClick={() => {
+                    onPick({ id: account.id, label });
+                    setSearch("");
+                    setDebouncedSearch("");
+                  }}
+                  className="block w-full border-b border-border/40 px-3 py-2 text-left text-xs last:border-b-0 hover:bg-muted/50"
+                >
+                  <span className="block truncate font-medium">{label}</span>
+                  <span className="block truncate text-muted-foreground">
+                    {secondary}
+                  </span>
+                </button>
+              );
+            })
           )}
         </div>
       )}
@@ -526,44 +568,6 @@ function Group({
       <div className="overflow-hidden rounded-lg border border-border/60 bg-background">
         {children}
       </div>
-    </div>
-  );
-}
-
-function AddPicker({
-  value,
-  placeholder,
-  options,
-  onPick,
-  disabledReason,
-}: {
-  readonly value: string;
-  readonly placeholder: string;
-  readonly options: readonly { id: string; label: string }[];
-  readonly onPick: (id: string) => void;
-  readonly disabledReason?: string;
-}) {
-  return (
-    <div
-      className="border-b border-border/40 px-3 py-2 last:border-b-0"
-      title={disabledReason}
-    >
-      <Select
-        value={value}
-        onValueChange={onPick}
-        disabled={Boolean(disabledReason) || options.length === 0}
-      >
-        <SelectTrigger className="h-8 w-full text-[12px]">
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((o) => (
-            <SelectItem key={o.id} value={o.id}>
-              {o.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
     </div>
   );
 }
@@ -647,4 +651,16 @@ function userOverrideLabel(override: {
     return `${displayName} (${override.user_email})`;
   }
   return displayName || override.user_email || override.user_id;
+}
+
+function orgOverrideLabel(override: {
+  readonly org_id: string;
+  readonly org_display_name: string | null;
+  readonly org_slug: string | null;
+}): string {
+  const displayName = override.org_display_name?.trim();
+  if (displayName && override.org_slug) {
+    return `${displayName} (${override.org_slug})`;
+  }
+  return displayName || override.org_slug || override.org_id;
 }

--- a/frontend/src/schemas/admin-feature-flags.ts
+++ b/frontend/src/schemas/admin-feature-flags.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-export const adminFeatureFlagTargetKindSchema = z.enum(["global", "user"]);
+export const adminFeatureFlagTargetKindSchema = z.enum([
+  "global",
+  "org",
+  "user",
+]);
 export type AdminFeatureFlagTargetKind = z.infer<
   typeof adminFeatureFlagTargetKindSchema
 >;
@@ -14,12 +18,25 @@ export const adminUserFeatureFlagOverrideSchema = z.object({
   updated_by: z.string(),
 });
 
+export const adminOrgFeatureFlagOverrideSchema = z.object({
+  org_id: z.string(),
+  org_display_name: z.string().nullable(),
+  org_slug: z.string().nullable(),
+  enabled: z.boolean(),
+  updated_at: z.string(),
+  updated_by: z.string(),
+});
+export type AdminOrgFeatureFlagOverride = z.infer<
+  typeof adminOrgFeatureFlagOverrideSchema
+>;
+
 export const adminFeatureFlagSchema = z.object({
   key: z.string(),
   description: z.string(),
   default_enabled: z.boolean(),
   org_manageable: z.boolean(),
   global_override: z.boolean().nullable(),
+  org_overrides: z.array(adminOrgFeatureFlagOverrideSchema),
   user_overrides: z.array(adminUserFeatureFlagOverrideSchema),
 });
 export type AdminFeatureFlag = z.infer<typeof adminFeatureFlagSchema>;

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -13,6 +13,8 @@ export interface AdminUser {
   readonly id: string;
   readonly email: string;
   readonly display_name: string | null;
+  /// Org accounts only; null/absent for person accounts.
+  readonly slug?: string | null;
   readonly avatar_url: string | null;
   readonly email_verified: boolean;
   readonly is_active: boolean;


### PR DESCRIPTION
## Summary

Platform admins can now set and clear **org-wide feature-flag overrides** directly from the admin API and the `/admin/feature-flags` page. Previously the org section was disabled with a pointer to each organization page — which only works for orgs where the platform admin also holds org-admin membership (`require_org_admin` has no platform bypass), leaving no UI/API path at all for other orgs.

**API** (admin router, human-only group, `require_admin` writes):
- `PUT/DELETE /api/v1/admin/feature-flags/{flag_key}` accept `target_kind: "org"` with `target_key` = the org's user id. The row is stored in the existing per-org shape (`org_user_id` + `target_kind=org`), so flag resolution and the org's own flags page pick it up with zero resolver changes. Role targets remain org-API-only.
- `GET /api/v1/admin/feature-flags` now returns `org_overrides` per flag, enriched (display name + slug) via a single batched `$in` query with a narrow projection — mirroring the existing user enrichment.
- No `org_manageable` gate on the staff path (that gate restricts org admins; staff own the registry). The target must be a real **org** account — unknown ids and person accounts 404. Audit events (`admin_feature_flag_override_set/_cleared`) now carry `org_user_id`; the admin list query stays separate from `list_platform_overrides` so cross-org rows can never leak into resolution.
- `GET /api/v1/admin/users` gains an optional `user_type=person|org` filter. Org searches match name/slug/email; person and unfiltered searches keep the exact email-only behavior (zero change for existing flows). Items gain `slug`.

**Security hardening shipped with this** (closes a gap the new capability would have opened):
- The org self-serve **clear** path now enforces the same unknown-flag / `org_manageable` gates as set — an org admin can no longer delete a staff-set row on a staff-only flag. No-op for existing data (org admins could never create such rows).
- Fixed a latent frontend bug in `applyChanges` that mapped org drafts to `target_kind: "global"` — previously unreachable (picker disabled), it would have turned a per-org toggle into a **platform-wide killswitch write** the moment org rows rendered. A regression test locks in the org wire shape.

**Frontend:** the disabled org picker is replaced with a working debounced server-side org search (labels: display name + slug, missing-org fallback); existing org overrides render as toggle rows and summary pills. The user picker now filters to person accounts so org accounts can't be staged as per-user targets.

## Rollout impact

None by itself — additive API surface, no migration, no flag defaults change, and no existing override rows are touched. Org admins will see staff-set rows appear on their org flags page (unattributed there; a "set by staff" badge is a possible follow-up). Staff/tenant writes on the same row are last-writer-wins, consistent with the existing model.

## Verification

- `cargo test`: **4662 passed, 0 failed** — including new round-trips against real MongoDB (staff sets org override on a staff-only flag → enriched in admin list → identical row visible to the org's own listing → clear removes it from both), non-org target 404s, and org-admin set/clear both 403 on staff-only flags. `cargo fmt` + clippy clean.
- Frontend: **1839 tests passed** (3 new on this page incl. the org wire-shape regression), `npm run build` (tsc -b gate) passes, lint clean in touched files.
- Wizard bundle rebuilt byte-identical (admin page chunk isn't in the CLI wizard subset), so the freshness gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)