### PR TITLE
fix(assistant): accept Aevatar PR #2923 wrapped chat-history transcript

### DIFF
--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -294,6 +294,13 @@ pub async fn list_conversations(
 }
 
 /// `GET /api/v1/assistant/conversations/{id}` -- transcript.
+///
+/// The body is opaque here: NyxID never parses or reshapes it. Aevatar PR
+/// #2923 wrapped the flat `[StoredChatMessage]` array in
+/// `{messages, stateVersion}`, and both shapes stream through this route
+/// unmodified -- the client owns the decoding (see the transcript reader in
+/// `frontend/src/lib/assistant/aevatar-transport.ts`). Keeping the route
+/// shape-agnostic is what lets Aevatar and NyxID deploy independently.
 pub async fn get_history(
     State(state): State<AppState>,
     auth_user: AuthUser,

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -99,6 +99,45 @@ sessions + proxy-only identity handling). Changes:
   RFC 8707 resource (re-minted from a `binding_id` via token exchange). The backend
   already supports all of that; see TD-3.
 
+## Implemented in cut 5 (2026-07-23 — Aevatar PR #2923 transcript-shape alignment)
+
+Aevatar PR #2923 wrapped the chat-history detail response in
+`{messages, stateVersion}`, added a `conversation.minimumStateVersion`
+continuation requirement to `POST /api/chat`, and added `stateVersion` to the
+`aevatar.chat.context` SSE payload. No routes added or removed. What NyxID
+changed (approach reviewed by codex `gpt-5.6-sol`, session
+`019f8d1e-ee56-78b2-915d-2897fc5b64c0`):
+
+- **Frontend (the only functional change).** `loadHistory` typed the body as
+  `AevatarHistoryEntry[]` and called `.map` on it; the wrapper made that throw,
+  and `getHistory`'s catch-all fallback served the index-merged empty mirror —
+  so every conversation would have rendered **blank, with no error**. The
+  transcript read now goes through one strict decoder accepting exactly the
+  legacy array and the wrapper; anything else raises `AssistantProtocolError`.
+- **Fallback narrowed.** `getHistory` no longer swallows every failure: a
+  protocol error always surfaces, and a transient failure serves the mirror only
+  when the mirror holds a real transcript. An index-only placeholder
+  (`EMPTY_TURN_STATE`) can no longer be dressed up as a successful empty read.
+- **`stateVersion` is ignored, deliberately** — not read, not validated, not
+  stored; wrapped acceptance is keyed **only** on array-valued `messages`. It is
+  the continuation watermark for `/api/chat`, and NyxID's production transport is
+  `nyxid-chat/…:stream`, which has no such parameter. Storing it would be state
+  nobody maintains (`mergeIndexEntry` rebuilds `StoredConversation` and would
+  silently drop it); *requiring* it would turn a field with zero consumers into
+  an outage. It becomes load-bearing only on an `/api/chat` migration.
+- **Backend: no functional change.** `get_history` never parses the body; both
+  shapes stream through `execute_proxy` unmodified. That shape-agnosticism is
+  what lets Aevatar and NyxID deploy independently.
+- **Legacy-array branch is intentional, bounded compat.** The deployed Aevatar
+  shape could not be verified from this environment (unauthenticated probe →
+  401), and the two services deploy independently: committing to one shape
+  breaks chat either immediately or the moment Aevatar ships. Removal condition,
+  recorded at the type: delete the array branch once **every** supported Aevatar
+  environment is confirmed on the wrapper — not after one prod probe.
+- **Not done (out of scope):** migrating the production transport from `:stream`
+  to `POST /api/chat` + `aevatar.chat.context`. That is a transport rewrite and
+  belongs with `CHAT_REWORK_SPEC.md`.
+
 ## Implemented in cut 4 (2026-07-18 — TD-3 interim bridge: marker-hardened forward token)
 
 Resurrects the mint-and-forward bridge WITH the hardening whose absence killed
@@ -248,13 +287,21 @@ none surface as a surprise "next broken leg":**
 
 ## Enable-ready (proven, awaiting a decision — not blocked on code)
 
