### PR TITLE
fix(assistant): open new chats immediately

### DIFF
--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { AssistantPage } from "./assistant";
+
+const testState = vi.hoisted(() => ({
+  search: {} as Record<string, unknown>,
+  navigate: vi.fn(),
+  useConversation: vi.fn(),
+  conversation: {
+    id: "conversation-1",
+    title: "Existing chat",
+    created_at: "2026-07-24T00:00:00.000Z",
+    last_message_at: "2026-07-24T00:05:00.000Z",
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => testState.navigate,
+  useRouterState: ({
+    select,
+  }: {
+    readonly select: (state: {
+      readonly location: { readonly search: Record<string, unknown> };
+    }) => unknown;
+  }) => select({ location: { search: testState.search } }),
+}));
+
+vi.mock("@/components/assistant/assistant-shell", () => ({
+  AssistantShell: ({
+    title,
+    sidebar,
+    children,
+  }: {
+    readonly title: string;
+    readonly sidebar: ReactNode;
+    readonly children: ReactNode;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {sidebar}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/assistant/assistant-sidebar", () => ({
+  AssistantSidebar: ({
+    activeConversationId,
+    onNewChat,
+  }: {
+    readonly activeConversationId?: string;
+    readonly onNewChat: () => void;
+  }) => (
+    <button
+      type="button"
+      data-active-conversation={activeConversationId ?? ""}
+      onClick={onNewChat}
+    >
+      New chat
+    </button>
+  ),
+}));
+
+vi.mock("@/components/assistant/chat-composer", () => ({
+  ChatComposer: () => null,
+}));
+
+vi.mock("@/components/assistant/chat-thread", () => ({
+  ChatThread: () => <div>Chat thread</div>,
+}));
+
+vi.mock("@/components/assistant/approvals-view", () => ({
+  ApprovalsView: () => null,
+}));
+
+vi.mock("@/components/assistant/plugins-view", () => ({
+  PluginsView: () => null,
+}));
+
+vi.mock("@/hooks/use-assistant", () => ({
+  describeSendFailure: () => ({ message: "failed", description: "failed" }),
+  useConversations: () => ({ data: [testState.conversation] }),
+  useConversation: (conversationId: string | undefined) => {
+    testState.useConversation(conversationId);
+    return {
+      data: conversationId
+        ? { conversation: testState.conversation, messages: [] }
+        : undefined,
+      isLoading: false,
+      isError: false,
+    };
+  },
+  useAssistantTurn: () => ({ data: null }),
+  useSendMessage: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useCancelTurn: () => ({ mutateAsync: vi.fn() }),
+  useDecideApproval: () => ({ mutateAsync: vi.fn() }),
+  useDeleteConversation: () => ({
+    isPending: false,
+    variables: undefined,
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+describe("AssistantPage new chat", () => {
+  beforeEach(() => {
+    testState.search = {};
+    testState.navigate.mockReset();
+    testState.useConversation.mockReset();
+  });
+
+  it("navigates to the local new-chat state without waiting for a backend create", async () => {
+    const user = userEvent.setup();
+    render(<AssistantPage />);
+
+    await user.click(screen.getByRole("button", { name: "New chat" }));
+
+    expect(testState.navigate).toHaveBeenCalledWith({
+      to: "/assistant",
+      search: { c: "new" },
+    });
+  });
+
+  it("does not fall back to an existing conversation in the new-chat state", () => {
+    testState.search = { c: "new" };
+
+    render(<AssistantPage />);
+
+    expect(testState.useConversation).toHaveBeenCalledWith(undefined);
+    expect(screen.getByRole("heading", { name: "New chat" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New chat" })).toHaveAttribute(
+      "data-active-conversation",
+      "",
+    );
+  });
+});

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -13,12 +13,13 @@ import {
   useCancelTurn,
   useConversation,
   useConversations,
-  useCreateConversation,
   useDecideApproval,
   useDeleteConversation,
   useSendMessage,
 } from "@/hooks/use-assistant";
 import { isTurnActive } from "@/types/assistant";
+
+const NEW_CHAT_SEARCH_VALUE = "new";
 
 export function AssistantPage({
   view = "chat",
@@ -35,6 +36,7 @@ export function AssistantPage({
   const conversations = useConversations();
   const selectedId = useMemo(() => {
     const items = conversations.data ?? [];
+    if (selectedFromSearch === NEW_CHAT_SEARCH_VALUE) return undefined;
     if (
       selectedFromSearch &&
       items.some((item) => item.id === selectedFromSearch)
@@ -45,7 +47,6 @@ export function AssistantPage({
   }, [conversations.data, selectedFromSearch]);
   const history = useConversation(selectedId);
   const turn = useAssistantTurn(selectedId);
-  const createConversation = useCreateConversation();
   const sendMessage = useSendMessage(selectedId);
   const cancelTurn = useCancelTurn(selectedId);
   const decideApproval = useDecideApproval(selectedId);
@@ -58,9 +59,11 @@ export function AssistantPage({
     });
   }
 
-  async function createNewChat() {
-    const conversation = await createConversation.mutateAsync();
-    selectConversation(conversation.id);
+  function createNewChat() {
+    void navigate({
+      to: "/assistant" as never,
+      search: { c: NEW_CHAT_SEARCH_VALUE } as never,
+    });
   }
 
   // Deleting the URL-addressed conversation must also drop `?c=`, or the
@@ -112,11 +115,11 @@ export function AssistantPage({
       conversations={conversations.data ?? []}
       activeConversationId={view === "chat" ? selectedId : undefined}
       activeView={view}
-      creating={createConversation.isPending}
+      creating={false}
       deletingId={
         deleteConversation.isPending ? deleteConversation.variables : undefined
       }
-      onNewChat={() => void createNewChat()}
+      onNewChat={createNewChat}
       onSelect={selectConversation}
       onDelete={(conversationId) => void handleDelete(conversationId)}
     />


### PR DESCRIPTION
## Summary

- Switch **New chat** to a local empty-chat route state immediately instead of waiting for conversation creation and cache refreshes.
- Reuse the existing first-send auto-create flow so the backend conversation is created only when the user sends the first message.
- Add page-level regression coverage for immediate navigation and preventing fallback to an existing conversation.

Fixes #1232

## Test Plan

- [x] Full frontend test suite passes (`npm test`: 176 files, 2022 tests)
- [x] New regression tests added for the New chat flow
- [x] Frontend production builds pass (`npm run build`)
- [x] Targeted ESLint passes for changed files
- [x] Manually tested `/assistant?mock`: the URL changes to `?c=new`, the empty thread renders, and no existing chat remains selected

## Checklist

- [x] Code follows the project architecture rules
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Documentation update is not applicable for this behavior-only frontend fix