### PR TITLE
fix(assistant): first-send auto-create, stream error surfacing, composite delete

### DIFF
--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -8,25 +8,34 @@
 //! Every route is an explicit mapping onto one Aevatar path. A blanket
 //! `/{*path}` pass-through would expose all ~248 routes of Aevatar's spec
 //! (admin, workflow, and streaming-proxy surfaces included) through a
-//! session-authed mount; the assistant needs eight.
+//! session-authed mount; the assistant needs nine.
 //!
 //! Forwarding goes through `proxy::execute_proxy`, so credential injection,
 //! identity propagation, per-agent rate limiting, approval gating, and audit
 //! all apply unchanged -- the assistant is not a special case in the data
 //! plane (PRD N4). SSE responses stream through it unbuffered.
 
+use std::time::Duration;
+
 use axum::{
-    body::Body,
+    Json,
+    body::{Body, to_bytes},
     extract::{Path, State},
-    http::Request,
-    response::Response,
+    http::{Method, Request, StatusCode},
+    response::{IntoResponse, Response},
 };
 
 use crate::AppState;
-use crate::errors::AppResult;
+use crate::errors::{AppError, AppResult};
 use crate::handlers::proxy::execute_proxy;
 use crate::mw::auth::AuthUser;
 use crate::services::assistant_service;
+
+/// Create responses are a ~300-byte accepted envelope; the cap only guards
+/// against a misbehaving upstream.
+const MAX_CREATE_RESPONSE_BYTES: usize = 64 * 1024;
+/// The actor index is bare `{actorId}` rows (~60 bytes each).
+const MAX_INDEX_RESPONSE_BYTES: usize = 512 * 1024;
 
 /// Resolve the admin-managed Aevatar service and forward `path` to it.
 ///
@@ -55,13 +64,84 @@ async fn forward(
 }
 
 /// `POST /api/v1/assistant/conversations` -- create a conversation.
+///
+/// Create is async-accepted upstream (202 + `actorId`), and streaming into
+/// an actor before it appears in the `nyxid-chat` actor index races the
+/// materialization. Mirror the reference client (`waitForConversation`):
+/// after a successful create, poll the actor index with bounded backoff
+/// before returning, so a caller that immediately streams (the first-send
+/// flow) never hits the race. Best-effort — a poll failure never fails the
+/// create.
 pub async fn create_conversation(
     State(state): State<AppState>,
     auth_user: AuthUser,
     request: Request<Body>,
 ) -> AppResult<Response> {
-    let path = assistant_service::conversations_path(&auth_user.user_id.to_string());
-    forward(&state, &auth_user, path, request).await
+    let user_id = auth_user.user_id.to_string();
+    let path = assistant_service::conversations_path(&user_id);
+    let response = forward(&state, &auth_user, path, request).await?;
+    if !response.status().is_success() {
+        return Ok(response);
+    }
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, MAX_CREATE_RESPONSE_BYTES)
+        .await
+        .map_err(|_| {
+            AppError::Internal(
+                "assistant: conversation create response exceeded the buffer cap".to_string(),
+            )
+        })?;
+    if let Some(actor_id) = serde_json::from_slice::<serde_json::Value>(&bytes)
+        .ok()
+        .as_ref()
+        .and_then(assistant_service::extract_actor_id)
+        .map(str::to_owned)
+    {
+        wait_for_conversation_materialization(&state, &auth_user, &user_id, &actor_id).await;
+    }
+    Ok(Response::from_parts(parts, Body::from(bytes)))
+}
+
+/// Poll the `nyxid-chat` actor index until it lists `actor_id`, giving up
+/// after the bounded backoff schedule. Never fails: the create already
+/// succeeded, and a stream that still races simply fails visibly and can be
+/// retried.
+async fn wait_for_conversation_materialization(
+    state: &AppState,
+    auth_user: &AuthUser,
+    user_id: &str,
+    actor_id: &str,
+) {
+    for attempt in 0..assistant_service::CREATE_POLL_ATTEMPTS {
+        let Ok(index_request) = Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .body(Body::empty())
+        else {
+            return;
+        };
+        let path = assistant_service::conversations_path(user_id);
+        let Ok(response) = forward(state, auth_user, path, index_request).await else {
+            return;
+        };
+        if response.status().is_success() {
+            let Ok(bytes) = to_bytes(response.into_body(), MAX_INDEX_RESPONSE_BYTES).await else {
+                return;
+            };
+            if serde_json::from_slice::<serde_json::Value>(&bytes)
+                .map(|index| assistant_service::actor_index_contains(&index, actor_id))
+                .unwrap_or(false)
+            {
+                return;
+            }
+        }
+        if attempt + 1 < assistant_service::CREATE_POLL_ATTEMPTS {
+            tokio::time::sleep(Duration::from_millis(
+                assistant_service::create_poll_delay_ms(attempt),
+            ))
+            .await;
+        }
+    }
 }
 
 /// `GET /api/v1/assistant/conversations` -- list the caller's conversations
@@ -91,16 +171,41 @@ pub async fn get_history(
     forward(&state, &auth_user, path, request).await
 }
 
-/// `DELETE /api/v1/assistant/conversations/{id}`.
+/// `DELETE /api/v1/assistant/conversations/{id}` -- composite delete.
+///
+/// Removes both the `nyxid-chat` actor and the chat-history row (the Chat
+/// History contract's dual-delete): an `/api/chat`-created row has no
+/// actor, and a cascaded actor delete may have already dropped the history
+/// row, so 404 from either side counts as done. Anything else propagates
+/// that upstream response unchanged.
 pub async fn delete_conversation(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Path(conversation_id): Path<String>,
     request: Request<Body>,
 ) -> AppResult<Response> {
-    let path =
-        assistant_service::conversation_path(&auth_user.user_id.to_string(), &conversation_id)?;
-    forward(&state, &auth_user, path, request).await
+    let user_id = auth_user.user_id.to_string();
+    let actor_path = assistant_service::conversation_path(&user_id, &conversation_id)?;
+    let history_path = assistant_service::history_path(&user_id, &conversation_id)?;
+
+    let actor_response = forward(&state, &auth_user, actor_path, request).await?;
+    if !assistant_service::delete_status_acceptable(actor_response.status().as_u16()) {
+        return Ok(actor_response);
+    }
+
+    let history_request = Request::builder()
+        .method(Method::DELETE)
+        .uri("/")
+        .body(Body::empty())
+        .map_err(|_| {
+            AppError::Internal("assistant: failed to build the history delete request".to_string())
+        })?;
+    let history_response = forward(&state, &auth_user, history_path, history_request).await?;
+    if !assistant_service::delete_status_acceptable(history_response.status().as_u16()) {
+        return Ok(history_response);
+    }
+
+    Ok((StatusCode::OK, Json(serde_json::json!({}))).into_response())
 }
 
 /// `POST /api/v1/assistant/conversations/{id}/stream` -- AG-UI SSE turn.

--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -21,7 +21,7 @@ use axum::{
     Json,
     body::{Body, to_bytes},
     extract::{Path, State},
-    http::{Method, Request, StatusCode},
+    http::{HeaderValue, Method, Request, StatusCode, header},
     response::{IntoResponse, Response},
 };
 
@@ -36,6 +36,25 @@ use crate::services::assistant_service;
 const MAX_CREATE_RESPONSE_BYTES: usize = 64 * 1024;
 /// The actor index is bare `{actorId}` rows (~60 bytes each).
 const MAX_INDEX_RESPONSE_BYTES: usize = 512 * 1024;
+
+/// Server-initiated upstream request derived from a caller request (the
+/// materialization polls, the history half of the composite delete).
+///
+/// Carries the caller's `Authorization` so a `forward_access_token`
+/// service treats the derived call exactly like the original — without it,
+/// Bearer callers would see their polls 401 and their composite delete
+/// fail halfway while the row config still forwards tokens. Everything
+/// else (cookies, client metadata) is intentionally absent.
+fn synthetic_request(
+    method: Method,
+    authorization: Option<&HeaderValue>,
+) -> Result<Request<Body>, axum::http::Error> {
+    let mut builder = Request::builder().method(method).uri("/");
+    if let Some(value) = authorization {
+        builder = builder.header(header::AUTHORIZATION, value.clone());
+    }
+    builder.body(Body::empty())
+}
 
 /// Resolve the admin-managed Aevatar service and forward `path` to it.
 ///