+> **Superseded in part by Aevatar PR #2923 (see the cut below).** The
+> `chatHistory:{conversationId,turnId,userText}` intent described here is no
+> longer the whole story: continuation on `/api/chat` now also requires
+> `conversation:{conversationId, minimumStateVersion>0}`, and the caller must
+> **not** splice transcript into `prompt` — Aevatar injects server history into
+> the workflow context itself. The product decision below is unchanged.
+
 `/api/chat` history-write is verified working. To make workflow-mode (or any
-`/api/chat`) turns persist and appear in the unified history list, the only change is
-the frontend sending `chatHistory:{conversationId,turnId,userText}` (all trim-nonempty)
-on the run. Deferred because it changes product behavior (workflow chats currently
-reset on reload by design, per Calvin's earlier waiver) and would surface workflow
-conversations in the nyxid-chat history list but not the workflow transport's own
-in-memory list. Decision needed: should workflow/`/api/chat` chats persist?
+`/api/chat`) turns persist and appear in the unified history list, the frontend
+must send the history-write intent on the run (plus the #2923 continuation
+watermark above). Deferred because it changes product behavior (workflow chats
+currently reset on reload by design, per Calvin's earlier waiver) and would
+surface workflow conversations in the nyxid-chat history list but not the
+workflow transport's own in-memory list. Decision needed: should
+workflow/`/api/chat` chats persist?
 
 ## Guiding constraints (Calvin, 2026-07-17)
 
@@ -317,10 +364,17 @@ From the Studio Chat History API contract:
 - Index: `{"conversations": [...]}` sorted by `updatedAt` desc; fields `id, title,
   serviceId, serviceKind, createdAt, updatedAt, messageCount, llmRoute?, llmModel?`.
   No pagination. Titles come from the server — no client-side title synthesis.
-- Detail: flat `[StoredChatMessage]`; ids are `{turnId}:user` / `{turnId}:assistant`;
-  `status` is `complete|error`; **an empty array is a valid answer** meaning
-  deleted / not yet materialized / zero turns — never treat it as an error and never
-  refuse to replace cached state with it.
+- Detail: **two accepted shapes** — the legacy flat `[StoredChatMessage]`, and
+  Aevatar PR #2923's `{messages: [StoredChatMessage], stateVersion}` wrapper.
+  Entry shape is identical in both: ids are `{turnId}:user` / `{turnId}:assistant`,
+  `status` is `complete|error`. Acceptance is keyed **only** on array-valued
+  `messages`; `stateVersion` is ignored by this transport (see cut 5). Anything
+  that is neither shape is a protocol error and must surface, not degrade to empty.
+  **An empty transcript is a valid answer** (`[]` or `{"messages":[]}`) meaning
+  deleted / not yet materialized / zero turns — never treat it as an error. It
+  replaces cached state *except* under the deliberate keep-max guard: for a few
+  hundred ms after a turn completes the read model lags the local mirror, and a
+  shorter server answer there is staleness, not truth.
 - Delete: `200` with empty body; the read model is eventually consistent — the row
   may briefly reappear in the index. Use optimistic removal + a short client-side
   tombstone.
@@ -329,6 +383,15 @@ From the Studio Chat History API contract:
   `{conversationId, turnId, userText}` intent (all three trim-nonempty or the server
   returns 400 `INVALID_CHAT_HISTORY`). `nyxid-chat` conversations persist history
   server-side on their own; the intent only matters for workflow-chat runs.
+- **Continuation on `/api/chat` (PR #2923).** A new conversation passes
+  `conversation:{conversationId:null}`. Continuing an existing one **must** pass
+  `conversation:{conversationId, minimumStateVersion>0}`, where the watermark is the
+  `stateVersion` last read from the detail endpoint or from the SSE
+  `aevatar.chat.context` payload (which gained the field). Behind the watermark →
+  `503 CHAT_HISTORY_RESERVATION_UNAVAILABLE` (re-read the conversation, then retry);
+  unknown conversation → `404 CONVERSATION_NOT_FOUND`. Callers must stop splicing
+  local transcript into `prompt` — `prompt` is this turn's user input only, and the
+  server injects the history context into the workflow run.
 - Errors before the SSE stream starts are a JSON envelope `{code, message}`; errors
   after the stream starts arrive as SSE frames. Parse them separately.
 
@@ -359,8 +422,10 @@ harness).**
    messageCount; llmRoute/llmModel optional). Delete the up-to-20-request title
    fan-out (F13).
 2. Delete: optimistic removal + short tombstone against eventual consistency (F15).
-3. Fix the keep-max guard so a legitimately empty transcript replaces cached state
-   (F14).
+3. ~~Fix the keep-max guard so a legitimately empty transcript replaces cached
+   state (F14).~~ **Not done, deliberately** — the keep-max guard is load-bearing
+   against post-turn materialization lag (the server briefly answers shorter than
+   the local mirror). See the empty-transcript rule under "Contract facts".
 4. Parse pre-SSE `{code, message}` envelopes instead of collapsing to
    `http_<status>` (F16).
 5. (Optional, only if workflow-mode history is wanted now) send `chatHistory`

