### PR TITLE
feat(mcp): add nyx__list_connected_services meta-tool

### DIFF
--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -579,10 +579,10 @@ fn is_scoped_api_key(auth: &McpAuthContext) -> bool {
 /// Names of tools that SSH-gate on agent scope.
 const SSH_META_TOOL_NAMES: &[&str] = &["nyx__ssh_exec", "nyx__ssh_list_services"];
 
-/// Drop user-managed services the API key is not scoped to, and reject all
-/// platform services (scoped API keys are UserService-only, matching the REST
-/// proxy check in `execute_proxy_inner`). OAuth/session callers keep every
-/// service since `allow_all_services` is `true` in `McpAuthContext::user`.
+/// Drop user-managed services the caller is not scoped to, and reject all
+/// platform services. Scoped API keys and relay tokens are UserService-only,
+/// matching the REST proxy check in `execute_proxy_inner`; unrestricted
+/// OAuth/session callers keep every service.
 fn filter_services_by_scope(
     services: Vec<mcp_service::McpToolService>,
     auth: &McpAuthContext,
@@ -1166,6 +1166,9 @@ async fn handle_tools_call(
         "nyx__discover_services" => {
             return handle_meta_discover(state, &auth.user_id, &arguments, request.id.clone())
                 .await;
+        }
+        "nyx__list_connected_services" => {
+            return handle_meta_list_connected(state, auth, &arguments, request.id.clone()).await;
         }
         "nyx__connect_service" => {
             return handle_meta_connect(
@@ -1759,27 +1762,13 @@ async fn handle_meta_search(
         return tool_result(request_id, "Search query too long (max 200 chars)", true);
     }
 
-    // Load ALL user tools including non-executable (for discovery).
-    // Scope-aware so scoped keys don't see tools whose only dispatchable
-    // routes are outside their node allow-list (twentieth-round Codex
-    // P2).
-    let services = match mcp_service::load_user_tools_all_scoped(
-        &state.db,
-        state.node_ws_manager.as_ref(),
-        &auth.user_id,
-        mcp_node_scope(auth),
-    )
-    .await
-    {
+    let services = match load_all_services_for_meta_tools(state, auth).await {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("Failed to load tools for search: {e}");
             return tool_result(request_id, "Failed to load tools", true);
         }
     };
-
-    // Scoped API keys only see services in their allow-list.
-    let services = filter_services_by_scope(services, auth);
 
     // Search across ALL tools (does NOT activate services -- use nyx__call_tool
     // to invoke discovered tools, which auto-activates on first call)
@@ -1805,6 +1794,46 @@ async fn handle_meta_search(
     });
 
     let text = serde_json::to_string_pretty(&response_json).unwrap_or_default();
+    tool_result(request_id, &text, false)
+}
+
+/// Load connected services through the same node- and service-scoped chain
+/// used by MCP metadata tools.
+async fn load_all_services_for_meta_tools(
+    state: &AppState,
+    auth: &McpAuthContext,
+) -> crate::errors::AppResult<Vec<mcp_service::McpToolService>> {
+    let services = mcp_service::load_user_tools_all_scoped(
+        &state.db,
+        state.node_ws_manager.as_ref(),
+        &auth.user_id,
+        mcp_node_scope(auth),
+    )
+    .await?;
+    Ok(filter_services_by_scope(services, auth))
+}
+
+async fn handle_meta_list_connected(
+    state: &AppState,
+    auth: &McpAuthContext,
+    arguments: &serde_json::Value,
+    request_id: Option<serde_json::Value>,
+) -> Response {
+    let query = arguments.get("query").and_then(|query| query.as_str());
+    if query.is_some_and(|query| query.len() > 200) {
+        return tool_result(request_id, "Search query too long (max 200 chars)", true);
+    }
+
+    let services = match load_all_services_for_meta_tools(state, auth).await {
+        Ok(services) => services,
+        Err(error) => {
+            tracing::error!("Failed to load connected services: {error}");
+            return tool_result(request_id, "Failed to load connected services", true);
+        }
+    };
+
+    let result = mcp_service::list_connected_services(&services, query);
+    let text = serde_json::to_string_pretty(&result).unwrap_or_default();
     tool_result(request_id, &text, false)
 }
 
@@ -2835,6 +2864,7 @@ mod tests {
                 node_id: None,
                 has_server_credential: true,
             },
+            executable: true,
             is_generic_proxy: false,
         }
     }
@@ -2850,6 +2880,7 @@ mod tests {
             source: McpToolSource::Platform {
                 downstream_service_id: id.into(),
             },
+            executable: true,
             is_generic_proxy: false,
         }
     }
@@ -2861,6 +2892,38 @@ mod tests {
         let filtered = filter_services_by_scope(services, &auth);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].service_id, "svc-a");