@@ -78,6 +97,7 @@ pub async fn create_conversation(
     request: Request<Body>,
 ) -> AppResult<Response> {
     let user_id = auth_user.user_id.to_string();
+    let authorization = request.headers().get(header::AUTHORIZATION).cloned();
     let path = assistant_service::conversations_path(&user_id);
     let response = forward(&state, &auth_user, path, request).await?;
     if !response.status().is_success() {
@@ -97,7 +117,14 @@ pub async fn create_conversation(
         .and_then(assistant_service::extract_actor_id)
         .map(str::to_owned)
     {
-        wait_for_conversation_materialization(&state, &auth_user, &user_id, &actor_id).await;
+        wait_for_conversation_materialization(
+            &state,
+            &auth_user,
+            &user_id,
+            &actor_id,
+            authorization.as_ref(),
+        )
+        .await;
     }
     Ok(Response::from_parts(parts, Body::from(bytes)))
 }
@@ -111,13 +138,10 @@ async fn wait_for_conversation_materialization(
     auth_user: &AuthUser,
     user_id: &str,
     actor_id: &str,
+    authorization: Option<&HeaderValue>,
 ) {
     for attempt in 0..assistant_service::CREATE_POLL_ATTEMPTS {
-        let Ok(index_request) = Request::builder()
-            .method(Method::GET)
-            .uri("/")
-            .body(Body::empty())
-        else {
+        let Ok(index_request) = synthetic_request(Method::GET, authorization) else {
             return;
         };
         let path = assistant_service::conversations_path(user_id);
@@ -178,6 +202,13 @@ pub async fn get_history(
 /// actor, and a cascaded actor delete may have already dropped the history
 /// row, so 404 from either side counts as done. Anything else propagates
 /// that upstream response unchanged.
+///
+/// Deliberate divergence from the reference BFF (which attempts both
+/// deletes even when the first hard-fails): a non-404 actor-delete failure
+/// short-circuits here so the conversation stays fully intact and
+/// retryable, instead of deleting the history row and leaving an orphaned
+/// actor that no list surface can show. Retrying converges either way
+/// (a half-gone actor answers 404 next time and the history delete runs).
 pub async fn delete_conversation(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -185,6 +216,7 @@ pub async fn delete_conversation(
     request: Request<Body>,
 ) -> AppResult<Response> {
     let user_id = auth_user.user_id.to_string();
+    let authorization = request.headers().get(header::AUTHORIZATION).cloned();
     let actor_path = assistant_service::conversation_path(&user_id, &conversation_id)?;
     let history_path = assistant_service::history_path(&user_id, &conversation_id)?;
 
@@ -193,11 +225,8 @@ pub async fn delete_conversation(
         return Ok(actor_response);
     }
 
-    let history_request = Request::builder()
-        .method(Method::DELETE)
-        .uri("/")
-        .body(Body::empty())
-        .map_err(|_| {
+    let history_request =
+        synthetic_request(Method::DELETE, authorization.as_ref()).map_err(|_| {
             AppError::Internal("assistant: failed to build the history delete request".to_string())
         })?;
     let history_response = forward(&state, &auth_user, history_path, history_request).await?;
@@ -283,4 +312,28 @@ pub async fn workflow_chat_ws(
         request,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_requests_carry_the_callers_authorization() {
+        let value = HeaderValue::from_static("Bearer nyx_test_token");
+        let request = synthetic_request(Method::DELETE, Some(&value)).unwrap();
+        assert_eq!(request.method(), Method::DELETE);
+        assert_eq!(
+            request.headers().get(header::AUTHORIZATION),
+            Some(&HeaderValue::from_static("Bearer nyx_test_token"))
+        );
+    }
+
+    #[test]
+    fn synthetic_requests_without_authorization_stay_bare() {
+        let request = synthetic_request(Method::GET, None).unwrap();
+        assert_eq!(request.method(), Method::GET);
+        assert!(request.headers().get(header::AUTHORIZATION).is_none());
+        assert!(request.headers().get(header::COOKIE).is_none());
+    }
 }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -148,7 +148,7 @@ pub fn workflow_chat_ws_path() -> String {
 pub const CREATE_POLL_ATTEMPTS: u32 = 6;
 
 /// Delay before the next poll attempt (200ms, 300ms, ... capped by the
-/// attempt count; ~1.4s worst case).
+/// attempt count; ~2.0s of sleeps worst case, before network time).
 pub fn create_poll_delay_ms(attempt: u32) -> u64 {
     200 + u64::from(attempt) * 100
 }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -139,6 +139,53 @@ pub fn workflow_chat_ws_path() -> String {
     "api/ws/chat".to_string()
 }
 
+/// Post-create materialization poll bounds. Conversation create is
+/// async-accepted (202 + `actorId`); streaming into an actor before it
+/// appears in the `nyxid-chat` actor index races the materialization, so
+/// create waits for the actor with the same bounded backoff the reference
+/// client uses (nyxid-chat `server.mjs` `waitForConversation`).
+pub const CREATE_POLL_ATTEMPTS: u32 = 5;
+
+/// Delay before the next poll attempt (200ms, 300ms, ... capped by the
+/// attempt count; ~1.4s worst case).
+pub fn create_poll_delay_ms(attempt: u32) -> u64 {
+    200 + u64::from(attempt) * 100
+}
+
+/// `actorId` from a create-conversation response body. Aevatar responses
+/// have been observed in both camel- and Pascal-case.
+pub fn extract_actor_id(body: &serde_json::Value) -> Option<&str> {
+    body.get("actorId")
+        .or_else(|| body.get("ActorId"))?
+        .as_str()
+}
+
+/// Whether the `nyxid-chat` actor index (`{"conversations":[{"actorId"}]}`)
+/// lists the given actor.
+pub fn actor_index_contains(index: &serde_json::Value, actor_id: &str) -> bool {
+    index
+        .get("conversations")
+        .or_else(|| index.get("Conversations"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|conversations| {
+            conversations.iter().any(|entry| {
+                entry
+                    .get("actorId")
+                    .or_else(|| entry.get("ActorId"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(actor_id)
+            })
+        })
+}
+
+/// Composite-delete tolerance: deleting a conversation removes both the
+/// `nyxid-chat` actor and the chat-history row, and either side may already
+/// be gone (an `/api/chat`-created row has no actor; a cascaded actor
+/// delete may have removed the history row first). 404 is success-shaped.
+pub fn delete_status_acceptable(status: u16) -> bool {
+    (200..300).contains(&status) || status == 404
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,5 +246,49 @@ mod tests {
     fn accepts_the_opaque_ids_aevatar_issues() {
         assert!(history_path(USER, CONV).is_ok());
         assert!(history_path(USER, "abc_DEF-123").is_ok());
+    }
+
+    #[test]
+    fn extracts_actor_ids_in_both_observed_casings() {
+        let camel = serde_json::json!({ "status": "accepted", "actorId": CONV });
+        let pascal = serde_json::json!({ "ActorId": CONV });
+        assert_eq!(extract_actor_id(&camel), Some(CONV));
+        assert_eq!(extract_actor_id(&pascal), Some(CONV));
+        assert_eq!(extract_actor_id(&serde_json::json!({})), None);
+        assert_eq!(extract_actor_id(&serde_json::json!({ "actorId": 7 })), None);
+    }
+
+    #[test]
+    fn finds_actors_in_the_index_and_tolerates_shape_drift() {
+        let index = serde_json::json!({
+            "conversations": [{ "actorId": "other" }, { "actorId": CONV }],
+            "stateVersion": 3,
+        });
+        assert!(actor_index_contains(&index, CONV));
+        assert!(!actor_index_contains(&index, "missing"));
+        let pascal = serde_json::json!({ "Conversations": [{ "ActorId": CONV }] });
+        assert!(actor_index_contains(&pascal, CONV));
+        assert!(!actor_index_contains(&serde_json::json!({}), CONV));
+        assert!(!actor_index_contains(&serde_json::json!([1, 2]), CONV));
+    }
+
+    #[test]
+    fn composite_delete_accepts_success_and_absent_but_nothing_else() {
+        assert!(delete_status_acceptable(200));
+        assert!(delete_status_acceptable(204));
+        assert!(delete_status_acceptable(404));
+        assert!(!delete_status_acceptable(401));
+        assert!(!delete_status_acceptable(403));
+        assert!(!delete_status_acceptable(500));
+        assert!(!delete_status_acceptable(502));
+    }
+
+    #[test]
+    fn create_poll_backoff_is_bounded() {
+        let total: u64 = (0..CREATE_POLL_ATTEMPTS).map(create_poll_delay_ms).sum();
+        assert!(
+            total <= 2_000,
+            "poll wait must stay well under stream-start latency budgets, got {total}ms"
+        );
     }
 }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -142,9 +142,10 @@ pub fn workflow_chat_ws_path() -> String {
 /// Post-create materialization poll bounds. Conversation create is
 /// async-accepted (202 + `actorId`); streaming into an actor before it
 /// appears in the `nyxid-chat` actor index races the materialization, so
-/// create waits for the actor with the same bounded backoff the reference
-/// client uses (nyxid-chat `server.mjs` `waitForConversation`).
-pub const CREATE_POLL_ATTEMPTS: u32 = 5;
+/// create waits for the actor with the same attempt count and a comparable
+/// backoff budget (~2s) to the reference client (nyxid-chat `server.mjs`
+/// `waitForConversation`: 6 attempts, 250ms + 100ms/attempt).
+pub const CREATE_POLL_ATTEMPTS: u32 = 6;
 
 /// Delay before the next poll attempt (200ms, 300ms, ... capped by the
 /// attempt count; ~1.4s worst case).
@@ -285,9 +286,13 @@ mod tests {
 
     #[test]
     fn create_poll_backoff_is_bounded() {
-        let total: u64 = (0..CREATE_POLL_ATTEMPTS).map(create_poll_delay_ms).sum();
+        // Sleeps happen between attempts; the last attempt's delay is never
+        // slept.
+        let total: u64 = (0..CREATE_POLL_ATTEMPTS - 1)
+            .map(create_poll_delay_ms)
+            .sum();
         assert!(
-            total <= 2_000,
+            total <= 2_500,
             "poll wait must stay well under stream-start latency budgets, got {total}ms"
         );
     }

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -40,6 +40,35 @@ security** question (can a body `scopeId` *override* the derived scope for anoth
 user — needs a second account, cannot be tested with one token) and the browser
 **cookie-401** fix (needs the Aevatar identity-token change).
 
+## Implemented in cut 3 (2026-07-17 late — first-send fix, stream correctness, composite delete)
+
+Reference alignment pass against `eanz17/nyxid-chat` (latest: first-party
+sessions + proxy-only identity handling). Changes:
+
+- **Backend:** `POST /assistant/conversations` now waits for the created actor
+  to appear in the `nyxid-chat` actor index (bounded backoff, ~1.4s worst case,
+  best-effort — mirrors the reference `waitForConversation`) so an immediate
+  first stream cannot race the async-202 materialization.
+  `DELETE /assistant/conversations/{id}` is now the composite dual-delete
+  (actor + chat-history row, 404-tolerant on each side, 200 `{}` on success).
+- **Frontend:** first send from the "New chat" empty state auto-creates a
+  conversation and streams into it (previously a silent no-op: no selected
+  conversation → internal throw → composer swallowed it — the "chat looks
+  dead" prod symptom). Send failures now toast (`describeSendFailure`).
+  Stream handling: pre-SSE `{code,message}` / `{error,error_code,message}`
+  envelopes surface as the turn error (401/403 keeps the auth-specific,
+  you-are-still-signed-in copy); EOF without `RUN_FINISHED`/`RUN_ERROR` is a
+  failed `stream_closed` turn (was: silently reported success); the final
+  unterminated SSE frame is flushed; bare-`\r` framing normalized; every
+  `:stream` body carries a per-conversation `sessionId` (optional upstream,
+  reference-aligned).
+- **Reference-mandated aevatar row config** (README, nyxid-chat): 
+  `identity_propagation_mode:"jwt"`, `identity_jwt_audience:"urn:aevatar:api"`,
+  `inject_delegation_token:true`, `forward_access_token:false`. Prod row drift
+  as of 2026-07-17: audience empty, forward true, inject false — flip together
+  with the Aevatar-side identity-token validation (TD-3), NOT before (Bearer
+  forwarding is what keeps CLI callers working today).
+
 ## Implemented in this cut (2026-07-17, uncommitted, gates green)
 
 - **Backend:** added `history_index_path()` (`assistant_service.rs`) and repointed
@@ -127,7 +156,7 @@ in-memory list. Decision needed: should workflow/`/api/chat` chats persist?
 | `POST /api/v1/assistant/conversations` | `api/scopes/{uid}/nyxid-chat/conversations` | create actor |
 | `GET /api/v1/assistant/conversations` | `api/scopes/{uid}/chat-history` | **changed** — contract-B index |
 | `GET /api/v1/assistant/conversations/{id}` | `api/scopes/{uid}/chat-history/conversations/{id}` | unchanged |
-| `DELETE /api/v1/assistant/conversations/{id}` | actor delete **+** history-row delete | **changed** — composite |
+| `DELETE /api/v1/assistant/conversations/{id}` | actor delete **+** history-row delete | composite — **implemented** (cut 3) |
 | `POST /api/v1/assistant/conversations/{id}/stream` | `...:stream` (AG-UI SSE) | unchanged |
 | `POST /api/v1/assistant/conversations/{id}/approve` | `...:approve` | unchanged |
 | `POST /api/v1/assistant/completions` | `v1/chat/completions` | unchanged |
@@ -240,35 +269,29 @@ unless noted. Each item: what, risk, trigger.
   `ChatInput` DTO with server-forced scope; fail closed on identity generation; drop
   or gate the WS route. Trigger: probe failure = immediate blocker; otherwise before
   GA.
-- **TD-3 — Browser auth: client must carry a real Bearer (mint bridge reverted
-  2026-07-17).** Aevatar accepts a NyxID-signed Bearer and derives the scope
-  from its `sub`; cookie-only callers have no Bearer to forward, so a pure
-  cookie + admin-mount browser session 401s downstream. **Decision: do NOT mint
-  a NyxID token server-side** (an interim mint-and-forward bridge was tried and
-  reverted — a NyxID-audienced token handed downstream is replayable back at
-  NyxID). Instead the client presents a real Bearer, both already fully
-  supported by the backend:
-  - **Agent/dev:** a `nyxid_ag_` API key (scoped to the aevatar service) used
-    directly as the Bearer. `{scopeId}` = the key owner's user id.
-  - **Production:** OAuth Authorization-Code + PKCE (S256) at `/oauth/authorize`,
-    scopes `openid profile email proxy`, with RFC 8707 `resource` params for the
-    aevatar / chrono-llm-public / ornn-api proxy URIs. The token response returns
-    a ~5-min `access_token` **plus a `binding_id`** (`bnd_<32-hex>`,
-    `models/oauth_broker_binding.rs`); store the binding server-side and re-mint
-    access tokens via token exchange (`grant_type=…token-exchange`,
-    `subject_token_type=urn:nyxid:params:oauth:token-type:binding-id`). The
-    access token carries `resources` + `allowed_service_ids`; if the aevatar URI
-    is absent, calls 403 / return `AUTHORIZATION_REQUIRED` mid-run.
-  - **No NyxID code needed** — OAuth PKCE, binding-id token exchange, resource
-    indicators, agent keys, and `forward_access_token` all exist. The identity
-    token NyxID also emits (`X-NyxID-Identity-Token`, TD note) stays the cleaner
-    long-term path but is not required for the Bearer flow.
-  - **Consequence for our dashboard FE:** the current transport uses cookie auth
-    against the `/api/v1/assistant/*` mount, which has no Bearer to forward — so
-    with the bridge reverted it 401s in a browser. Making the product browser
-    surface work means the client acquires a real Bearer (agent key now; a
-    thin BFF holding the `binding_id` + token exchange for prod), per the client
-    brief. That client work is the open item; the backend is ready.
+- **TD-3 — Browser auth: Aevatar validates the identity token (superseded
+  "real Bearer" plan, 2026-07-17 reference alignment).** The reference client
+  (`eanz17/nyxid-chat`) DELETED its developer-app OAuth/binding flow entirely
+  (`/api/auth/authorize` → 410) and lands on exactly our dashboard's model:
+  same-site session cookie → NyxID proxy → proxy injects short-lived
+  `X-NyxID-Identity-Token` (aud `urn:aevatar:api`) + `X-NyxID-Delegation-Token`;
+  Aevatar validates the identity token against NyxID's JWKS (issuer, audience,
+  expiry), derives the scope from `sub`, re-checks path-scope == `sub` (403
+  mismatch), and uses the delegation token to call NyxID APIs/LLM/tools on the
+  user's behalf mid-run. Both prior "client presents a real Bearer"
+  alternatives are structurally broken and are dropped:
+  - `nyxid_ag_` agent keys are rejected by the assistant mount's human-only
+    router (`routes.rs` reject layers) — they never reach the proxy here.
+  - Resource-scoped OAuth tokens die in the legacy catalog branch's
+    scoped-token check (`proxy.rs` "Scoped API keys must use configured
+    services") before contacting Aevatar.
+  The mint-and-forward bridge stays dead (NyxID-audienced tokens are
+  replayable at NyxID). Rollout: (1) Aevatar team validates
+  `X-NyxID-Identity-Token` — the header already flows on every pass-through
+  call; (2) flip the aevatar row to `identity_jwt_audience:"urn:aevatar:api"`,
+  `inject_delegation_token:true`, `forward_access_token:false` (three-field
+  drift from today's prod row). Do NOT flip before (1): Bearer forwarding is
+  what keeps CLI callers working today.
 - **TD-4 — Feature flag not enforced server-side (F17).** Any authenticated human can
   call `/api/v1/assistant/*` with `experimental:ai-assistant` off; the flag only
   hides navigation.
@@ -282,10 +305,15 @@ unless noted. Each item: what, risk, trigger.
   The AG-UI transport renders text only: `TOOL_APPROVAL_REQUEST`, authorization,
   tool, usage, reasoning, keepalive and all `CUSTOM aevatar.*` frames are dropped;
   there is no credential/reasoning redaction (reference `protocol.js` scrubber
-  unported); EOF without `RUN_FINISHED` is treated as success; switching transport
-  modes mid-stream can cross-wire conversation state; mock artifact counts still
-  render. Fix: port the reference normalizer + redactor into one shared protocol
-  module. Trigger: before approvals/tool-use become user-visible chat features.
+  unported); mock artifact counts still render. (Fixed in cut 3: EOF without
+  `RUN_FINISHED` now fails the turn; pre-SSE error envelopes surface.) Two
+  reference-confirmed additions for this item: `:approve` responds with an SSE
+  stream — `decideApproval` currently JSON-parses and will break the moment
+  approval cards render; and `AUTHORIZATION_REQUIRED` must render a
+  service-config card that preserves the failed request for an EXPLICIT retry
+  only (never auto-retry a partially-executed run). Fix: port the reference
+  normalizer + redactor into one shared protocol module. Trigger: before
+  approvals/tool-use become user-visible chat features.
 - **TD-8 — `resolve_admin_service` under-validates provisioning (F2).** It checks
   slug + `requires_user_credential:false` only — not `service_category`, master
   credential, or `identity_propagation_mode`; a misconfigured row degrades silently.

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -46,7 +46,7 @@ Reference alignment pass against `eanz17/nyxid-chat` (latest: first-party
 sessions + proxy-only identity handling). Changes:
 
 - **Backend:** `POST /assistant/conversations` now waits for the created actor
-  to appear in the `nyxid-chat` actor index (bounded backoff, ~1.4s worst case,
+  to appear in the `nyxid-chat` actor index (bounded backoff, ~2.0s of sleeps worst case,
   best-effort — mirrors the reference `waitForConversation`) so an immediate
   first stream cannot race the async-202 materialization.
   `DELETE /assistant/conversations/{id}` is now the composite dual-delete
@@ -62,7 +62,7 @@ sessions + proxy-only identity handling). Changes:
   unterminated SSE frame is flushed; bare-`\r` framing normalized; every
   `:stream` body carries a per-conversation `sessionId` (optional upstream,
   reference-aligned).
-- **Reference-mandated aevatar row config** (README, nyxid-chat): 
+- **Reference-mandated aevatar row config** (README, nyxid-chat):
   `identity_propagation_mode:"jwt"`, `identity_jwt_audience:"urn:aevatar:api"`,
   `inject_delegation_token:true`, `forward_access_token:false`. Prod row drift
   as of 2026-07-17: audience empty, forward true, inject false — flip together

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -2,9 +2,13 @@ import { act, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import { ApiError } from "@/lib/api-client";
 import { AssistantTurnActiveError } from "@/lib/assistant/errors";
-import { resetAssistantTransport } from "@/lib/assistant/transport";
+import {
+  assistantTransport,
+  resetAssistantTransport,
+} from "@/lib/assistant/transport";
 import type { ConversationHistory } from "@/types/assistant";
 import {
   assistantKeys,
@@ -133,6 +137,93 @@ describe("assistant hooks", () => {
     );
     expect(settled?.messages.at(-1)?.role).toBe("assistant");
 
+    unmount();
+    queryClient.clear();
+  });
+
+  it("shares one auto-created conversation across racing empty-state sends", async () => {
+    // Two sends arriving before React commits the disabled/sending state
+    // must not allocate two actors: the create is single-flight, and the
+    // loser is rejected by the active-turn guard.
+    const { queryClient, Wrapper } = createHarness();
+    const createSpy = vi.spyOn(assistantTransport, "createConversation");
+    const { result, unmount } = renderHook(
+      () => ({
+        send: useSendMessage(undefined),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    let outcomes: PromiseSettledResult<SentMessage>[] = [];
+    await act(async () => {
+      const race = Promise.allSettled([
+        result.current.send.mutateAsync("First racing send."),
+        result.current.send.mutateAsync("Second racing send."),
+      ]);
+      await vi.advanceTimersByTimeAsync(0);
+      outcomes = await race;
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const fulfilled = outcomes.filter(
+      (outcome) => outcome.status === "fulfilled",
+    );
+    const rejected = outcomes.filter(
+      (outcome) => outcome.status === "rejected",
+    );
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(String(rejected[0]?.reason)).toMatch(/already active/i);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    createSpy.mockRestore();
+    unmount();
+    queryClient.clear();
+  });
+
+  it("toasts when a started stream later fails, since the mutation already resolved", async () => {
+    // Pre-SSE rejections and truncated streams surface as a failed
+    // `turn.completed` AFTER `mutateAsync` resolved — without a toast the
+    // failure would exist only as cached state nothing renders.
+    const { queryClient, Wrapper } = createHarness();
+    const toastSpy = vi.spyOn(toast, "error");
+    const sendSpy = vi
+      .spyOn(assistantTransport, "sendMessage")
+      .mockImplementation((_conversationId, _content, onEvent) => {
+        onEvent({
+          cursor: 1,
+          event: "turn.status",
+          turn_id: "turn-doomed",
+          status: "running",
+        });
+        onEvent({
+          cursor: 2,
+          event: "turn.completed",
+          turn_id: "turn-doomed",
+          status: "failed",
+          error: { code: "http_502", message: "Aevatar timed out." },
+        });
+        return { turnId: "turn-doomed", cancel: () => {} };
+      });
+    const { result, unmount } = renderHook(
+      () => ({ send: useSendMessage("conversation-stripe") }),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await result.current.send.mutateAsync("Doomed message.");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(toastSpy).toHaveBeenCalledWith(
+      "The assistant reply failed",
+      expect.objectContaining({ description: "Aevatar timed out." }),
+    );
+
+    sendSpy.mockRestore();
+    toastSpy.mockRestore();
     unmount();
     queryClient.clear();
   });

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -3,14 +3,19 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/lib/api-client";
+import { AssistantTurnActiveError } from "@/lib/assistant/errors";
 import { resetAssistantTransport } from "@/lib/assistant/transport";
+import type { ConversationHistory } from "@/types/assistant";
 import {
+  assistantKeys,
+  describeSendFailure,
   describeTransportError,
   useAssistantTurn,
   useCancelTurn,
   useConversation,
   useDecideApproval,
   useSendMessage,
+  type SentMessage,
 } from "./use-assistant";
 
 const TEST_NOW = Date.parse("2026-07-16T04:00:00.000Z");
@@ -83,6 +88,50 @@ describe("assistant hooks", () => {
     if (completed?.type === "text") {
       expect(completed.text).toContain("API transport swap");
     }
+
+    unmount();
+    queryClient.clear();
+  });
+
+  it("auto-creates a conversation for a send with none selected", async () => {
+    // The "New chat" empty state has no conversation. The first send must
+    // create one and stream into it — never silently no-op (the pre-fix
+    // behavior: an internal throw the composer swallowed).
+    const { queryClient, Wrapper } = createHarness();
+    const { result, unmount } = renderHook(
+      () => ({
+        send: useSendMessage(undefined),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    let sent: SentMessage | null = null;
+    await act(async () => {
+      sent = await result.current.send.mutateAsync(
+        "Hello from the empty state.",
+      );
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const conversationId = (sent as SentMessage | null)?.conversationId ?? "";
+    expect(conversationId).not.toBe("");
+    const history = queryClient.getQueryData<ConversationHistory>(
+      assistantKeys.history(conversationId),
+    );
+    expect(history?.messages.at(0)?.role).toBe("user");
+    expect(history?.messages.at(0)?.blocks[0]).toMatchObject({
+      type: "text",
+      text: "Hello from the empty state.",
+    });
+
+    // The scripted turn still streams to completion in the new conversation.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    const settled = queryClient.getQueryData<ConversationHistory>(
+      assistantKeys.history(conversationId),
+    );
+    expect(settled?.messages.at(-1)?.role).toBe("assistant");
 
     unmount();
     queryClient.clear();
@@ -240,5 +289,31 @@ describe("describeTransportError", () => {
   it("falls back to a generic message for non-401 failures", () => {
     const { message } = describeTransportError(new Error("network down"));
     expect(message).toBe("Could not load your chats");
+  });
+});
+
+describe("describeSendFailure", () => {
+  it("explains a downstream 401/403 without implying the session died", () => {
+    const { message, description } = describeSendFailure(
+      new ApiError(401, {
+        error: "unauthorized",
+        error_code: 1001,
+        message: "Unauthorized",
+      }),
+    );
+    expect(message).toBe("Message not sent");
+    expect(description).toContain("still signed in");
+  });
+
+  it("asks the user to wait when a turn is already active", () => {
+    const { description } = describeSendFailure(new AssistantTurnActiveError());
+    expect(description).toContain("current reply");
+  });
+
+  it("surfaces the underlying error message otherwise", () => {
+    const { description } = describeSendFailure(
+      new Error("Aevatar did not return a conversation id."),
+    );
+    expect(description).toBe("Aevatar did not return a conversation id.");
   });
 });

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -233,6 +233,12 @@ export interface SentMessage {
   readonly handle: TurnHandle;
 }
 
+// Single-flight guard for the empty-state auto-create: two sends racing in
+// before React commits the disabled/sending state must share ONE created
+// conversation (the second is then rejected by the active-turn guard)
+// instead of allocating two actors and streaming into both.
+let pendingAutoCreate: Promise<Conversation> | null = null;
+
 /**
  * Send a message into the bound conversation — or, when no conversation is
  * selected (the "New chat" empty state), create one first and send there.
@@ -246,7 +252,12 @@ export function useSendMessage(conversationId: string | undefined) {
     mutationFn: async (content: string): Promise<SentMessage> => {
       let target = conversationId;
       if (!target) {
-        const conversation = await assistantTransport.createConversation();
+        pendingAutoCreate ??= assistantTransport
+          .createConversation()
+          .finally(() => {
+            pendingAutoCreate = null;
+          });
+        const conversation = await pendingAutoCreate;
         target = conversation.id;
         await projectTransportState(queryClient, target);
       }
@@ -270,6 +281,18 @@ export function useSendMessage(conversationId: string | undefined) {
           }
           if (event.event === "turn.completed") {
             activeHandles.delete(targetId);
+            // The mutation resolved when the stream STARTED, so failures
+            // after that (pre-SSE rejection, truncated stream, RUN_ERROR)
+            // never reject `mutateAsync` — without this toast they exist
+            // only as cached turn state nothing renders, and the chat
+            // looks dead again. Stable id: at-least-once event delivery
+            // must not stack duplicates.
+            if (event.status === "failed" && event.error) {
+              toast.error("The assistant reply failed", {
+                id: `assistant-turn-failed-${event.turn_id}`,
+                description: event.error.message,
+              });
+            }
           }
           void projectTransportState(queryClient, targetId);
         },

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api-client";
+import { AssistantTurnActiveError } from "@/lib/assistant/errors";
 import {
   useApprovalRequests,
   useNotificationSettings,
@@ -157,13 +158,13 @@ export function useWorkspaceCounts() {
 const TRANSPORT_TOAST_ID = "assistant-transport-unavailable";
 
 /**
- * Chat reaches aevatar through `/proxy/s/aevatar`, which passes the DOWNSTREAM's
- * status straight through. A 401 there means aevatar rejected the identity
- * NyxID forwarded — the NyxID session itself is fine — so the transport opts
- * those requests out of the global sign-out (`preserveSessionOn401` in
- * aevatar-transport) and the route stays put. Without a toast that failure is
- * invisible: the sidebar just renders empty, which reads as "no chats yet"
- * rather than "chat is down".
+ * Chat reaches aevatar through NyxID's `/api/v1/assistant/*` pass-through,
+ * which forwards the DOWNSTREAM's status straight through. A 401 there means
+ * aevatar rejected the identity NyxID forwarded — the NyxID session itself is
+ * fine — so the transport opts those requests out of the global sign-out
+ * (`preserveSessionOn401` in aevatar-transport) and the route stays put.
+ * Without a toast that failure is invisible: the sidebar just renders empty,
+ * which reads as "no chats yet" rather than "chat is down".
  */
 export function describeTransportError(error: unknown): {
   readonly message: string;
@@ -227,17 +228,35 @@ export function useCreateConversation() {
   });
 }
 
+export interface SentMessage {
+  readonly conversationId: string;
+  readonly handle: TurnHandle;
+}
+
+/**
+ * Send a message into the bound conversation — or, when no conversation is
+ * selected (the "New chat" empty state), create one first and send there.
+ * Without the auto-create, the first send of a fresh account has no target
+ * and must not silently do nothing; the caller navigates to the returned
+ * `conversationId` to follow the new thread.
+ */
 export function useSendMessage(conversationId: string | undefined) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (content: string): Promise<TurnHandle> => {
-      if (!conversationId) throw new Error("Select a conversation first.");
+    mutationFn: async (content: string): Promise<SentMessage> => {
+      let target = conversationId;
+      if (!target) {
+        const conversation = await assistantTransport.createConversation();
+        target = conversation.id;
+        await projectTransportState(queryClient, target);
+      }
+      const targetId = target;
       // Last-seen per-turn cursor, scoped to THIS send's event stream: a
       // rejected concurrent send never touches it, and at-least-once
       // duplicates (e.g. a late "running") cannot regress terminal state.
       let lastSeenCursor = 0;
       const handle = assistantTransport.sendMessage(
-        conversationId,
+        targetId,
         content,
         (event) => {
           if (event.cursor <= lastSeenCursor) return;
@@ -245,21 +264,54 @@ export function useSendMessage(conversationId: string | undefined) {
           const turn = turnFromEvent(event);
           if (turn) {
             queryClient.setQueryData<ActiveTurn | null>(
-              assistantKeys.turn(conversationId),
+              assistantKeys.turn(targetId),
               () => turn,
             );
           }
           if (event.event === "turn.completed") {
-            activeHandles.delete(conversationId);
+            activeHandles.delete(targetId);
           }
-          void projectTransportState(queryClient, conversationId);
+          void projectTransportState(queryClient, targetId);
         },
       );
-      activeHandles.set(conversationId, handle);
-      await projectTransportState(queryClient, conversationId);
-      return handle;
+      activeHandles.set(targetId, handle);
+      await projectTransportState(queryClient, targetId);
+      return { conversationId: targetId, handle };
     },
   });
+}
+
+/**
+ * Human-readable failure for a send that never became a turn (transport
+ * threw before any turn event existed). Failures after the stream starts
+ * surface inside the thread via `turn.completed`; this covers the gap
+ * before that, which previously vanished into the composer's restore-text
+ * catch and made the send button look dead.
+ */
+export function describeSendFailure(error: unknown): {
+  readonly message: string;
+  readonly description: string;
+} {
+  if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+    return {
+      message: "Message not sent",
+      description:
+        "NyxID could not authenticate you to the chat backend. You are still signed in — reconnect the aevatar service and try again.",
+    };
+  }
+  if (error instanceof AssistantTurnActiveError) {
+    return {
+      message: "Message not sent",
+      description: "Wait for the current reply to finish, then try again.",
+    };
+  }
+  return {
+    message: "Message not sent",
+    description:
+      error instanceof Error && error.message
+        ? error.message
+        : "The assistant backend did not respond. Your text was kept — try again.",
+  };
 }
 
 export function useCancelTurn(conversationId: string | undefined) {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -351,7 +351,99 @@ describe("AevatarAssistantTransport", () => {
     );
     expect(
       terminal?.event === "turn.completed" && terminal.error?.code,
-    ).toBe("http_409");
+    ).toBe("turn_active");
+  });
+
+  it("surfaces the pre-stream error envelope instead of a bare status", async () => {
+    // Errors before the SSE stream starts are a JSON `{code, message}`
+    // envelope (Chat History contract) — the turn error must carry it.
+    stubFetch(routeCreate, (url, init) =>
+      url.endsWith("/stream") && init?.method === "POST"
+        ? jsonResponse(
+            { code: "UPSTREAM_TIMEOUT", message: "Aevatar timed out." },
+            502,
+          )
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events = await collectTurn(transport, "Hello");
+
+    const terminal = events[events.length - 1];
+    const error =
+      terminal?.event === "turn.completed" ? terminal.error : undefined;
+    expect(error?.code).toBe("UPSTREAM_TIMEOUT");
+    expect(error?.message).toBe("Aevatar timed out.");
+  });
+
+  it("gives a stream 401 an auth-specific message, not a bare status", async () => {
+    stubFetch(routeCreate, (url, init) =>
+      url.endsWith("/stream") && init?.method === "POST"
+        ? jsonResponse({ error: "unauthorized" }, 401)
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events = await collectTurn(transport, "Hello");
+
+    const terminal = events[events.length - 1];
+    const error =
+      terminal?.event === "turn.completed" ? terminal.error : undefined;
+    expect(error?.code).toBe("unauthorized");
+    expect(error?.message).toContain("still signed in");
+  });
+
+  it("reports EOF without a terminal frame as a truncated run, keeping partial text", async () => {
+    // Idle-killed or dropped streams end mid-run with no RUN_FINISHED /
+    // RUN_ERROR. That is not a success (the reference client marks it
+    // "closed"); the partial text must still settle into the transcript.
+    stubFetch(
+      routeCreate,
+      routeStream([OBSERVED_FRAMES[0], OBSERVED_FRAMES[1], OBSERVED_FRAMES[2]]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events = await collectTurn(transport, "Hello");
+
+    const terminal = events[events.length - 1];
+    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
+      "failed",
+    );
+    expect(
+      terminal?.event === "turn.completed" && terminal.error?.code,
+    ).toBe("stream_closed");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    expect(history.messages[1]?.blocks).toEqual([
+      { type: "text", block_id: "m-1-text", text: "Hello, " },
+    ]);
+  });
+
+  it("flushes a final RUN_FINISHED frame that has no trailing blank line", async () => {
+    const terminatedFrames = OBSERVED_FRAMES.slice(0, -1)
+      .map((frame) => `data: ${JSON.stringify(frame)}\n\n`)
+      .join("");
+    // The capture ends right after the last data line — no blank line.
+    const body = `${terminatedFrames}data: ${JSON.stringify({ type: "RUN_FINISHED" })}`;
+    stubFetch(routeCreate, (url, init) =>
+      url.endsWith("/stream") && init?.method === "POST"
+        ? new Response(body, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          })
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events = await collectTurn(transport, "Hello");
+
+    const terminal = events[events.length - 1];
+    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
+      "completed",
+    );
   });
 
   it("settles open blocks and the turn on cancel", async () => {
@@ -562,7 +654,34 @@ describe("captured production wire shapes", () => {
       "Content-Type": "application/json",
       Accept: "text/event-stream",
     });
-    expect(JSON.parse(String(init.body))).toEqual({ prompt: "Hello there" });
+    const body = JSON.parse(String(init.body)) as {
+      prompt: string;
+      sessionId: string;
+    };
+    expect(body.prompt).toBe("Hello there");
+    // Run-session correlation id (optional upstream; the reference client
+    // sends one per conversation).
+    expect(body.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("keeps one sessionId per conversation across turns", async () => {
+    const fetchMock = stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    await collectTurn(transport, "First turn");
+    await collectTurn(transport, "Second turn");
+
+    const sessionIds = fetchMock.mock.calls
+      .filter(([input]) => String(input).endsWith("/stream"))
+      .map(
+        ([, init]) =>
+          (JSON.parse(String(init?.body)) as { sessionId: string }).sessionId,
+      );
+    expect(sessionIds).toHaveLength(2);
+    expect(sessionIds[0]).toBe(sessionIds[1]);
   });
 });
 

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -666,12 +666,51 @@ describe("captured production wire shapes", () => {
     );
   });
 
-  it("keeps one sessionId per conversation across turns", async () => {
-    const fetchMock = stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+  it("keeps one sessionId per conversation across turns and reprojection", async () => {
+    // Between turns, the real hook reloads history and the conversation
+    // list (`projectTransportState`), both of which rebuild the stored
+    // conversation — the session id must survive that, not just the
+    // straight-line two-sends case.
+    const fetchMock = stubFetch(
+      routeCreate,
+      routeStream(OBSERVED_FRAMES),
+      (url, init) =>
+        url === `${ASSISTANT_BASE}/conversations` &&
+        (init?.method ?? "GET") === "GET"
+          ? jsonResponse({
+              conversations: [
+                {
+                  id: CONVERSATION_ID,
+                  title: "Say hello",
+                  updatedAt: "2026-07-17T03:05:00+00:00",
+                  messageCount: 1,
+                },
+              ],
+            })
+          : undefined,
+      routeHistory([
+        {
+          id: "t1:user",
+          role: "user",
+          content: "First turn",
+          timestamp: 1784192889074,
+        },
+        {
+          id: "t1:assistant",
+          role: "assistant",
+          content: "Hello, hope your day shines.",
+          timestamp: 1784192899074,
+        },
+      ]),
+    );
     const transport = new AevatarAssistantTransport();
     await transport.createConversation();
 
     await collectTurn(transport, "First turn");
+    // Post-turn reprojection: server history (equal length) replaces the
+    // local mirror; the list merge rebuilds the conversation row.
+    await transport.getHistory(CONVERSATION_ID);
+    await transport.listConversations();
     await collectTurn(transport, "Second turn");
 
     const sessionIds = fetchMock.mock.calls

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1,6 +1,6 @@
 import { apiClient } from "@/lib/api-client";
 import { AssistantTurnActiveError } from "@/lib/assistant/errors";
-import { drainSseBuffer } from "@/lib/assistant/sse";
+import { drainSseBuffer, flushSseBuffer } from "@/lib/assistant/sse";
 import {
   applyTurnEvent,
   EMPTY_TURN_STATE,
@@ -97,6 +97,12 @@ interface AevatarHistoryEntry {
 interface StoredConversation {
   conversation: Conversation;
   turnState: TurnReducerState;
+  /**
+   * Aevatar run-session correlation id, minted once per conversation and
+   * sent on every `:stream` body (the reference client keeps one session
+   * per conversation; the field is optional upstream).
+   */
+  sessionId?: string;
 }
 
 interface RunningTurn {
@@ -146,6 +152,54 @@ function deriveTitle(messages: AssistantMessage[]): string | null {
     return null;
   }
   return firstText.text.trim().slice(0, 40);
+}
+
+/**
+ * Map a pre-stream rejection to a turn error. Errors before the SSE stream
+ * starts arrive as a JSON envelope — NyxID's `{error, error_code, message}`
+ * or Aevatar's `{code, message}` — and must not collapse to a bare
+ * `http_<status>`. A 401/403 here means the downstream rejected the
+ * identity NyxID forwarded, not that the NyxID session died — this raw
+ * fetch never touches auth state, so it cannot trigger a sign-out; the
+ * copy says so explicitly.
+ */
+function streamStartError(
+  status: number,
+  bodyText: string,
+): { code: string; message: string } {
+  interface ErrorEnvelope {
+    readonly error?: unknown;
+    readonly code?: unknown;
+    readonly message?: unknown;
+  }
+  let envelope: ErrorEnvelope | null = null;
+  try {
+    envelope = JSON.parse(bodyText) as ErrorEnvelope;
+  } catch {
+    envelope = null;
+  }
+  const envelopeCode =
+    typeof envelope?.code === "string" && envelope.code
+      ? envelope.code
+      : typeof envelope?.error === "string" && envelope.error
+        ? envelope.error
+        : null;
+  const envelopeMessage =
+    typeof envelope?.message === "string" && envelope.message.trim()
+      ? envelope.message
+      : null;
+  if (status === 401 || status === 403) {
+    return {
+      code: envelopeCode ?? "unauthorized",
+      message:
+        "NyxID could not authenticate you to the chat backend. You are still signed in — reconnect the aevatar service and try again.",
+    };
+  }
+  return {
+    code: envelopeCode ?? `http_${String(status)}`,
+    message:
+      envelopeMessage ?? "The assistant stream could not be started.",
+  };
 }
 
 /**
@@ -441,6 +495,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
     prompt: string,
   ): Promise<void> {
     try {
+      const stored = this.conversations.get(conversationId);
+      const sessionId = stored && (stored.sessionId ??= crypto.randomUUID());
       // Hand-rolled fetch (not `apiClient`): the response is an SSE stream,
       // and the endpoint 415s without an explicit JSON content type.
       const response = await fetch(
@@ -452,15 +508,18 @@ export class AevatarAssistantTransport implements AssistantTransport {
             Accept: "text/event-stream",
           },
           credentials: "include",
-          body: JSON.stringify({ prompt }),
+          body: JSON.stringify(sessionId ? { prompt, sessionId } : { prompt }),
           signal: run.controller.signal,
         },
       );
       if (!response.ok || !response.body) {
-        this.finishTurn(conversationId, run, "failed", {
-          code: `http_${String(response.status)}`,
-          message: "The assistant stream could not be started.",
-        });
+        const bodyText = await response.text().catch(() => "");
+        this.finishTurn(
+          conversationId,
+          run,
+          "failed",
+          streamStartError(response.status, bodyText),
+        );
         return;
       }
       const reader = response.body.getReader();
@@ -477,10 +536,23 @@ export class AevatarAssistantTransport implements AssistantTransport {
           if (run.finished) return;
         }
       }
-      // Stream closed without a RUN_FINISHED frame: settle rather than
-      // leaving the turn spinning forever.
+      // The final frame may arrive without a trailing blank line; flush it
+      // before judging how the stream ended.
+      buffer += decoder.decode();
+      for (const payload of flushSseBuffer(buffer)) {
+        this.handleAgUiFrame(conversationId, run, payload);
+        if (run.finished) return;
+      }
+      // EOF without RUN_FINISHED / RUN_ERROR is a truncated run (proxy idle
+      // kill, upstream drop), not a success. Settle the partial text and
+      // report it; the server-side run may still finish, in which case the
+      // full reply surfaces on the next history reload.
       this.closeOpenMessage(conversationId, run);
-      this.finishTurn(conversationId, run, "completed", null);
+      this.finishTurn(conversationId, run, "failed", {
+        code: "stream_closed",
+        message:
+          "The stream ended before the assistant finished. The reply may be incomplete — it will appear in full once the conversation reloads.",
+      });
     } catch (error) {
       // The cancel path aborts the fetch after emitting its own terminal
       // events; an abort here is not a failure.

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -420,6 +420,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     this.conversations.set(id, {
       conversation,
       turnState: existing?.turnState ?? EMPTY_TURN_STATE,
+      // Reprojection must not re-mint the run-session id: one session per
+      // conversation is the reference contract.
+      sessionId: existing?.sessionId,
     });
   }
 
@@ -458,6 +461,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
         activeTurn: existing?.turnState.activeTurn ?? null,
         lastCursor: existing?.turnState.lastCursor ?? 0,
       },
+      // Post-turn history reloads run through here; losing the session id
+      // would silently start a new upstream run-session every turn.
+      sessionId: existing?.sessionId,
     };
     this.conversations.set(conversationId, stored);
     return stored;

--- a/frontend/src/lib/assistant/sse.test.ts
+++ b/frontend/src/lib/assistant/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { drainSseBuffer } from "@/lib/assistant/sse";
+import { drainSseBuffer, flushSseBuffer } from "@/lib/assistant/sse";
 
 describe("drainSseBuffer", () => {
   it("extracts complete data payloads and keeps the unterminated tail", () => {
@@ -22,5 +22,33 @@ describe("drainSseBuffer", () => {
     const { payloads, rest } = drainSseBuffer("data: [DONE]\n\n");
     expect(payloads).toEqual(["[DONE]"]);
     expect(rest).toBe("");
+  });
+
+  it("handles bare-CR framing, including a CRLF split across reads", () => {
+    const lone = drainSseBuffer('data: {"a":1}\r\rdata: {"partial"');
+    expect(lone.payloads).toEqual(['{"a":1}']);
+
+    // A `\r\n\r\n` boundary split right after the first `\r`: the first
+    // drain keeps the tail, the second read completes the boundary.
+    const first = drainSseBuffer('data: {"a":1}\r');
+    expect(first.payloads).toEqual([]);
+    const second = drainSseBuffer(`${first.rest}\n\r\ndata: {"b":2}\r\n\r\n`);
+    expect(second.payloads).toEqual(['{"a":1}', '{"b":2}']);
+    expect(second.rest).toBe("");
+  });
+});
+
+describe("flushSseBuffer", () => {
+  it("recovers a final frame with no trailing blank line", () => {
+    const { payloads, rest } = drainSseBuffer(
+      'data: {"a":1}\n\ndata: {"type":"RUN_FINISHED"}',
+    );
+    expect(payloads).toEqual(['{"a":1}']);
+    expect(flushSseBuffer(rest)).toEqual(['{"type":"RUN_FINISHED"}']);
+  });
+
+  it("returns nothing for whitespace-only remainders", () => {
+    expect(flushSseBuffer("")).toEqual([]);
+    expect(flushSseBuffer("\n")).toEqual([]);
   });
 });

--- a/frontend/src/lib/assistant/sse.test.ts
+++ b/frontend/src/lib/assistant/sse.test.ts
@@ -24,6 +24,17 @@ describe("drainSseBuffer", () => {
     expect(rest).toBe("");
   });
 
+  it("does not split a multi-data-line event when a chunk ends inside a CRLF", () => {
+    // One event, two `data:` lines, network read ends right after the `\r`
+    // of the FIRST line's `\r\n`. Eagerly normalizing that trailing `\r`
+    // would fabricate a `\n\n` boundary and split the event in two.
+    const first = drainSseBuffer('data: {"part":\r');
+    expect(first.payloads).toEqual([]);
+    const second = drainSseBuffer(`${first.rest}\ndata: "two"}\r\n\r\n`);
+    expect(second.payloads).toEqual(['{"part":\n"two"}']);
+    expect(second.rest).toBe("");
+  });
+
   it("handles bare-CR framing, including a CRLF split across reads", () => {
     const lone = drainSseBuffer('data: {"a":1}\r\rdata: {"partial"');
     expect(lone.payloads).toEqual(['{"a":1}']);

--- a/frontend/src/lib/assistant/sse.ts
+++ b/frontend/src/lib/assistant/sse.ts
@@ -10,15 +10,22 @@
  * unterminated remainder for the next read.
  *
  * Line endings are normalized for all three SSE-legal forms (`\r\n`, `\n`,
- * and bare `\r`). Normalizing a trailing `\r` that later turns out to be
- * half of a split `\r\n` is safe: the reassembled buffer still produces the
- * same `\n\n` frame boundary on the next drain.
+ * and bare `\r`). A trailing `\r` is held back undecided: it may be half of
+ * a `\r\n` split across network reads, and eagerly converting it to `\n`
+ * would fabricate a `\n\n` frame boundary when the matching `\n` arrives
+ * (splitting one multi-`data:`-line event into two payloads).
  */
 export function drainSseBuffer(buffer: string): {
   readonly payloads: string[];
   readonly rest: string;
 } {
-  const normalized = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  let working = buffer;
+  let heldCr = "";
+  if (working.endsWith("\r")) {
+    heldCr = "\r";
+    working = working.slice(0, -1);
+  }
+  const normalized = working.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const segments = normalized.split("\n\n");
   const rest = segments.pop() ?? "";
   const payloads: string[] = [];
@@ -30,7 +37,7 @@ export function drainSseBuffer(buffer: string): {
       .join("\n");
     if (data) payloads.push(data);
   }
-  return { payloads, rest };
+  return { payloads, rest: rest + heldCr };
 }
 
 /**

--- a/frontend/src/lib/assistant/sse.ts
+++ b/frontend/src/lib/assistant/sse.ts
@@ -8,12 +8,17 @@
 /**
  * Consumes complete `data:` payloads from the buffer and returns the
  * unterminated remainder for the next read.
+ *
+ * Line endings are normalized for all three SSE-legal forms (`\r\n`, `\n`,
+ * and bare `\r`). Normalizing a trailing `\r` that later turns out to be
+ * half of a split `\r\n` is safe: the reassembled buffer still produces the
+ * same `\n\n` frame boundary on the next drain.
  */
 export function drainSseBuffer(buffer: string): {
   readonly payloads: string[];
   readonly rest: string;
 } {
-  const normalized = buffer.replace(/\r\n/g, "\n");
+  const normalized = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const segments = normalized.split("\n\n");
   const rest = segments.pop() ?? "";
   const payloads: string[] = [];
@@ -26,4 +31,15 @@ export function drainSseBuffer(buffer: string): {
     if (data) payloads.push(data);
   }
   return { payloads, rest };
+}
+
+/**
+ * Flushes the final, unterminated SSE frame at end of stream. Servers may
+ * close the connection right after the last `data:` line without a trailing
+ * blank line; dropping that frame loses terminal events (`RUN_FINISHED`),
+ * which would misreport a completed run as truncated.
+ */
+export function flushSseBuffer(rest: string): string[] {
+  if (!rest.trim()) return [];
+  return drainSseBuffer(`${rest}\n\n`).payloads;
 }

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { toast } from "sonner";
 import { AssistantShell } from "@/components/assistant/assistant-shell";
 import { AssistantSidebar } from "@/components/assistant/assistant-sidebar";
 import { ChatComposer } from "@/components/assistant/chat-composer";
@@ -7,6 +8,7 @@ import { ChatThread } from "@/components/assistant/chat-thread";
 import { ApprovalsView } from "@/components/assistant/approvals-view";
 import { PluginsView } from "@/components/assistant/plugins-view";
 import {
+  describeSendFailure,
   useAssistantTurn,
   useCancelTurn,
   useConversation,
@@ -57,6 +59,23 @@ export function AssistantPage({
   async function createNewChat() {
     const conversation = await createConversation.mutateAsync();
     selectConversation(conversation.id);
+  }
+
+  // First send from the "New chat" empty state has no conversation yet; the
+  // mutation auto-creates one and this follows the navigation to it. A send
+  // that fails before any turn exists must be said out loud — the composer
+  // restores the text, and without the toast the button just looks dead.
+  async function handleSend(content: string) {
+    try {
+      const sent = await sendMessage.mutateAsync(content);
+      if (sent.conversationId !== selectedId) {
+        selectConversation(sent.conversationId);
+      }
+    } catch (error) {
+      const { message, description } = describeSendFailure(error);
+      toast.error(message, { description });
+      throw error;
+    }
   }
 
   const title =
@@ -111,9 +130,7 @@ export function AssistantPage({
         <ChatComposer
           active={active}
           sending={sendMessage.isPending}
-          onSend={(content) =>
-            sendMessage.mutateAsync(content).then(() => undefined)
-          }
+          onSend={handleSend}
           onStop={() => cancelTurn.mutateAsync()}
         />
       </div>


### PR DESCRIPTION
## What broke on prod

Typing into the `/assistant` "New chat" empty state and pressing Send did nothing. Two stacked causes:

1. **FE silent no-op (fixed here):** a fresh account has no conversations → `selectedId` is `undefined` → `useSendMessage` threw internally → `chat-composer` swallowed the rejection and just restored the text. Nothing ever auto-created a conversation on first send; only the "+ New chat" button did. The mock-mode POC never hit this because mock data pre-seeds conversations.
2. **Auth (TD-3, not this PR):** cookie sessions have no Bearer to forward, so live Aevatar 401s every pass-through call. Fix = Aevatar validates `X-NyxID-Identity-Token` + the three-field service-row flip (`identity_jwt_audience:"urn:aevatar:api"`, `inject_delegation_token:true`, `forward_access_token:false`) — per the `eanz17/nyxid-chat` reference README. External dependency; tracked in `docs/CHAT_ASSISTANT_SPECS.md` TD-3 (rewritten in this PR).

## Changes

**Frontend**
- First send auto-creates a conversation and streams into it; the page follows the navigation to the new thread.
- Send failures toast (`describeSendFailure`) — never silent again.
- Pre-SSE error envelopes (`{code,message}` / NyxID `{error,error_code,message}`) surface as the turn error; 401/403 keep the auth-specific "still signed in" copy → **supersedes draft #1195** (same copy, wider coverage), which can be closed.
- EOF without `RUN_FINISHED`/`RUN_ERROR` = failed `stream_closed` turn (truncated streams no longer report success); final unterminated SSE frame flushed; bare-`\r` framing normalized.
- Per-conversation `sessionId` on every `:stream` body (reference-aligned; verified accepted by prod Aevatar via CLI).

**Backend**
- `POST /assistant/conversations`: bounded best-effort wait for the created actor to appear in the actor index (async-202 materialization race; mirrors reference `waitForConversation`).
- `DELETE /assistant/conversations/{id}`: composite dual-delete (actor + chat-history row, 404-tolerant each side, `200 {}`).

## Verification

- Local E2E against a mock Aevatar implementing the nyxid-chat + chat-history contracts: empty-state send → create (202) → materialization poll → stream → rendered reply; composite delete observed as both upstream DELETEs; 401 mode shows the "Message not sent" toast with text restored.
- Full CLI matrix against **prod** stays green (list/create/stream/history/delete), including a stream with the new `sessionId` field.
- Gates: backend `cargo fmt` + `clippy --all-targets` clean + assistant tests 8/8; frontend 1880+ tests, lint 0 errors, `npm run build` (tsc -b) green; wizard bundle byte-identical.

## Not in this PR (tracked in CHAT_ASSISTANT_SPECS.md)

- TD-3 rollout (Aevatar-side identity-token validation, then the row flip — do not flip early, Bearer forwarding is what keeps CLI callers working today).
- TD-7 frame-taxonomy port (`protocol.js`: approval/tool/authorization cards + redaction) — includes fixing `decideApproval` to consume the SSE `:approve` response.
- Startup seed/reconcile of the aevatar row + strict admin-target proxy mode (TD-1/TD-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)