--- a/docs/CHAT_SPEC.md
+++ b/docs/CHAT_SPEC.md
@@ -61,12 +61,12 @@ verified `AuthUser.user_id` — the browser cannot address another user's scope.
 |---|---|---|
 | `POST /assistant/conversations` | `api/scopes/{uid}/nyxid-chat/conversations` | create actor (202 + `actorId`), then polls the actor index until it materializes |
 | `GET /assistant/conversations` | `api/scopes/{uid}/chat-history` | Chat History index (server titles/timestamps/counts) |
-| `GET /assistant/conversations/{id}` | `api/scopes/{uid}/chat-history/conversations/{id}` | transcript passed through as-is; `[]` is Aevatar's representation of empty/deleted (the route does not itself coerce errors to `[]`) |
+| `GET /assistant/conversations/{id}` | `api/scopes/{uid}/chat-history/conversations/{id}` | transcript passed through as-is, body opaque to NyxID. Two accepted shapes: the legacy flat array and Aevatar PR #2923's `{messages, stateVersion}` wrapper. An empty transcript (`[]` or `{"messages":[]}`) is Aevatar's representation of empty/deleted; the route does not itself coerce errors to either shape |
 | `DELETE /assistant/conversations/{id}` | actor delete **+** history-row delete | composite, 404-tolerant on each side |
 | `POST /assistant/conversations/{id}/stream` | `…/nyxid-chat/conversations/{id}:stream` | AG-UI SSE turn, streamed unbuffered |
 | `POST /assistant/conversations/{id}/approve` | `…:approve` | approval decision (SSE response) |
 | `POST /assistant/completions` | `v1/chat/completions` | OpenAI-compatible (retained, unused by the UI) |
-| `POST /assistant/workflow-chat` | `api/chat` | ad-hoc workflow chat (retained, unused by the UI) |
+| `POST /assistant/workflow-chat` | `api/chat` | ad-hoc workflow chat (retained, unused by the UI). Body forwarded verbatim, so Aevatar PR #2923's continuation contract falls on the **caller**: continuing a conversation now requires `conversation:{conversationId, minimumStateVersion>0}` (omit it and Aevatar answers `503 CHAT_HISTORY_RESERVATION_UNAVAILABLE`; unknown id answers `404 CONVERSATION_NOT_FOUND`), and the caller must stop splicing transcript into `prompt` — the backend injects server history itself |
 | `GET /assistant/workflow-chat/ws` | `api/ws/chat` | WS twin (retained, unused by the UI) |
 
 All routes funnel through one function — `assistant::forward` — which resolves

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -113,11 +113,14 @@ function routeStream(frames: unknown[]): FetchRoute {
       : undefined;
 }
 
-function routeHistory(entries: unknown[]): FetchRoute {
+// `body` is the whole transcript response, not just its entries: the reader
+// accepts the legacy flat array and the PR #2923 `{messages, stateVersion}`
+// wrapper, and must reject anything else.
+function routeHistory(body: unknown): FetchRoute {
   return (url, init) =>
     url.startsWith(`${ASSISTANT_BASE}/conversations/`) &&
     (init?.method ?? "GET") === "GET"
-      ? jsonResponse(entries)
+      ? jsonResponse(body)
       : undefined;
 }
 
@@ -863,6 +866,80 @@ describe("captured production wire shapes", () => {
       "Name two colors. Answer in two short sen",
     );
   });