+    }
+
+    #[test]
+    fn connected_services_listing_respects_api_key_allow_list() {
+        let auth = api_key_auth(vec!["svc-a".into()]);
+        let services = vec![
+            user_managed("svc-a"),
+            user_managed("svc-b"),
+            platform("svc-c"),
+        ];
+
+        let visible = filter_services_by_scope(services, &auth);
+        let result = mcp_service::list_connected_services(&visible, None);
+        let services = result["services"].as_array().expect("services array");
+
+        assert_eq!(result["count"], 1);
+        assert_eq!(services[0]["service_id"], "svc-a");
+    }
+
+    #[test]
+    fn connected_services_listing_respects_relay_allow_list() {
+        let mut auth = McpAuthContext::user("user-1".into(), AuthMethod::Relay);
+        auth.allow_all_services = false;
+        auth.allowed_service_ids = vec!["svc-b".into()];
+        let services = vec![user_managed("svc-a"), user_managed("svc-b")];
+
+        let visible = filter_services_by_scope(services, &auth);
+        let result = mcp_service::list_connected_services(&visible, None);
+        let services = result["services"].as_array().expect("services array");
+
+        assert_eq!(result["count"], 1);
+        assert_eq!(services[0]["service_id"], "svc-b");
     }
 
     #[test]
@@ -3533,6 +3596,7 @@ mod tests {
         assert!(SSH_META_TOOL_NAMES.contains(&"nyx__ssh_exec"));
         assert!(SSH_META_TOOL_NAMES.contains(&"nyx__ssh_list_services"));
         assert!(!SSH_META_TOOL_NAMES.contains(&"nyx__call_tool"));
+        assert!(!SSH_META_TOOL_NAMES.contains(&"nyx__list_connected_services"));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -157,6 +157,9 @@ pub struct McpToolService {
     pub service_category: String,
     pub endpoints: Vec<McpToolEndpoint>,
     pub source: McpToolSource,
+    /// Whether the service can currently execute requests with its configured
+    /// credential and routing state.
+    pub executable: bool,
     /// true if this service has only a generic proxy tool (custom endpoint, no predefined endpoints)
     pub is_generic_proxy: bool,
 }
@@ -635,6 +638,7 @@ async fn load_user_tools_inner(
                 node_id: us.node_id.clone(),
                 has_server_credential: r.has_server_credential,
             },
+            executable: r.executable,
             is_generic_proxy: is_generic,
         });
     }
@@ -664,6 +668,7 @@ async fn load_user_tools_inner(
             source: McpToolSource::Platform {
                 downstream_service_id: svc.id.clone(),
             },
+            executable: true,
             is_generic_proxy: false,
         });
     }
@@ -722,6 +727,7 @@ struct ResolvedUserService {
     service: UserService,
     effective_owner_id: String,
     has_server_credential: bool,
+    executable: bool,
 }
 
 /// Load all callable UserServices for the user: personal + org-shared (where
@@ -909,6 +915,7 @@ async fn load_callable_user_services(
             service: us,
             effective_owner_id: user_id.to_string(),
             has_server_credential: cred_info.has_server_credential,
+            executable: cred_info.is_executable,
         });
     }
 
@@ -948,6 +955,7 @@ async fn load_callable_user_services(
             service: us,
             effective_owner_id: org_user_id,
             has_server_credential: cred_info.has_server_credential,
+            executable: cred_info.is_executable,
         });
     }
 
@@ -1103,7 +1111,7 @@ fn build_generic_proxy_input_schema() -> serde_json::Value {
 // ---------------------------------------------------------------------------
 
 /// Generate MCP tool definitions from loaded services.
-/// Always includes the three `nyx__` meta-tools.
+/// Always includes the built-in `nyx__` meta-tools.
 ///
 /// `activated_service_ids` controls which services' tools are included:
 /// - `None` = include all services (backward compat for REST /mcp/config)
@@ -1135,7 +1143,8 @@ pub fn generate_tool_definitions(
     tools.push(McpToolDefinition {
         name: "nyx__discover_services".to_string(),
         description: "Browse available services you can connect to on this NyxID instance. \
-            Returns services you are NOT yet connected to."
+            Returns services you are NOT yet connected to. For services you are already \
+            connected to, use nyx__list_connected_services."
             .to_string(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -1150,6 +1159,23 @@ pub fn generate_tool_definitions(
                     "description": "Optional: filter by service category"
                 }
             }
+        }),
+    });
+
+    tools.push(McpToolDefinition {
+        name: "nyx__list_connected_services".to_string(),
+        description: "List services you are already connected to, including services that \
+            are currently unavailable. This is the complement of nyx__discover_services."
+            .to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Optional substring filter over service name, slug, or description"
+                }
+            },
+            "required": []
         }),
     });
 
