### PR TITLE
fix(assistant): auth-specific message on a streaming 401

### DIFF
--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -157,11 +157,12 @@ export function useWorkspaceCounts() {
 const TRANSPORT_TOAST_ID = "assistant-transport-unavailable";
 
 /**
- * Chat reaches aevatar through `/proxy/s/aevatar`, which passes the DOWNSTREAM's
- * status straight through. A 401 there means aevatar rejected the identity
- * NyxID forwarded — the NyxID session itself is fine — so the transport opts
- * those requests out of the global sign-out (`preserveSessionOn401` in
- * aevatar-transport) and the route stays put. Without a toast that failure is
+ * Chat reaches aevatar through NyxID's `/api/v1/assistant/*` pass-through, which
+ * forwards the DOWNSTREAM's status straight through. A 401 there means aevatar
+ * rejected the identity NyxID forwarded — the NyxID session itself is fine — so
+ * the transport opts those requests out of the global sign-out
+ * (`preserveSessionOn401` in aevatar-transport) and the route stays put.
+ * Without a toast that failure is
  * invisible: the sidebar just renders empty, which reads as "no chats yet"
  * rather than "chat is down".
  */

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -354,6 +354,24 @@ describe("AevatarAssistantTransport", () => {
     ).toBe("http_409");
   });
 
+  it("gives a stream 401 an auth-specific code and message, not a bare status", async () => {
+    stubFetch(routeCreate, (url, init) =>
+      url.endsWith("/stream") && init?.method === "POST"
+        ? jsonResponse({ error: "unauthorized" }, 401)
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events = await collectTurn(transport, "Hello");
+
+    const terminal = events[events.length - 1];
+    const error =
+      terminal?.event === "turn.completed" ? terminal.error : undefined;
+    expect(error?.code).toBe("unauthorized");
+    expect(error?.message).toContain("still signed in");
+  });
+
   it("settles open blocks and the turn on cancel", async () => {
     // A stream that emits the message start then stays open forever.
     const openStream = new ReadableStream<Uint8Array>({

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -457,9 +457,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
         },
       );
       if (!response.ok || !response.body) {
+        // A 401/403 here means aevatar rejected the forwarded identity, not
+        // that the NyxID session died — this raw fetch never touches auth
+        // state, so it cannot trigger a sign-out. Surface an auth-specific
+        // message rather than a bare status so the failed turn is legible.
+        const unauthorized = response.status === 401 || response.status === 403;
         this.finishTurn(conversationId, run, "failed", {
-          code: `http_${String(response.status)}`,
-          message: "The assistant stream could not be started.",
+          code: unauthorized ? "unauthorized" : `http_${String(response.status)}`,
+          message: unauthorized
+            ? "NyxID could not authenticate you to the chat backend. You are still signed in — reconnect the aevatar service and try again."
+            : "The assistant stream could not be started.",
         });
         return;
       }


### PR DESCRIPTION
Small follow-up to #1194 (merged). That PR landed the assistant chat integration
and removed the mode toggle; this adds the streaming-path 401 safeguard that was
in flight when #1194 merged, so it didn't make it in.

## Change
The streaming turn uses a raw `fetch` (SSE), so a downstream **401/403** from
aevatar previously surfaced as a bare `http_401` "could not be started" failure.
This gives it the same auth-specific wording the query paths already use
("You are still signed in — reconnect the aevatar service and try again"), so the
failed turn is legible. The raw fetch never touches auth state, so this still
cannot trigger a sign-out.

Also fixes a stale comment (`describeTransportError` said chat reaches aevatar via
`/proxy/s/aevatar`; it's the `/api/v1/assistant/*` mount now).

3 files, +33/-7. Adds a regression test. FE 1838/1838 + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