+
+  // Aevatar PR #2923 wrapped the transcript in `{messages, stateVersion}`.
+  // Both shapes must map to the identical transcript, and the wrapper must
+  // not be confused with a body that merely happens to be an object.
+  it("maps the PR #2923 wrapped transcript identically to the legacy array", async () => {
+    stubFetch(
+      routeHistory({ messages: capturedHistory, stateVersion: 7 }),
+    );
+    const transport = new AevatarAssistantTransport();
+
+    const wrapped = await transport.getHistory(CONVERSATION_ID);
+
+    stubFetch(routeHistory(capturedHistory));
+    const legacy = await new AevatarAssistantTransport().getHistory(
+      CONVERSATION_ID,
+    );
+    expect(wrapped.messages).toEqual(legacy.messages);
+    expect(wrapped.conversation.title).toBe(legacy.conversation.title);
+  });
+
+  it.each([
+    ["with a stateVersion", { messages: [], stateVersion: 0 }],
+    // Acceptance is keyed ONLY on array-valued `messages`. `stateVersion` has
+    // zero consumers on the `:stream` transport, so requiring it would turn a
+    // field we never read into an outage.
+    ["without a stateVersion", { messages: [] }],
+  ])(
+    "treats an empty wrapped transcript %s as a valid empty conversation",
+    async (_label, body) => {
+      // The contract's "empty is a real answer" rule (deleted / not yet
+      // materialized / zero turns) survives the wrapper — it must not be
+      // mistaken for a shape violation.
+      stubFetch(routeHistory(body));
+      const transport = new AevatarAssistantTransport();
+
+      const history = await transport.getHistory(CONVERSATION_ID);
+
+      expect(history.messages).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["no messages field", {}],
+    ["a null messages field", { messages: null }],
+    ["a non-array messages field", { messages: { "0": {} } }],
+    ["a bare string", "nyxid-chat-f836"],
+  ])(
+    "surfaces a transcript response with %s instead of rendering it empty",
+    async (_label, body) => {
+      // The regression this whole change exists for: an unrecognized body
+      // must NOT be laundered into "this chat has no messages". The index
+      // has already merged the conversation in (mirror present but empty),
+      // which is exactly the state the old catch-all fallback dressed up as
+      // a successful empty read.
+      stubFetch(
+        (url, init) =>
+          url === `${ASSISTANT_BASE}/conversations` &&
+          (init?.method ?? "GET") === "GET"
+            ? jsonResponse({
+                conversations: [
+                  { id: CONVERSATION_ID, title: "Server title" },
+                ],
+              })
+            : undefined,
+        routeHistory(body),
+      );
+      const transport = new AevatarAssistantTransport();
+      await transport.listConversations();
+
+      await expect(transport.getHistory(CONVERSATION_ID)).rejects.toThrow(
+        /did not match the expected shape/,
+      );
+    },
+  );
 
   it("sends the exact request shape the aevatar stream endpoint requires", async () => {
     const fetchMock = stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
@@ -1971,6 +2048,54 @@ describe("live AG-UI frame taxonomy", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await transport.deleteConversation(CONVERSATION_ID);
     releaseHistory();
+
+    await expect(pendingRead).rejects.toThrow("Conversation was not found.");
+  });
+
+  it("answers not-found, not the read failure, when a delete lands mid-read and the read then fails", async () => {
+    // Fourth-pass codex P2: narrowing the getHistory catch added two early
+    // throws that could bypass the post-await tombstone check. Delete must
+    // still win — with an index-only mirror (EMPTY_TURN_STATE), a read that
+    // rejects after the delete must report "not found", not the transport
+    // failure.
+    let rejectHistory: (error: Error) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        if (url === `${ASSISTANT_BASE}/conversations` && method === "GET") {
+          return Promise.resolve(
+            jsonResponse({
+              conversations: [{ id: CONVERSATION_ID, title: "Server title" }],
+            }),
+          );
+        }
+        if (
+          url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}` &&
+          method === "DELETE"
+        ) {
+          return Promise.resolve(jsonResponse({}));
+        }
+        if (
+          url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}` &&
+          method === "GET"
+        ) {
+          return new Promise<Response>((_resolve, reject) => {
+            rejectHistory = reject;
+          });
+        }
+        return Promise.resolve(jsonResponse({}, 404));
+      }),
+    );
+    const transport = new AevatarAssistantTransport();
+    // Index-only mirror: no turn ever ran, so `turnState` is EMPTY_TURN_STATE.
+    await transport.listConversations();
+
+    const pendingRead = transport.getHistory(CONVERSATION_ID);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await transport.deleteConversation(CONVERSATION_ID);
+    rejectHistory(new Error("network down"));
 
     await expect(pendingRead).rejects.toThrow("Conversation was not found.");
   });

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1,5 +1,6 @@
 import { apiClient } from "@/lib/api-client";
 import {
+  AssistantProtocolError,
   AssistantTurnActiveError,
   AssistantTurnCancelledError,
 } from "@/lib/assistant/errors";
@@ -240,6 +241,32 @@ interface AevatarHistoryEntry {
   readonly turnId?: unknown;
 }
 