@@ -1472,6 +1498,7 @@ pub async fn load_public_tools(db: &mongodb::Database) -> AppResult<Vec<McpToolS
             source: McpToolSource::Platform {
                 downstream_service_id: svc.id,
             },
+            executable: true,
             is_generic_proxy: false,
         });
     }
@@ -3089,6 +3116,55 @@ pub fn search_all_tools(services: &[McpToolService], query: &str) -> SearchResul
 }
 
 // ---------------------------------------------------------------------------
+// Meta-tool: nyx__list_connected_services
+// ---------------------------------------------------------------------------
+
+/// Summarize the connected services already loaded for an MCP caller.
+pub fn list_connected_services(
+    services: &[McpToolService],
+    query: Option<&str>,
+) -> serde_json::Value {
+    let query = query
+        .map(str::trim)
+        .filter(|query| !query.is_empty())
+        .map(str::to_lowercase);
+
+    let results: Vec<serde_json::Value> = services
+        .iter()
+        .filter(|service| {
+            query.as_ref().is_none_or(|query| {
+                service.service_name.to_lowercase().contains(query)
+                    || service.service_slug.to_lowercase().contains(query)
+                    || service
+                        .description
+                        .as_deref()
+                        .is_some_and(|description| description.to_lowercase().contains(query))
+            })
+        })
+        .map(|service| {
+            let source = match &service.source {
+                McpToolSource::Platform { .. } => "platform",
+                McpToolSource::UserManaged { .. } => "user_service",
+            };
+            serde_json::json!({
+                "service_id": service.service_id,
+                "name": service.service_name,
+                "slug": service.service_slug,
+                "description": service.description,
+                "category": service.service_category,
+                "source": source,
+                "executable": service.executable,
+                "tool_count": service.endpoints.len(),
+                "is_generic_proxy": service.is_generic_proxy,
+            })
+        })
+        .collect();
+
+    let count = results.len();
+    serde_json::json!({ "services": results, "count": count })
+}
+
+// ---------------------------------------------------------------------------
 // Meta-tool: nyx__discover_services
 // ---------------------------------------------------------------------------
 
