### PR TITLE
fix(frontend): collapse the plugin connect modal into one continuous block

### DIFF
--- a/frontend/src/components/dashboard/add-key-dialog.tsx
+++ b/frontend/src/components/dashboard/add-key-dialog.tsx
@@ -20,10 +20,7 @@ import { OAuthCallbackGuidance } from "@/components/shared/twitter-oauth-guidanc
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
-  DialogHeader,
-  DialogTitle,
 } from "@/components/ui/dialog";
 import {
   Select,
@@ -49,6 +46,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { ServiceIcon } from "@/components/service-icon";
+import { StepHeader } from "@/components/dashboard/step-header";
 import {
   ConnectVerifyStep,
   type CreatedKey,
@@ -489,16 +487,18 @@ function RoutingStep({
         Back to catalog
       </button>
 
-      {catalogEntry && (
-        <div className="rounded-lg border border-border bg-muted/50 p-3">
-          <p className="text-[12px] font-medium">{catalogEntry.name}</p>
-          {catalogEntry.description && (
-            <p className="text-xs text-muted-foreground">
-              {catalogEntry.description}
-            </p>
-          )}
-        </div>
-      )}
+      <StepHeader
+        slug={catalogEntry?.slug}
+        title={
+          catalogEntry
+            ? `Configure routing for ${catalogEntry.name}`
+            : "Configure routing"
+        }
+        description={
+          catalogEntry?.description ??
+          "Choose how requests reach the endpoint."
+        }
+      />
 
       <div className="space-y-3">
         <Label>How should requests reach this service?</Label>
@@ -645,26 +645,25 @@ function KeyForm({
         Back
       </button>
 
-      {catalogEntry && (
-        <div className="rounded-lg border border-border bg-muted/50 p-3">
-          <p className="text-[12px] font-medium">{catalogEntry.name}</p>
-          {catalogEntry.description && (
-            <p className="text-xs text-muted-foreground">
-              {catalogEntry.description}
-            </p>
-          )}
-          {catalogEntry.api_key_url && (
-            <a
-              href={catalogEntry.api_key_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            >
-              Get API key
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          )}
-        </div>
+      <StepHeader
+        slug={catalogEntry?.slug}
+        title={catalogEntry ? `Configure ${catalogEntry.name}` : "Custom endpoint"}
+        description={
+          catalogEntry?.description ??
+          "Configure your custom endpoint and credentials."
+        }
+      />
+
+      {catalogEntry?.api_key_url && (
+        <a
+          href={catalogEntry.api_key_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          Get API key
+          <ExternalLink className="h-3 w-3" />
+        </a>
       )}
 
       {catalogEntry?.api_key_instructions && (
@@ -1026,6 +1025,14 @@ function NodeSetupStep({
         Back
       </button>
 
+      <StepHeader
+        slug={catalogEntry?.slug}
+        title={
+          catalogEntry ? `${catalogEntry.name} — Node setup` : "Node setup"
+        }
+        description="Configure credentials on your node agent."
+      />
+
       <div className="space-y-1.5">
         <Label htmlFor="node-label">
           Label <span className="text-destructive">*</span>
@@ -1367,19 +1374,11 @@ function OAuthStep({
         Back
       </button>
 
-      <div className="rounded-lg border border-border bg-muted/50 p-3">
-        <p className="text-[12px] font-medium">{catalogEntry.name}</p>
-        {catalogEntry.description && (
-          <p className="text-xs text-muted-foreground">
-            {catalogEntry.description}
-          </p>
-        )}
-      </div>
-
-      <p className="text-[12px] text-muted-foreground">
-        This service uses OAuth to authenticate. Click the button below to
-        connect your account.
-      </p>
+      <StepHeader
+        slug={catalogEntry?.slug}
+        title={`${reconnectMode ? "Reconnect" : "Connect"} to ${catalogEntry.name}`}
+        description="This service uses OAuth to authenticate. Click the button below to connect your account."
+      />
 
       <UpstreamScopePicker
         catalog={catalogEntry.scope_catalog ?? []}
@@ -1763,19 +1762,11 @@ function DeviceCodeStep({
           Back
         </button>
 
-        <div className="rounded-lg border border-border bg-muted/50 p-3">
-          <p className="text-[12px] font-medium">{catalogEntry.name}</p>
-          {catalogEntry.description && (
-            <p className="text-xs text-muted-foreground">
-              {catalogEntry.description}
-            </p>
-          )}
-        </div>
-
-        <p className="text-[12px] text-muted-foreground">
-          This service uses a device code to authenticate. Click continue to
-          request a code.
-        </p>
+        <StepHeader
+          slug={catalogEntry?.slug}
+          title={`${reconnectMode ? "Reconnect" : "Connect"} to ${catalogEntry.name}`}
+          description="This service uses a device code to authenticate. Click continue to request a code."
+        />
 
         {supportsAdditionalScopes ? (
           <UpstreamScopePicker
@@ -1813,11 +1804,13 @@ function DeviceCodeStep({
           <ArrowLeft className="h-3 w-3" />
           Back
         </button>
-        <div className="flex flex-col items-center gap-3 py-8">
+        <StepHeader
+          slug={catalogEntry?.slug}
+          title={`${reconnectMode ? "Reconnect" : "Connect"} to ${catalogEntry.name}`}
+          description={`Requesting code from ${catalogEntry.name}...`}
+        />
+        <div className="flex justify-center py-6">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          <p className="text-[12px] text-muted-foreground">
-            Requesting code from {catalogEntry.name}...
-          </p>
         </div>
       </div>
     );
@@ -1826,11 +1819,13 @@ function DeviceCodeStep({
   if (flowStep === "success") {
     return (
       <div className="space-y-4">
-        <div className="flex flex-col items-center gap-3 py-4">
+        <StepHeader
+          slug={catalogEntry?.slug}
+          title={`${catalogEntry.name} connected`}
+          description={`Your ${catalogEntry.name} account has been connected successfully.`}
+        />
+        <div className="flex justify-center py-4">
           <CheckCircle2 className="h-8 w-8 text-success" />
-          <p className="text-[12px] text-center text-muted-foreground">
-            Your {catalogEntry.name} account has been connected successfully.
-          </p>
         </div>
         <Button
           variant="primary"
@@ -1859,6 +1854,11 @@ function DeviceCodeStep({
           <ArrowLeft className="h-3 w-3" />
           Back
         </button>
+        <StepHeader
+          slug={catalogEntry?.slug}
+          title={`${reconnectMode ? "Reconnect" : "Connect"} to ${catalogEntry.name}`}
+          description="Something went wrong. Review the error below and try again."
+        />
         <div className="flex flex-col items-center gap-3 py-4">
           <AlertCircle className="h-8 w-8 text-destructive" />
           <p className="text-[12px] text-destructive text-center">{errorMessage}</p>
@@ -1886,6 +1886,12 @@ function DeviceCodeStep({
         <ArrowLeft className="h-3 w-3" />
         Back
       </button>
+
+      <StepHeader
+        slug={catalogEntry?.slug}
+        title={`${reconnectMode ? "Reconnect" : "Connect"} to ${catalogEntry.name}`}
+        description={`Enter this code at ${catalogEntry.name} to finish authenticating.`}
+      />
 
       <div className="flex flex-col items-center gap-3 rounded-lg border-2 border-dashed border-primary/30 bg-primary/5 p-6">
         <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
@@ -1988,12 +1994,11 @@ function OAuthCredentialsStep({
         Back
       </button>
 
-      <div className="rounded-lg border border-border bg-muted/50 p-3">
-        <p className="text-[12px] font-medium">{catalogEntry.name}</p>
-        <p className="text-xs text-muted-foreground">
-          This service requires your own OAuth app credentials.
-        </p>
-      </div>
+      <StepHeader
+        slug={catalogEntry?.slug}
+        title={`Setup ${catalogEntry.name} credentials`}
+        description="This service requires your own OAuth app credentials."
+      />
 
       {catalogEntry.documentation_url && (
         <a
@@ -2557,82 +2562,24 @@ export function AddKeyDialog({
     });
   }
 
-  function dialogTitle(): string {
-    switch (step) {
-      case "catalog":
-        return isReconnect ? "Reconnect Service" : "Add AI Service";
-      case "routing":
-        return "Configure Routing";
-      case "node_setup":
-        return "Node Setup";
-      case "oauth_credentials":
-        return `Setup ${selectedEntry?.name ?? "Service"} Credentials`;
-      case "oauth":
-        return `${isReconnect ? "Reconnect" : "Connect"} to ${selectedEntry?.name ?? "Service"}`;
-      case "device_code":
-        return `${isReconnect ? "Reconnect" : "Connect"} to ${selectedEntry?.name ?? "Service"}`;
-      case "verify":
-        return `${createdKey?.serviceName ?? "Service"} connected`;
-      default:
-        return "Configure Service";
-    }
-  }
-
-  function dialogDescription(): string {
-    switch (step) {
-      case "catalog":
-        return isReconnect
-          ? "Restart authentication for this existing service."
-          : "Pick from the catalog or create a custom endpoint.";
-      case "routing":
-        return "Choose how requests reach the endpoint.";
-      case "node_setup":
-        return "Configure credentials on your node agent.";
-      case "oauth_credentials":
-        return `Enter your OAuth app credentials for ${selectedEntry?.name ?? "the service"}.`;
-      case "oauth":
-        return `Authenticate with ${selectedEntry?.name ?? "the service"} via OAuth.`;
-      case "device_code":
-        return `Authenticate with ${selectedEntry?.name ?? "the service"} using a device code.`;
-      case "verify":
-        return "Connect your AI tools to this service through NyxID.";
-      default:
-        return selectedEntry
-          ? `Set up your ${selectedEntry.name} credentials.`
-          : "Configure your custom endpoint and credentials.";
-    }
-  }
-
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
-        <DialogHeader>
-          <DialogTitle>
-            {step === "verify" && createdKey ? (
-              // Umbrella framing: the DialogTitle communicates the state
-              // (Service "<name>" connected) — that's the umbrella. The
-              // body then tells the user what's needed next (an Agent
-              // Key to let their AI tools actually use it).
-              //
-              // "Service" prefix is intentional per Calvin's ask — it
-              // labels the noun so the quoted name isn't dangling.
-              <span className="inline-flex items-center gap-2">
-                <ServiceIcon slug={createdKey.catalogSlug} size="sm" />
-                <span>
-                  Service{" "}
-                  <span className="text-muted-foreground">&ldquo;</span>
-                  {createdKey.serviceName}
-                  <span className="text-muted-foreground">&rdquo;</span>{" "}
-                  connected
-                </span>
-              </span>
-            ) : (
-              dialogTitle()
-            )}
-          </DialogTitle>
-          <DialogDescription>{dialogDescription()}</DialogDescription>
-        </DialogHeader>
-
+        {/* No DialogHeader here on purpose: each step body renders its own
+            <StepHeader>, which owns the real DialogTitle/DialogDescription.
+            That keeps the title visually attached to the content it
+            introduces instead of sitting above it across DialogContent's
+            gap-4, and leaves exactly one heading in the a11y tree. */}
+        {step === "catalog" && (
+          <StepHeader
+            title={isReconnect ? "Reconnect Service" : "Add AI Service"}
+            description={
+              isReconnect
+                ? "Restart authentication for this existing service."
+                : "Pick from the catalog or create a custom endpoint."
+            }
+          />
+        )}
         {step === "catalog" && (
           <OwnerPicker value={targetOrgId} onChange={setTargetOrgId} />
         )}

--- a/frontend/src/components/dashboard/connect-verify-step.test.tsx
+++ b/frontend/src/components/dashboard/connect-verify-step.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import type { ApiKeyCreateResponse } from "@/types/api";
 import { ConnectVerifyStep, type CreatedKey } from "./connect-verify-step";
 import {
@@ -76,6 +78,26 @@ function rejected(status: number): Response {
   return new Response("{}", { status });
 }
 
+/**
+ * Renders the step the way production does — inside a Dialog. Its header is
+ * the dialog's real DialogTitle/DialogDescription (see `step-header.tsx`),
+ * and Radix's title primitive throws outside a Dialog context.
+ */
+function renderStep(props: Partial<ComponentProps<typeof ConnectVerifyStep>> = {}) {
+  return render(
+    <Dialog open>
+      <DialogContent>
+        <ConnectVerifyStep
+          createdKey={CREATED_KEY}
+          isNodeRouted={false}
+          onDone={vi.fn()}
+          {...props}
+        />
+      </DialogContent>
+    </Dialog>,
+  );
+}
+
 async function mintKey(user: ReturnType<typeof userEvent.setup>) {
   createApiKeyMutate.mockImplementation((_params, opts) => {
     opts?.onSuccess?.(MINTED_KEY);
@@ -93,13 +115,7 @@ beforeEach(() => {
 
 describe("ConnectVerifyStep — initial phase (connected)", () => {
   it("renders the 'you need an Agent Key' prompt and both CTAs", () => {
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
 
     expect(document.body.textContent ?? "").toMatch(
       /need an\s+Agent Key\s+to call/i,
@@ -112,13 +128,7 @@ describe("ConnectVerifyStep — initial phase (connected)", () => {
 
   it("REGRESSION (silent CTA): clicking 'Create Agent Key' fires the mutation", async () => {
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
 
     await user.click(screen.getByRole("button", { name: /Create Agent Key/i }));
 
@@ -143,13 +153,7 @@ describe("ConnectVerifyStep — initial phase (connected)", () => {
   it("'Maybe later' calls onDone without firing the mutation", async () => {
     const onDone = vi.fn();
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={onDone}
-      />,
-    );
+    renderStep({ onDone });
 
     await user.click(screen.getByRole("button", { name: /Maybe later/i }));
 
@@ -164,13 +168,7 @@ describe("ConnectVerifyStep — key_ready phase", () => {
       opts?.onSuccess?.(MINTED_KEY);
     });
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
 
     await user.click(screen.getByRole("button", { name: /Create Agent Key/i }));
 
@@ -188,13 +186,7 @@ describe("ConnectVerifyStep — key_ready phase", () => {
       opts?.onError?.(new Error("scoped-service-must-be-active"));
     });
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
 
     await user.click(screen.getByRole("button", { name: /Create Agent Key/i }));
 
@@ -223,13 +215,7 @@ describe("ConnectVerifyStep — probe (downstream OK)", () => {
     window.addEventListener(FIRST_PROXY_CALL_SUCCEEDED_EVENT, succeededSpy);
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -269,13 +255,7 @@ describe("ConnectVerifyStep — probe (agent key VALID despite downstream failur
     window.addEventListener(FIRST_PROXY_CALL_SUCCEEDED_EVENT, succeededSpy);
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -303,13 +283,7 @@ describe("ConnectVerifyStep — probe (agent key VALID despite downstream failur
     vi.spyOn(window, "fetch").mockResolvedValue(proxied(404));
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -330,13 +304,7 @@ describe("ConnectVerifyStep — probe (agent key INVALID: NyxID-layer rejection)
     window.addEventListener(FIRST_PROXY_CALL_SUCCEEDED_EVENT, succeededSpy);
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -358,13 +326,7 @@ describe("ConnectVerifyStep — probe (agent key INVALID: NyxID-layer rejection)
     vi.spyOn(window, "fetch").mockResolvedValue(rejected(403));
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -391,13 +353,7 @@ describe("ConnectVerifyStep — probe (agent key INVALID: NyxID-layer rejection)
       );
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -418,13 +374,7 @@ describe("ConnectVerifyStep — probe (agent key INVALID: NyxID-layer rejection)
     vi.spyOn(window, "fetch").mockRejectedValue(new TypeError("network down"));
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -464,13 +414,7 @@ describe("ConnectVerifyStep — no Test button when we can't be highly confident
     const fetchSpy = vi.spyOn(window, "fetch");
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CODEX_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep({ createdKey: CODEX_KEY });
     await user.click(screen.getByRole("button", { name: /Create Agent Key/i }));
 
     // Panel appears — user can still copy the key.
@@ -510,13 +454,7 @@ describe("ConnectVerifyStep — no Test button when we can't be highly confident
     const fetchSpy = vi.spyOn(window, "fetch");
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CUSTOM_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep({ createdKey: CUSTOM_KEY });
     await user.click(screen.getByRole("button", { name: /Create Agent Key/i }));
 
     await waitFor(() =>
@@ -545,13 +483,7 @@ describe("ConnectVerifyStep — no Test button when we can't be highly confident
     });
     const onDone = vi.fn();
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CODEX_KEY}
-        isNodeRouted={false}
-        onDone={onDone}
-      />,
-    );
+    renderStep({ createdKey: CODEX_KEY, onDone });
     await user.click(screen.getByRole("button", { name: /Create Agent Key/i }));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /^Done$/i })).toBeEnabled(),
@@ -572,13 +504,7 @@ describe("ConnectVerifyStep — loading events + Done", () => {
     window.addEventListener(VERIFY_KEY_LOADING_END_EVENT, endSpy);
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
 
@@ -593,13 +519,7 @@ describe("ConnectVerifyStep — loading events + Done", () => {
     vi.spyOn(window, "fetch").mockResolvedValue(proxied(200));
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep();
     await mintKey(user);
 
     // Not visible before the probe runs.
@@ -620,18 +540,14 @@ describe("ConnectVerifyStep — loading events + Done", () => {
     vi.spyOn(window, "fetch").mockResolvedValue(proxied(200));
 
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={{
-          ...CREATED_KEY,
-          slug: "llm-openrouter",
-          catalogSlug: "llm-openrouter",
-          serviceName: "OpenRouter",
-        }}
-        isNodeRouted={false}
-        onDone={vi.fn()}
-      />,
-    );
+    renderStep({
+      createdKey: {
+        ...CREATED_KEY,
+        slug: "llm-openrouter",
+        catalogSlug: "llm-openrouter",
+        serviceName: "OpenRouter",
+      },
+    });
     await mintKey(user);
 
     // llm-openrouter is registered in PROBE_REGISTRY, so the Test
@@ -651,13 +567,7 @@ describe("ConnectVerifyStep — loading events + Done", () => {
 
     const onDone = vi.fn();
     const user = userEvent.setup();
-    render(
-      <ConnectVerifyStep
-        createdKey={CREATED_KEY}
-        isNodeRouted={false}
-        onDone={onDone}
-      />,
-    );
+    renderStep({ onDone });
     await mintKey(user);
     await user.click(screen.getByRole("button", { name: /Test Agent Key/i }));
     await waitFor(() =>

--- a/frontend/src/components/dashboard/connect-verify-step.tsx
+++ b/frontend/src/components/dashboard/connect-verify-step.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { AlertTriangle, Check, KeyRound, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyableField } from "@/components/shared/copyable-field";
+import { StepHeader } from "@/components/dashboard/step-header";
 import { useCreateApiKey } from "@/hooks/use-api-keys";
 import {
   FIRST_PROXY_CALL_SUCCEEDED_EVENT,
@@ -64,8 +65,9 @@ function proxyBaseUrl(slug: string): string {
 /**
  * Wave-aha-1 A4+ — umbrella-view post-connect setup.
  *
- * The DialogTitle owns the umbrella state ("<service> connected").
- * This component's body morphs per phase:
+ * The inline <StepHeader> owns the umbrella state ("<service> connected")
+ * and doubles as the dialog's DialogTitle. Below it, the body morphs per
+ * phase:
  *
  *   connected      → one-line "you need an Agent Key to use this"
  *                    + Maybe later / Create Agent Key
@@ -163,6 +165,22 @@ export function ConnectVerifyStep({
 
   return (
     <div className="space-y-4 py-2">
+      {/* Umbrella heading — the dialog's real DialogTitle, rendered here in
+          the body (rather than in a DialogHeader above it) so the modal
+          reads as one continuous block. "Service" prefix is intentional per
+          Calvin's ask — it labels the noun so the quoted name isn't
+          dangling. */}
+      <StepHeader
+        slug={createdKey.catalogSlug}
+        title={
+          <>
+            Service <span className="text-muted-foreground">&ldquo;</span>
+            {createdKey.serviceName}
+            <span className="text-muted-foreground">&rdquo;</span> connected
+          </>
+        }
+        description="Connect your AI tools to this service through NyxID."
+      />
       <Body
         phase={phase}
         createdKey={createdKey}

--- a/frontend/src/components/dashboard/step-header.tsx
+++ b/frontend/src/components/dashboard/step-header.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { ServiceIcon } from "@/components/service-icon";
+import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
+
+/**
+ * Inline header for a step body inside `AddKeyDialog`.
+ *
+ * This renders the *real* Radix `DialogTitle` / `DialogDescription` rather
+ * than a visual copy of them, so the dialog keeps its `aria-labelledby` /
+ * `aria-describedby` wiring and the accessibility tree holds exactly one
+ * heading. (An earlier pass rendered a plain `<h2>` here and left an
+ * sr-only `DialogHeader` above — that put two same-named headings in the
+ * a11y tree and screen readers announced the title twice.)
+ *
+ * Rendering the title inside the step body — instead of in a `DialogHeader`
+ * separated from it by `DialogContent`'s `gap-4` — is what makes the modal
+ * read as one continuous block. Every step body renders exactly one of
+ * these; because only a single step is mounted at a time, the dialog always
+ * has exactly one title.
+ */
+export function StepHeader({
+  slug,
+  title,
+  description,
+}: {
+  /** Catalog slug for the brand glyph. Omitted for custom endpoints. */
+  readonly slug?: string | null;
+  readonly title: ReactNode;
+  readonly description?: ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      {slug && (
+        <div className="mt-0.5 shrink-0">
+          <ServiceIcon slug={slug} size="md" />
+        </div>
+      )}
+      <div className="min-w-0 space-y-1">
+        <DialogTitle className="leading-tight">{title}</DialogTitle>
+        {description && <DialogDescription>{description}</DialogDescription>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

On the assistant **Plugins** page, clicking **Connect** on a connector opened a dialog that read as two stacked panels:

1. `DialogHeader` — step title + description
2. *(`DialogContent`'s `gap-4`)*
3. Step body, which opened with its **own** bordered card repeating the service name and catalog description
4. …then a third helper line ("This service uses OAuth to authenticate…")

Nothing actionable was visible until the fourth block, and the name + description appeared twice.

## Change

Each step body now renders a single inline `<StepHeader>` (brand glyph + title + description) directly above its content.

`StepHeader` renders the **real** Radix `DialogTitle`/`DialogDescription` rather than a visual copy, so the dialog keeps its `aria-labelledby`/`aria-describedby` wiring and the accessibility tree holds exactly one heading. The parent `DialogHeader` and the now-dead `dialogTitle()`/`dialogDescription()` switches are deleted.

Redundant `[name + description]` cards removed from `RoutingStep`, `KeyForm`, `OAuthStep`, `DeviceCodeStep`, `OAuthCredentialsStep`. Steps that previously leaned on the visible `DialogHeader` for context — `catalog`, `node_setup`, and the device-code `requesting`/`show_code`/`success`/`error` sub-flows — gain a header of their own. `ConnectVerifyStep`'s umbrella heading moves inline through the same component.

### Both modals considered

The **Manage** modal (`manage-connection-modal.tsx`) already followed this shape — icon + label + status badge in one `DialogTitle`, no `DialogDescription`, content immediately after. It is **unchanged**; the connect flow now matches it.

## Tests

`ConnectVerifyStep`'s tests rendered the component bare, which throws once it owns a `DialogTitle` (`DialogTitle` must be used within `Dialog`). They now render it inside a `Dialog` via a `renderStep()` helper — the way production mounts it. **All assertions unchanged**; this fixes the harness, not the expectations.

## Verification

- `npm run build` (tsc -b + vite) — clean
- `npm run lint` — 0 errors (20 pre-existing warnings, none in touched files)
- `npm test` — 169/169 files, 1837/1837 tests pass
- Wizard bundle regenerated — no diff (add-key-dialog isn't in that chunk)

⚠️ **Not verified in a live browser.** No browser host was available in the session, and reaching the modal needs a running backend + auth. Worth a manual pass on `/assistant/plugins` → Connect for an OAuth service (Anthropic API) and a device-code service (Codex API) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)