+/**
+ * Transcript read (`chat-history/conversations/{id}`), in both shapes we
+ * accept.
+ *
+ * Aevatar PR #2923 wrapped the flat array in `{messages, stateVersion}`, where
+ * `stateVersion` is the conversation read model's materialized watermark. The
+ * legacy array stays accepted because NyxID and Aevatar deploy independently:
+ * committing to one shape breaks chat either now or the moment Aevatar ships.
+ *
+ * REMOVE the array branch once every supported Aevatar environment is
+ * confirmed on the wrapped contract — not after a single prod probe.
+ *
+ * `stateVersion` is deliberately **ignored** — not read, not validated, not
+ * stored. It is the continuation watermark for `POST /api/chat`, and NyxID's
+ * production transport is `nyxid-chat/…:stream`, which has no such parameter.
+ * Storing an unread watermark would be state nobody maintains
+ * (`mergeIndexEntry` rebuilds `StoredConversation` and would silently drop
+ * it), and *requiring* it would turn a field with zero consumers into an
+ * outage. Acceptance is therefore keyed only on array-valued `messages`.
+ * `stateVersion` becomes load-bearing only if the transport migrates to
+ * `/api/chat`.
+ */
+type AevatarHistoryResponse =
+  | readonly AevatarHistoryEntry[]
+  | { readonly messages?: unknown; readonly stateVersion?: unknown };
+
 interface StoredConversation {
   conversation: Conversation;
   turnState: TurnReducerState;
@@ -399,6 +426,31 @@ function historyEntryToMessage(
     ...(status ? { status } : {}),
     ...(error !== undefined ? { error } : {}),
   };
+}
+
+/**
+ * Narrow a transcript read to its message entries, or reject it.
+ *
+ * Strict on purpose. A permissive reader that degraded `{}` or
+ * `{messages: null}` to an empty transcript would render "no messages" for a
+ * broken upstream — the same silent failure the `stateVersion` wrapper caused
+ * against the old array-typed reader. An empty array (or an empty wrapped
+ * `messages`) remains a valid answer meaning deleted / not yet materialized /
+ * zero turns; only a body that is neither accepted shape is a protocol error.
+ */
+function readHistoryEntries(
+  body: AevatarHistoryResponse,
+): readonly AevatarHistoryEntry[] {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === "object") {
+    const { messages } = body as { readonly messages?: unknown };
+    if (Array.isArray(messages)) {
+      return messages as readonly AevatarHistoryEntry[];
+    }
+  }
+  throw new AssistantProtocolError(
+    "The conversation history response did not match the expected shape.",
+  );
 }
 
 function deriveTitle(messages: AssistantMessage[]): string | null {
@@ -684,19 +736,31 @@ export class AevatarAssistantTransport implements AssistantTransport {
         has_more: false,
       };
     }
