### PR TITLE
refactor(assistant): disable approval polling ahead of SSE

### DIFF
--- a/frontend/src/hooks/use-approvals.ts
+++ b/frontend/src/hooks/use-approvals.ts
@@ -112,11 +112,15 @@ export function useRemoveDevice() {
 
 // --- Approval Requests ---
 
+// No `refetchInterval` here by design: approval liveness is moving to a
+// server-pushed SSE stream, so nothing in the app polls this endpoint.
+// Cross-surface decisions (Telegram, mobile, another tab) land on the next
+// window focus / mount until that stream ships. Local decisions still
+// refresh immediately — `useDecideApproval` invalidates this key.
 export function useApprovalRequests(
   page: number = 1,
   perPage: number = 20,
   status?: string,
-  options?: { readonly refetchIntervalMs?: number },
 ) {
   return useQuery({
     queryKey: ["approvals", "requests", page, perPage, status],
@@ -130,10 +134,6 @@ export function useApprovalRequests(
         `/approvals/requests?${params.toString()}`,
       );
     },
-    // Polling only fires while the tab is focused (TanStack default); used
-    // by the assistant surfaces so decisions made elsewhere (Telegram,
-    // mobile, another tab) show up without a manual refresh.
-    refetchInterval: options?.refetchIntervalMs,
   });
 }
 

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -39,10 +39,6 @@ export const assistantKeys = {
   workspace: [...ROOT, "workspace"] as const,
 } as const;
 
-// Live-update cadence for real approval data. Pending requests are
-// time-sensitive (they expire), so they poll faster than history.
-const PENDING_APPROVALS_POLL_MS = 5_000;
-const APPROVAL_HISTORY_POLL_MS = 15_000;
 // One page comfortably above anything a single user accumulates as
 // simultaneously-pending; the badge uses the server-side total anyway.
 const PENDING_APPROVALS_PAGE_SIZE = 50;
@@ -84,14 +80,15 @@ function turnFromEvent(event: TurnEvent): ActiveTurn | undefined {
 }
 
 /**
- * Pending approval requests, polled so requests raised (or decided) from
- * anywhere — agents hitting the proxy, Telegram, mobile, another tab —
- * appear live. Shares its query cache with the sidebar badge.
+ * Pending approval requests. Shares its query cache with the sidebar badge.
+ *
+ * Polling is intentionally off: liveness for requests raised (or decided)
+ * elsewhere — agents hitting the proxy, Telegram, mobile, another tab — is
+ * moving to a server-pushed SSE stream. Until that lands, the list refreshes
+ * on mount, on window focus, and on any local decision.
  */
 function usePendingApprovalRequests() {
-  return useApprovalRequests(1, PENDING_APPROVALS_PAGE_SIZE, "pending", {
-    refetchIntervalMs: PENDING_APPROVALS_POLL_MS,
-  });
+  return useApprovalRequests(1, PENDING_APPROVALS_PAGE_SIZE, "pending");
 }
 
 /**
@@ -101,12 +98,7 @@ function usePendingApprovalRequests() {
 export function useAssistantApprovals() {
   const settings = useNotificationSettings();
   const pendingQuery = usePendingApprovalRequests();
-  const historyQuery = useApprovalRequests(
-    1,
-    APPROVAL_HISTORY_PAGE_SIZE,
-    undefined,
-    { refetchIntervalMs: APPROVAL_HISTORY_POLL_MS },
-  );
+  const historyQuery = useApprovalRequests(1, APPROVAL_HISTORY_PAGE_SIZE);
 
   // Grant-mode approvals create a reusable grant with the user-configured
   // expiry; surface that duration on the card so "approve" is informed.
@@ -157,7 +149,7 @@ export function useWorkspaceCounts() {
 
 // One stable sonner id for the whole surface: refetches and the history query
 // failing alongside the list update this toast instead of stacking a new one
-// every poll.
+// on every refetch.
 const TRANSPORT_TOAST_ID = "assistant-transport-unavailable";
 
 /**


### PR DESCRIPTION
## What

Turns off the approval polling on the NyxID chat assistant surfaces. Approval liveness is moving to a server-pushed SSE stream; this lands the "stop polling" half first so the two mechanisms never run against each other during the switch.

Removed:
- `PENDING_APPROVALS_POLL_MS` (5s) and `APPROVAL_HISTORY_POLL_MS` (15s) in `frontend/src/hooks/use-assistant.ts`
- the `refetchIntervalMs` option on `useApprovalRequests` (`frontend/src/hooks/use-approvals.ts`) that existed only to carry those timers — the assistant was its only caller, so it is deleted rather than left dead until the SSE work lands

Page sizes, the response mapping, and every other approval behaviour are unchanged.

## Behaviour after this change

| Trigger | Still refreshes? |
| --- | --- |
| Deciding an approval in the assistant | Yes — `useDecideApproval` invalidates `["approvals","requests"]` |
| Mounting the Approvals view / sidebar | Yes |
| Returning to the tab (window focus, past the 60s `staleTime`) | Yes |
| Approval raised or decided elsewhere (agent hitting the proxy, Telegram, mobile, another tab) while the tab stays focused | No — waits for the next focus/mount until SSE ships |

That last row is the accepted regression for this interim step. The pending-approvals badge in the assistant sidebar shares the same query, so it follows the same cadence.

## Testing

- `npm run build` (tsc -b + both Vite builds) — passes
- `npm run lint` — 0 errors (20 pre-existing warnings, unchanged)
- `npm test` — 172 files / 1915 tests passing
- Wizard bundle: neither changed file appears in `cli/src/wizard/bundle-meta/index.manifest`, so no bundle regeneration is required

## Follow-up

Replace the removed cadence with the SSE approval stream, which restores live cross-surface updates without the timers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)