@@ -3225,6 +3301,8 @@ pub async fn connect_service(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::downstream_service::test_helpers::dummy_service;
+    use crate::test_utils::{connect_test_database, test_user_endpoint, test_user_service};
 
     fn make_endpoint(name: &str, description: &str) -> McpToolEndpoint {
         McpToolEndpoint {
@@ -3257,6 +3335,7 @@ mod tests {
             source: McpToolSource::Platform {
                 downstream_service_id: id.to_string(),
             },
+            executable: true,
             is_generic_proxy: false,
         }
     }
@@ -3410,6 +3489,156 @@ mod tests {
         assert!(result.matched_service_ids.is_empty());
     }
 
+    // -- list_connected_services tests --
+
+    #[test]
+    fn list_connected_services_filters_by_name_slug_and_description() {
+        let mut weather = make_service(
+            "svc-1",
+            "Forecast Service",
+            "weather",
+            vec![make_endpoint("get_forecast", "Get weather forecast")],
+        );
+        weather.description = Some("Hourly climate data".to_string());
+        let news = make_service(
+            "svc-2",
+            "News",
+            "news",
+            vec![make_endpoint("headlines", "Get headlines")],
+        );
+
+        let services = [weather, news];
+        for query in ["FORECAST", "weather", "CLIMATE"] {
+            let result = list_connected_services(&services, Some(query));
+            let matches = result["services"].as_array().expect("services array");
+
+            assert_eq!(result["count"], 1);
+            assert_eq!(matches[0]["service_id"], "svc-1");
+            assert_eq!(matches[0]["tool_count"], 1);
+            assert_eq!(matches[0]["source"], "platform");
+        }
+    }
+
+    #[tokio::test]
+    async fn connected_service_loader_excludes_unconnected_and_marks_unavailable() {
+        let Some(db) = connect_test_database("mcp_connected_services").await else {
+            eprintln!("skipping MCP connected-services test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let connected_id = uuid::Uuid::new_v4().to_string();
+        let unconnected_id = uuid::Uuid::new_v4().to_string();
+        let unavailable_id = uuid::Uuid::new_v4().to_string();
+
+        let mut connected = dummy_service();
+        connected.id = connected_id.clone();
+        connected.name = "Connected Platform".to_string();
+        connected.slug = "connected-platform".to_string();
+        connected.description = Some("Connected service".to_string());
+        connected.requires_user_credential = true;
+
+        let mut unconnected = dummy_service();
+        unconnected.id = unconnected_id.clone();
+        unconnected.name = "Unconnected Platform".to_string();
+        unconnected.slug = "unconnected-platform".to_string();
+        unconnected.requires_user_credential = true;
+
+        db.collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+            .insert_many(vec![connected, unconnected])
+            .await
+            .expect("insert platform services");
+
+        db.collection::<UserServiceConnection>(CONNECTIONS)
+            .insert_one(UserServiceConnection {
+                id: uuid::Uuid::new_v4().to_string(),
+                user_id: user_id.clone(),
+                service_id: connected_id.clone(),
+                credential_encrypted: Some(vec![1]),
+                credential_type: Some("api_key".to_string()),
+                credential_label: None,
+                metadata: None,
+                is_active: true,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .expect("insert connection");
+
+        db.collection::<ServiceEndpoint>(SERVICE_ENDPOINTS)
+            .insert_one(ServiceEndpoint {
+                id: uuid::Uuid::new_v4().to_string(),
+                service_id: connected_id.clone(),
+                name: "status".to_string(),
+                description: Some("Get status".to_string()),
+                method: "GET".to_string(),
+                path: "/status".to_string(),
+                parameters: None,
+                request_body_schema: None,
+                request_content_type: None,
+                request_body_required: false,
+                response_description: None,
+                is_active: true,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .expect("insert endpoint");
+
+        let endpoint_id = uuid::Uuid::new_v4().to_string();
+        db.collection::<UserEndpoint>(USER_ENDPOINTS)
+            .insert_one(test_user_endpoint(
+                &endpoint_id,
+                &user_id,
+                "Unavailable User Service",
+                "https://unavailable.example.com",
+                None,
+                None,
+            ))
+            .await
+            .expect("insert user endpoint");
+        let mut unavailable = test_user_service(
+            &unavailable_id,
+            &user_id,
+            "unavailable-user-service",
+            &endpoint_id,
+            None,
+            None,
+        );
+        unavailable.auth_method = "bearer".to_string();
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(unavailable)
+            .await
+            .expect("insert unavailable user service");
+
+        let node_ws_manager = NodeWsManager::new(30, 100);
+        let loaded =
+            load_user_tools_all_scoped(&db, &node_ws_manager, &user_id, NodeScope::Unrestricted)
+                .await
+                .expect("load connected services");
+        let result = list_connected_services(&loaded, None);
+        let services = result["services"].as_array().expect("services array");
+
+        assert_eq!(result["count"], 2);
+        assert!(
+            services
+                .iter()
+                .any(|service| service["service_id"] == connected_id)
+        );
+        assert!(
+            services
+                .iter()
+                .all(|service| service["service_id"] != unconnected_id)
+        );
+        let unavailable = services
+            .iter()
+            .find(|service| service["service_id"] == unavailable_id)
+            .expect("unavailable connected service should be listed");
+        assert_eq!(unavailable["executable"], false);
+        assert_eq!(unavailable["source"], "user_service");
+        assert_eq!(unavailable["is_generic_proxy"], true);
+    }
+
     // -- generate_tool_definitions tests --
 
     #[test]
@@ -3424,8 +3653,8 @@ mod tests {
         let empty_set = HashSet::new();
         let tools = generate_tool_definitions(&services, Some(&empty_set));
 
-        // Should only have the 12 meta-tools (4 core + 2 SSH + 6 oracle)
-        assert_eq!(tools.len(), 12);
+        // Should only have the 13 meta-tools (5 core + 2 SSH + 6 oracle)
+        assert_eq!(tools.len(), 13);
         assert!(tools.iter().all(|t| t.name.starts_with("nyx__")));
     }
 
@@ -3450,8 +3679,8 @@ mod tests {
         activated.insert("svc-1".to_string());
         let tools = generate_tool_definitions(&services, Some(&activated));
 
-        // 12 meta-tools + 1 weather tool (news excluded)
-        assert_eq!(tools.len(), 13);
+        // 13 meta-tools + 1 weather tool (news excluded)
+        assert_eq!(tools.len(), 14);
         assert!(tools.iter().any(|t| t.name == "weather__get_forecast"));
         assert!(!tools.iter().any(|t| t.name == "news__headlines"));
     }
@@ -3475,8 +3704,8 @@ mod tests {
 
         let tools = generate_tool_definitions(&services, None);
 
-        // 12 meta-tools + 2 service tools
-        assert_eq!(tools.len(), 14);
+        // 13 meta-tools + 2 service tools
+        assert_eq!(tools.len(), 15);
         assert!(tools.iter().any(|t| t.name == "weather__get_forecast"));
         assert!(tools.iter().any(|t| t.name == "news__headlines"));
     }
@@ -3509,6 +3738,18 @@ mod tests {
         );
         assert_eq!(required_for("nyx__oracle_extract"), vec!["pool", "url"]);
         assert_eq!(required_for("nyx__oracle_session"), vec!["conversation_id"]);
+    }
+
+    #[test]
+    fn generate_tool_definitions_includes_connected_services_meta_tool() {
+        let tools = generate_tool_definitions(&[], None);
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name == "nyx__list_connected_services")
+            .expect("connected-services meta-tool");
+
+        assert_eq!(tool.input_schema["required"], serde_json::json!([]));
+        assert!(tool.input_schema["properties"]["query"].is_object());
     }
 
     #[test]

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -1144,7 +1144,8 @@ pub fn generate_tool_definitions(
         name: "nyx__discover_services".to_string(),
         description: "Browse available services you can connect to on this NyxID instance. \
             Returns services you are NOT yet connected to. For services you are already \
-            connected to, use nyx__list_connected_services."
+            connected to, use nyx__list_connected_services. Services that require no \
+            credential are auto-connected and appear there."
             .to_string(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -1165,7 +1166,8 @@ pub fn generate_tool_definitions(
     tools.push(McpToolDefinition {
         name: "nyx__list_connected_services".to_string(),
         description: "List services you are already connected to, including services that \
-            are currently unavailable. This is the complement of nyx__discover_services."
+            are currently unavailable. Services that require no credential are auto-connected \
+            and appear here. This is the complement of nyx__discover_services."
             .to_string(),
         input_schema: serde_json::json!({
             "type": "object",
@@ -3175,15 +3177,24 @@ pub async fn discover_services(
     query: Option<&str>,
     category: Option<&str>,
 ) -> AppResult<serde_json::Value> {
-    // Load old-model connections
+    // Load all old-model connections so an inactive row can distinguish an
+    // explicit disconnect from an auto-connected service with no row.
     let connections: Vec<UserServiceConnection> = db
         .collection::<UserServiceConnection>(CONNECTIONS)
-        .find(doc! { "user_id": user_id, "is_active": true })
+        .find(doc! { "user_id": user_id })
         .await?
         .try_collect()
         .await?;
 
-    let connected_ids: HashSet<&str> = connections.iter().map(|c| c.service_id.as_str()).collect();
+    let connected_ids: HashSet<&str> = connections
+        .iter()
+        .filter(|connection| connection.is_active)
+        .map(|connection| connection.service_id.as_str())
+        .collect();
+    let connection_ids: HashSet<&str> = connections
+        .iter()
+        .map(|connection| connection.service_id.as_str())
+        .collect();
 
     // Load new-model AI Services -- exclude catalog services already provisioned
     let user_services: Vec<UserService> = db
@@ -3224,6 +3235,11 @@ pub async fn discover_services(
         .filter(|svc| {
             // Already connected via old model
             if connected_ids.contains(svc.id.as_str()) {
+                return false;
+            }
+            // Credential-free services are auto-connected unless an inactive
+            // connection row records an explicit disconnect.
+            if !svc.requires_user_credential && !connection_ids.contains(svc.id.as_str()) {
                 return false;
             }
             // Already provisioned as a UserService (by catalog ID or slug match)
@@ -3637,6 +3653,86 @@ mod tests {
         assert_eq!(unavailable["executable"], false);
         assert_eq!(unavailable["source"], "user_service");
         assert_eq!(unavailable["is_generic_proxy"], true);
+    }
+
+    #[tokio::test]
+    async fn discover_and_connected_services_are_disjoint_for_auto_connect_states() {
+        let Some(db) = connect_test_database("mcp_auto_connect_complement").await else {
+            eprintln!("skipping MCP auto-connect test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let auto_connected_id = uuid::Uuid::new_v4().to_string();
+        let auto_disconnected_id = uuid::Uuid::new_v4().to_string();
+        let credential_required_id = uuid::Uuid::new_v4().to_string();
+
+        let mut auto_connected = dummy_service();
+        auto_connected.id = auto_connected_id.clone();
+        auto_connected.name = "Auto Connected".to_string();
+        auto_connected.slug = "auto-connected".to_string();
+        auto_connected.requires_user_credential = false;
+
+        let mut auto_disconnected = dummy_service();
+        auto_disconnected.id = auto_disconnected_id.clone();
+        auto_disconnected.name = "Auto Disconnected".to_string();
+        auto_disconnected.slug = "auto-disconnected".to_string();
+        auto_disconnected.requires_user_credential = false;
+
+        let mut credential_required = dummy_service();
+        credential_required.id = credential_required_id.clone();
+        credential_required.name = "Credential Required".to_string();
+        credential_required.slug = "credential-required".to_string();
+        credential_required.requires_user_credential = true;
+
+        db.collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+            .insert_many(vec![auto_connected, auto_disconnected, credential_required])
+            .await
+            .expect("insert discovery services");
+
+        db.collection::<UserServiceConnection>(CONNECTIONS)
+            .insert_one(UserServiceConnection {
+                id: uuid::Uuid::new_v4().to_string(),
+                user_id: user_id.clone(),
+                service_id: auto_disconnected_id.clone(),
+                credential_encrypted: None,
+                credential_type: None,
+                credential_label: None,
+                metadata: None,
+                is_active: false,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .expect("insert explicit disconnect");
+
+        let node_ws_manager = NodeWsManager::new(30, 100);
+        let loaded =
+            load_user_tools_all_scoped(&db, &node_ws_manager, &user_id, NodeScope::Unrestricted)
+                .await
+                .expect("load connected services");
+        let connected = list_connected_services(&loaded, None);
+        let discover = discover_services(&db, &user_id, None, Some("connection"))
+            .await
+            .expect("discover services");
+
+        let service_ids = |result: &serde_json::Value| -> HashSet<String> {
+            result["services"]
+                .as_array()
+                .expect("services array")
+                .iter()
+                .filter_map(|service| service["service_id"].as_str().map(str::to_string))
+                .collect()
+        };
+        let connected_ids = service_ids(&connected);
+        let discover_ids = service_ids(&discover);
+
+        assert_eq!(connected_ids, HashSet::from([auto_connected_id]));
+        assert_eq!(
+            discover_ids,
+            HashSet::from([auto_disconnected_id, credential_required_id])
+        );
+        assert!(connected_ids.is_disjoint(&discover_ids));
     }
 
     // -- generate_tool_definitions tests --

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1796,16 +1796,18 @@ Instead of loading all 80+ tools at session startup, NyxID uses a three-phase ap
 Initialize Session
     |
     v
-Load 3 Meta-Tools
+Load Built-In Meta-Tools (core shown)
     |-- nyx__search_tools
     |-- nyx__discover_services
+    |-- nyx__list_connected_services
     |-- nyx__connect_service
+    |-- nyx__call_tool
     |
     v
-LLM Calls Search/Connect
+LLM Calls Connect/Call
     |
     v
-Activate Matching Service Tools
+Activate Invoked Service Tools
     |
     v
 Send notifications/tools/list_changed
@@ -1818,32 +1820,37 @@ Client Auto-Refreshes Tool List
 
 The MCP proxy maintains session-based activation state in `McpSessionStore`:
 
-- **Initial state**: Only 3 meta-tools loaded
-- **On `nyx__search_tools` call**: Matching service tools are activated and added to the session
+- **Initial state**: Built-in meta-tools only; no per-service tools are activated
+- **On `nyx__search_tools` call**: Search all connected tools without activating services
+- **On `nyx__list_connected_services` call**: Enumerate connected services without activating tools
 - **On `nyx__connect_service` call**: That service's tools are activated
-- **On `nyx__discover_services` call**: Browse services only (does NOT activate tools)
+- **On `nyx__call_tool` call**: The invoked tool's service is activated
+- **On `nyx__discover_services` call**: Browse unconnected services only (does NOT activate tools)
 - **Maximum activated services**: 20 per session (bounded to prevent memory issues)
 
 ### Dynamic Tool Loading Flow
 
-1. **Session initialization** -- MCP server creates a new session and loads only the 3 meta-tools
+1. **Session initialization** -- MCP server creates a new session and loads built-in meta-tools only
 2. **Search phase** -- LLM calls `nyx__search_tools` with a query (e.g., "payment processing")
-3. **Activation** -- Server finds matching services, activates their tools, adds to session state
-4. **Notification** -- Server sends `notifications/tools/list_changed` to the client
-5. **Client refresh** -- Client (Cursor, Claude Code) re-fetches the full tool list via `tools/list`
-6. **Tool invocation** -- LLM can now call the newly activated service tools
+3. **Invocation** -- LLM calls `nyx__call_tool` with a search result
+4. **Activation** -- Server activates the invoked tool's service and adds it to session state
+5. **Notification** -- Server sends `notifications/tools/list_changed` to the client
+6. **Client refresh** -- Client (Cursor, Claude Code) re-fetches the full tool list via `tools/list`
+7. **Direct invocation** -- LLM can now call the activated per-service tools directly
 
 ### Meta-Tools
 
 | Tool Name | Purpose | Tool Activation |
 |-----------|---------|-----------------|
-| `nyx__search_tools` | Search and activate service tools by keyword | YES - activates matching services |
-| `nyx__discover_services` | Browse all available services | NO - browse-only |
+| `nyx__search_tools` | Search connected service tools by keyword | NO - search-only |
+| `nyx__discover_services` | Browse services that are not connected | NO - browse-only |
+| `nyx__list_connected_services` | Enumerate connected services and availability | NO - browse-only |
 | `nyx__connect_service` | Connect to a specific service and activate its tools | YES - activates the service |
+| `nyx__call_tool` | Invoke a connected tool by name | YES - activates the invoked service |
 
 ### REST API Compatibility
 
-The REST endpoint `/api/v1/mcp/config` still returns the full list of all tools for backward compatibility with non-MCP clients.
+The REST endpoint `/api/v1/mcp/config` still returns the full executable service and endpoint configuration for backward compatibility with non-MCP clients.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1081,19 +1081,23 @@ MCP clients that support OAuth (e.g., Claude Desktop) will automatically discove
 To optimize performance, NyxID implements dynamic tool loading:
 
 **Session Initialization:**
-- MCP sessions start with only 3 meta-tools:
-  - `nyx__search_tools` -- Search and activate service tools by keyword
-  - `nyx__discover_services` -- Browse available services (does not activate)
+- MCP sessions start with built-in meta-tools and no activated per-service tools. Core meta-tools include:
+  - `nyx__search_tools` -- Search connected service tools by keyword
+  - `nyx__discover_services` -- Browse unconnected services (does not activate)
+  - `nyx__list_connected_services` -- Enumerate connected services and availability (does not activate)
   - `nyx__connect_service` -- Connect to a specific service and activate its tools
+  - `nyx__call_tool` -- Invoke a connected tool and activate its service
 
 **On-Demand Activation:**
-- When the LLM calls `nyx__search_tools`, the server activates matching service tools and sends a `notifications/tools/list_changed` notification
 - When the LLM calls `nyx__connect_service`, that service's tools are activated
+- When the LLM calls `nyx__call_tool`, the invoked tool's service is activated
+- `nyx__search_tools`, `nyx__discover_services`, and `nyx__list_connected_services` do not activate service tools
 - Clients (Cursor, Claude Code) automatically refresh their tool list when they receive the notification
 
 **Constraints:**
 - Maximum 20 activated services per session (bounded memory usage)
 - `nyx__discover_services` is browse-only and does NOT activate tools
+- `nyx__list_connected_services` is browse-only and does NOT activate tools
 
 ### How Tools Are Generated
 

--- a/docs/connecting-services/ai-driven.md
+++ b/docs/connecting-services/ai-driven.md
@@ -1,6 +1,6 @@
 # AI-Driven — Let Your Agent Connect a Service for You
 
-Use Claude Code, Codex, or Cursor to call NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__connect_service`, `nyx__call_tool`) and connect a service end-to-end.
+Use Claude Code, Codex, or Cursor to call NyxID's MCP meta-tools (`nyx__discover_services`, `nyx__list_connected_services`, `nyx__connect_service`, `nyx__call_tool`) and connect a service end-to-end.
 
 This path involves more moving parts than the [Web UI](web-ui.md) or [CLI](cli.md) — MCP setup, agent prompt interpretation, model behavior. If this is your **first** service ever, prefer the Web UI. If you already have one working service, this path is faster than clicking through the dashboard for service two and beyond.
 
@@ -31,7 +31,7 @@ The first run opens your browser to authenticate (OAuth) and stores a session.
 
 ### What you should see after this step
 
-Your agent now sees NyxID's meta-tools: `nyx__discover_services`, `nyx__connect_service`, `nyx__search_tools`, `nyx__call_tool`. These are NyxID itself — not yet a connected downstream service.
+Your agent now sees NyxID's core meta-tools: `nyx__discover_services`, `nyx__list_connected_services`, `nyx__connect_service`, `nyx__search_tools`, `nyx__call_tool`. These are NyxID itself — not yet a connected downstream service.
 
 ## Step 2 — Paste this prompt into your agent
 

--- a/docs/site/ai/getting-started/connect-your-agent.md
+++ b/docs/site/ai/getting-started/connect-your-agent.md
@@ -155,6 +155,7 @@ nyxid mcp config --tool generic   # raw MCP URL only
 After the client authenticates, you should see NyxID's meta-tools:
 
 - `nyx__discover_services` — browse the catalog
+- `nyx__list_connected_services` — enumerate services already connected to your account
 - `nyx__connect_service` — add a service from within the agent
 - `nyx__search_tools` — find tools across connected services
 - `nyx__call_tool` — invoke any connected service endpoint

--- a/docs/site/ai/guides/mcp-proxy.md
+++ b/docs/site/ai/guides/mcp-proxy.md
@@ -17,13 +17,14 @@ Each service endpoint becomes one MCP tool. Tool names follow the pattern `{serv
 
 The `operationId` comes from the service's OpenAPI spec. If no `operationId` is set, NyxID generates a name from the HTTP method and path (e.g. `post_v1_chat_completions`). Adding `operationId` to spec entries produces cleaner tool names.
 
-In addition to per-service tools, NyxID always surfaces four meta-tools:
+In addition to per-service tools, NyxID always surfaces five core meta-tools:
 
 | Tool | Purpose |
 |---|---|
-| `nyx__discover_services` | Browse the catalog and list connected services |
+| `nyx__discover_services` | Browse catalog services that are not connected |
+| `nyx__list_connected_services` | Enumerate connected services and their current availability |
 | `nyx__connect_service` | Add a service from within the agent |
-| `nyx__search_tools` | Fuzzy-search across all available tools |
+| `nyx__search_tools` | Search across all available tools |
 | `nyx__call_tool` | Invoke any tool by name with arbitrary arguments |
 
 ## Connecting a service via the agent

--- a/docs/site/shared/concepts/mcp-proxy.md
+++ b/docs/site/shared/concepts/mcp-proxy.md
@@ -29,9 +29,11 @@ NyxID also exposes a small number of built-in tools for navigation:
 
 | Tool | Purpose |
 |------|---------|
-| `nyx__discover_services` | Browse all available services |
-| `nyx__search_tools` | Search and activate tools by keyword |
+| `nyx__discover_services` | Browse services that are not connected |
+| `nyx__list_connected_services` | List connected services, including currently unavailable ones |
+| `nyx__search_tools` | Search connected tools by keyword |
 | `nyx__connect_service` | Connect to a specific service and activate its tools |
+| `nyx__call_tool` | Invoke a connected tool by name and activate its service |
 
 ## How a tool call flows
 


### PR DESCRIPTION
## Summary

Session-backed MCP clients (OAuth + `mcp-session-id`) had no way to enumerate the services they are already connected to: `tools/list` returns only meta-tools plus session-activated services, `nyx__search_tools` requires a query and caps at 25 results, and `nyx__discover_services` deliberately returns only NOT-yet-connected services. Stateless API-key clients already receive the full tool list up front, so the information was never sensitive -- the gap was an oversight.

This PR adds a `nyx__list_connected_services` meta-tool and fixes a semantic contradiction it exposed in `nyx__discover_services`.

### `nyx__list_connected_services` (142b254a)

- Always-present meta-tool, the complement of `nyx__discover_services`. Optional `query` substring filter over name/slug/description (200-char cap, matching search).
- Response per service: `service_id`, `name`, `slug`, `description`, `category`, `source` (`platform` / `user_service`), `executable`, `tool_count`, `is_generic_proxy`, plus top-level `count`. Metadata only -- never credentials.
- Backed by the same discovery chain as `nyx__search_tools` (`load_user_tools_all_scoped` + `filter_services_by_scope`), factored into a shared `load_all_services_for_meta_tools` helper so both meta-tools enforce API-key/relay service allow-lists and node scope identically.
- New `executable` flag on `McpToolService`: connected services whose credentials/routes are currently unavailable (node offline, inactive key) are listed with `executable: false` instead of being hidden.
- Listing does not activate session tools. Scoped API keys keep access (only SSH meta-tools are stripped -- this tool is scope-filtered, not scope-escaping). The anonymous `/public/mcp` surface is unaffected (separate `generate_public_tool_definitions`).

### Disjoint discovery sets (5f4a29bb)

The tool loader treats credential-free platform services as auto-connected, but `discover_services` only excluded services with an active connection row -- so an auto-connected service appeared simultaneously in "connected" and "NOT yet connected". `discover_services` now excludes credential-free services unless an inactive connection row records an explicit disconnect, making the two result sets mutually exclusive. Both tool descriptions document the auto-connect boundary.

### Docs

Updated the MCP meta-tool documentation in `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md`, `docs/connecting-services/ai-driven.md`, and `docs/site` MCP pages.

## Test plan

- [x] Unit tests: meta-tool registration/schema, query filtering (name/slug/description), API-key allow-list filtering, relay allow-list filtering, SSH-strip exclusion
- [x] MongoDB-backed tests (local instance, port 27018): connected services returned / unconnected excluded / unavailable service listed with `executable: false`; discover-vs-connected disjointness across all three auto-connect states (no row, inactive row, credential-required)
- [x] Full `cargo test -p nyxid`: 4775 passed, 0 failed
- [x] `cargo build -p nyxid`, `cargo clippy -p nyxid -- -D warnings`, `cargo fmt --all -- --check`: clean
- [ ] Manual verification against a live MCP client (session-backed OAuth flow)

Implemented by Codex gpt-5.6-sol (xhigh) with two rounds of code review; the round-1 review found and drove the disjointness fix.