### PR TITLE
fix(assistant): guard Enter during IME composition

### DIFF
--- a/frontend/src/components/assistant/chat-composer.test.tsx
+++ b/frontend/src/components/assistant/chat-composer.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatComposer } from "./chat-composer";
+
+function renderComposer() {
+  const onSend = vi.fn().mockResolvedValue(undefined);
+  render(
+    <ChatComposer
+      active={false}
+      sending={false}
+      onSend={onSend}
+      onStop={vi.fn().mockResolvedValue(undefined)}
+    />,
+  );
+  return {
+    composer: screen.getByPlaceholderText("Message NyxID Assistant..."),
+    onSend,
+  };
+}
+
+describe("ChatComposer IME handling", () => {
+  it("lets Enter commit an active IME composition without sending", async () => {
+    const { composer, onSend } = renderComposer();
+    fireEvent.change(composer, { target: { value: "workfl" } });
+
+    fireEvent.compositionStart(composer);
+    fireEvent.keyDown(composer, { key: "Enter", code: "Enter" });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composer).toHaveValue("workfl");
+
+    fireEvent.compositionEnd(composer);
+    fireEvent.keyDown(composer, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledWith("workfl"));
+    expect(composer).toHaveValue("");
+  });
+
+  it("also honors the native composing flag when composition events are unavailable", () => {
+    const { composer, onSend } = renderComposer();
+    fireEvent.change(composer, { target: { value: "workflow" } });
+
+    fireEvent.keyDown(composer, {
+      key: "Enter",
+      code: "Enter",
+      isComposing: true,
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composer).toHaveValue("workflow");
+  });
+
+  it("does not send legacy IME key events reported with key code 229", () => {
+    const { composer, onSend } = renderComposer();
+    fireEvent.change(composer, { target: { value: "workflow" } });
+
+    fireEvent.keyDown(composer, {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 229,
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composer).toHaveValue("workflow");
+  });
+});

--- a/frontend/src/components/assistant/chat-composer.tsx
+++ b/frontend/src/components/assistant/chat-composer.tsx
@@ -27,6 +27,7 @@ export function ChatComposer({
 }) {
   const [content, setContent] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composingRef = useRef(false);
 
   // Grow the textarea to fit the draft, capped at MAX_ROWS.
   useLayoutEffect(() => {
@@ -67,7 +68,11 @@ export function ChatComposer({
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
-    if (event.key === "Enter" && !event.shiftKey) {
+    const isComposing =
+      composingRef.current ||
+      event.nativeEvent.isComposing ||
+      event.keyCode === 229;
+    if (event.key === "Enter" && !event.shiftKey && !isComposing) {
       event.preventDefault();
       void submit();
     }
@@ -83,6 +88,12 @@ export function ChatComposer({
           ref={textareaRef}
           value={content}
           onChange={(event) => setContent(event.target.value)}
+          onCompositionStart={() => {
+            composingRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            composingRef.current = false;
+          }}
           onKeyDown={handleKeyDown}
           disabled={active}
           rows={1}


### PR DESCRIPTION
## Summary

- Track `compositionstart` and `compositionend` in the chat composer so Enter can commit active IME text without submitting the message.
- Also honor native `isComposing` and legacy key code 229 for cross-browser IME behavior.
- Add regression coverage for active composition, native composing events, legacy IME events, and normal submission after composition ends.
- Rebased onto the latest `main` and preserved the composer auto-resize behavior added by #1235.

Fixes #1233

## Test Plan

- [x] Full frontend test suite passes (`npm test`: 178 files, 2036 tests)
- [x] New IME regression tests cover active composition and post-composition Enter
- [x] Frontend production builds pass (`npm run build`)
- [x] Targeted ESLint passes for changed files
- [x] Manually verified the composer renders, edits normally, and enables/disables Send correctly in `/assistant?mock`

## Checklist

- [x] Code follows the project architecture rules
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Documentation update is not applicable for this behavior-only frontend fix