### PR TITLE
fix(assistant): make "New chat" respond on click instead of after provisioning

### DIFF
--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -9,7 +9,7 @@ import {
   assistantTransport,
   resetAssistantTransport,
 } from "@/lib/assistant/transport";
-import type { ConversationHistory } from "@/types/assistant";
+import type { Conversation, ConversationHistory } from "@/types/assistant";
 import {
   assistantKeys,
   describeSendFailure,
@@ -17,6 +17,7 @@ import {
   useAssistantTurn,
   useCancelTurn,
   useConversation,
+  useCreateConversation,
   useDecideApproval,
   useSendMessage,
   type SentMessage,
@@ -174,6 +175,43 @@ describe("assistant hooks", () => {
     expect(fulfilled).toHaveLength(1);
     expect(rejected).toHaveLength(1);
     expect(String(rejected[0]?.reason)).toMatch(/already active/i);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    createSpy.mockRestore();
+    unmount();
+    queryClient.clear();
+  });
+
+  it("shares one conversation between the New chat button and a racing send", async () => {
+    // "New chat" navigates optimistically, so the draft thread accepts a
+    // send while its actor is still being provisioned. The button's create
+    // and the empty-state auto-create must resolve to the SAME actor —
+    // otherwise the message streams into an orphan the sidebar never shows.
+    const { queryClient, Wrapper } = createHarness();
+    const createSpy = vi.spyOn(assistantTransport, "createConversation");
+    const { result, unmount } = renderHook(
+      () => ({
+        create: useCreateConversation(),
+        send: useSendMessage(undefined),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    let created: Conversation | null = null;
+    let sent: SentMessage | null = null;
+    await act(async () => {
+      const createPromise = result.current.create.mutateAsync();
+      const sendPromise = result.current.send.mutateAsync("Sent mid-provision.");
+      await vi.advanceTimersByTimeAsync(0);
+      [created, sent] = await Promise.all([createPromise, sendPromise]);
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect((sent as SentMessage | null)?.conversationId).toBe(
+      (created as Conversation | null)?.id,
+    );
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_000);

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -221,10 +221,27 @@ export function useAssistantTurn(conversationId: string | undefined) {
   });
 }
 
+/**
+ * Single-flight guard around actor creation, shared by every path that can
+ * allocate one: the "New chat" button and the empty-state auto-create in
+ * `useSendMessage`. Both are legitimately in flight at once now that the
+ * button navigates optimistically — the user can type and send into the
+ * draft thread before the actor lands — and without one promise between
+ * them that send would allocate a second actor and stream into it.
+ */
+let pendingCreate: Promise<Conversation> | null = null;
+
+function createConversationOnce(): Promise<Conversation> {
+  pendingCreate ??= assistantTransport.createConversation().finally(() => {
+    pendingCreate = null;
+  });
+  return pendingCreate;
+}
+
 export function useCreateConversation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => assistantTransport.createConversation(),
+    mutationFn: () => createConversationOnce(),
     onSuccess: async (conversation) => {
       await projectTransportState(queryClient, conversation.id);
     },
@@ -308,12 +325,6 @@ function createTurnEventPump(
   };
 }
 
-// Single-flight guard for the empty-state auto-create: two sends racing in
-// before React commits the disabled/sending state must share ONE created
-// conversation (the second is then rejected by the active-turn guard)
-// instead of allocating two actors and streaming into both.
-let pendingAutoCreate: Promise<Conversation> | null = null;
-
 /**
  * Send a message into the bound conversation — or, when no conversation is
  * selected (the "New chat" empty state), create one first and send there.
@@ -327,12 +338,11 @@ export function useSendMessage(conversationId: string | undefined) {
     mutationFn: async (content: string): Promise<SentMessage> => {
       let target = conversationId;
       if (!target) {
-        pendingAutoCreate ??= assistantTransport
-          .createConversation()
-          .finally(() => {
-            pendingAutoCreate = null;
-          });
-        const conversation = await pendingAutoCreate;
+        // Shares `createConversationOnce` with the "New chat" button: two
+        // sends racing before React commits the disabled state, or a send
+        // landing mid-provision, all resolve to the SAME actor (the losers
+        // are then rejected by the active-turn guard).
+        const conversation = await createConversationOnce();
         target = conversation.id;
         await projectTransportState(queryClient, target);
       }

--- a/frontend/src/lib/assistant/search.test.ts
+++ b/frontend/src/lib/assistant/search.test.ts
@@ -1,0 +1,84 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { describe, expect, it } from "vitest";
+import { parseAssistantSearch } from "./search";
+
+describe("parseAssistantSearch", () => {
+  it("keeps a conversation id", () => {
+    expect(parseAssistantSearch({ c: "conv-1" })).toEqual({ c: "conv-1" });
+  });
+
+  it("accepts draft as a boolean and as the string a typed URL produces", () => {
+    expect(parseAssistantSearch({ draft: true })).toEqual({ draft: true });
+    expect(parseAssistantSearch({ draft: "true" })).toEqual({ draft: true });
+  });
+
+  it("drops junk rather than letting it reach the page", () => {
+    expect(parseAssistantSearch({ c: 42, draft: "yes", other: "x" })).toEqual(
+      {},
+    );
+  });
+});
+
+/**
+ * The page's stubbed-router tests cannot see this seam: whether a real
+ * router actually round-trips `{ draft: true }` through the URL and back.
+ * A param silently dropped by `validateSearch`, or serialized to something
+ * `parseAssistantSearch` no longer recognises, would leave "New chat"
+ * navigating to a URL that reads as "no draft" — the exact dead-button
+ * symptom this change fixes, reintroduced one layer down.
+ */
+function buildAssistantRouter(initialUrl: string) {
+  const rootRoute = createRootRoute();
+  const assistantRoute = createRoute({
+    path: "/assistant",
+    getParentRoute: () => rootRoute,
+    validateSearch: parseAssistantSearch,
+    component: () => null,
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([assistantRoute]),
+    history: createMemoryHistory({ initialEntries: [initialUrl] }),
+  });
+}
+
+describe("/assistant search round-trip through a real router", () => {
+  it("survives a navigate to the draft state", async () => {
+    const router = buildAssistantRouter("/assistant");
+    await router.load();
+
+    await router.navigate({ to: "/assistant", search: { draft: true } });
+    await router.invalidate();
+
+    const search = router.state.location.search as Record<string, unknown>;
+    expect(parseAssistantSearch(search).draft).toBe(true);
+    expect(router.state.location.searchStr).toContain("draft");
+  });
+
+  it("swaps the draft for a conversation id", async () => {
+    const router = buildAssistantRouter("/assistant?draft=true");
+    await router.load();
+    expect(
+      parseAssistantSearch(
+        router.state.location.search as Record<string, unknown>,
+      ).draft,
+    ).toBe(true);
+
+    await router.navigate({
+      to: "/assistant",
+      search: { c: "conv-new" },
+      replace: true,
+    });
+    await router.invalidate();
+
+    const search = parseAssistantSearch(
+      router.state.location.search as Record<string, unknown>,
+    );
+    expect(search.c).toBe("conv-new");
+    expect(search.draft).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/assistant/search.ts
+++ b/frontend/src/lib/assistant/search.ts
@@ -1,0 +1,29 @@
+/**
+ * The `/assistant` search contract, in one place: the router validates with
+ * it and the page reads with it, so the two cannot drift into disagreeing
+ * about what a draft is.
+ *
+ * - `c`     addresses a conversation.
+ * - `draft` is the pre-provision "New chat" state. The button paints an
+ *   empty thread under `?draft` immediately, then swaps in `?c=<id>` once
+ *   the actor lands (see AssistantPage.createNewChat).
+ *
+ * `draft` is accepted as a boolean and as the string "true": the router's
+ * search parser hands back a real boolean for its own round-tripped links,
+ * but a hand-typed or copy-pasted URL arrives as a string.
+ */
+export interface AssistantSearch {
+  readonly c?: string;
+  readonly draft?: boolean;
+}
+
+export function parseAssistantSearch(
+  search: Record<string, unknown>,
+): AssistantSearch {
+  return {
+    ...(typeof search.c === "string" ? { c: search.c } : {}),
+    ...(search.draft === true || search.draft === "true"
+      ? { draft: true }
+      : {}),
+  };
+}

--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Conversation } from "@/types/assistant";
+import { AssistantPage } from "./assistant";
+
+const {
+  mockNavigate,
+  mockCreateMutateAsync,
+  mockSendMutateAsync,
+  mockToastError,
+  state,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockCreateMutateAsync: vi.fn(),
+  mockSendMutateAsync: vi.fn(),
+  mockToastError: vi.fn(),
+  state: {
+    pathname: "/assistant",
+    search: {} as Record<string, unknown>,
+    conversations: [] as Conversation[],
+  },
+}));
+
+// Getters, not a snapshot: the page reads the router AFTER awaiting the
+// create, precisely to detect that the user navigated away meanwhile.
+const routerStub = {
+  state: {
+    location: {
+      get pathname() {
+        return state.pathname;
+      },
+      get search() {
+        return state.search;
+      },
+    },
+  },
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useRouter: () => routerStub,
+  useRouterState: ({
+    select,
+  }: {
+    select: (s: { location: { search: Record<string, unknown> } }) => unknown;
+  }) => select({ location: { search: state.search } }),
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+    readonly to?: string;
+    readonly children?: ReactNode;
+  }) => (
+    <a data-to={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// The shell is chrome (theme, auth menu, mobile drawer); this page's
+// behaviour is the sidebar + thread it wraps.
+vi.mock("@/components/assistant/assistant-shell", () => ({
+  AssistantShell: ({
+    title,
+    sidebar,
+    children,
+  }: {
+    readonly title: string;
+    readonly sidebar: ReactNode;
+    readonly children: ReactNode;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {sidebar}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/hooks/use-assistant", () => ({
+  useConversations: () => ({ data: state.conversations }),
+  useConversation: (conversationId: string | undefined) => ({
+    data: conversationId
+      ? {
+          conversation: state.conversations.find(
+            (item) => item.id === conversationId,
+          ),
+          messages: [],
+        }
+      : undefined,
+    isLoading: false,
+    isError: false,
+  }),
+  useAssistantTurn: () => ({ data: null }),
+  useCreateConversation: () => ({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+  }),
+  useSendMessage: () => ({
+    mutateAsync: mockSendMutateAsync,
+    isPending: false,
+  }),
+  useCancelTurn: () => ({ mutateAsync: vi.fn() }),
+  useDecideApproval: () => ({ mutateAsync: vi.fn() }),
+  useDeleteConversation: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  }),
+  useWorkspaceCounts: () => ({ data: { artifacts: 0, pendingApprovals: 0 } }),
+  describeSendFailure: () => ({ message: "Message not sent", description: "" }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError },
+}));
+
+const EXISTING: Conversation = {
+  id: "conv-1",
+  title: "Quarterly digest",
+  created_at: "2026-07-20T00:00:00.000Z",
+  last_message_at: "2026-07-20T00:05:00.000Z",
+};
+
+function renderPage() {
+  render(
+    <TooltipProvider>
+      <AssistantPage />
+    </TooltipProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.pathname = "/assistant";
+  state.search = {};
+  state.conversations = [EXISTING];
+});
+
+describe("AssistantPage new chat", () => {
+  it("navigates to the draft thread before the actor is provisioned", async () => {
+    const user = userEvent.setup();
+    // Never resolves: the point is that the UI moves without waiting.
+    mockCreateMutateAsync.mockReturnValue(new Promise(() => {}));
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /New chat/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ search: { draft: true } }),
+    );
+  });
+
+  it("swaps the draft for the conversation id once the create lands", async () => {
+    const user = userEvent.setup();
+    mockCreateMutateAsync.mockResolvedValue({ ...EXISTING, id: "conv-new" });
+    renderPage();
+
+    // The optimistic navigation is what puts the app in draft; mirror it,
+    // since the router is stubbed.
+    state.search = { draft: true };
+    await user.click(screen.getByRole("button", { name: /New chat/ }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ search: { c: "conv-new" }, replace: true }),
+      );
+    });
+  });
+
+  it("does not yank the user back when they navigated away mid-create", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: (conversation: Conversation) => void = () => {};
+    mockCreateMutateAsync.mockReturnValue(
+      new Promise<Conversation>((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+    renderPage();
+
+    state.search = { draft: true };
+    await user.click(screen.getByRole("button", { name: /New chat/ }));
+    mockNavigate.mockClear();
+
+    // They opened another chat while the actor was still provisioning.
+    state.search = { c: EXISTING.id };
+    resolveCreate({ ...EXISTING, id: "conv-new" });
+
+    await waitFor(() => {
+      expect(mockCreateMutateAsync).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("says a failed create out loud instead of stopping silently", async () => {
+    const user = userEvent.setup();
+    mockCreateMutateAsync.mockRejectedValue(new Error("aevatar is down"));
+    renderPage();
+
+    state.search = { draft: true };
+    await user.click(screen.getByRole("button", { name: /New chat/ }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Could not start a new chat",
+        expect.objectContaining({ description: "aevatar is down" }),
+      );
+    });
+  });
+
+  it("renders the empty draft thread rather than falling back to the newest chat", () => {
+    state.search = { draft: true };
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "New chat" })).toBeInTheDocument();
+  });
+
+  it("still falls back to the newest chat when there is no draft", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: EXISTING.title }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { useNavigate, useRouter, useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { AssistantShell } from "@/components/assistant/assistant-shell";
 import { AssistantSidebar } from "@/components/assistant/assistant-sidebar";
@@ -18,6 +18,7 @@ import {
   useDeleteConversation,
   useSendMessage,
 } from "@/hooks/use-assistant";
+import { parseAssistantSearch } from "@/lib/assistant/search";
 import { isTurnActive } from "@/types/assistant";
 
 export function AssistantPage({
@@ -26,11 +27,17 @@ export function AssistantPage({
   readonly view?: "chat" | "plugins" | "approvals";
 }) {
   const navigate = useNavigate();
+  const router = useRouter();
+  // Two selectors returning primitives rather than one returning an object:
+  // a fresh object identity would re-render the page on every router tick.
   const selectedFromSearch = useRouterState({
-    select: (state) => {
-      const search = state.location.search as Record<string, unknown>;
-      return typeof search.c === "string" ? search.c : undefined;
-    },
+    select: (state) =>
+      parseAssistantSearch(state.location.search as Record<string, unknown>).c,
+  });
+  const drafting = useRouterState({
+    select: (state) =>
+      parseAssistantSearch(state.location.search as Record<string, unknown>)
+        .draft === true,
   });
   const conversations = useConversations();
   // The composer floats over the thread, so the thread has to know how tall it
@@ -57,8 +64,13 @@ export function AssistantPage({
     ) {
       return selectedFromSearch;
     }
+    // A draft is a deliberately empty thread painted before its actor
+    // exists, so it must NOT fall through to the newest chat — that
+    // fallback is what makes a plain `/assistant` land on your last
+    // conversation, and it would make "New chat" look like it did nothing.
+    if (drafting) return undefined;
     return items[0]?.id;
-  }, [conversations.data, selectedFromSearch]);
+  }, [conversations.data, drafting, selectedFromSearch]);
   const history = useConversation(selectedId);
   const turn = useAssistantTurn(selectedId);
   const createConversation = useCreateConversation();
@@ -67,16 +79,52 @@ export function AssistantPage({
   const decideApproval = useDecideApproval(selectedId);
   const deleteConversation = useDeleteConversation();
 
-  function selectConversation(conversationId: string) {
+  function selectConversation(conversationId: string, replace = false) {
     void navigate({
       to: "/assistant" as never,
       search: { c: conversationId } as never,
+      replace,
     });
   }
 
+  /**
+   * The click paints the empty thread immediately (`?draft`), then
+   * provisions the actor in the background and swaps in `?c=<id>` once it
+   * lands. Awaiting the create first made the button spin through three
+   * sequential round trips — create, history, list — before anything moved,
+   * and a failure resolved to nothing at all: no navigation, no message,
+   * just a button that stopped spinning.
+   *
+   * `replace` on the swap keeps Back going where the user came from rather
+   * than to the draft URL of a chat that now exists. The live router read
+   * (not the render-time `drafting`) is deliberate: if they navigated on —
+   * Plugins, another chat, or a send that already claimed this actor — the
+   * late resolve must not yank them back.
+   */
   async function createNewChat() {
-    const conversation = await createConversation.mutateAsync();
-    selectConversation(conversation.id);
+    void navigate({
+      to: "/assistant" as never,
+      search: { draft: true } as never,
+    });
+    try {
+      const conversation = await createConversation.mutateAsync();
+      const stillDrafting =
+        router.state.location.pathname === "/assistant" &&
+        parseAssistantSearch(
+          router.state.location.search as Record<string, unknown>,
+        ).draft === true;
+      if (stillDrafting) selectConversation(conversation.id, true);
+    } catch (error) {
+      // The draft stays put and the composer's auto-create retries the
+      // provision on first send, so this is a recoverable failure — but an
+      // unsaid one reads as the button being broken.
+      toast.error("Could not start a new chat", {
+        description:
+          error instanceof Error && error.message
+            ? error.message
+            : "The assistant backend did not respond. Send a message to try again.",
+      });
+    }
   }
 
   // Deleting the URL-addressed conversation must also drop `?c=`, or the

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -17,6 +17,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { hasAdminRead } from "@/types/api";
 import { shouldRedirectFromBilling } from "@/lib/billing-availability";
 import { normalizeAdminOAuthClientSearch } from "@/lib/admin-oauth-clients";
+import { parseAssistantSearch } from "@/lib/assistant/search";
 
 import {
   LandingPage,
@@ -290,9 +291,10 @@ const assistantBeforeLoad = async ({
 const assistantRoute = createRoute({
   path: "/assistant",
   getParentRoute: () => rootRoute,
-  validateSearch: (search: Record<string, unknown>): { c?: string } => ({
-    ...(typeof search.c === "string" ? { c: search.c } : {}),
-  }),
+  // Shared with AssistantPage so the router and the page agree on what
+  // `?draft` means; a param dropped here makes the optimistic "New chat"
+  // navigation a silent no-op.
+  validateSearch: parseAssistantSearch,
   beforeLoad: assistantBeforeLoad,
   component: AssistantPage,
 });


### PR DESCRIPTION
## Problem

The **New chat** button awaited three sequential round trips — `createConversation` → `getHistory` → `listConversations` — before anything moved on screen. Worse, `createNewChat` had no `try`/`catch` while its caller was `() => void createNewChat()`, so a failed create resolved to **nothing at all**: no navigation, no message, just a button that stopped spinning. `handleSend` and `handleDelete` both surfaced their failures; this was the one path that didn't.

## Change

The click now paints the empty thread immediately under `?draft`, provisions the actor in the background, and swaps in `?c=<id>` once it lands — `replace: true`, so Back goes where the user came from rather than to the draft URL of a chat that now exists. A failed create toasts and leaves the draft in place, where the composer's existing auto-create retries the provision on first send.

Three consequences of navigating *before* the actor exists, each handled:

- **The draft must not fall back.** `selectedId` defaults to the newest conversation when `?c` is absent — that fallback alone would land "New chat" on your last chat and read as a no-op. `?draft` suppresses it.
- **A send can now land mid-provision.** `useCreateConversation` and `useSendMessage`'s empty-state auto-create share one single-flight promise (`createConversationOnce`), so a racing send joins the same actor instead of allocating a second one and streaming into an orphan the sidebar never shows.
- **No yanking.** The post-await check reads the live router, not the render-time closure: click New chat, then Plugins, and the late resolve leaves you alone.

The `/assistant` search contract moves to `lib/assistant/search.ts` so the router's `validateSearch` and the page's readers can't drift into disagreeing about what a draft is — and so the round-trip is testable against a real router.

## Testing

- `frontend/src/pages/assistant.test.tsx` (new, 6 cases): optimistic navigation before the create resolves, the `?draft` → `?c=<id>` swap, no-yank on navigate-away, the failure toast, and the draft empty state vs. the newest-chat fallback. Verified meaningful — **5 of 6 fail against the old code**.
- `frontend/src/lib/assistant/search.test.ts` (new, 5 cases): unit coverage plus a round-trip through a **real** TanStack router. The page tests stub the router, so a `validateSearch` that silently dropped `draft` would reintroduce the dead button one layer down; this catches that.
- `frontend/src/hooks/use-assistant.test.tsx`: new case asserting the button's create and a racing send resolve to the same actor (`createConversation` called once).

Full gate green locally on this base: `npm run build` ✓, lint 0 errors ✓, **2033 tests / 177 files** ✓, `cargo test -p nyxid-cli --test wizard_bundle_freshness` ✓ (no touched file is in the wizard closure).

## Notes

Rebased onto `32d8b1d6` (#1235), which touched the same page; the only conflict was the import block.

Out of scope: clicking New chat still provisions an actor eagerly, so clicking it and walking away leaves an empty conversation in the sidebar — pre-existing behavior, unchanged. The machinery to defer creation until the first send is now in place (drop the background create; the composer already auto-creates) if we want that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)