-    let stored: StoredConversation | undefined;
+    let stored: StoredConversation;
     try {
       stored = await this.loadHistory(conversationId);
-    } catch {
+    } catch (error) {
+      // Delete wins over every other outcome, including the throws below:
+      // once the conversation is tombstoned, "not found" is the answer, not
+      // whatever the doomed read happened to fail with.
+      if (this.deletedConversationIds.has(conversationId)) {
+        throw new Error("Conversation was not found.");
+      }
+      // A contract break must reach the user. Swallowing it here is what
+      // turned the PR #2923 array→`{messages, stateVersion}` change into a
+      // blank transcript instead of a visible failure.
+      if (error instanceof AssistantProtocolError) throw error;
+      // Transient failures (network, 5xx) may serve the local mirror — but
+      // only when it holds a real transcript. A conversation the index
+      // merged in carries `EMPTY_TURN_STATE`, and answering with that would
+      // dress a failed read as a legitimately empty chat.
+      if (!existing || existing.turnState.messages.length === 0) throw error;
       stored = existing;
     }
     // Re-check AFTER the await: a delete completing while the history
     // request was in flight must not be answered with the pre-delete
     // snapshot captured above (the fallback `existing`).
     if (this.deletedConversationIds.has(conversationId)) {
-      throw new Error("Conversation was not found.");
-    }
-    if (!stored) {
       throw new Error("Conversation was not found.");
     }
     return {
@@ -994,7 +1058,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private async loadHistory(
     conversationId: string,
   ): Promise<StoredConversation> {
-    const entries = await assistantApi.get<AevatarHistoryEntry[]>(
+    const body = await assistantApi.get<AevatarHistoryResponse>(
       `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
     );
     // The conversation may have been deleted while this request was in
@@ -1003,6 +1067,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (this.deletedConversationIds.has(conversationId)) {
       throw new Error("Conversation was not found.");
     }
+    const entries = readHistoryEntries(body);
     const existing = this.conversations.get(conversationId);
     const messages = entries
       .map((entry, index) => historyEntryToMessage(entry, index))

--- a/frontend/src/lib/assistant/errors.ts
+++ b/frontend/src/lib/assistant/errors.ts
@@ -15,3 +15,17 @@ export class AssistantTurnCancelledError extends Error {
     this.name = "AssistantTurnCancelledError";
   }
 }
+
+/**
+ * Aevatar answered with a body that does not match any contract shape we
+ * accept. Distinct from a transport failure on purpose: a transient blip may
+ * fall back to a cached transcript, but a contract break must never be
+ * laundered into "this chat has no messages" — that is exactly how the
+ * array→`{messages, stateVersion}` change would have gone unnoticed.
+ */
+export class AssistantProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssistantProtocolError";
+  }
+}


### PR DESCRIPTION
## What breaks without this

Aevatar PR #2923 wraps the chat-history detail response in `{messages, stateVersion}`.

`loadHistory` typed the body as `AevatarHistoryEntry[]` and called `.map` on it, so the wrapper throws — and `getHistory`'s catch-all fallback answers with the index-merged empty mirror. **Every conversation would render blank, with no error and no toast.** Not a crash, not a "transcript failed to load" — a silently empty chat.

Verified the blast radius: the backend is untouched by the change (`get_history` is a verbatim pass-through and never parses the body), and the production chat path itself is unaffected (`nyxid-chat/…:stream`, which #2923 doesn't touch).

## The fix

One strict transcript decoder accepting exactly two shapes — the legacy flat array and the #2923 wrapper. Anything else raises a new `AssistantProtocolError` and surfaces.

**Acceptance is keyed only on array-valued `messages`; `stateVersion` is ignored.** It's the continuation watermark for `POST /api/chat`, and our production transport is `:stream`, which has no such parameter. Storing it would be state nobody maintains — `mergeIndexEntry` rebuilds `StoredConversation` and would silently drop it — and *requiring* a field with zero consumers would turn benign upstream variation into an outage.

**Fallback narrowed to match.** A protocol error always surfaces; the local mirror is served only when it holds a real transcript, so an index-only `EMPTY_TURN_STATE` placeholder can no longer be dressed up as a successful empty read. Delete still wins over both — the catch checks the tombstone set before either throw.

## Two things reviewers should weigh in on

1. **I could not verify Aevatar's deployed shape.** An unauthenticated probe returns 401 and no live session was available. That's exactly why the legacy-array branch stays: NyxID and Aevatar deploy independently, so committing to one shape breaks chat either now or the moment Aevatar ships. The removal condition is recorded at the type — delete the array branch once *every* supported Aevatar environment is confirmed on the wrapper, not after one prod probe.
2. **`POST /assistant/workflow-chat` is affected, even though the UI doesn't use it.** It forwards bodies verbatim, so external callers now owe `conversation.minimumStateVersion` on continuation or get a `503 CHAT_HISTORY_RESERVATION_UNAVAILABLE` (unknown id → `404 CONVERSATION_NOT_FOUND`). No NyxID code change is possible or needed; documented so callers aren't surprised.

## Docs

Corrected the `CHAT_SPEC.md` endpoint map (detail row + the workflow-chat row above), and two **stale normative** passages in `CHAT_ASSISTANT_SPECS.md` that still said detail is a flat array and that sending `chatHistory` was the only continuation requirement. Also struck the old F14 work-plan item ("fix the keep-max guard so an empty transcript replaces cached state") — it contradicts the deliberate materialization-lag guard, which is load-bearing.

## Out of scope

Migrating the production transport from `:stream` to `POST /api/chat` + `aevatar.chat.context`. That's a transport rewrite and belongs with `CHAT_REWORK_SPEC.md`.

## Review + gates

Approach and implementation reviewed by codex `gpt-5.6-sol` across 3 rounds. It cut a proposed `stateVersion` staleness guard as unnecessary, and caught a real regression I introduced: the narrowed catch initially bypassed the post-await tombstone check, so a read that rejected *after* a delete leaked the transport error instead of "Conversation was not found." Fixed, with a regression test verified to fail without the fix (leaks `network down`). Final verdict: "Ready to ship. No blockers found."

- frontend: 1923/1923 tests, lint 0 errors, build green
- backend: 16/16 assistant tests
- wizard bundle byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)