### PR TITLE
feat(assistant): ChatGPT-style chat scrolling + single-CTA connector cards

### DIFF
--- a/frontend/src/components/assistant/chat-composer.tsx
+++ b/frontend/src/components/assistant/chat-composer.tsx
@@ -1,6 +1,18 @@
-import { useState, type KeyboardEvent } from "react";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { Send, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
+
+/**
+ * The composer floats over the thread, so it cannot be allowed to eat the
+ * conversation. It starts as a single line and grows with the draft up to this
+ * many rows, after which the textarea scrolls internally.
+ */
+const MAX_ROWS = 4;
 
 export function ChatComposer({
   active,
@@ -14,6 +26,34 @@ export function ChatComposer({
   readonly onStop: () => Promise<void>;
 }) {
   const [content, setContent] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Grow the textarea to fit the draft, capped at MAX_ROWS.
+  useLayoutEffect(() => {
+    const element = textareaRef.current;
+    if (!element) return;
+
+    const styles = getComputedStyle(element);
+    const lineHeight = Number.parseFloat(styles.lineHeight) || 21;
+    const padding =
+      Number.parseFloat(styles.paddingTop) +
+      Number.parseFloat(styles.paddingBottom);
+    const oneRow = lineHeight + padding;
+    const maxHeight = lineHeight * MAX_ROWS + padding;
+
+    // Measure unconstrained, then put the old height back and force a reflow
+    // before writing the target. Without that restore the browser's
+    // before-change style is already the natural height, so the CSS height
+    // transition has nothing to animate from and the box snaps.
+    const previous = element.style.height;
+    element.style.height = "auto";
+    const natural = element.scrollHeight;
+    element.style.height = previous;
+    void element.offsetHeight;
+
+    element.style.height = `${String(Math.max(Math.min(natural, maxHeight), oneRow))}px`;
+    element.style.overflowY = natural > maxHeight ? "auto" : "hidden";
+  }, [content]);
 
   async function submit() {
     const message = content.trim();
@@ -40,16 +80,17 @@ export function ChatComposer({
     >
       <div className="rounded-xl border border-hairline bg-card p-2 transition-colors focus-within:border-hairline-strong">
         <textarea
+          ref={textareaRef}
           value={content}
           onChange={(event) => setContent(event.target.value)}
           onKeyDown={handleKeyDown}
           disabled={active}
-          rows={2}
+          rows={1}
           maxLength={32_768}
           placeholder={
             active ? "Assistant is working..." : "Message NyxID Assistant..."
           }
-          className="max-h-40 min-h-[42px] w-full resize-none bg-transparent px-2 py-1 text-[13px] leading-relaxed text-foreground outline-none placeholder:text-text-tertiary disabled:cursor-not-allowed disabled:opacity-50"
+          className="w-full resize-none overflow-hidden bg-transparent px-2 py-1 text-[13px] leading-relaxed text-foreground outline-none transition-[height] duration-150 ease-out placeholder:text-text-tertiary disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none"
         />
         <div className="flex items-center justify-end">
           {active ? (

--- a/frontend/src/components/assistant/chat-thread.test.tsx
+++ b/frontend/src/components/assistant/chat-thread.test.tsx
@@ -70,6 +70,27 @@ describe("ChatThread", () => {
     ).toBeInTheDocument();
   });
 
+  it("reserves tail room and fades over the composer it scrolls behind", () => {
+    const { container } = render(
+      <ChatThread
+        messages={[
+          message({
+            blocks: [{ type: "text", block_id: "text-1", text: "Answer" }],
+          }),
+        ]}
+        bottomInset={140}
+        onDecideApproval={vi.fn()}
+      />,
+    );
+
+    const scroller = container.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(scroller?.style.maskImage).toContain("calc(100% - 140px)");
+    // Tail padding keeps the last turn clear of the composer at scroll bottom.
+    expect(
+      scroller?.firstElementChild?.getAttribute("style"),
+    ).toContain("140px");
+  });
+
   it("hides the thinking indicator once assistant content streams", () => {
     render(
       <ChatThread

--- a/frontend/src/components/assistant/chat-thread.tsx
+++ b/frontend/src/components/assistant/chat-thread.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef } from "react";
+import { Fragment, useCallback, useEffect, useRef } from "react";
 import { AlertCircle } from "lucide-react";
 import { NyxidIcon } from "@/components/brand/nyxid-icon";
 import { ApprovalCard } from "@/components/assistant/blocks/approval-card";
@@ -149,10 +149,16 @@ function ThinkingRow() {
   );
 }
 
+// Slack, in px, within which the thread still counts as "following" the tail.
+// Below it the reader has deliberately scrolled up and must not be yanked back
+// while the assistant streams.
+const FOLLOW_THRESHOLD = 48;
+
 export function ChatThread({
   messages,
   thinking = false,
   streaming = false,
+  bottomInset = 0,
   onDecideApproval,
 }: {
   readonly messages: readonly AssistantMessage[];
@@ -168,23 +174,56 @@ export function ChatThread({
    * reads as live typing rather than a frozen partial answer.
    */
   readonly streaming?: boolean;
+  /**
+   * Height in px of the composer floating over the thread. Turns are allowed to
+   * scroll behind it (ChatGPT-style), so the thread reserves this much room at
+   * the tail and dissolves into it over the same distance.
+   */
+  readonly bottomInset?: number;
   readonly onDecideApproval: (
     blockId: string,
     approved: boolean,
   ) => Promise<void>;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const following = useRef(true);
+  const lastSentId = useRef<string | undefined>(undefined);
+
+  const handleScroll = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    following.current =
+      element.scrollHeight - element.scrollTop - element.clientHeight <
+      FOLLOW_THRESHOLD;
+  }, []);
 
   useEffect(() => {
     const element = scrollRef.current;
-    if (element) element.scrollTop = element.scrollHeight;
-  }, [messages, thinking, streaming]);
+    if (!element) return;
+    // Sending always pulls the view back to the tail; only assistant streaming
+    // respects a deliberate scroll-up. Keyed on the message id so the poll loop
+    // re-rendering the same turn doesn't keep yanking a reader back down.
+    const latest = messages.at(-1);
+    if (latest?.role === "user" && latest.id !== lastSentId.current) {
+      lastSentId.current = latest.id;
+      following.current = true;
+    }
+    if (following.current) element.scrollTop = element.scrollHeight;
+  }, [messages, thinking, streaming, bottomInset]);
 
   const groups = groupMessages(messages);
 
+  // Opaque down to the top of the composer, then dissolved to nothing by the
+  // bottom edge — content passing behind the composer fades out instead of
+  // being clipped by a hard line.
+  const fadeMask = `linear-gradient(to bottom, #000 0, #000 calc(100% - ${String(bottomInset)}px), transparent 100%)`;
+
   if (messages.length === 0) {
     return (
-      <div className="flex flex-1 items-center justify-center px-6 text-center">
+      <div
+        className="flex flex-1 items-center justify-center px-6 text-center"
+        style={{ paddingBottom: `${String(bottomInset)}px` }}
+      >
         <div>
           <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl border border-nyx-secondary-400/20 bg-nyx-secondary-400/[0.06]">
             <NyxidIcon className="h-5 w-5" />
@@ -204,9 +243,14 @@ export function ChatThread({
     <div className="relative flex min-h-0 flex-1 flex-col">
       <div
         ref={scrollRef}
+        onScroll={handleScroll}
         className="@container min-h-0 flex-1 overflow-y-auto overscroll-contain"
+        style={{ maskImage: fadeMask, WebkitMaskImage: fadeMask }}
       >
-        <div className="mx-auto flex w-full max-w-[680px] flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8">
+        <div
+          className="mx-auto flex w-full max-w-[680px] flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8"
+          style={{ paddingBottom: `calc(${String(bottomInset)}px + 1.5rem)` }}
+        >
           {groups.map((group, groupIndex) => {
             const first = group.messages[0];
             const time = formatClockTime(first?.created_at);
@@ -289,16 +333,6 @@ export function ChatThread({
           {thinking ? <ThinkingRow /> : null}
         </div>
       </div>
-      {/*
-        Very-thin scroll fade so the last turn dissolves into the composer
-        instead of hard-cutting at its top edge. Fades to the page background
-        (which the composer also sits on); pointer-events-none so it never
-        eats clicks on the content beneath it.
-      */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 bottom-0 h-4 bg-gradient-to-t from-background to-transparent"
-      />
     </div>
   );
 }

--- a/frontend/src/components/assistant/manage-connection-modal.tsx
+++ b/frontend/src/components/assistant/manage-connection-modal.tsx
@@ -8,12 +8,19 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { useDeleteKey, useKey, useUpdateKey } from "@/hooks/use-keys";
+import {
+  useDeleteKey,
+  useKey,
+  useUpdateExternalApiKey,
+  useUpdateKey,
+} from "@/hooks/use-keys";
+import { ApiError } from "@/lib/api-client";
 import { formatDate } from "@/lib/utils";
 import { connectorInitial } from "@/lib/assistant/plugins";
 import type { KeyInfo } from "@/types/keys";
@@ -55,6 +62,21 @@ function readOnlyReason(key: KeyInfo): string {
   return "Managed by your organization — an org admin can change it.";
 }
 
+/**
+ * Whether a pasted secret can replace this credential. OAuth and node-managed
+ * credentials aren't user-held strings, and a connection still awaiting its
+ * first auth has nothing to rotate — the same gate `ApiKeySection` applies on
+ * the Studio page (key-detail.tsx:453).
+ */
+function canReplaceCredential(key: KeyInfo): boolean {
+  return (
+    Boolean(key.api_key_id) &&
+    key.credential_type !== "oauth2" &&
+    key.credential_type !== "node_managed" &&
+    key.status !== "pending_auth"
+  );
+}
+
 function DetailRow({
   label,
   children,
@@ -74,27 +96,120 @@ function DetailRow({
   );
 }
 
+/** Inline credential replacement — the one rotation path a plugin user needs,
+ *  kept in this modal so managing a connection never leaves it. */
+function ReplaceCredential({ apiKeyId }: { readonly apiKeyId: string }) {
+  const [open, setOpen] = useState(false);
+  const [credential, setCredential] = useState("");
+  const updateApiKey = useUpdateExternalApiKey();
+
+  function submit() {
+    const next = credential.trim();
+    if (!next) return;
+    updateApiKey.mutate(
+      { keyId: apiKeyId, credential: next },
+      {
+        onSuccess: () => {
+          toast.success("Credential replaced");
+          setCredential("");
+          setOpen(false);
+        },
+        onError: (error) =>
+          toast.error(
+            error instanceof ApiError
+              ? error.message
+              : "Could not replace the credential.",
+          ),
+      },
+    );
+  }
+
+  if (!open) {
+    return (
+      <div className="flex items-center justify-between gap-4 py-2.5">
+        <div>
+          <p className="text-[12px] font-medium text-foreground">Credential</p>
+          <p className="text-[11px] text-text-tertiary">
+            Paste a new secret to replace the stored one.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setOpen(true)}
+        >
+          Replace
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 py-2.5">
+      <p className="text-[12px] font-medium text-foreground">
+        Replace credential
+      </p>
+      <Input
+        type="password"
+        autoFocus
+        value={credential}
+        onChange={(event) => setCredential(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            submit();
+          }
+        }}
+        placeholder="New credential"
+        aria-label="New credential"
+      />
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setCredential("");
+            setOpen(false);
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          disabled={!credential.trim()}
+          isLoading={updateApiKey.isPending}
+          onClick={submit}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /**
- * Compact connection-management modal for the assistant Plugins surface: the
- * high-value actions (enable/disable, revoke) plus an escape hatch into the
- * full Studio key-detail page for rotation, routing, and scope edits.
+ * One connection's full management surface. Rendered once per credential, so a
+ * service with several connections shows them stacked in the same modal rather
+ * than making the user pick one first.
  */
-export function ManageConnectionModal({
+function ConnectionPanel({
   keyId,
-  onClose,
+  showLabel,
+  onRevoked,
 }: {
   readonly keyId: string;
-  readonly onClose: () => void;
+  /** Multi-connection cards head each panel with its credential label. */
+  readonly showLabel: boolean;
+  readonly onRevoked: () => void;
 }) {
   const { data: key, isLoading, error, refetch } = useKey(keyId);
   const updateKey = useUpdateKey();
   const deleteKey = useDeleteKey();
   const [confirmingRevoke, setConfirmingRevoke] = useState(false);
-
-  function close() {
-    setConfirmingRevoke(false);
-    onClose();
-  }
 
   function toggleActive(nextActive: boolean) {
     if (!key) return;
@@ -113,157 +228,230 @@ export function ManageConnectionModal({
     deleteKey.mutate(key.id, {
       onSuccess: () => {
         toast.success("Connection revoked");
-        close();
+        onRevoked();
       },
       onError: () => toast.error("Could not revoke the connection."),
     });
   }
 
-  const grantedScopes = key?.granted_scopes ?? null;
-  const modifiable = key ? canModifyKey(key) : false;
+  if (isLoading) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <Loader2 className="h-4 w-4 animate-spin text-text-tertiary" />
+      </div>
+    );
+  }
+
+  if (error || !key) {
+    return (
+      <div className="flex h-40 flex-col items-center justify-center gap-3 text-center">
+        <p className="text-[12px] text-muted-foreground">
+          Couldn't load this connection.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void refetch()}
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const grantedScopes = key.granted_scopes ?? null;
+  const modifiable = canModifyKey(key);
 
   return (
-    <Dialog open onOpenChange={(next) => (next ? undefined : close())}>
-      <DialogContent className="max-w-md">
-        {isLoading ? (
-          <div className="flex h-40 items-center justify-center">
-            <Loader2 className="h-4 w-4 animate-spin text-text-tertiary" />
-          </div>
-        ) : error || !key ? (
-          <div className="flex h-40 flex-col items-center justify-center gap-3 text-center">
-            <p className="text-[12px] text-muted-foreground">
-              Couldn't load this connection.
-            </p>
-            <Button
+    <section>
+      {showLabel && (
+        <div className="flex items-center justify-between gap-2 pb-1">
+          <p className="min-w-0 truncate text-[12px] font-medium text-foreground">
+            {key.label}
+          </p>
+          <Badge variant={statusVariant(key.status)}>
+            {key.status.replaceAll("_", " ")}
+          </Badge>
+        </div>
+      )}
+
+      <div className="divide-y divide-border/60">
+        {/* Multi-connection panels carry status beside their label; a lone
+            connection has no label row, so it reads as a field instead. */}
+        {!showLabel && (
+          <DetailRow label="Status">
+            <Badge variant={statusVariant(key.status)}>
+              {key.status.replaceAll("_", " ")}
+            </Badge>
+          </DetailRow>
+        )}
+        <DetailRow label="Credential">
+          {key.credential_type.replaceAll("_", " ")}
+        </DetailRow>
+        {grantedScopes && grantedScopes.length > 0 && (
+          <DetailRow label="Scopes">
+            <span className="flex flex-wrap justify-end gap-1">
+              {grantedScopes.map((scope) => (
+                <span
+                  key={scope}
+                  className="rounded bg-overlay-strong px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                >
+                  {scope}
+                </span>
+              ))}
+            </span>
+          </DetailRow>
+        )}
+        {key.proxy_url && (
+          <DetailRow label="Proxy URL">
+            <button
               type="button"
+              onClick={() => {
+                void navigator.clipboard?.writeText(key.proxy_url ?? "");
+                toast.success("Proxy URL copied");
+              }}
+              className="inline-flex max-w-full items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span className="truncate">{key.proxy_url}</span>
+              <Copy className="h-3 w-3 shrink-0" />
+            </button>
+          </DetailRow>
+        )}
+        <DetailRow label="Last used">
+          {key.last_used_at ? formatDate(key.last_used_at) : "Never"}
+        </DetailRow>
+        {modifiable ? (
+          <>
+            <div className="flex items-center justify-between gap-4 py-2.5">
+              <div>
+                <p className="text-[12px] font-medium text-foreground">
+                  Enabled
+                </p>
+                <p className="text-[11px] text-text-tertiary">
+                  Pause to block the assistant from using this connection.
+                </p>
+              </div>
+              <Switch
+                checked={key.is_active}
+                disabled={updateKey.isPending}
+                onCheckedChange={toggleActive}
+                aria-label="Toggle connection enabled"
+              />
+            </div>
+            {canReplaceCredential(key) && (
+              <ReplaceCredential apiKeyId={key.api_key_id as string} />
+            )}
+          </>
+        ) : (
+          <div className="flex items-center gap-2 py-2.5 text-[11px] text-text-tertiary">
+            <Lock className="h-3 w-3 shrink-0" />
+            {readOnlyReason(key)}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2 pt-2.5">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/keys/$keyId" params={{ keyId: key.id }}>
+            Advanced settings
+            <ExternalLink />
+          </Link>
+        </Button>
+        {modifiable &&
+          (confirmingRevoke ? (
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] text-text-tertiary">
+                Revoke this connection?
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmingRevoke(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                isLoading={deleteKey.isPending}
+                onClick={revoke}
+              >
+                Revoke
+              </Button>
+            </div>
+          ) : (
+            <Button
               variant="outline"
               size="sm"
-              onClick={() => void refetch()}
+              className="text-destructive hover:text-destructive"
+              onClick={() => setConfirmingRevoke(true)}
             >
-              Try again
+              Revoke
             </Button>
-          </div>
-        ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2.5">
-                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-[12px] font-semibold text-muted-foreground">
-                  {key.catalog_service_slug ? (
-                    <ServiceIcon slug={key.catalog_service_slug} size="md" />
-                  ) : (
-                    connectorInitial(key.label)
-                  )}
-                </span>
-                <span className="min-w-0 truncate">{key.label}</span>
-                <Badge variant={statusVariant(key.status)} className="ml-1">
-                  {key.status.replaceAll("_", " ")}
-                </Badge>
-              </DialogTitle>
-            </DialogHeader>
+          ))}
+      </div>
+    </section>
+  );
+}
 
-            <div className="divide-y divide-border/60">
-              <DetailRow label="Credential">
-                {key.credential_type.replaceAll("_", " ")}
-              </DetailRow>
-              {grantedScopes && grantedScopes.length > 0 && (
-                <DetailRow label="Scopes">
-                  <span className="flex flex-wrap justify-end gap-1">
-                    {grantedScopes.map((scope) => (
-                      <span
-                        key={scope}
-                        className="rounded bg-overlay-strong px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
-                      >
-                        {scope}
-                      </span>
-                    ))}
-                  </span>
-                </DetailRow>
-              )}
-              {key.proxy_url && (
-                <DetailRow label="Proxy URL">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void navigator.clipboard?.writeText(key.proxy_url ?? "");
-                      toast.success("Proxy URL copied");
-                    }}
-                    className="inline-flex max-w-full items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-                  >
-                    <span className="truncate">{key.proxy_url}</span>
-                    <Copy className="h-3 w-3 shrink-0" />
-                  </button>
-                </DetailRow>
-              )}
-              <DetailRow label="Last used">
-                {key.last_used_at ? formatDate(key.last_used_at) : "Never"}
-              </DetailRow>
-              {modifiable ? (
-                <div className="flex items-center justify-between gap-4 py-2.5">
-                  <div>
-                    <p className="text-[12px] font-medium text-foreground">
-                      Enabled
-                    </p>
-                    <p className="text-[11px] text-text-tertiary">
-                      Pause to block the assistant from using this connection.
-                    </p>
-                  </div>
-                  <Switch
-                    checked={key.is_active}
-                    disabled={updateKey.isPending}
-                    onCheckedChange={toggleActive}
-                    aria-label="Toggle connection enabled"
-                  />
-                </div>
+/**
+ * Connection management for the assistant Plugins surface. Everything a plugin
+ * user needs lives in this one modal — including every credential behind a
+ * service, stacked rather than staged behind a picker. Deep service config
+ * (endpoint, routing, headers, node setup) stays on the Studio key page, one
+ * click away per connection.
+ */
+export function ManageConnectionModal({
+  keyIds,
+  serviceName,
+  iconSlug,
+  onClose,
+}: {
+  readonly keyIds: readonly string[];
+  readonly serviceName: string;
+  readonly iconSlug?: string | null;
+  readonly onClose: () => void;
+}) {
+  const multiple = keyIds.length > 1;
+
+  return (
+    <Dialog open onOpenChange={(next) => (next ? undefined : onClose())}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2.5">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-[12px] font-semibold text-muted-foreground">
+              {iconSlug ? (
+                <ServiceIcon slug={iconSlug} size="md" />
               ) : (
-                <div className="flex items-center gap-2 py-2.5 text-[11px] text-text-tertiary">
-                  <Lock className="h-3 w-3 shrink-0" />
-                  {readOnlyReason(key)}
-                </div>
+                connectorInitial(serviceName)
               )}
-            </div>
+            </span>
+            <span className="min-w-0 truncate">{serviceName}</span>
+            {multiple && (
+              <Badge variant="secondary" className="ml-1">
+                {keyIds.length} connections
+              </Badge>
+            )}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Manage the credentials this service is connected with.
+          </DialogDescription>
+        </DialogHeader>
 
-            <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <Button asChild variant="ghost" size="sm">
-                <Link to="/keys/$keyId" params={{ keyId: key.id }}>
-                  Open full settings
-                  <ExternalLink />
-                </Link>
-              </Button>
-              {modifiable &&
-                (confirmingRevoke ? (
-                  <div className="flex items-center gap-2">
-                    <span className="text-[11px] text-text-tertiary">
-                      Revoke this connection?
-                    </span>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setConfirmingRevoke(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      isLoading={deleteKey.isPending}
-                      onClick={revoke}
-                    >
-                      Revoke
-                    </Button>
-                  </div>
-                ) : (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="text-destructive hover:text-destructive"
-                    onClick={() => setConfirmingRevoke(true)}
-                  >
-                    Revoke
-                  </Button>
-                ))}
-            </DialogFooter>
-          </>
-        )}
+        <div className="divide-y divide-border">
+          {keyIds.map((keyId) => (
+            <div key={keyId} className="py-4 first:pt-0 last:pb-0">
+              <ConnectionPanel
+                keyId={keyId}
+                showLabel={multiple}
+                // Revoking the last connection empties the modal, so close it;
+                // with others left, the card stays open on what remains.
+                onRevoked={multiple ? () => undefined : onClose}
+              />
+            </div>
+          ))}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/assistant/plugins-view.test.tsx
+++ b/frontend/src/components/assistant/plugins-view.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   useKey: vi.fn(),
   useUpdateKey: vi.fn(),
   useDeleteKey: vi.fn(),
+  useUpdateExternalApiKey: vi.fn(),
 }));
 
 // The full add-service dialog has its own test suite and many hooks; stub it
@@ -36,6 +37,7 @@ vi.mock("@/hooks/use-keys", () => ({
   useKey: mocks.useKey,
   useUpdateKey: mocks.useUpdateKey,
   useDeleteKey: mocks.useDeleteKey,
+  useUpdateExternalApiKey: mocks.useUpdateExternalApiKey,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -153,6 +155,7 @@ describe("PluginsView", () => {
     mocks.useKey.mockReturnValue({
       data: {
         ...keys[0],
+        api_key_id: "api-key-1",
         status: "active",
         is_active: true,
         proxy_url: "http://localhost:3011/api/v1/proxy/s/openai",
@@ -163,6 +166,10 @@ describe("PluginsView", () => {
     });
     mocks.useUpdateKey.mockReturnValue({ mutate: vi.fn(), isPending: false });
     mocks.useDeleteKey.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mocks.useUpdateExternalApiKey.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    });
   });
 
   it("splits connectors into real connections and unconnected catalog entries", () => {
@@ -180,33 +187,37 @@ describe("PluginsView", () => {
     expect(screen.getByText("oauth")).toBeInTheDocument();
   });
 
-  it("opens the add-service dialog prefilled with the catalog slug on Connect", async () => {
+  it("connects straight from the card, with no intermediate detail step", async () => {
     const user = userEvent.setup();
     render(<PluginsView />);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    await user.click(
-      screen.getAllByRole("button", { name: "Connect" })[0] as HTMLElement,
-    );
+    // The card itself is the only CTA — there is no nested Connect button.
+    await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     const dialog = await screen.findByRole("dialog", { name: "Add service" });
     expect(dialog).toHaveAttribute("data-prefill", "github");
   });
 
-  it("opens the compact manage modal for a single-connection service", async () => {
+  it("connects from the keyboard", async () => {
     const user = userEvent.setup();
     render(<PluginsView />);
-    // Conditional mount: no key detail is fetched before Manage is clicked.
+    screen.getByRole("button", { name: "Connect Stripe" }).focus();
+    await user.keyboard("{Enter}");
+    expect(
+      await screen.findByRole("dialog", { name: "Add service" }),
+    ).toHaveAttribute("data-prefill", "stripe");
+  });
+
+  it("opens the manage modal straight from a connected card", async () => {
+    const user = userEvent.setup();
+    render(<PluginsView />);
+    // Conditional mount: no key detail is fetched before the card is clicked.
     expect(mocks.useKey).not.toHaveBeenCalled();
-    // The OpenAI card (single connection) manages via a button, not a link.
-    const manageButtons = screen.getAllByRole("button", { name: "Manage" });
-    await user.click(manageButtons[0] as HTMLElement);
-    // Modal renders the key's details + the full-settings escape hatch.
+    await user.click(screen.getByRole("button", { name: "Manage OpenAI" }));
     expect(mocks.useKey).toHaveBeenCalledWith("key-1");
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
-    const fullSettings = screen.getByRole("link", {
-      name: /open full settings/i,
-    });
-    expect(fullSettings).toHaveAttribute("data-to", "/keys/$keyId");
-    expect(fullSettings).toHaveAttribute("data-params", '{"keyId":"key-1"}');
+    const advanced = screen.getByRole("link", { name: /advanced settings/i });
+    expect(advanced).toHaveAttribute("data-to", "/keys/$keyId");
+    expect(advanced).toHaveAttribute("data-params", '{"keyId":"key-1"}');
   });
 
   it("toggles the connection active state through the modal", async () => {
@@ -214,7 +225,7 @@ describe("PluginsView", () => {
     mocks.useUpdateKey.mockReturnValue({ mutate, isPending: false });
     const user = userEvent.setup();
     render(<PluginsView />);
-    await user.click(screen.getAllByRole("button", { name: "Manage" })[0] as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Manage OpenAI" }));
     await user.click(
       await screen.findByRole("switch", { name: /toggle connection enabled/i }),
     );
@@ -224,12 +235,30 @@ describe("PluginsView", () => {
     );
   });
 
+  it("replaces the stored credential from inside the modal", async () => {
+    const mutate = vi.fn();
+    mocks.useUpdateExternalApiKey.mockReturnValue({
+      mutate,
+      isPending: false,
+    });
+    const user = userEvent.setup();
+    render(<PluginsView />);
+    await user.click(screen.getByRole("button", { name: "Manage OpenAI" }));
+    await user.click(await screen.findByRole("button", { name: "Replace" }));
+    await user.type(screen.getByLabelText("New credential"), "sk-new-secret");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(mutate).toHaveBeenCalledWith(
+      { keyId: "api-key-1", credential: "sk-new-secret" },
+      expect.anything(),
+    );
+  });
+
   it("requires an explicit confirmation before revoking", async () => {
     const mutate = vi.fn();
     mocks.useDeleteKey.mockReturnValue({ mutate, isPending: false });
     const user = userEvent.setup();
     render(<PluginsView />);
-    await user.click(screen.getAllByRole("button", { name: "Manage" })[0] as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Manage OpenAI" }));
     // First Revoke click only arms the inline confirmation — no delete yet.
     await user.click(await screen.findByRole("button", { name: "Revoke" }));
     expect(mutate).not.toHaveBeenCalled();
@@ -256,16 +285,62 @@ describe("PluginsView", () => {
     });
     const user = userEvent.setup();
     render(<PluginsView />);
-    await user.click(screen.getAllByRole("button", { name: "Manage" })[0] as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Manage OpenAI" }));
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
     expect(screen.queryByRole("switch")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Revoke" }),
     ).not.toBeInTheDocument();
-    // The full-settings escape hatch remains.
     expect(
-      screen.getByRole("link", { name: /open full settings/i }),
+      screen.queryByRole("button", { name: "Replace" }),
+    ).not.toBeInTheDocument();
+    // The advanced-settings escape hatch remains.
+    expect(
+      screen.getByRole("link", { name: /advanced settings/i }),
     ).toBeInTheDocument();
+  });
+
+  it("stacks every credential of a multi-connection service in one modal", async () => {
+    mockLoaded({
+      keyRows: [
+        ...keys,
+        {
+          id: "key-3",
+          label: "OpenAI (org)",
+          slug: "openai-2",
+          endpoint_url: "https://api.openai.com/v1",
+          credential_type: "api_key",
+          catalog_service_slug: "openai",
+          service_type: "http",
+        },
+      ] as unknown as readonly KeyInfo[],
+    });
+    // Each panel fetches its own connection.
+    mocks.useKey.mockImplementation((keyId: string) => ({
+      data: {
+        id: keyId,
+        label: keyId === "key-1" ? "OpenAI" : "OpenAI (org)",
+        credential_type: "api_key",
+        status: "active",
+        is_active: true,
+        last_used_at: null,
+        granted_scopes: null,
+      },
+      isLoading: false,
+    }));
+    const user = userEvent.setup();
+    render(<PluginsView />);
+    await user.click(screen.getByRole("button", { name: "Manage OpenAI" }));
+
+    const dialog = await screen.findByRole("dialog");
+    // Both connections are managed in place — no keys-list hand-off.
+    expect(mocks.useKey).toHaveBeenCalledWith("key-1");
+    expect(mocks.useKey).toHaveBeenCalledWith("key-3");
+    expect(within(dialog).getByText("2 connections")).toBeInTheDocument();
+    expect(within(dialog).getAllByRole("switch")).toHaveLength(2);
+    expect(
+      within(dialog).getAllByRole("link", { name: /advanced settings/i }),
+    ).toHaveLength(2);
   });
 
   it("shows loading skeletons while either query is in flight", () => {
@@ -315,7 +390,7 @@ describe("PluginsView", () => {
       screen.getByText(/No connected services yet/),
     ).toBeInTheDocument();
     // All catalog entries are available when nothing is connected.
-    expect(screen.getAllByRole("button", { name: "Connect" })).toHaveLength(3);
+    expect(screen.getAllByRole("button", { name: /^Connect / })).toHaveLength(3);
   });
 
   it("filters the catalog by search", async () => {
@@ -354,75 +429,22 @@ describe("PluginsView", () => {
     expect(screen.getByText("Ornn · v1.2")).toBeInTheDocument();
 
     await user.click(
-      screen.getAllByRole("button", { name: "Install" })[0] as HTMLElement,
+      screen.getAllByRole("button", { name: /^Install / })[0] as HTMLElement,
     );
     expect(screen.getAllByText("Installed")).toHaveLength(2);
   });
 
-  it("expands a card into a detail view with the full description and its action", async () => {
+  it("leaves an installed skill's card inert (no management flow yet)", async () => {
     const user = userEvent.setup();
     render(<PluginsView />);
-    // The grid alone shows no dialog — the detail view is click-driven.
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "GitHub details" }));
-    const detail = await screen.findByRole("dialog", { name: /GitHub/ });
-    // Untruncated description + the meta line, inside the dialog itself.
-    expect(within(detail).getByText("Repos, issues, and PRs.")).toBeInTheDocument();
-    expect(within(detail).getByText("oauth")).toBeInTheDocument();
-
-    // The dialog's Connect is the card's own action: same add-service flow.
-    await user.click(within(detail).getByRole("button", { name: "Connect" }));
-    const addDialog = await screen.findByRole("dialog", { name: "Add service" });
-    expect(addDialog).toHaveAttribute("data-prefill", "github");
-    // Acting closes the detail view rather than stacking dialogs on it.
-    expect(screen.queryByRole("dialog", { name: /GitHub/ })).not.toBeInTheDocument();
-  });
-
-  it("shows the Connected badge and manage action in an added card's detail view", async () => {
-    const user = userEvent.setup();
-    render(<PluginsView />);
-    await user.click(screen.getByRole("button", { name: "OpenAI details" }));
-    const detail = await screen.findByRole("dialog", { name: /OpenAI/ });
-    expect(within(detail).getByText("Connected")).toBeInTheDocument();
-
-    // Single-connection service: Manage opens the compact modal, as on the card.
-    await user.click(within(detail).getByRole("button", { name: "Manage" }));
-    expect(mocks.useKey).toHaveBeenCalledWith("key-1");
+    await user.click(screen.getByRole("tab", { name: "Skills" }));
+    // Available skills are clickable; the installed one exposes no action.
     expect(
-      await screen.findByRole("link", { name: /open full settings/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("does not expand the card when its inline action button is clicked", async () => {
-    const user = userEvent.setup();
-    render(<PluginsView />);
-    // The Connect button lives inside the clickable card surface; its click
-    // must not bubble into the expand handler.
-    await user.click(
-      screen.getAllByRole("button", { name: "Connect" })[0] as HTMLElement,
-    );
-    expect(
-      await screen.findByRole("dialog", { name: "Add service" }),
+      screen.getByRole("button", { name: /^Install / }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("dialog", { name: /GitHub/ }),
+      screen.queryByRole("button", { name: /^Manage / }),
     ).not.toBeInTheDocument();
-  });
-
-  it("expands a card from the keyboard", async () => {
-    const user = userEvent.setup();
-    render(<PluginsView />);
-    const card = screen.getByRole("button", { name: "Stripe details" });
-    card.focus();
-    await user.keyboard("{Enter}");
-    expect(await screen.findByRole("dialog", { name: /Stripe/ })).toBeInTheDocument();
-
-    // Space is the other role="button" activation key.
-    await user.keyboard("{Escape}");
-    card.focus();
-    await user.keyboard("[Space]");
-    expect(await screen.findByRole("dialog", { name: /Stripe/ })).toBeInTheDocument();
   });
 
   it("keeps installed skills across unmount and remount", async () => {
@@ -430,7 +452,7 @@ describe("PluginsView", () => {
     const first = render(<PluginsView />);
     await user.click(screen.getByRole("tab", { name: "Skills" }));
     await user.click(
-      screen.getAllByRole("button", { name: "Install" })[0] as HTMLElement,
+      screen.getAllByRole("button", { name: /^Install / })[0] as HTMLElement,
     );
     expect(screen.getAllByText("Installed")).toHaveLength(2);
     first.unmount();

--- a/frontend/src/components/assistant/plugins-view.tsx
+++ b/frontend/src/components/assistant/plugins-view.tsx
@@ -1,16 +1,7 @@
 import { useMemo, useState } from "react";
-import { Link } from "@tanstack/react-router";
-import { Plus, Search } from "lucide-react";
+import { ArrowRight, Plus, Search } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import { AddKeyDialog } from "@/components/dashboard/add-key-dialog";
@@ -62,149 +53,109 @@ function PluginTile({
   );
 }
 
-/** Full-description detail view for a card, with the card's own primary action.
- *  The action node is the identical element the card renders, so Connect /
- *  Manage / Install keep their exact handlers (including the manage-modal vs
- *  /keys-link split). Any action click also closes this dialog, so the
- *  manage/add-service modal it opens is never stacked on top of it. */
-function PluginDetailDialog({
-  item,
-  addedBadge,
-  action,
-  onClose,
-}: {
-  readonly item: PluginCardShape;
-  readonly addedBadge: "Connected" | "Installed";
-  readonly action: React.ReactNode;
-  readonly onClose: () => void;
-}) {
-  return (
-    <Dialog open onOpenChange={(next) => (next ? undefined : onClose())}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2.5">
-            <PluginTile>
-              {item.iconSlug ? (
-                <ServiceIcon slug={item.iconSlug} size="md" />
-              ) : (
-                item.initial
-              )}
-            </PluginTile>
-            <span className="min-w-0 flex-1">
-              <span className="block truncate">{item.name}</span>
-              <span className="block text-[10px] font-normal uppercase tracking-[0.5px] text-text-tertiary">
-                {item.category}
-              </span>
-            </span>
-            {item.added && <Badge variant="success">{addedBadge}</Badge>}
-          </DialogTitle>
-        </DialogHeader>
-
-        <DialogDescription className="whitespace-pre-line break-words text-[12px] text-muted-foreground">
-          {item.description}
-        </DialogDescription>
-
-        <DialogFooter className="sm:items-center sm:justify-between">
-          <span className="font-mono text-[10px] text-text-tertiary">
-            {item.meta}
-          </span>
-          <span onClick={onClose}>{action}</span>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
+/**
+ * A catalog card with exactly one call to action: the card itself. Clicking
+ * anywhere runs the primary action — Connect for an unconnected service,
+ * Manage for a connected one — rather than staging a detail view in front of
+ * it. `actionLabel` is the card's own affordance; it is deliberately a label,
+ * not a nested button, so the whole surface stays a single hit target.
+ *
+ * A card with no `onActivate` (an installed skill, whose management isn't
+ * built yet) renders inert: not focusable, no pointer affordance.
+ */
 function PluginCard({
   item,
   addedBadge,
   addedMeta,
-  addedAction,
-  availableAction,
+  actionLabel,
+  onActivate,
 }: {
   readonly item: PluginCardShape;
   readonly addedBadge: "Connected" | "Installed";
   /** Extra mono note next to the added badge (e.g. "2 connections"). */
   readonly addedMeta?: string;
-  readonly addedAction: React.ReactNode;
-  readonly availableAction: React.ReactNode;
+  readonly actionLabel: string;
+  readonly onActivate?: () => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const action = item.added ? addedAction : availableAction;
+  const interactive = Boolean(onActivate);
 
   return (
-    <>
-      {/* Clickable surface, not a <button>: the card holds its own action
-          button/link, which may not nest inside one. Same role/tabIndex/keydown
-          pattern the dashboard list cards use (api-key-table, channel-bots). */}
-      <div
-        role="button"
-        tabIndex={0}
-        aria-label={`${item.name} details`}
-        onClick={() => setExpanded(true)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            setExpanded(true);
+    <div
+      {...(interactive
+        ? {
+            role: "button",
+            tabIndex: 0,
+            "aria-label": `${actionLabel} ${item.name}`,
+            onClick: onActivate,
+            onKeyDown: (event: React.KeyboardEvent) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onActivate?.();
+              }
+            },
           }
-        }}
-        className={`flex ${CARD_HEIGHT} cursor-pointer flex-col gap-2.5 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-hairline-strong`}
-      >
-        <div className="flex items-start gap-2.5">
-          <PluginTile>
-            {item.iconSlug ? (
-              <ServiceIcon slug={item.iconSlug} size="md" />
-            ) : (
-              item.initial
-            )}
-          </PluginTile>
-          <div className="min-w-0">
-            <p className="truncate text-[13px] font-medium text-foreground">
-              {item.name}
-            </p>
-            <p className="text-[10px] uppercase tracking-[0.5px] text-text-tertiary">
-              {item.category}
-            </p>
-          </div>
-        </div>
-        <p className="flex-1 break-words text-[12px] leading-[17px] text-muted-foreground line-clamp-3">
-          {item.description}
-        </p>
-        <div className="flex shrink-0 items-center justify-between gap-2">
-          {item.added ? (
-            <span className="flex min-w-0 items-center gap-2">
-              <Badge variant="success">{addedBadge}</Badge>
-              {addedMeta && (
-                <span className="truncate font-mono text-[10px] text-text-tertiary">
-                  {addedMeta}
-                </span>
-              )}
-            </span>
+        : {})}
+      // The clamped description is the only truncated text on the card, and
+      // the card no longer expands — the native tooltip keeps the full copy
+      // reachable without a second surface.
+      title={item.description}
+      className={`group flex ${CARD_HEIGHT} flex-col gap-2.5 rounded-xl border border-border bg-card p-4 text-left transition-colors ${
+        interactive ? "cursor-pointer hover:border-hairline-strong" : ""
+      }`}
+    >
+      <div className="flex items-start gap-2.5">
+        <PluginTile>
+          {item.iconSlug ? (
+            <ServiceIcon slug={item.iconSlug} size="md" />
           ) : (
-            <span className="font-mono text-[10px] text-text-tertiary">
-              {item.meta}
-            </span>
+            item.initial
           )}
-          {/* The inline action stays a plain action: it must not also expand. */}
-          <span
-            className="shrink-0"
-            onClick={(event) => event.stopPropagation()}
-            onKeyDown={(event) => event.stopPropagation()}
-          >
-            {action}
-          </span>
+        </PluginTile>
+        <div className="min-w-0">
+          <p className="truncate text-[13px] font-medium text-foreground">
+            {item.name}
+          </p>
+          <p className="text-[10px] uppercase tracking-[0.5px] text-text-tertiary">
+            {item.category}
+          </p>
         </div>
       </div>
-
-      {expanded && (
-        <PluginDetailDialog
-          item={item}
-          addedBadge={addedBadge}
-          action={action}
-          onClose={() => setExpanded(false)}
-        />
-      )}
-    </>
+      {/* The spacer absorbs the card's slack so the action row stays pinned to
+          the bottom; the clamp lives on the text itself, or `flex-1` would
+          stretch the box past three lines and clip a fourth mid-glyph. */}
+      <div className="min-h-0 flex-1">
+        <p className="break-words text-[12px] leading-[17px] text-muted-foreground line-clamp-3">
+          {item.description}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center justify-between gap-2">
+        {item.added ? (
+          <span className="flex min-w-0 items-center gap-2">
+            <Badge variant="success">{addedBadge}</Badge>
+            {addedMeta && (
+              <span className="truncate font-mono text-[10px] text-text-tertiary">
+                {addedMeta}
+              </span>
+            )}
+          </span>
+        ) : (
+          <span className="font-mono text-[10px] text-text-tertiary">
+            {item.meta}
+          </span>
+        )}
+        <span
+          aria-hidden
+          className={`flex shrink-0 items-center gap-1 text-[12px] transition-colors ${
+            interactive
+              ? "text-muted-foreground group-hover:text-foreground"
+              : "text-text-tertiary"
+          }`}
+        >
+          {actionLabel}
+          {interactive && <ArrowRight className="h-3 w-3" />}
+        </span>
+      </div>
+    </div>
   );
 }
 
@@ -276,44 +227,22 @@ function ConnectorCard({
   onConnect,
 }: {
   readonly item: ConnectorCardItem;
-  readonly onManage: (keyId: string) => void;
+  readonly onManage: (cardId: string) => void;
   readonly onConnect: (slug: string) => void;
 }) {
+  const connectSlug = item.connectSlug;
   return (
     <PluginCard
       item={item}
       addedBadge="Connected"
-      addedMeta={item.manageKeyId ? undefined : item.meta}
-      addedAction={
-        item.manageKeyId ? (
-          // Single-connection service: manage in a compact modal in-place.
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => onManage(item.manageKeyId as string)}
-          >
-            Manage
-          </Button>
-        ) : (
-          // Multi-connection service: which credential is ambiguous, so send
-          // to the Studio keys list (filtered) rather than a single-key modal.
-          <Button asChild variant="outline" size="sm">
-            <Link to="/keys">Manage</Link>
-          </Button>
-        )
-      }
-      availableAction={
-        item.connectSlug ? (
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            onClick={() => onConnect(item.connectSlug as string)}
-          >
-            Connect
-          </Button>
-        ) : null
+      addedMeta={(item.manageKeyIds?.length ?? 0) > 1 ? item.meta : undefined}
+      actionLabel={item.added ? "Manage" : "Connect"}
+      onActivate={
+        item.added
+          ? () => onManage(item.id)
+          : connectSlug
+            ? () => onConnect(connectSlug)
+            : undefined
       }
     />
   );
@@ -322,13 +251,17 @@ function ConnectorCard({
 function ConnectorsTab({ query }: { readonly query: string }) {
   const keysQuery = useKeys();
   const catalogQuery = useCatalog();
-  const [manageKeyId, setManageKeyId] = useState<string | null>(null);
+  const [manageCardId, setManageCardId] = useState<string | null>(null);
   const [connectSlug, setConnectSlug] = useState<string | null>(null);
 
   const items = useMemo(
     () => deriveConnectorItems(keysQuery.data ?? [], catalogQuery.data ?? []),
     [keysQuery.data, catalogQuery.data],
   );
+  // Resolved from the live list rather than snapshotted at open time, so
+  // revoking one of several connections updates the modal in place, and
+  // revoking the last one unmounts it.
+  const manageItem = items.added.find((item) => item.id === manageCardId);
 
   if (keysQuery.isLoading || catalogQuery.isLoading) return <LoadingGrid />;
 
@@ -370,7 +303,7 @@ function ConnectorsTab({ query }: { readonly query: string }) {
                   <ConnectorCard
                     key={item.id}
                     item={item}
-                    onManage={setManageKeyId}
+                    onManage={setManageCardId}
                     onConnect={setConnectSlug}
                   />
                 ))}
@@ -393,7 +326,7 @@ function ConnectorsTab({ query }: { readonly query: string }) {
               <ConnectorCard
                 key={item.id}
                 item={item}
-                onManage={setManageKeyId}
+                onManage={setManageCardId}
                 onConnect={setConnectSlug}
               />
             ))}
@@ -401,10 +334,12 @@ function ConnectorsTab({ query }: { readonly query: string }) {
         </>
       )}
 
-      {manageKeyId !== null && (
+      {manageItem && (
         <ManageConnectionModal
-          keyId={manageKeyId}
-          onClose={() => setManageKeyId(null)}
+          keyIds={manageItem.manageKeyIds ?? []}
+          serviceName={manageItem.name}
+          iconSlug={manageItem.iconSlug}
+          onClose={() => setManageCardId(null)}
         />
       )}
 
@@ -451,20 +386,11 @@ function SkillsTab({ query }: { readonly query: string }) {
         key={item.id}
         item={item}
         addedBadge="Installed"
-        addedAction={
-          <Button type="button" variant="outline" size="sm" disabled>
-            Manage
-          </Button>
-        }
-        availableAction={
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            onClick={() => setAddedIds(addSkill(item.id))}
-          >
-            Install
-          </Button>
+        actionLabel={item.added ? "Manage" : "Install"}
+        // Skill management isn't built yet, so an installed skill's card is
+        // inert rather than offering an action that does nothing.
+        onActivate={
+          item.added ? undefined : () => setAddedIds(addSkill(item.id))
         }
       />
     );

--- a/frontend/src/lib/assistant/plugins.test.ts
+++ b/frontend/src/lib/assistant/plugins.test.ts
@@ -54,7 +54,7 @@ describe("deriveConnectorItems", () => {
       [makeEntry({})],
     );
     expect(added).toHaveLength(1);
-    expect(added[0]?.manageKeyId).toBe("key-1");
+    expect(added[0]?.manageKeyIds).toEqual(["key-1"]);
     expect(available).toHaveLength(1);
   });
 
@@ -68,15 +68,16 @@ describe("deriveConnectorItems", () => {
     );
     expect(added).toHaveLength(1);
     expect(added[0]?.meta).toBe("2 connections");
-    // Multi-connection cards manage from the keys list, not one key detail.
-    expect(added[0]?.manageKeyId).toBeUndefined();
+    // Every credential rides on the one card, so the manage modal can show
+    // them together instead of handing off to the keys list.
+    expect(added[0]?.manageKeyIds).toEqual(["key-1", "key-8"]);
     expect(added[0]?.iconSlug).toBe("openai");
     expect(available).toHaveLength(0);
   });
 
-  it("keeps single-connection manage links pointing at the key detail", () => {
+  it("carries the single connection's key id on its card", () => {
     const { added } = deriveConnectorItems([makeKey({})], [makeEntry({})]);
-    expect(added[0]?.manageKeyId).toBe("key-1");
+    expect(added[0]?.manageKeyIds).toEqual(["key-1"]);
     expect(added[0]?.iconSlug).toBe("openai");
   });
 

--- a/frontend/src/lib/assistant/plugins.ts
+++ b/frontend/src/lib/assistant/plugins.ts
@@ -19,8 +19,12 @@ export interface ConnectorCardItem {
   /** Footer meta shown for not-yet-added items (e.g. "api key", "oauth"). */
   readonly meta: string;
   readonly added: boolean;
-  /** Added items only: UserService id for the `/keys/$keyId` manage page. */
-  readonly manageKeyId?: string;
+  /**
+   * Added items only: every UserService id behind this card. A service with
+   * several credentials keeps them all here so the manage modal can show them
+   * together rather than handing the user off to the Studio keys list.
+   */
+  readonly manageKeyIds?: readonly string[];
   /** Available items only: catalog slug for the `/keys?slug=` connect deep link. */
   readonly connectSlug?: string;
 }
@@ -86,7 +90,7 @@ function addedServiceItem(
         ? `${String(group.length)} connections`
         : first.credential_type.replaceAll("_", " "),
     added: true,
-    manageKeyId: group.length === 1 ? first.id : undefined,
+    manageKeyIds: group.map((key) => key.id),
   };
 }
 
@@ -102,7 +106,7 @@ function addedCustomItem(key: KeyInfo): ConnectorCardItem {
       `Connected through the NyxID proxy (${key.endpoint_url}).`,
     meta: key.credential_type.replaceAll("_", " "),
     added: true,
-    manageKeyId: key.id,
+    manageKeyIds: [key.id],
   };
 }
 

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { AssistantShell } from "@/components/assistant/assistant-shell";
@@ -33,6 +33,22 @@ export function AssistantPage({
     },
   });
   const conversations = useConversations();
+  // The composer floats over the thread, so the thread has to know how tall it
+  // currently is — it grows with the draft — to reserve the matching tail room
+  // and place its fade.
+  const composerRef = useRef<HTMLDivElement>(null);
+  const [composerHeight, setComposerHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = composerRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      setComposerHeight(entries[0]?.contentRect.height ?? 0);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [view]);
+
   const selectedId = useMemo(() => {
     const items = conversations.data ?? [];
     if (
@@ -132,7 +148,7 @@ export function AssistantPage({
 
   return (
     <AssistantShell title={title} sidebar={sidebar}>
-      <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="relative flex h-full min-h-0 flex-col bg-background">
         {history.isLoading ? (
           <div className="flex flex-1 items-center justify-center text-[12px] text-text-tertiary">
             Loading conversation...
@@ -144,6 +160,7 @@ export function AssistantPage({
         ) : (
           <ChatThread
             messages={history.data?.messages ?? []}
+            bottomInset={composerHeight}
             thinking={
               active &&
               history.data?.messages.at(-1)?.role !== "assistant"
@@ -157,12 +174,14 @@ export function AssistantPage({
             }
           />
         )}
-        <ChatComposer
-          active={active}
-          sending={sendMessage.isPending}
-          onSend={handleSend}
-          onStop={() => cancelTurn.mutateAsync()}
-        />
+        <div ref={composerRef} className="absolute inset-x-0 bottom-0 z-10">
+          <ChatComposer
+            active={active}
+            sending={sendMessage.isPending}
+            onSend={handleSend}
+            onStop={() => cancelTurn.mutateAsync()}
+          />
+        </div>
       </div>
     </AssistantShell>
   );


### PR DESCRIPTION
Two assistant-surface changes, requested together.

## Chat scrolling (`/assistant`)

Turns now scroll *behind* the composer rather than stopping above it, matching ChatGPT.

- **Overlay layout** — the composer moves from a flex sibling to an overlay on a `relative` container, so the thread owns the full height. A `ResizeObserver` feeds its live height to the thread, since that height changes as the draft grows.
- **Fade after the textbox** — the old 16px solid gradient strip is replaced by a `mask-image` on the scroll container: opaque to the composer's top edge, dissolved to nothing by the bottom. Content passing behind the composer fades instead of hard-cutting, and the fade region tracks the composer as it grows. Matching tail padding keeps the last turn clear at scroll-bottom.
- **One box that expands** — `rows={1}` plus a layout effect that caps growth at 4 rows, computed from the live `line-height` so it stays correct if the type scale changes; past the cap the textarea scrolls internally. Growth animates over 150ms (`motion-reduce` opts out).
- **Scroll-follow fix** — the thread force-scrolled to the bottom on every poll tick, yanking you back if you'd scrolled up to re-read mid-stream. It now follows only within 48px of the tail, while a message you just sent always returns to it (keyed on message id so re-renders of the same turn don't re-trigger).

Measured in-browser: 1 line → 29.1px, 2 → 50px, long draft caps at 92.5px with `overflow-y: auto`; the fade tracked the composer from 130px to ~190px.

## Connectors / Plugins page

- **Single CTA** — the card *is* the button. Clicking anywhere connects, or manages when already connected. The intermediate detail dialog and the nested Connect/Manage buttons are gone; the bottom-right is a label plus arrow, not an interactive element, so the whole surface is one hit target. The full description the detail dialog carried becomes a card tooltip. Installed skills have no management flow yet, so those cards render inert rather than offering an action that does nothing.
- **One manage modal, no staging** — every credential behind a service renders stacked in the same dialog instead of sending multi-connection services off to `/keys`, and credentials can be replaced inline so rotation no longer leaves the plugin surface. Deep service config (endpoint, routing, node setup, headers) stays on the Studio key page behind a per-connection "Advanced settings" link. The modal resolves its connection list from the live query rather than snapshotting at open time, so revoking one of several updates in place and revoking the last closes it.

Two drive-by fixes: `flex-1` was stretching card descriptions past their 3-line clamp and clipping a fourth line mid-glyph (visible on GitHub's long copy), and the manage dialog was missing the description Radix warns about on every open.

## Verification

Both surfaces driven in a headless browser against throwaway harnesses mounting the real components (since removed) — scroll-behind and fade, textarea growth and cap, single- and multi-connection modals, inline replace form, skills tab, clean console.

- `tsc -b` clean, lint clean on changed files
- Full frontend suite **1916/1916**
- Plugins tests rewritten for the new interaction: four detail-dialog tests dropped, four added covering card-click connect, keyboard connect, credential replacement, and the stacked multi-connection modal. One new test covers the thread's composer inset and mask.
- No wizard-bundle manifest files touched, so no bundle rebuild needed.

## Notes

- Scrolling the wheel *over* the composer card won't scroll the thread (the overlay isn't inside the scroller), and content behind the composer isn't clickable or selectable. Both match ChatGPT.
- With many credentials on one service the manage modal becomes a long scroll, since every panel is expanded. Fine at two or three; collapsing all but the first is the natural follow-up if five-plus shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)