### PR TITLE
fix(assistant): send the required `type` discriminator on the chat stream

### DIFF
--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -970,12 +970,19 @@ describe("captured production wire shapes", () => {
     const body = JSON.parse(String(init.body)) as {
       prompt: string;
       clientRequestId: string;
+      type: string;
       sessionId?: string;
     };
     expect(body.prompt).toBe("Hello there");
     expect(body.clientRequestId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+    expect(body.type).toBe("text");
+    expect(Object.keys(body).sort()).toEqual([
+      "clientRequestId",
+      "prompt",
+      "type",
+    ]);
     expect(body.sessionId).toBeUndefined();
   });
 
@@ -1072,12 +1079,20 @@ describe("captured production wire shapes", () => {
       .map(
         ([, init]) =>
           JSON.parse(String(init?.body)) as {
+            prompt: string;
             clientRequestId: string;
+            type: string;
             sessionId?: string;
           },
       );
     expect(bodies).toHaveLength(2);
     expect(bodies[0]?.clientRequestId).toBe(bodies[1]?.clientRequestId);
+    expect(bodies[0]).toEqual({
+      prompt: "Retry this delivery",
+      clientRequestId: bodies[0]?.clientRequestId,
+      type: "text",
+    });
+    expect(bodies[1]).toEqual(bodies[0]);
     expect(bodies[0]?.sessionId).toBeUndefined();
   });
 

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1257,6 +1257,10 @@ export class AevatarAssistantTransport implements AssistantTransport {
             body: JSON.stringify({
               prompt,
               clientRequestId: run.clientRequestId,
+              // Aevatar NyxIdChatEndpoints.Streaming.cs:58 uses an ordinal
+              // discriminator comparison, so a normal turn requires this
+              // exact lowercase value.
+              type: "text",
             }),
             signal: run.controller.signal,
           },


### PR DESCRIPTION
## The outage

NyxID assistant chat has been fully down in production since ~2026-07-23. Every turn returned **HTTP 400 with an empty body** — no error code, no message, nothing in the logs, which is why it took days to place.

## Root cause (upstream contract, not our regression)

Aevatar's stream handler requires a `type` discriminator on the request body. It reads `request.Type?.Trim() ?? string.Empty`, branches on an **ordinal** comparison against `"text"` / `"action.continue"`, and sends anything else — **including absent** — to a bare `StatusCode = 400; return;`. The handler returns `Task`, not `IResult`, so that bare return writes no body. The DTO defaults `Type = null`, so there was never a backward-compatible default.

| Vendor source (`NyxIdChatEndpoints.Streaming.cs`) | |
|---|---|
| `:37` | discriminator read, absent → empty string |
| `:58` | ordinal `"text"` match |
| `:85-89` | bodyless 400 fallthrough |
| `:720` | `string? Type = null` — no compat default |

We send `{prompt, clientRequestId}`, so we always landed in the fallthrough.

## Verification

Against production, same conversation, back to back:

```
{"prompt":"say ONE","clientRequestId":"x"}               -> 400, 0 bytes
{"prompt":"say ONE","clientRequestId":"x","type":"text"} -> 200 + AG-UI SSE
```

A neat independent confirmation from gate ordering: the handler checks scope (403) → token (401) → **type (400)** → conversation admission (404). Production returned exactly 400, which proves the requests passed auth and never reached conversation lookup. The status code alone rules out the competing hypotheses.

## Two constraints the tests lock

Violating either reproduces an **identical** bodyless 400, so both are now asserted:

1. The value must be exactly lowercase `"text"` (`StringComparison.Ordinal`).
2. The DTO is `[JsonUnmappedMemberHandling(Disallow)]` — **any** member outside `{prompt, sessionId, inputParts, clientRequestId, type, originTurnId, actions}` fails at bind time, before the handler runs. The test asserts the exact key set, not just presence.

`clientRequestId` stays: it is a real DTO field (`:719`) and the retry-idempotency key feeding `CreateTurnId` (`:605`), and the retry replay must reuse it verbatim. `sessionId` is deliberately not sent — upstream marks it `[Obsolete]` "deprecated and ignored" (`:716`).

## Scope

One line plus tests. The create/new-chat path was audited against the same source and needs **no** change: it already polls the actor registry with bounded backoff after the upstream 202 (`backend/src/handlers/assistant.rs:245-278`), and create-then-immediate-send was confirmed clean on production across three consecutive runs. Reporting that honestly rather than inventing work.

An unrelated `cli/src/wizard/assets/index.html` delta appeared during the build and was **deliberately excluded** — the freshness check is source-only over a manifest that does not include `aevatar-transport.ts`, the stored hash is unchanged, and `cargo test -p nyxid-cli --test wizard_bundle_freshness` passes without it. Shipping it would have put opaque CLI UI churn in an incident patch.

## Process

Diagnosis independently verified by **Codex** and **Opus** reading the vendor source directly; both returned CONFIRMED. Codex then reviewed this diff and initially returned REQUEST CHANGES on the wizard-bundle file, which is why it was dropped.

## Gates

- 2083 frontend tests passing (180 files)
- `npm run lint` clean
- `npm run build` passing (the real CI gate — `tsc --noEmit` would miss it)
- wizard bundle freshness passing

## Known follow-ups (deliberately not in this PR)

1. **Long turns can stall.** After this fix I saw `RUN_STARTED` → `TEXT_MESSAGE_START` → keepalives with no completion past 180s. The stream is healthy and the LLM step is `running`, so this is the pre-existing G-hang, not a contract bug. Aevatar enforces a 5-minute terminal deadline vs our 120s client watchdog.
2. **No `:stop` / `:steer` wiring.** Our cancel is client-local only, so an aborted turn leaves the actor `Active` and later sends get `ACTIVE_TURN_REQUIRES_STEERING` with no recovery path.
3. **No `action.continue` support** for browser-action handoff (upstream registry appears to default off).
4. **Conversation list silently capped at 50** — we send no `pageSize`/`cursor` and ignore `nextCursor`.
5. **Error observability** — a bodyless upstream 400 was invisible end to end. Worth surfacing upstream status through the proxy.

Also worth raising with Aevatar: this looks like a breaking change shipped without a deprecation window or compat default, and no test covers the absent-`type` case. I could not date it — the clone available here is shallow — so that should be stated as unproven when raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)