### PR TITLE
feat(assistant): server-side :stop pass-through per the Aevatar feature/integrate contract

### DIFF
--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -8,7 +8,7 @@
 //! Every route is an explicit mapping onto one Aevatar path. A blanket
 //! `/{*path}` pass-through would expose all ~248 routes of Aevatar's spec
 //! (admin, workflow, and streaming-proxy surfaces included) through a
-//! session-authed mount; the assistant needs nine.
+//! session-authed mount; the assistant needs ten.
 //!
 //! Forwarding goes through `proxy::execute_proxy`, so credential injection,
 //! identity propagation, per-agent rate limiting, approval gating, and audit
@@ -373,6 +373,23 @@ pub async fn decide_approval(
     request: Request<Body>,
 ) -> AppResult<Response> {
     let path = assistant_service::approve_path(&auth_user.user_id.to_string(), &conversation_id)?;
+    forward(&state, &auth_user, path, request).await
+}
+
+/// `POST /api/v1/assistant/conversations/{id}/stop` -- stop active work.
+///
+/// Forwards the caller's control body (`turnId`, `stopRequestId`,
+/// `clientRequestId`, `expectedStateVersion`) verbatim to Aevatar's `:stop`
+/// route. Aevatar answers 202-accepted and commits a stop fence; without this
+/// route, cancel is a client-side abort only and the server run keeps
+/// executing until its own terminal.
+pub async fn stop_turn(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(conversation_id): Path<String>,
+    request: Request<Body>,
+) -> AppResult<Response> {
+    let path = assistant_service::stop_path(&auth_user.user_id.to_string(), &conversation_id)?;
     forward(&state, &auth_user, path, request).await
 }
 

--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -8,7 +8,7 @@
 //! Every route is an explicit mapping onto one Aevatar path. A blanket
 //! `/{*path}` pass-through would expose all ~248 routes of Aevatar's spec
 //! (admin, workflow, and streaming-proxy surfaces included) through a
-//! session-authed mount; the assistant needs ten.
+//! session-authed mount; the assistant needs fourteen.
 //!
 //! Forwarding goes through `proxy::execute_proxy`, so credential injection,
 //! identity propagation, per-agent rate limiting, approval gating, and audit
@@ -390,6 +390,74 @@ pub async fn stop_turn(
     request: Request<Body>,
 ) -> AppResult<Response> {
     let path = assistant_service::stop_path(&auth_user.user_id.to_string(), &conversation_id)?;
+    forward(&state, &auth_user, path, request).await
+}
+
+/// `POST /api/v1/assistant/conversations/{id}/steer` -- redirect active
+/// work (`turnId`, `steeringId`, `clientRequestId`, `instruction`, optional
+/// `inputParts`, `expectedStateVersion`), forwarded verbatim to `:steer`.
+/// The contract's answer to "send while a turn is active": a plain text
+/// submission is rejected with `ACTIVE_TURN_REQUIRES_STEERING`; this is the
+/// sanctioned redirect.
+pub async fn steer_turn(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(conversation_id): Path<String>,
+    request: Request<Body>,
+) -> AppResult<Response> {
+    let path = assistant_service::steer_path(&auth_user.user_id.to_string(), &conversation_id)?;
+    forward(&state, &auth_user, path, request).await
+}
+
+/// `GET /api/v1/assistant/conversations/{id}/state` -- conditional
+/// current-state query. The `afterStateVersion` / `turnId` cursors ride the
+/// forwarded query string (`execute_proxy` preserves it); results are the
+/// contract's `current` / `not_modified` / `reload_required` / `not_found`
+/// envelope. This is the reconnect surface for a page reload mid-turn.
+pub async fn get_state(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(conversation_id): Path<String>,
+    request: Request<Body>,
+) -> AppResult<Response> {
+    let path = assistant_service::state_path(&auth_user.user_id.to_string(), &conversation_id)?;
+    forward(&state, &auth_user, path, request).await
+}
+
+/// `POST /api/v1/assistant/conversations/{id}/turns/{turn}/steps/{step}/retry`
+/// -- retry one step (`taskId`, `retryRequestId`, `clientRequestId`,
+/// `expectedOperationGeneration`, `expectedStateVersion`), forwarded
+/// verbatim to `:retry`. Availability is actor-computed upstream; NyxID
+/// only validates the path segments.
+pub async fn retry_step(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((conversation_id, turn_id, step_id)): Path<(String, String, String)>,
+    request: Request<Body>,
+) -> AppResult<Response> {
+    let path = assistant_service::retry_path(
+        &auth_user.user_id.to_string(),
+        &conversation_id,
+        &turn_id,
+        &step_id,
+    )?;
+    forward(&state, &auth_user, path, request).await
+}
+
+/// `POST /api/v1/assistant/conversations/{id}/turns/{turn}/steps/{step}/skip`
+/// -- skip one optional step, forwarded verbatim to `:skip`.
+pub async fn skip_step(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((conversation_id, turn_id, step_id)): Path<(String, String, String)>,
+    request: Request<Body>,
+) -> AppResult<Response> {
+    let path = assistant_service::skip_path(
+        &auth_user.user_id.to_string(),
+        &conversation_id,
+        &turn_id,
+        &step_id,
+    )?;
     forward(&state, &auth_user, path, request).await
 }
 

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1312,6 +1312,10 @@ pub fn build_router(
             "/conversations/{conversation_id}/approve",
             post(handlers::assistant::decide_approval),
         )
+        .route(
+            "/conversations/{conversation_id}/stop",
+            post(handlers::assistant::stop_turn),
+        )
         .route("/completions", post(handlers::assistant::completions))
         .route("/workflow-chat", post(handlers::assistant::workflow_chat))
         .route(

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1316,6 +1316,22 @@ pub fn build_router(
             "/conversations/{conversation_id}/stop",
             post(handlers::assistant::stop_turn),
         )
+        .route(
+            "/conversations/{conversation_id}/steer",
+            post(handlers::assistant::steer_turn),
+        )
+        .route(
+            "/conversations/{conversation_id}/state",
+            get(handlers::assistant::get_state),
+        )
+        .route(
+            "/conversations/{conversation_id}/turns/{turn_id}/steps/{step_id}/retry",
+            post(handlers::assistant::retry_step),
+        )
+        .route(
+            "/conversations/{conversation_id}/turns/{turn_id}/steps/{step_id}/skip",
+            post(handlers::assistant::skip_step),
+        )
         .route("/completions", post(handlers::assistant::completions))
         .route("/workflow-chat", post(handlers::assistant::workflow_chat))
         .route(

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -152,17 +152,26 @@ pub fn state_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
 }
 
 /// Turn/step ids follow the upstream control-identity grammar
-/// (`TryValidateControlIdentity`): at most 128 chars, no whitespace or
-/// control characters, and none of `/ \ ? #`. Anything else the server may
-/// legitimately issue (`turn.v2`, `step:3`, …) must round-trip, so accepted
+/// (`TryValidateControlIdentity`): at most 128 UTF-16 code units (the C#
+/// `string.Length` the upstream counts — NOT bytes, so 65 `é`s pass), no
+/// whitespace or control characters, and none of `/ \ ? #`. Accepted
 /// segments are percent-encoded before interpolation — an unencoded `:`
 /// inside a step id would collide with the `:retry`/`:skip` suffix parse.
+///
+/// Two documented NyxID narrowings of the upstream grammar, both
+/// fail-closed here rather than deeper with a less precise error:
+/// - `%` is rejected: the proxy's path hardening repeat-decodes nested
+///   escapes, so a literal `%2F`-shaped id would be 400'd downstream even
+///   double-encoded.
+/// - dot-only segments (`.`, `..`) are rejected: they form
+///   traversal-shaped path segments if any later layer normalizes.
 fn encode_control_segment(segment: &str) -> AppResult<String> {
     let valid = !segment.is_empty()
-        && segment.len() <= 128
-        && segment
-            .chars()
-            .all(|c| !c.is_whitespace() && !c.is_control() && !matches!(c, '/' | '\\' | '?' | '#'));
+        && segment.encode_utf16().count() <= 128
+        && segment.chars().all(|c| {
+            !c.is_whitespace() && !c.is_control() && !matches!(c, '/' | '\\' | '?' | '#' | '%')
+        })
+        && !segment.chars().all(|c| c == '.');
     if !valid {
         return Err(AppError::BadRequest("Invalid turn or step id.".to_string()));
     }
@@ -326,14 +335,10 @@ mod tests {
                 "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn.v2/steps/step%3A3:retry"
             )
         );
-        // A literal `%` also round-trips (doubly-encoded), so a caller
-        // cannot smuggle traversal via pre-encoded sequences.
-        assert_eq!(
-            skip_path(USER, CONV, "turn-1", "%2e%2e").unwrap(),
-            format!(
-                "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn-1/steps/%252e%252e:skip"
-            )
-        );
+        // Non-ASCII identities count UTF-16 code units like the upstream
+        // C# validator: 65 `é`s are 65 units (130 UTF-8 bytes) and pass.
+        let accented = "é".repeat(65);
+        assert!(retry_path(USER, CONV, &accented, "step_a").is_ok());
     }
 
     #[test]
@@ -341,6 +346,9 @@ mod tests {
         // The control-identity grammar forbids whitespace, control chars,
         // and `/ \ ? #` (upstream `TryValidateControlIdentity`); everything
         // else is accepted and percent-encoded.
+        // `%` and dot-only segments are documented NyxID narrowings of the
+        // upstream grammar: nested escapes would be 400'd by the proxy's
+        // repeat-decode hardening, and `.`/`..` are traversal-shaped.
         for bad in [
             "",
             "abc/def",
@@ -350,6 +358,10 @@ mod tests {
             "abc def",
             "tab\there",
             "\u{7}bell",
+            "%2e%2e",
+            "a%2Fb",
+            ".",
+            "..",
         ] {
             assert!(
                 retry_path(USER, CONV, bad, "step_a").is_err(),

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -151,18 +151,22 @@ pub fn state_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
     ))
 }
 
-/// Turn/step ids share the conversation-id grammar: opaque server-issued
-/// handles, so anything carrying a separator is a caller reshaping the URL.
-fn validate_control_segment(segment: &str) -> AppResult<()> {
+/// Turn/step ids follow the upstream control-identity grammar
+/// (`TryValidateControlIdentity`): at most 128 chars, no whitespace or
+/// control characters, and none of `/ \ ? #`. Anything else the server may
+/// legitimately issue (`turn.v2`, `step:3`, …) must round-trip, so accepted
+/// segments are percent-encoded before interpolation — an unencoded `:`
+/// inside a step id would collide with the `:retry`/`:skip` suffix parse.
+fn encode_control_segment(segment: &str) -> AppResult<String> {
     let valid = !segment.is_empty()
         && segment.len() <= 128
         && segment
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+            .all(|c| !c.is_whitespace() && !c.is_control() && !matches!(c, '/' | '\\' | '?' | '#'));
     if !valid {
         return Err(AppError::BadRequest("Invalid turn or step id.".to_string()));
     }
-    Ok(())
+    Ok(urlencoding::encode(segment).into_owned())
 }
 
 /// `nyxid-chat/conversations/{id}/turns/{turn}/steps/{step}:retry` --
@@ -173,10 +177,10 @@ pub fn retry_path(
     turn_id: &str,
     step_id: &str,
 ) -> AppResult<String> {
-    validate_control_segment(turn_id)?;
-    validate_control_segment(step_id)?;
+    let turn = encode_control_segment(turn_id)?;
+    let step = encode_control_segment(step_id)?;
     Ok(format!(
-        "{}/turns/{turn_id}/steps/{step_id}:retry",
+        "{}/turns/{turn}/steps/{step}:retry",
         conversation_path(user_id, conversation_id)?
     ))
 }
@@ -189,10 +193,10 @@ pub fn skip_path(
     turn_id: &str,
     step_id: &str,
 ) -> AppResult<String> {
-    validate_control_segment(turn_id)?;
-    validate_control_segment(step_id)?;
+    let turn = encode_control_segment(turn_id)?;
+    let step = encode_control_segment(step_id)?;
     Ok(format!(
-        "{}/turns/{turn_id}/steps/{step_id}:skip",
+        "{}/turns/{turn}/steps/{step}:skip",
         conversation_path(user_id, conversation_id)?
     ))
 }
@@ -313,6 +317,50 @@ mod tests {
                 "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn-1/steps/step_a:skip"
             )
         );
+        // Upstream may issue identities with `.` / `:`; they round-trip
+        // percent-encoded so a raw `:` cannot collide with the `:retry`
+        // suffix parse.
+        assert_eq!(
+            retry_path(USER, CONV, "turn.v2", "step:3").unwrap(),
+            format!(
+                "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn.v2/steps/step%3A3:retry"
+            )
+        );
+        // A literal `%` also round-trips (doubly-encoded), so a caller
+        // cannot smuggle traversal via pre-encoded sequences.
+        assert_eq!(
+            skip_path(USER, CONV, "turn-1", "%2e%2e").unwrap(),
+            format!(
+                "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn-1/steps/%252e%252e:skip"
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_control_segments_outside_the_upstream_grammar() {
+        // The control-identity grammar forbids whitespace, control chars,
+        // and `/ \ ? #` (upstream `TryValidateControlIdentity`); everything
+        // else is accepted and percent-encoded.
+        for bad in [
+            "",
+            "abc/def",
+            "abc\\def",
+            "abc?x=1",
+            "abc#frag",
+            "abc def",
+            "tab\there",
+            "\u{7}bell",
+        ] {
+            assert!(
+                retry_path(USER, CONV, bad, "step_a").is_err(),
+                "expected turn {bad:?} to be rejected"
+            );
+            assert!(retry_path(USER, CONV, "turn-1", bad).is_err());
+            assert!(skip_path(USER, CONV, bad, "step_a").is_err());
+            assert!(skip_path(USER, CONV, "turn-1", bad).is_err());
+        }
+        assert!(retry_path(USER, CONV, &"a".repeat(129), "step_a").is_err());
+        assert!(retry_path(USER, CONV, "turn-1", &"a".repeat(129)).is_err());
         assert_eq!(
             history_index_path(USER),
             format!("api/scopes/{USER}/chat-history")
@@ -343,11 +391,6 @@ mod tests {
             assert!(stop_path(USER, bad).is_err());
             assert!(steer_path(USER, bad).is_err());
             assert!(state_path(USER, bad).is_err());
-            // Escaping turn/step segments is rejected the same way.
-            assert!(retry_path(USER, CONV, bad, "step_a").is_err());
-            assert!(retry_path(USER, CONV, "turn-1", bad).is_err());
-            assert!(skip_path(USER, CONV, bad, "step_a").is_err());
-            assert!(skip_path(USER, CONV, "turn-1", bad).is_err());
         }
         assert!(history_path(USER, &"a".repeat(129)).is_err());
     }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -130,6 +130,73 @@ pub fn stop_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
     ))
 }
 
+/// `nyxid-chat/conversations/{id}:steer` -- redirect active work
+/// (202-accepted; Aevatar serializes the steering fence and starts a
+/// server-owned continuation turn at a safe checkpoint).
+pub fn steer_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
+    Ok(format!(
+        "{}:steer",
+        conversation_path(user_id, conversation_id)?
+    ))
+}
+
+/// `nyxid-chat/conversations/{id}/state` -- conditional current-state query
+/// (GET; `afterStateVersion` / `turnId` cursors ride the forwarded query
+/// string). This is the contract's reconnect surface: clients poll it
+/// instead of replaying events.
+pub fn state_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
+    Ok(format!(
+        "{}/state",
+        conversation_path(user_id, conversation_id)?
+    ))
+}
+
+/// Turn/step ids share the conversation-id grammar: opaque server-issued
+/// handles, so anything carrying a separator is a caller reshaping the URL.
+fn validate_control_segment(segment: &str) -> AppResult<()> {
+    let valid = !segment.is_empty()
+        && segment.len() <= 128
+        && segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if !valid {
+        return Err(AppError::BadRequest("Invalid turn or step id.".to_string()));
+    }
+    Ok(())
+}
+
+/// `nyxid-chat/conversations/{id}/turns/{turn}/steps/{step}:retry` --
+/// retry one failed/interrupted step (202-accepted control command).
+pub fn retry_path(
+    user_id: &str,
+    conversation_id: &str,
+    turn_id: &str,
+    step_id: &str,
+) -> AppResult<String> {
+    validate_control_segment(turn_id)?;
+    validate_control_segment(step_id)?;
+    Ok(format!(
+        "{}/turns/{turn_id}/steps/{step_id}:retry",
+        conversation_path(user_id, conversation_id)?
+    ))
+}
+
+/// `nyxid-chat/conversations/{id}/turns/{turn}/steps/{step}:skip` -- skip
+/// one optional step (202-accepted control command).
+pub fn skip_path(
+    user_id: &str,
+    conversation_id: &str,
+    turn_id: &str,
+    step_id: &str,
+) -> AppResult<String> {
+    validate_control_segment(turn_id)?;
+    validate_control_segment(step_id)?;
+    Ok(format!(
+        "{}/turns/{turn_id}/steps/{step_id}:skip",
+        conversation_path(user_id, conversation_id)?
+    ))
+}
+
 /// `v1/chat/completions` -- OpenAI-compatible surface. Scope-free: the
 /// endpoint is stateless and carries its history in the request body.
 pub fn completions_path() -> String {
@@ -227,6 +294,26 @@ mod tests {
             format!("api/scopes/{USER}/nyxid-chat/conversations/{CONV}:stop")
         );
         assert_eq!(
+            steer_path(USER, CONV).unwrap(),
+            format!("api/scopes/{USER}/nyxid-chat/conversations/{CONV}:steer")
+        );
+        assert_eq!(
+            state_path(USER, CONV).unwrap(),
+            format!("api/scopes/{USER}/nyxid-chat/conversations/{CONV}/state")
+        );
+        assert_eq!(
+            retry_path(USER, CONV, "turn-1", "step_a").unwrap(),
+            format!(
+                "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn-1/steps/step_a:retry"
+            )
+        );
+        assert_eq!(
+            skip_path(USER, CONV, "turn-1", "step_a").unwrap(),
+            format!(
+                "api/scopes/{USER}/nyxid-chat/conversations/{CONV}/turns/turn-1/steps/step_a:skip"
+            )
+        );
+        assert_eq!(
             history_index_path(USER),
             format!("api/scopes/{USER}/chat-history")
         );
@@ -254,6 +341,13 @@ mod tests {
             assert!(stream_path(USER, bad).is_err());
             assert!(approve_path(USER, bad).is_err());
             assert!(stop_path(USER, bad).is_err());
+            assert!(steer_path(USER, bad).is_err());
+            assert!(state_path(USER, bad).is_err());
+            // Escaping turn/step segments is rejected the same way.
+            assert!(retry_path(USER, CONV, bad, "step_a").is_err());
+            assert!(retry_path(USER, CONV, "turn-1", bad).is_err());
+            assert!(skip_path(USER, CONV, bad, "step_a").is_err());
+            assert!(skip_path(USER, CONV, "turn-1", bad).is_err());
         }
         assert!(history_path(USER, &"a".repeat(129)).is_err());
     }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -120,6 +120,16 @@ pub fn approve_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
     ))
 }
 
+/// `nyxid-chat/conversations/{id}:stop` -- stop active work (202-accepted
+/// control command; Aevatar commits a stop fence before any successor
+/// operation may start).
+pub fn stop_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
+    Ok(format!(
+        "{}:stop",
+        conversation_path(user_id, conversation_id)?
+    ))
+}
+
 /// `v1/chat/completions` -- OpenAI-compatible surface. Scope-free: the
 /// endpoint is stateless and carries its history in the request body.
 pub fn completions_path() -> String {
@@ -213,6 +223,10 @@ mod tests {
             format!("api/scopes/{USER}/nyxid-chat/conversations/{CONV}:approve")
         );
         assert_eq!(
+            stop_path(USER, CONV).unwrap(),
+            format!("api/scopes/{USER}/nyxid-chat/conversations/{CONV}:stop")
+        );
+        assert_eq!(
             history_index_path(USER),
             format!("api/scopes/{USER}/chat-history")
         );
@@ -239,6 +253,7 @@ mod tests {
             );
             assert!(stream_path(USER, bad).is_err());
             assert!(approve_path(USER, bad).is_err());
+            assert!(stop_path(USER, bad).is_err());
         }
         assert!(history_path(USER, &"a".repeat(129)).is_err());
     }

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -161,11 +161,15 @@ ignored upstream) and the missing stop control. This cut adds the stop:
   `POST …/stop` with `{turnId, stopRequestId, clientRequestId,
   expectedStateVersion: 0}` (fresh UUID control identities;
   `expectedStateVersion <= 0` skips the optimistic-concurrency fence
-  upstream, which the transport does not track). Only fires once the server
-  announced a `turnId`; failures are swallowed — the pre-existing
-  client-abort behavior is the floor. The approval pause
+  upstream, which the transport does not track). Failures are swallowed —
+  the pre-existing client-abort behavior is the floor. The approval pause
   (`pauseForApproval`) deliberately does **not** stop: the server turn is
-  waiting for the decision.
+  waiting for the decision. Two codex (gpt-5.6-sol) P1s hardened the
+  timing: (a) follow-up sends and the composite delete serialize behind
+  the in-flight stop (bounded `STOP_FENCE_WAIT_MS`) so they cannot reach
+  Aevatar before the fence commits; (b) a cancel that lands before
+  `RUN_STARTED` defers its abort (bounded `PRE_START_STOP_WINDOW_MS`) so
+  the announcing frame can still deliver the `turnId` the stop needs.
 - **Known remaining `feature/integrate` gaps (deliberate, recorded):**
   `:steer`, per-step `:retry`/`:skip`, the conditional
   `GET …/conversations/{id}/state` query, the `nyxid.task.*` /

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -166,14 +166,23 @@ ignored upstream) and the missing stop control. This cut adds the stop:
   (`pauseForApproval`) deliberately does **not** stop: the server turn is
   waiting for the decision. Two codex (gpt-5.6-sol) P1s hardened the
   timing: (a) follow-up sends and the composite delete serialize behind
-  the in-flight stop (bounded `STOP_FENCE_WAIT_MS`) so they cannot reach
-  Aevatar before the fence commits; (b) a cancel that lands before
-  `RUN_STARTED` defers its abort (bounded `PRE_START_STOP_WINDOW_MS`) so
-  the announcing frame can still deliver the `turnId` the stop needs.
+  the in-flight stop fence so they cannot reach Aevatar before the fence
+  commits — awaited directly, since every fence entry is self-bounded
+  (the stop request carries `STOP_REQUEST_DEADLINE_MS`, the pre-start
+  placeholder expires with `PRE_START_STOP_WINDOW_MS`); (b) a cancel that
+  lands before `RUN_STARTED` installs that placeholder synchronously and
+  defers its abort so the announcing frame can still deliver the `turnId`
+  the stop needs. The 120s watchdog's pre-`RUN_STARTED` abort stays
+  client-only by design: after that much silence there is no addressable
+  turn identity, and no announcing frame is coming.
 - **Backend (cut 6b):** the remaining conversation-control surfaces are now
   pass-throughs too — `:steer`, `GET …/state` (cursors ride the forwarded
-  query string), and per-step `:retry`/`:skip` (turn/step path segments
-  validated with the conversation-id grammar). No UI consumers yet: steering
+  query string), and per-step `:retry`/`:skip`. Turn/step path segments
+  follow the upstream control-identity grammar (≤128 UTF-16 code units, no
+  whitespace/control chars, none of `/ \ ? #`) and are percent-encoded on
+  interpolation; `%` and dot-only segments are documented NyxID narrowings
+  (fail closed here instead of deeper in the proxy's repeat-decode
+  hardening). No UI consumers yet: steering
   and step controls need task-frame rendering (the FE currently ignores
   `nyxid.task.*` CUSTOM frames), and reconnect-via-state is a follow-up.
 - **Known remaining `feature/integrate` gaps (deliberate, recorded):**

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -59,9 +59,11 @@ sessions + proxy-only identity handling). Changes:
   envelopes surface as the turn error (401/403 keeps the auth-specific,
   you-are-still-signed-in copy); EOF without `RUN_FINISHED`/`RUN_ERROR` is a
   failed `stream_closed` turn (was: silently reported success); the final
-  unterminated SSE frame is flushed; bare-`\r` framing normalized; every
-  `:stream` body carries a per-conversation `sessionId` (optional upstream,
-  reference-aligned).
+  unterminated SSE frame is flushed; bare-`\r` framing normalized.
+  *(Correction, 2026-07-28: this cut originally described a per-conversation
+  `sessionId` on the `:stream` body. That field was never shipped, and the
+  current Aevatar contract deprecates and ignores it — the body is
+  `{type:"text", prompt, clientRequestId}`; see cut 6.)*
 - **Reference-mandated aevatar row config** (README, nyxid-chat):
   `identity_propagation_mode:"jwt"`, `identity_jwt_audience:"urn:aevatar:api"`,
   `inject_delegation_token:true`, `forward_access_token:false`. Prod row drift
@@ -137,6 +139,42 @@ changed (approach reviewed by codex `gpt-5.6-sol`, session
 - **Not done (out of scope):** migrating the production transport from `:stream`
   to `POST /api/chat` + `aevatar.chat.context`. That is a transport rewrite and
   belongs with `CHAT_REWORK_SPEC.md`.
+
+## Implemented in cut 6 (2026-07-28 — `feature/integrate` alignment: `:stop` pass-through)
+
+The authoritative Aevatar contract is now `aevatarAI/aevatar` branch
+`feature/integrate` (`docs/canon/nyxid-chat-api.md` + the
+`agents/Aevatar.GAgents.NyxidChat` host), superseding the `eanz17/nyxid-chat`
+sample. A full conformance pass (2026-07-27) against that branch found the
+stream-body `type` discriminator gap (fixed in #1251: body is
+`{type:"text", prompt, clientRequestId}`; `sessionId` is deprecated and
+ignored upstream) and the missing stop control. This cut adds the stop:
+
+- **Backend:** `POST /api/v1/assistant/conversations/{id}/stop` →
+  `…/nyxid-chat/conversations/{id}:stop` (`stop_path` in
+  `assistant_service.rs`, `stop_turn` in `handlers/assistant.rs`, same
+  `forward()`/`execute_proxy` funnel, body forwarded verbatim). Aevatar
+  answers `202 {status:"accepted", requestId, commandId, correlationId,
+  stateUrl}` and commits a stop fence: no later old-plan LLM round or tool
+  may start.
+- **Frontend:** `cancelTurn` and the stream watchdog now fire a best-effort
+  `POST …/stop` with `{turnId, stopRequestId, clientRequestId,
+  expectedStateVersion: 0}` (fresh UUID control identities;
+  `expectedStateVersion <= 0` skips the optimistic-concurrency fence
+  upstream, which the transport does not track). Only fires once the server
+  announced a `turnId`; failures are swallowed — the pre-existing
+  client-abort behavior is the floor. The approval pause
+  (`pauseForApproval`) deliberately does **not** stop: the server turn is
+  waiting for the decision.
+- **Known remaining `feature/integrate` gaps (deliberate, recorded):**
+  `:steer`, per-step `:retry`/`:skip`, the conditional
+  `GET …/conversations/{id}/state` query, the `nyxid.task.*` /
+  `nyxid.action.request` CUSTOM frames (ignored by the FE), and the
+  NyxID-owned `GET /api/v1/assistant/actions` registry (schema v4) with the
+  `action.continue` stream body. The registry is default-disabled on the
+  Aevatar side (`Aevatar:NyxId:AssistantActions:Enabled=false`, fails closed
+  `NYXID_ACTION_UNSUPPORTED`), so its absence is compatible until the
+  browser-action handoff is scheduled.
 
 ## Implemented in cut 4 (2026-07-18 — TD-3 interim bridge: marker-hardened forward token)
 
@@ -353,6 +391,7 @@ workflow/`/api/chat` chats persist?
 | `DELETE /api/v1/assistant/conversations/{id}` | actor delete **+** history-row delete | composite — **implemented** (cut 3) |
 | `POST /api/v1/assistant/conversations/{id}/stream` | `...:stream` (AG-UI SSE) | unchanged |
 | `POST /api/v1/assistant/conversations/{id}/approve` | `...:approve` | unchanged |
+| `POST /api/v1/assistant/conversations/{id}/stop` | `...:stop` | **added** (cut 6) — 202-accepted stop fence |
 | `POST /api/v1/assistant/completions` | `v1/chat/completions` | unchanged |
 | `POST /api/v1/assistant/workflow-chat` | `api/chat` | unchanged; body forwarded verbatim (TD-2) |
 | `GET /api/v1/assistant/workflow-chat/ws` | `api/ws/chat` | unchanged (TD-2) |

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -170,11 +170,16 @@ ignored upstream) and the missing stop control. This cut adds the stop:
   Aevatar before the fence commits; (b) a cancel that lands before
   `RUN_STARTED` defers its abort (bounded `PRE_START_STOP_WINDOW_MS`) so
   the announcing frame can still deliver the `turnId` the stop needs.
+- **Backend (cut 6b):** the remaining conversation-control surfaces are now
+  pass-throughs too — `:steer`, `GET …/state` (cursors ride the forwarded
+  query string), and per-step `:retry`/`:skip` (turn/step path segments
+  validated with the conversation-id grammar). No UI consumers yet: steering
+  and step controls need task-frame rendering (the FE currently ignores
+  `nyxid.task.*` CUSTOM frames), and reconnect-via-state is a follow-up.
 - **Known remaining `feature/integrate` gaps (deliberate, recorded):**
-  `:steer`, per-step `:retry`/`:skip`, the conditional
-  `GET …/conversations/{id}/state` query, the `nyxid.task.*` /
-  `nyxid.action.request` CUSTOM frames (ignored by the FE), and the
-  NyxID-owned `GET /api/v1/assistant/actions` registry (schema v4) with the
+  FE rendering of the `nyxid.task.*` / `nyxid.action.request` CUSTOM frames,
+  FE consumers for steer/retry/skip/state, and the NyxID-owned
+  `GET /api/v1/assistant/actions` registry (schema v4) with the
   `action.continue` stream body. The registry is default-disabled on the
   Aevatar side (`Aevatar:NyxId:AssistantActions:Enabled=false`, fails closed
   `NYXID_ACTION_UNSUPPORTED`), so its absence is compatible until the
@@ -396,6 +401,10 @@ workflow/`/api/chat` chats persist?
 | `POST /api/v1/assistant/conversations/{id}/stream` | `...:stream` (AG-UI SSE) | unchanged |
 | `POST /api/v1/assistant/conversations/{id}/approve` | `...:approve` | unchanged |
 | `POST /api/v1/assistant/conversations/{id}/stop` | `...:stop` | **added** (cut 6) — 202-accepted stop fence |
+| `POST /api/v1/assistant/conversations/{id}/steer` | `...:steer` | **added** (cut 6) — steering control, no UI consumer yet |
+| `GET /api/v1/assistant/conversations/{id}/state` | `.../state` | **added** (cut 6) — conditional state query, cursors via query string |
+| `POST .../turns/{turn}/steps/{step}/retry` | `...:retry` | **added** (cut 6) — per-step retry, no UI consumer yet |
+| `POST .../turns/{turn}/steps/{step}/skip` | `...:skip` | **added** (cut 6) — per-step skip, no UI consumer yet |
 | `POST /api/v1/assistant/completions` | `v1/chat/completions` | unchanged |
 | `POST /api/v1/assistant/workflow-chat` | `api/chat` | unchanged; body forwarded verbatim (TD-2) |
 | `GET /api/v1/assistant/workflow-chat/ws` | `api/ws/chat` | unchanged (TD-2) |

--- a/docs/CHAT_SPEC.md
+++ b/docs/CHAT_SPEC.md
@@ -65,6 +65,7 @@ verified `AuthUser.user_id` — the browser cannot address another user's scope.
 | `DELETE /assistant/conversations/{id}` | actor delete **+** history-row delete | composite, 404-tolerant on each side |
 | `POST /assistant/conversations/{id}/stream` | `…/nyxid-chat/conversations/{id}:stream` | AG-UI SSE turn, streamed unbuffered |
 | `POST /assistant/conversations/{id}/approve` | `…:approve` | approval decision (SSE response) |
+| `POST /assistant/conversations/{id}/stop` | `…:stop` | stop control (`{turnId, stopRequestId, clientRequestId, expectedStateVersion}`, 202-accepted; Aevatar commits a stop fence). Fired best-effort by the frontend on cancel and on the stream watchdog |
 | `POST /assistant/completions` | `v1/chat/completions` | OpenAI-compatible (retained, unused by the UI) |
 | `POST /assistant/workflow-chat` | `api/chat` | ad-hoc workflow chat (retained, unused by the UI). Body forwarded verbatim, so Aevatar PR #2923's continuation contract falls on the **caller**: continuing a conversation now requires `conversation:{conversationId, minimumStateVersion>0}` (omit it and Aevatar answers `503 CHAT_HISTORY_RESERVATION_UNAVAILABLE`; unknown id answers `404 CONVERSATION_NOT_FOUND`), and the caller must stop splicing transcript into `prompt` — the backend injects server history itself |
 | `GET /assistant/workflow-chat/ws` | `api/ws/chat` | WS twin (retained, unused by the UI) |

--- a/docs/CHAT_SPEC.md
+++ b/docs/CHAT_SPEC.md
@@ -66,6 +66,10 @@ verified `AuthUser.user_id` — the browser cannot address another user's scope.
 | `POST /assistant/conversations/{id}/stream` | `…/nyxid-chat/conversations/{id}:stream` | AG-UI SSE turn, streamed unbuffered |
 | `POST /assistant/conversations/{id}/approve` | `…:approve` | approval decision (SSE response) |
 | `POST /assistant/conversations/{id}/stop` | `…:stop` | stop control (`{turnId, stopRequestId, clientRequestId, expectedStateVersion}`, 202-accepted; Aevatar commits a stop fence). Fired best-effort by the frontend on cancel and on the stream watchdog |
+| `POST /assistant/conversations/{id}/steer` | `…:steer` | steering control (`{turnId, steeringId, clientRequestId, instruction, inputParts?, expectedStateVersion}`, 202-accepted; server starts a continuation turn at a safe checkpoint). No UI consumer yet |
+| `GET /assistant/conversations/{id}/state` | `…/state` | conditional current-state query; `afterStateVersion`/`turnId` cursors ride the forwarded query string. The contract's reconnect surface; no UI consumer yet |
+| `POST /assistant/conversations/{id}/turns/{turn}/steps/{step}/retry` | `…/turns/{turn}/steps/{step}:retry` | per-step retry control (`{taskId, retryRequestId, clientRequestId, expectedOperationGeneration, expectedStateVersion}`). No UI consumer yet |
+| `POST /assistant/conversations/{id}/turns/{turn}/steps/{step}/skip` | `…:skip` | per-step skip control, same body shape with `skipRequestId`. No UI consumer yet |
 | `POST /assistant/completions` | `v1/chat/completions` | OpenAI-compatible (retained, unused by the UI) |
 | `POST /assistant/workflow-chat` | `api/chat` | ad-hoc workflow chat (retained, unused by the UI). Body forwarded verbatim, so Aevatar PR #2923's continuation contract falls on the **caller**: continuing a conversation now requires `conversation:{conversationId, minimumStateVersion>0}` (omit it and Aevatar answers `503 CHAT_HISTORY_RESERVATION_UNAVAILABLE`; unknown id answers `404 CONVERSATION_NOT_FOUND`), and the caller must stop splicing transcript into `prompt` — the backend injects server history itself |
 | `GET /assistant/workflow-chat/ws` | `api/ws/chat` | WS twin (retained, unused by the UI) |

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -946,6 +946,106 @@ describe("AevatarAssistantTransport", () => {
     expect(streamCalls).toBe(2);
   }, 15_000);
 
+  it("keeps the earlier stop fence when a queued follow-up is cancelled", async () => {
+    // Regression (codex round 4): cancelling a follow-up that is still
+    // QUEUED behind an earlier turn's stop must not install a pre-start
+    // placeholder — that would overwrite the earlier fence and let a third
+    // send overtake the still-pending stop. A never-dispatched run cancels
+    // purely locally.
+    const encoder = new TextEncoder();
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    let releaseStop: (() => void) | undefined;
+    let stopCalls = 0;
+    let streamCalls = 0;
+    const streamBodies: string[] = [];
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          stopCalls += 1;
+          return new Promise<Response>((resolve) => {
+            releaseStop = () =>
+              resolve(jsonResponse({ status: "accepted" }, 202));
+          });
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          streamCalls += 1;
+          streamBodies.push(String(init?.body));
+          return Promise.resolve(
+            streamCalls === 1
+              ? new Response(firstStream, {
+                  status: 200,
+                  headers: { "Content-Type": "text/event-stream" },
+                })
+              : sseResponse(OBSERVED_FRAMES),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    // Turn A: streams, gets its turnId, cancelled → stop A held pending.
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(CONVERSATION_ID, "Turn A", (e) => {
+        if (e.event === "turn.completed") resolve();
+        if (e.event === "block.delta") handle.cancel();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(stopCalls).toBe(1);
+    expect(releaseStop).toBeDefined();
+
+    // Turn B: queued behind stop A (its fetch never dispatches), then
+    // cancelled. Must not touch the fence.
+    const handleB = transport.sendMessage(CONVERSATION_ID, "Turn B", () => {});
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(streamCalls).toBe(1);
+    handleB.cancel();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Turn C: must still be fenced by stop A.
+    const completedC = new Promise<void>((resolve) => {
+      transport.sendMessage(CONVERSATION_ID, "Turn C", (e) => {
+        if (e.event === "turn.completed") resolve();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(streamCalls).toBe(1);
+
+    releaseStop?.();
+    await completedC;
+    // B never dispatched; C is the second and only other stream, sent
+    // after the fence lifted.
+    expect(streamCalls).toBe(2);
+    expect(streamBodies[1]).toContain("Turn C");
+    expect(stopCalls).toBe(1);
+  });
+
   it("serializes a follow-up send behind the in-flight stop", async () => {
     // The stop fence must commit upstream before the next :stream goes out;
     // otherwise the follow-up can arrive first and fail with

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -628,6 +628,165 @@ describe("AevatarAssistantTransport", () => {
     ]);
   });
 
+  it("fires a best-effort server-side stop carrying the turn identity on cancel", async () => {
+    const openStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    const stopBodies: Array<Record<string, unknown>> = [];
+    let streamClientRequestId: string | undefined;
+    stubFetch(
+      routeCreate,
+      (url, init) => {
+        if (
+          url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/stop` &&
+          init?.method === "POST"
+        ) {
+          stopBodies.push(
+            JSON.parse(String(init.body)) as Record<string, unknown>,
+          );
+          return jsonResponse({ status: "accepted" }, 202);
+        }
+        return undefined;
+      },
+      (url, init) => {
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          streamClientRequestId = (
+            JSON.parse(String(init.body)) as { clientRequestId: string }
+          ).clientRequestId;
+          return new Response(openStream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        }
+        return undefined;
+      },
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(
+        CONVERSATION_ID,
+        "Hello",
+        (event) => {
+          if (event.event === "turn.completed") resolve();
+          if (event.event === "block.delta") handle.cancel();
+        },
+      );
+    });
+    // The stop POST is fire-and-forget; give its microtask a beat to land.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(stopBodies).toHaveLength(1);
+    const stop = stopBodies[0];
+    expect(stop?.turnId).toBe(TURN_ID);
+    expect(stop?.expectedStateVersion).toBe(0);
+    // Fresh control identities: neither reuses the turn's clientRequestId.
+    expect(stop?.stopRequestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(stop?.clientRequestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(stop?.stopRequestId).not.toBe(stop?.clientRequestId);
+    expect(stop?.clientRequestId).not.toBe(streamClientRequestId);
+  });
+
+  it("sends no server-side stop when cancel lands before RUN_STARTED", async () => {
+    // A stream that never announces the turn: there is no committed turn
+    // identity to address, so cancel must stay a pure client-side abort.
+    const silentStream = new ReadableStream<Uint8Array>({ start() {} });
+    const fetchMock = stubFetch(routeCreate, (url, init) =>
+      url.endsWith("/stream") && init?.method === "POST"
+        ? new Response(silentStream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          })
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(
+        CONVERSATION_ID,
+        "Hello",
+        (event) => {
+          if (event.event === "turn.completed") resolve();
+        },
+      );
+      setTimeout(() => handle.cancel(), 0);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const stopCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).endsWith("/stop"),
+    );
+    expect(stopCalls).toHaveLength(0);
+  });
+
+  it("keeps the local cancel settled when the server-side stop fails", async () => {
+    const openStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    stubFetch(
+      routeCreate,
+      (url, init) =>
+        url.endsWith("/stop") && init?.method === "POST"
+          ? jsonResponse(
+              { error: "internal", error_code: 1006, message: "boom" },
+              500,
+            )
+          : undefined,
+      (url, init) =>
+        url.endsWith("/stream") && init?.method === "POST"
+          ? new Response(openStream, {
+              status: 200,
+              headers: { "Content-Type": "text/event-stream" },
+            })
+          : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events: TurnEvent[] = [];
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(
+        CONVERSATION_ID,
+        "Hello",
+        (event) => {
+          events.push(event);
+          if (event.event === "turn.completed") resolve();
+          if (event.event === "block.delta") handle.cancel();
+        },
+      );
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const terminal = events[events.length - 1];
+    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
+      "cancelled",
+    );
+  });
+
   it("throws when deciding an approval for an unknown block", async () => {
     stubFetch(routeHistory([]));
     const transport = new AevatarAssistantTransport();

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1294,6 +1294,53 @@ describe("AevatarAssistantTransport", () => {
     }
   });
 
+  it("normalizes numeric index timestamps so multi-row lists sort and sends work", async () => {
+    // Live-stack repro: the chat-history index carries epoch-ms NUMBERS;
+    // with 2+ conversations the sidebar sort called localeCompare on a
+    // number and every send died with "Message not sent". (A one-row list
+    // never invokes the comparator, which is why single-conversation
+    // smoke tests missed it.)
+    stubFetch(
+      routeCreate,
+      (url, init) =>
+        url === `${ASSISTANT_BASE}/conversations` &&
+        (init?.method ?? "GET") === "GET"
+          ? jsonResponse({
+              conversations: [
+                {
+                  id: "conv-old",
+                  title: "Older chat",
+                  createdAt: 1784192889074,
+                  updatedAt: 1784192899074,
+                  messageCount: 2,
+                },
+                {
+                  id: "conv-new",
+                  title: "Newer chat",
+                  createdAt: 1784192989074,
+                  updatedAt: 1784192999074,
+                  messageCount: 4,
+                },
+              ],
+            })
+          : undefined,
+      routeStream(OBSERVED_FRAMES),
+    );
+    const transport = new AevatarAssistantTransport();
+
+    const list = await transport.listConversations();
+    expect(list.map((c) => c.id)).toEqual(["conv-new", "conv-old"]);
+    for (const conversation of list) {
+      expect(typeof conversation.last_message_at).toBe("string");
+      expect(typeof conversation.created_at).toBe("string");
+    }
+
+    // A send with multiple rows in the mirror must still complete.
+    await transport.createConversation();
+    const events = await collectTurn(transport, "Does sending still work?");
+    expect(events[events.length - 1]?.event).toBe("turn.completed");
+  });
+
   it("coalesces concurrent deletes onto one in-flight operation", async () => {
     // Regression (codex round 6): a Set-style reservation let an
     // overlapping delete clear the flag while the other DELETE was still

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1046,6 +1046,196 @@ describe("AevatarAssistantTransport", () => {
     expect(stopCalls).toBe(1);
   });
 
+  it("rejects sends while a delete is waiting on the stop fence", async () => {
+    // Regression (codex round 5): deleteConversation removed the run
+    // synchronously, so a successor send admitted during its fence wait
+    // could dispatch a stream before the DELETE and recreate the actor.
+    const encoder = new TextEncoder();
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    let releaseStop: (() => void) | undefined;
+    let deleteCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          return new Promise<Response>((resolve) => {
+            releaseStop = () =>
+              resolve(jsonResponse({ status: "accepted" }, 202));
+          });
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          return Promise.resolve(
+            new Response(firstStream, {
+              status: 200,
+              headers: { "Content-Type": "text/event-stream" },
+            }),
+          );
+        }
+        if (init?.method === "DELETE") {
+          deleteCalls += 1;
+          return Promise.resolve(jsonResponse({}));
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(CONVERSATION_ID, "Turn A", (e) => {
+        if (e.event === "turn.completed") resolve();
+        if (e.event === "block.delta") handle.cancel();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(releaseStop).toBeDefined();
+
+    const deleting = transport.deleteConversation(CONVERSATION_ID);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(deleteCalls).toBe(0); // still fenced behind the held stop
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "Sneaky send", () => {}),
+    ).toThrow("This conversation is being deleted.");
+
+    releaseStop?.();
+    await deleting;
+    expect(deleteCalls).toBe(1);
+    // After success the tombstone takes over.
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "After delete", () => {}),
+    ).toThrow("Conversation was not found.");
+  });
+
+  it("holds an approval decision behind the in-flight stop fence", async () => {
+    // Regression (codex round 5): decideApproval dispatched /approve
+    // without awaiting the conversation's pending stop, so the approval
+    // continuation could overtake a cancelled turn's fence upstream.
+    const encoder = new TextEncoder();
+    const secondStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify({ type: "RUN_STARTED", turnId: "turn-2", actorId: CONVERSATION_ID })}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    let releaseStop: (() => void) | undefined;
+    let approveCalls = 0;
+    let streamCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          return new Promise<Response>((resolve) => {
+            releaseStop = () =>
+              resolve(jsonResponse({ status: "accepted" }, 202));
+          });
+        }
+        if (url.endsWith("/approve") && init?.method === "POST") {
+          approveCalls += 1;
+          return Promise.resolve(sseResponse(OBSERVED_FRAMES));
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          streamCalls += 1;
+          return Promise.resolve(
+            streamCalls === 1
+              ? sseResponse([
+                  { type: "RUN_STARTED", turnId: TURN_ID },
+                  {
+                    type: "TOOL_APPROVAL_REQUEST",
+                    toolApprovalRequest: {
+                      requestId: "req-fence",
+                      toolName: "lark_post",
+                      message: "Post the digest.",
+                    },
+                  },
+                ])
+              : new Response(secondStream, {
+                  status: 200,
+                  headers: { "Content-Type": "text/event-stream" },
+                }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    // Turn 1 parks an actionable approval card at EOF.
+    const turn1 = await collectTurn(transport, "Post the digest");
+    const card = turn1.find(
+      (event) =>
+        event.event === "block.started" &&
+        event.block.type === "approval_card",
+    );
+    if (!card || card.event !== "block.started") {
+      throw new Error("approval card never appeared");
+    }
+
+    // Turn 2 streams, gets cancelled mid-delta -> stop held pending.
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(CONVERSATION_ID, "Turn 2", (e) => {
+        if (e.event === "turn.completed") resolve();
+        if (e.event === "block.delta") handle.cancel();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(releaseStop).toBeDefined();
+
+    // Deciding the old card must wait for turn 2's stop fence.
+    const deciding = transport.decideApproval(
+      CONVERSATION_ID,
+      card.block.block_id,
+      true,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(approveCalls).toBe(0);
+
+    releaseStop?.();
+    await deciding;
+    expect(approveCalls).toBe(1);
+  });
+
   it("serializes a follow-up send behind the in-flight stop", async () => {
     // The stop fence must commit upstream before the next :stream goes out;
     // otherwise the follow-up can arrive first and fail with

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -699,9 +699,11 @@ describe("AevatarAssistantTransport", () => {
     expect(stop?.clientRequestId).not.toBe(streamClientRequestId);
   });
 
-  it("sends no server-side stop when cancel lands before RUN_STARTED", async () => {
-    // A stream that never announces the turn: there is no committed turn
-    // identity to address, so cancel must stay a pure client-side abort.
+  it("sends no server-side stop when the turn is never announced", async () => {
+    // A stream that never sends RUN_STARTED: there is never a turn identity
+    // to address, so no stop can go out. (The reader lingers briefly after
+    // the local settle — PRE_START_STOP_WINDOW_MS — in case the announcing
+    // frame is still in flight; see the next test for that path.)
     const silentStream = new ReadableStream<Uint8Array>({ start() {} });
     const fetchMock = stubFetch(routeCreate, (url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
@@ -730,6 +732,152 @@ describe("AevatarAssistantTransport", () => {
       String(input).endsWith("/stop"),
     );
     expect(stopCalls).toHaveLength(0);
+  });
+
+  it("delivers the deferred stop once RUN_STARTED names the turn after a pre-start cancel", async () => {
+    // Aevatar may have accepted the stream even though RUN_STARTED has not
+    // reached the browser yet. Cancel must not discard the only chance to
+    // learn the turnId: the reader stays alive, and the late RUN_STARTED
+    // triggers the stop before the connection drops.
+    let streamController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    const lateStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    const stopBodies: Array<Record<string, unknown>> = [];
+    stubFetch(
+      routeCreate,
+      (url, init) => {
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          stopBodies.push(
+            JSON.parse(String(init.body)) as Record<string, unknown>,
+          );
+          return jsonResponse({ status: "accepted" }, 202);
+        }
+        return undefined;
+      },
+      (url, init) =>
+        url.endsWith("/stream") && init?.method === "POST"
+          ? new Response(lateStream, {
+              status: 200,
+              headers: { "Content-Type": "text/event-stream" },
+            })
+          : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const events: TurnEvent[] = [];
+    const handle = transport.sendMessage(CONVERSATION_ID, "Hello", (event) =>
+      events.push(event),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    handle.cancel();
+
+    // The local turn settles immediately; no stop yet (no turnId).
+    expect(events[events.length - 1]?.event).toBe("turn.completed");
+    expect(stopBodies).toHaveLength(0);
+
+    if (!streamController) throw new Error("stream never started");
+    streamController.enqueue(
+      new TextEncoder().encode(
+        `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(stopBodies).toHaveLength(1);
+    expect(stopBodies[0]?.turnId).toBe(TURN_ID);
+    expect(stopBodies[0]?.expectedStateVersion).toBe(0);
+  });
+
+  it("serializes a follow-up send behind the in-flight stop", async () => {
+    // The stop fence must commit upstream before the next :stream goes out;
+    // otherwise the follow-up can arrive first and fail with
+    // ACTIVE_TURN_REQUIRES_STEERING. Hold the stop 202 pending and assert
+    // the second send waits for it.
+    const encoder = new TextEncoder();
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    let releaseStop: (() => void) | undefined;
+    let streamCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          return new Promise<Response>((resolve) => {
+            releaseStop = () =>
+              resolve(jsonResponse({ status: "accepted" }, 202));
+          });
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          streamCalls += 1;
+          return Promise.resolve(
+            streamCalls === 1
+              ? new Response(firstStream, {
+                  status: 200,
+                  headers: { "Content-Type": "text/event-stream" },
+                })
+              : sseResponse(OBSERVED_FRAMES),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    await new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(
+        CONVERSATION_ID,
+        "First turn",
+        (event) => {
+          if (event.event === "turn.completed") resolve();
+          if (event.event === "block.delta") handle.cancel();
+        },
+      );
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(releaseStop).toBeDefined();
+    expect(streamCalls).toBe(1);
+
+    // Follow-up send: must NOT reach /stream while the stop is pending.
+    const followUp = new Promise<void>((resolve) => {
+      transport.sendMessage(CONVERSATION_ID, "Second turn", (event) => {
+        if (event.event === "turn.completed") resolve();
+      });
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(streamCalls).toBe(1);
+
+    releaseStop?.();
+    await followUp;
+    expect(streamCalls).toBe(2);
   });
 
   it("keeps the local cancel settled when the server-side stop fails", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1129,6 +1129,56 @@ describe("AevatarAssistantTransport", () => {
     ).toThrow("Conversation was not found.");
   });
 
+  it("coalesces concurrent deletes onto one in-flight operation", async () => {
+    // Regression (codex round 6): a Set-style reservation let an
+    // overlapping delete clear the flag while the other DELETE was still
+    // in flight, re-admitting sends. Concurrent deletes must share one
+    // operation — one DELETE on the wire, both callers settle together.
+    let releaseDelete: (() => void) | undefined;
+    let deleteCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (init?.method === "DELETE") {
+          deleteCalls += 1;
+          return new Promise<Response>((resolve) => {
+            releaseDelete = () => resolve(jsonResponse({}));
+          });
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const first = transport.deleteConversation(CONVERSATION_ID);
+    const second = transport.deleteConversation(CONVERSATION_ID);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(deleteCalls).toBe(1);
+    // While the shared delete is in flight, sends stay rejected.
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "Sneaky send", () => {}),
+    ).toThrow("This conversation is being deleted.");
+
+    releaseDelete?.();
+    await Promise.all([first, second]);
+    expect(deleteCalls).toBe(1);
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "After delete", () => {}),
+    ).toThrow("Conversation was not found.");
+  });
+
   it("holds an approval decision behind the in-flight stop fence", async () => {
     // Regression (codex round 5): decideApproval dispatched /approve
     // without awaiting the conversation's pending stop, so the approval

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -870,6 +870,82 @@ describe("AevatarAssistantTransport", () => {
     expect(streamCalls).toBe(2);
   });
 
+  it("holds the pre-start fence beyond two seconds (full pre-start window)", async () => {
+    // Regression (codex round 3): an outer 2s race on awaitPendingStop
+    // abandoned the fence before the 5s pre-start window elapsed, letting
+    // a follow-up overtake a RUN_STARTED that arrived between seconds 2
+    // and 5. The fence must hold for the placeholder's full lifetime.
+    let streamController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    const lateStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    let stopCalls = 0;
+    let streamCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          stopCalls += 1;
+          return Promise.resolve(jsonResponse({ status: "accepted" }, 202));
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          streamCalls += 1;
+          return Promise.resolve(
+            streamCalls === 1
+              ? new Response(lateStream, {
+                  status: 200,
+                  headers: { "Content-Type": "text/event-stream" },
+                })
+              : sseResponse(OBSERVED_FRAMES),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const handle = transport.sendMessage(CONVERSATION_ID, "First", () => {});
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    handle.cancel(); // pre-start cancel installs the fence
+
+    const followUp = new Promise<void>((resolve) => {
+      transport.sendMessage(CONVERSATION_ID, "Second", (event) => {
+        if (event.event === "turn.completed") resolve();
+      });
+    });
+    // Past the old 2s cliff: the fence must still be holding.
+    await new Promise((resolve) => setTimeout(resolve, 2_300));
+    expect(streamCalls).toBe(1);
+
+    // RUN_STARTED at ~2.4s (inside the 5s window): stop fires, fence
+    // lifts, follow-up proceeds.
+    if (!streamController) throw new Error("stream never started");
+    streamController.enqueue(
+      new TextEncoder().encode(
+        `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+      ),
+    );
+    await followUp;
+    expect(stopCalls).toBe(1);
+    expect(streamCalls).toBe(2);
+  }, 15_000);
+
   it("serializes a follow-up send behind the in-flight stop", async () => {
     // The stop fence must commit upstream before the next :stream goes out;
     // otherwise the follow-up can arrive first and fail with

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -794,6 +794,82 @@ describe("AevatarAssistantTransport", () => {
     expect(stopBodies[0]?.expectedStateVersion).toBe(0);
   });
 
+  it("fences a follow-up send behind a pre-start cancel until the deferred stop settles", async () => {
+    // The stop request cannot exist until RUN_STARTED names the turn, but a
+    // follow-up send right after a pre-start cancel must already serialize
+    // behind the eventual stop — otherwise it can overtake the fence.
+    let streamController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    const lateStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    let stopCalls = 0;
+    let streamCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          stopCalls += 1;
+          return Promise.resolve(jsonResponse({ status: "accepted" }, 202));
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          streamCalls += 1;
+          return Promise.resolve(
+            streamCalls === 1
+              ? new Response(lateStream, {
+                  status: 200,
+                  headers: { "Content-Type": "text/event-stream" },
+                })
+              : sseResponse(OBSERVED_FRAMES),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const handle = transport.sendMessage(CONVERSATION_ID, "First", () => {});
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    handle.cancel(); // pre-start: no RUN_STARTED yet
+
+    const followUp = new Promise<void>((resolve) => {
+      transport.sendMessage(CONVERSATION_ID, "Second", (event) => {
+        if (event.event === "turn.completed") resolve();
+      });
+    });
+    // The fence holds while the first stream has not announced its turn.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(streamCalls).toBe(1);
+    expect(stopCalls).toBe(0);
+
+    // RUN_STARTED arrives: the deferred stop fires, the fence lifts, and
+    // only then does the follow-up stream go out.
+    if (!streamController) throw new Error("stream never started");
+    streamController.enqueue(
+      new TextEncoder().encode(
+        `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+      ),
+    );
+    await followUp;
+    expect(stopCalls).toBe(1);
+    expect(streamCalls).toBe(2);
+  });
+
   it("serializes a follow-up send behind the in-flight stop", async () => {
     // The stop fence must commit upstream before the next :stream goes out;
     // otherwise the follow-up can arrive first and fail with

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1129,6 +1129,146 @@ describe("AevatarAssistantTransport", () => {
     ).toThrow("Conversation was not found.");
   });
 
+  it("guards against re-entrant sends and deletes from the cancellation callback", async () => {
+    // Regression (codex round 7): the delete body ran synchronously before
+    // the reservation was installed, so the cancel's synchronous
+    // `turn.completed` callback could re-enter the transport and slip a
+    // send (or a second DELETE) past both guards.
+    const encoder = new TextEncoder();
+    const openStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(OBSERVED_FRAMES[0])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[1])}\n\n`,
+              `data: ${JSON.stringify(OBSERVED_FRAMES[2])}\n\n`,
+            ].join(""),
+          ),
+        );
+      },
+    });
+    let deleteCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (url.endsWith("/stop") && init?.method === "POST") {
+          return Promise.resolve(jsonResponse({ status: "accepted" }, 202));
+        }
+        if (url.endsWith("/stream") && init?.method === "POST") {
+          return Promise.resolve(
+            new Response(openStream, {
+              status: 200,
+              headers: { "Content-Type": "text/event-stream" },
+            }),
+          );
+        }
+        if (init?.method === "DELETE") {
+          deleteCalls += 1;
+          return Promise.resolve(jsonResponse({}));
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    let deleteStarted = false;
+    let reentrantSendError: string | null = null;
+    let reentrantDeleteRan = false;
+    const streaming = new Promise<void>((resolve) => {
+      transport.sendMessage(CONVERSATION_ID, "Turn A", (event) => {
+        if (event.event === "block.delta") resolve();
+        if (event.event === "turn.completed" && deleteStarted) {
+          // Synchronous re-entry from the cancellation callback.
+          try {
+            transport.sendMessage(CONVERSATION_ID, "reentrant", () => {});
+          } catch (error) {
+            reentrantSendError =
+              error instanceof Error ? error.message : String(error);
+          }
+          void transport.deleteConversation(CONVERSATION_ID);
+          reentrantDeleteRan = true;
+        }
+      });
+    });
+    await streaming;
+
+    deleteStarted = true;
+    await transport.deleteConversation(CONVERSATION_ID);
+
+    expect(reentrantDeleteRan).toBe(true);
+    expect(reentrantSendError).toBe("This conversation is being deleted.");
+    // The re-entrant delete coalesced: exactly one DELETE on the wire.
+    expect(deleteCalls).toBe(1);
+  });
+
+  it("rejects both delete callers when the DELETE dies, and stays retryable", async () => {
+    // Regression (codex round 7): the delete carried no deadline, so an
+    // accepted-but-unanswered DELETE pinned the reservation forever and
+    // locked the conversation. The request now aborts on its own deadline;
+    // this simulates the abort outcome and verifies recovery.
+    let deleteCalls = 0;
+    const mock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
+          return Promise.resolve(
+            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+          );
+        }
+        if (init?.method === "DELETE") {
+          deleteCalls += 1;
+          if (deleteCalls === 1) {
+            return new Promise<Response>((_, reject) => {
+              setTimeout(
+                () => reject(new DOMException("aborted", "AbortError")),
+                50,
+              );
+            });
+          }
+          return Promise.resolve(jsonResponse({}));
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", mock);
+    const transport = new AevatarAssistantTransport();
+    await transport.createConversation();
+
+    const first = transport.deleteConversation(CONVERSATION_ID);
+    const second = transport.deleteConversation(CONVERSATION_ID);
+    await expect(first).rejects.toBeTruthy();
+    await expect(second).rejects.toBeTruthy();
+
+    // Not tombstoned, reservation lifted: the conversation is retryable.
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "still here", () => {}),
+    ).not.toThrow("This conversation is being deleted.");
+    transport.cancelActiveTurn(CONVERSATION_ID);
+    await transport.deleteConversation(CONVERSATION_ID);
+    expect(deleteCalls).toBe(2);
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "after delete", () => {}),
+    ).toThrow("Conversation was not found.");
+  });
+
   it("coalesces concurrent deletes onto one in-flight operation", async () => {
     // Regression (codex round 6): a Set-style reservation let an
     // overlapping delete clear the flag while the other DELETE was still

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1214,59 +1214,84 @@ describe("AevatarAssistantTransport", () => {
     expect(deleteCalls).toBe(1);
   });
 
-  it("rejects both delete callers when the DELETE dies, and stays retryable", async () => {
-    // Regression (codex round 7): the delete carried no deadline, so an
+  it("aborts a hung DELETE at its own deadline and stays retryable", async () => {
+    // Regression (codex rounds 7-8): the delete carried no deadline, so an
     // accepted-but-unanswered DELETE pinned the reservation forever and
-    // locked the conversation. The request now aborts on its own deadline;
-    // this simulates the abort outcome and verifies recovery.
-    let deleteCalls = 0;
-    const mock = vi.fn(
-      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = String(input);
-        if (url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST") {
-          return Promise.resolve(
-            jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
-          );
-        }
-        if (init?.method === "DELETE") {
-          deleteCalls += 1;
-          if (deleteCalls === 1) {
-            return new Promise<Response>((_, reject) => {
-              setTimeout(
-                () => reject(new DOMException("aborted", "AbortError")),
-                50,
-              );
-            });
+    // locked the conversation. Signal-driven: the mock only rejects when
+    // the request's OWN AbortSignal fires, so this fails if the deadline
+    // controller, timer, or signal pass-through is ever removed.
+    vi.useFakeTimers();
+    try {
+      let deleteCalls = 0;
+      const mock = vi.fn(
+        (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+          const url = String(input);
+          if (
+            url === `${ASSISTANT_BASE}/conversations` &&
+            init?.method === "POST"
+          ) {
+            return Promise.resolve(
+              jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
+            );
           }
-          return Promise.resolve(jsonResponse({}));
-        }
-        return Promise.resolve(
-          jsonResponse(
-            { error: "not_found", error_code: -1, message: "404" },
-            404,
-          ),
+          if (init?.method === "DELETE") {
+            deleteCalls += 1;
+            if (deleteCalls === 1) {
+              return new Promise<Response>((_, reject) => {
+                init.signal?.addEventListener("abort", () =>
+                  reject(new DOMException("aborted", "AbortError")),
+                );
+              });
+            }
+            return Promise.resolve(jsonResponse({}));
+          }
+          return Promise.resolve(
+            jsonResponse(
+              { error: "not_found", error_code: -1, message: "404" },
+              404,
+            ),
+          );
+        },
+      );
+      vi.stubGlobal("fetch", mock);
+      const transport = new AevatarAssistantTransport();
+      await transport.createConversation();
+
+      const firstOutcome = transport
+        .deleteConversation(CONVERSATION_ID)
+        .then(
+          () => "resolved",
+          () => "rejected",
         );
-      },
-    );
-    vi.stubGlobal("fetch", mock);
-    const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+      const secondOutcome = transport
+        .deleteConversation(CONVERSATION_ID)
+        .then(
+          () => "resolved",
+          () => "rejected",
+        );
 
-    const first = transport.deleteConversation(CONVERSATION_ID);
-    const second = transport.deleteConversation(CONVERSATION_ID);
-    await expect(first).rejects.toBeTruthy();
-    await expect(second).rejects.toBeTruthy();
+      // Just before the deadline: still one DELETE, still reserved.
+      await vi.advanceTimersByTimeAsync(14_000);
+      expect(deleteCalls).toBe(1);
+      expect(() =>
+        transport.sendMessage(CONVERSATION_ID, "too early", () => {}),
+      ).toThrow("This conversation is being deleted.");
 
-    // Not tombstoned, reservation lifted: the conversation is retryable.
-    expect(() =>
-      transport.sendMessage(CONVERSATION_ID, "still here", () => {}),
-    ).not.toThrow("This conversation is being deleted.");
-    transport.cancelActiveTurn(CONVERSATION_ID);
-    await transport.deleteConversation(CONVERSATION_ID);
-    expect(deleteCalls).toBe(2);
-    expect(() =>
-      transport.sendMessage(CONVERSATION_ID, "after delete", () => {}),
-    ).toThrow("Conversation was not found.");
+      // Crossing the deadline aborts the request; both coalesced callers
+      // reject and the reservation lifts.
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(await firstOutcome).toBe("rejected");
+      expect(await secondOutcome).toBe("rejected");
+
+      // Not tombstoned: the retry delete goes through.
+      await transport.deleteConversation(CONVERSATION_ID);
+      expect(deleteCalls).toBe(2);
+      expect(() =>
+        transport.sendMessage(CONVERSATION_ID, "after delete", () => {}),
+      ).toThrow("Conversation was not found.");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("coalesces concurrent deletes onto one in-flight operation", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -91,6 +91,11 @@ const PRE_START_STOP_WINDOW_MS = 5_000;
 // entry forever and tax every later send/delete with the full fence wait.
 const STOP_REQUEST_DEADLINE_MS = 10_000;
 
+// Hard deadline on the composite DELETE. The deletion reservation rejects
+// sends and approvals while it holds, so an unanswered DELETE without a
+// bound would lock the conversation permanently.
+const DELETE_REQUEST_DEADLINE_MS = 15_000;
+
 // Inline media larger than this (base64 chars ≈ 6 MB decoded) is summarized
 // as text instead of being embedded as a data: URL artifact.
 const MAX_MEDIA_DATA_CHARS = 8_000_000;
@@ -835,28 +840,51 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // failure would clear it while the other DELETE is still in flight).
     const inFlight = this.deletingConversations.get(conversationId);
     if (inFlight) return inFlight;
-    const operation = (async () => {
+    // The body is DEFERRED to a microtask so the reservation is installed
+    // before any callback-capable work runs: cancelTurn emits
+    // `turn.completed` synchronously, and a re-entrant callback must
+    // already see the deletion guard — otherwise it can admit a send (or
+    // a second delete) into the exact window the reservation closes.
+    const operation = Promise.resolve().then(async () => {
       const run = this.running.get(conversationId);
       if (run) this.cancelTurn(conversationId, run);
       // The cancel above may have fired a `:stop`; let its fence commit
       // before the actor delete races the still-active work upstream.
       await this.awaitPendingStop(conversationId);
-      await assistantApi.del(
-        `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
+      // Own deadline: the reservation rejects sends while it holds, so an
+      // accepted-but-never-answered DELETE must not lock the conversation.
+      const deadline = new AbortController();
+      const deadlineTimer = setTimeout(
+        () => deadline.abort(),
+        DELETE_REQUEST_DEADLINE_MS,
       );
+      try {
+        await apiClient<unknown>(
+          `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
+          {
+            method: "DELETE",
+            preserveSessionOn401: true,
+            signal: deadline.signal,
+          },
+        );
+      } finally {
+        clearTimeout(deadlineTimer);
+      }
       // Local removal only after the server accepted: a failed delete keeps
       // the conversation listed and retryable.
       this.conversations.delete(conversationId);
       this.deletedConversationIds.add(conversationId);
-    })();
+    });
     this.deletingConversations.set(conversationId, operation);
     try {
       await operation;
     } finally {
       // On success the tombstone takes over; on failure the conversation
-      // becomes usable (and retryable) again. Only this owner clears the
-      // reservation — coalesced callers returned the shared promise above.
-      this.deletingConversations.delete(conversationId);
+      // becomes usable (and retryable) again. Identity-checked: only the
+      // entry this owner installed is cleared.
+      if (this.deletingConversations.get(conversationId) === operation) {
+        this.deletingConversations.delete(conversationId);
+      }
     }
   }
 

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -237,11 +237,31 @@ interface RoleChatCompletion {
 interface AevatarHistoryIndexEntry {
   readonly id?: string;
   readonly title?: string;
-  readonly createdAt?: string;
-  readonly updatedAt?: string;
+  /** Observed as both ISO strings and epoch-ms numbers upstream. */
+  readonly createdAt?: string | number;
+  readonly updatedAt?: string | number;
   readonly messageCount?: number;
   readonly llmRoute?: string | null;
   readonly llmModel?: string | null;
+}
+
+/**
+ * Normalize an index timestamp to an ISO string. The chat-history index
+ * has been observed sending epoch-ms numbers (message timestamps in the
+ * same API are epoch ms too); a number leaking into
+ * `Conversation.last_message_at` crashes the sidebar sort's
+ * `localeCompare` — which only fires once the list has 2+ rows, so a
+ * single-conversation smoke test never sees it.
+ */
+function indexTimestampToIso(
+  value: string | number | undefined,
+  fallback: string,
+): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (typeof value === "string" && value) return value;
+  return fallback;
 }
 
 interface AevatarConversationListResponse {
@@ -798,7 +818,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
     return [...this.conversations.values()]
       .map((stored) => stored.conversation)
-      .sort((a, b) => b.last_message_at.localeCompare(a.last_message_at));
+      .sort((a, b) =>
+        // Timestamps are normalized to ISO strings at the index boundary;
+        // String() keeps a stray non-string from crashing the whole list
+        // (ISO strings order identically either way).
+        String(b.last_message_at).localeCompare(String(a.last_message_at)),
+      );
   }
 
   async createConversation(): Promise<Conversation> {
@@ -1211,13 +1236,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
       return;
     }
     const epoch0 = new Date(0).toISOString();
-    const createdAt =
-      entry.createdAt ?? existing?.conversation.created_at ?? epoch0;
-    const lastMessageAt =
-      entry.updatedAt ??
-      entry.createdAt ??
-      existing?.conversation.last_message_at ??
-      createdAt;
+    const createdAt = indexTimestampToIso(
+      entry.createdAt,
+      existing?.conversation.created_at ?? epoch0,
+    );
+    const lastMessageAt = indexTimestampToIso(
+      entry.updatedAt ?? entry.createdAt,
+      existing?.conversation.last_message_at ?? createdAt,
+    );
     const title =
       entry.title?.trim() || existing?.conversation.title || "Conversation";
     const conversation: Conversation = {

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -764,6 +764,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * retire and resurrects the conversation.
    */
   private readonly deletedConversationIds = new Set<string>();
+  /**
+   * Deletion-in-progress reservation: set before the delete's cancel and
+   * fence wait, cleared when the delete settles (the tombstone takes over
+   * on success). Sends and approvals are rejected while present —
+   * otherwise a successor turn admitted during the fence wait can
+   * dispatch its stream before the DELETE and recreate the actor the
+   * user asked to remove.
+   */
+  private readonly deletingConversationIds = new Set<string>();
   private listFetchedAt = 0;
 
   async listConversations(): Promise<Conversation[]> {
@@ -815,18 +824,30 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // reference client's abort-then-delete order. The server side is the
     // #1199 composite delete (actor + history row, 404-tolerant), so one
     // call retires both upstream surfaces.
-    const run = this.running.get(conversationId);
-    if (run) this.cancelTurn(conversationId, run);
-    // The cancel above may have fired a `:stop`; let its fence commit before
-    // the actor delete races the still-active work upstream.
-    await this.awaitPendingStop(conversationId);
-    await assistantApi.del(
-      `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
-    );
-    // Local removal only after the server accepted: a failed delete keeps
-    // the conversation listed and retryable.
-    this.conversations.delete(conversationId);
-    this.deletedConversationIds.add(conversationId);
+    //
+    // Reserve the conversation for the whole delete: the cancel below emits
+    // the terminal synchronously, so without the reservation a successor
+    // send admitted during the fence wait could dispatch its stream before
+    // the DELETE and recreate the actor the user asked to remove.
+    this.deletingConversationIds.add(conversationId);
+    try {
+      const run = this.running.get(conversationId);
+      if (run) this.cancelTurn(conversationId, run);
+      // The cancel above may have fired a `:stop`; let its fence commit
+      // before the actor delete races the still-active work upstream.
+      await this.awaitPendingStop(conversationId);
+      await assistantApi.del(
+        `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
+      );
+      // Local removal only after the server accepted: a failed delete keeps
+      // the conversation listed and retryable.
+      this.conversations.delete(conversationId);
+      this.deletedConversationIds.add(conversationId);
+    } finally {
+      // On success the tombstone takes over; on failure the conversation
+      // becomes usable (and retryable) again.
+      this.deletingConversationIds.delete(conversationId);
+    }
   }
 
   async getHistory(conversationId: string): Promise<ConversationHistory> {
@@ -885,6 +906,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     const stored = this.conversations.get(conversationId);
     if (!stored) {
       throw new Error("Conversation was not found.");
+    }
+    if (this.deletingConversationIds.has(conversationId)) {
+      throw new Error("This conversation is being deleted.");
     }
     if (
       this.running.has(conversationId) ||
@@ -966,6 +990,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     approved: boolean,
     onEvent?: (event: TurnEvent) => void,
   ): Promise<TurnHandle | null> {
+    if (this.deletingConversationIds.has(conversationId)) {
+      throw new Error("This conversation is being deleted.");
+    }
     const stored = this.conversations.get(conversationId);
     const card = stored?.turnState.messages
       .flatMap((message) => message.blocks)
@@ -1004,6 +1031,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // (Read lastCursor only after pauseForApproval settled the prior turn.)
     run.cursor = stored.turnState.lastCursor;
     this.running.set(conversationId, run);
+
+    // Reservation first, THEN the fence: the approve must not overtake a
+    // prior turn's still-pending stop upstream, and the reservation keeps
+    // concurrent sends out while this waits. A cancel landing during the
+    // wait settles the run before anything was dispatched — bail with no
+    // continuation rather than posting a decision for a cancelled flow.
+    await this.awaitPendingStop(conversationId);
+    if (run.finished || run.controller.signal.aborted) {
+      return null;
+    }
 
     let response: Response;
     try {
@@ -1594,24 +1631,22 @@ export class AevatarAssistantTransport implements AssistantTransport {
           run.stopPendingStart = false;
           const releaseFence = run.resolvePreStartFence;
           run.resolvePreStartFence = undefined;
-          let stopInstalled = false;
+          let stop: Promise<void> | null = null;
           try {
-            this.requestServerStop(conversationId, run);
-            stopInstalled = true;
+            stop = this.requestServerStop(conversationId, run);
           } finally {
             if (releaseFence) {
-              if (stopInstalled) {
-                // The placeholder lifts only once the real stop settles, so
-                // a waiter serialized on it cannot overtake the fence
-                // commit.
-                void (
-                  this.pendingStops.get(conversationId) ?? Promise.resolve()
-                ).then(releaseFence);
+              if (stop) {
+                // The placeholder lifts only once the real stop settles
+                // (chained on the RAW stop, never the composed map entry —
+                // the entry contains the placeholder itself and chaining
+                // onto it would deadlock), so a waiter serialized on the
+                // fence cannot overtake the fence commit.
+                void stop.then(releaseFence);
               } else {
-                // The stop never launched (synchronous throw): the map may
-                // still hold the placeholder itself — chaining onto it
-                // would deadlock. Retire it outright.
-                this.pendingStops.delete(conversationId);
+                // The stop never launched (synchronous throw): release the
+                // placeholder outright; the composed entry retires itself
+                // once every component has settled.
                 releaseFence();
               }
             }
@@ -2623,17 +2658,17 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // RUN_STARTED names the turn, but a follow-up send or delete must
       // already serialize behind the eventual stop. Lifted when the
       // deferred stop settles, or when the window expires without a turn.
+      // trackFence COMPOSES with any live entry instead of replacing it.
       const fence = new Promise<void>((resolve) => {
         run.resolvePreStartFence = resolve;
       });
-      this.pendingStops.set(conversationId, fence);
+      this.trackFence(conversationId, fence);
       setTimeout(() => {
         if (run.stopPendingStart) {
-          // No RUN_STARTED inside the window: nothing to stop.
+          // No RUN_STARTED inside the window: nothing to stop. Resolve
+          // only — the composed map entry retires itself once every
+          // component has settled.
           run.stopPendingStart = false;
-          if (this.pendingStops.get(conversationId) === fence) {
-            this.pendingStops.delete(conversationId);
-          }
           run.resolvePreStartFence?.();
           run.resolvePreStartFence = undefined;
         }
@@ -2720,8 +2755,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * tracked in `pendingStops` so follow-up sends and deletes serialize
    * behind the fence.
    */
-  private requestServerStop(conversationId: string, run: RunningTurn): void {
-    if (!run.turnId) return;
+  private requestServerStop(
+    conversationId: string,
+    run: RunningTurn,
+  ): Promise<void> | null {
+    if (!run.turnId) return null;
     // Own deadline: a server that accepts but never answers must not pin
     // the pendingStops entry (and tax every later send with the full fence
     // wait). A manual controller instead of AbortSignal.timeout so this
@@ -2749,9 +2787,25 @@ export class AevatarAssistantTransport implements AssistantTransport {
       () => clearTimeout(deadlineTimer),
       () => clearTimeout(deadlineTimer),
     );
-    this.pendingStops.set(conversationId, pending);
-    void pending.then(() => {
-      if (this.pendingStops.get(conversationId) === pending) {
+    this.trackFence(conversationId, pending);
+    return pending;
+  }
+
+  /**
+   * Register a fence component for the conversation, COMPOSING with any
+   * live entry rather than replacing it — no control path may drop a
+   * still-pending fence someone else could be relying on. Every component
+   * is self-bounded, so the composition is too; the entry retires itself
+   * once everything it covers has settled.
+   */
+  private trackFence(conversationId: string, component: Promise<void>): void {
+    const prior = this.pendingStops.get(conversationId);
+    const tracked = prior
+      ? Promise.all([prior, component]).then(() => undefined)
+      : component;
+    this.pendingStops.set(conversationId, tracked);
+    void tracked.then(() => {
+      if (this.pendingStops.get(conversationId) === tracked) {
         this.pendingStops.delete(conversationId);
       }
     });

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -92,6 +92,11 @@ const STOP_FENCE_WAIT_MS = 2_000;
 // only chance to learn the turnId, leaving the upstream run uncancellable.
 const PRE_START_STOP_WINDOW_MS = 5_000;
 
+// Hard deadline on the `:stop` request itself. Without one, a server that
+// accepts the connection but never answers would pin the `pendingStops`
+// entry forever and tax every later send/delete with the full fence wait.
+const STOP_REQUEST_DEADLINE_MS = 10_000;
+
 // Inline media larger than this (base64 chars ≈ 6 MB decoded) is summarized
 // as text instead of being embedded as a data: URL artifact.
 const MAX_MEDIA_DATA_CHARS = 8_000_000;
@@ -308,6 +313,12 @@ interface RunningTurn {
    * the RUN_STARTED handler then submits the stop and aborts.
    */
   stopPendingStart: boolean;
+  /**
+   * Lifts the placeholder fence a pre-start cancel installed in
+   * `pendingStops` — called once the deferred stop settles, or when the
+   * pre-start window expires without a turn to stop.
+   */
+  resolvePreStartFence?: () => void;
   turnAnnounced: boolean;
   readonly controller: AbortController;
   readonly onEvent: (event: TurnEvent) => void;
@@ -1570,7 +1581,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
           // stop it was waiting on, then drop the connection — the local
           // turn already settled as cancelled.
           run.stopPendingStart = false;
+          const releaseFence = run.resolvePreStartFence;
+          run.resolvePreStartFence = undefined;
           this.requestServerStop(conversationId, run);
+          if (releaseFence) {
+            // The placeholder fence lifts only once the real stop settles,
+            // so a waiter serialized on it cannot overtake the fence commit.
+            void (
+              this.pendingStops.get(conversationId) ?? Promise.resolve()
+            ).then(releaseFence);
+          }
           run.controller.abort();
           return;
         }
@@ -2567,7 +2587,24 @@ export class AevatarAssistantTransport implements AssistantTransport {
       this.requestServerStop(conversationId, run);
     } else {
       run.stopPendingStart = true;
+      // Install the fence NOW: the stop request cannot exist until
+      // RUN_STARTED names the turn, but a follow-up send or delete must
+      // already serialize behind the eventual stop. Lifted when the
+      // deferred stop settles, or when the window expires without a turn.
+      const fence = new Promise<void>((resolve) => {
+        run.resolvePreStartFence = resolve;
+      });
+      this.pendingStops.set(conversationId, fence);
       setTimeout(() => {
+        if (run.stopPendingStart) {
+          // No RUN_STARTED inside the window: nothing to stop.
+          run.stopPendingStart = false;
+          if (this.pendingStops.get(conversationId) === fence) {
+            this.pendingStops.delete(conversationId);
+          }
+          run.resolvePreStartFence?.();
+          run.resolvePreStartFence = undefined;
+        }
         if (!run.controller.signal.aborted) run.controller.abort();
       }, PRE_START_STOP_WINDOW_MS);
     }
@@ -2653,20 +2690,26 @@ export class AevatarAssistantTransport implements AssistantTransport {
    */
   private requestServerStop(conversationId: string, run: RunningTurn): void {
     if (!run.turnId) return;
-    const pending = assistantApi
-      .post<unknown>(
-        `${ASSISTANT_PREFIX}/conversations/${conversationId}/stop`,
-        {
+    const pending = apiClient<unknown>(
+      `${ASSISTANT_PREFIX}/conversations/${conversationId}/stop`,
+      {
+        method: "POST",
+        body: {
           turnId: run.turnId,
           stopRequestId: crypto.randomUUID(),
           clientRequestId: crypto.randomUUID(),
           expectedStateVersion: 0,
         },
-      )
-      .then(
-        () => undefined,
-        () => undefined,
-      );
+        preserveSessionOn401: true,
+        // Own deadline: a server that accepts but never answers must not
+        // pin the pendingStops entry (and tax every later send with the
+        // full fence wait). The abort settles the promise; cleanup runs.
+        signal: AbortSignal.timeout(STOP_REQUEST_DEADLINE_MS),
+      },
+    ).then(
+      () => undefined,
+      () => undefined,
+    );
     this.pendingStops.set(conversationId, pending);
     void pending.then(() => {
       if (this.pendingStops.get(conversationId) === pending) {

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1438,6 +1438,10 @@ export class AevatarAssistantTransport implements AssistantTransport {
     this.clearWatchdog(run);
     if (run.finished || run.waitingForApproval) return;
     run.watchdog = setTimeout(() => {
+      // A hung run holds the conversation actor: without a server-side stop
+      // the next send fails with ACTIVE_TURN_REQUIRES_STEERING until the
+      // run reaches its own terminal. Best-effort, like user cancel.
+      this.requestServerStop(conversationId, run);
       this.closeOpenMessage(conversationId, run);
       this.finalizeActivity(conversationId, run, "failed");
       this.finishTurn(conversationId, run, "failed", {
@@ -2501,15 +2505,18 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   /**
-   * Client-side stop: aevatar's nyxid-chat surface has no cancel endpoint,
-   * so cancelling aborts the SSE fetch and settles the local turn per the
-   * PRD stop-flow — every open block reaches a terminal state (§5.6). The
-   * server-side run may still finish; its full reply then surfaces on the
-   * next history reload.
+   * Stop flow: aborts the SSE fetch, settles the local turn per the PRD
+   * stop-flow — every open block reaches a terminal state (§5.6) — and,
+   * when the server has announced a turn, fires a best-effort `:stop`
+   * control command so Aevatar commits a stop fence instead of running the
+   * turn to its own terminal. The stop is 202-accepted and asynchronous
+   * upstream; if it fails or never fires, the pre-existing behavior stands
+   * (the run finishes server-side and surfaces on the next history reload).
    */
   private cancelTurn(conversationId: string, run: RunningTurn): void {
     if (run.finished) return;
     run.controller.abort();
+    this.requestServerStop(conversationId, run);
     this.clearWatchdog(run);
     if (run.currentBlockId) {
       // Cancel runs the SAME projection as a normal message close. Two things
@@ -2576,5 +2583,28 @@ export class AevatarAssistantTransport implements AssistantTransport {
       });
     }
     this.finishTurn(conversationId, run, "cancelled", null);
+  }
+
+  /**
+   * Best-effort server-side stop (the `feature/integrate` `:stop` control
+   * contract): a fresh `stopRequestId` per intent keeps the command
+   * idempotent upstream, and `expectedStateVersion: 0` skips the
+   * optimistic-concurrency fence — the transport does not track actor
+   * state versions. Requires the server-announced `turnId`: before
+   * RUN_STARTED there is no committed turn to address, and aborting the
+   * fetch is the only cancellation available. Failures are swallowed —
+   * stop is an upgrade over the previous client-only cancel, never a new
+   * failure mode.
+   */
+  private requestServerStop(conversationId: string, run: RunningTurn): void {
+    if (!run.turnId) return;
+    void assistantApi
+      .post<unknown>(`${ASSISTANT_PREFIX}/conversations/${conversationId}/stop`, {
+        turnId: run.turnId,
+        stopRequestId: crypto.randomUUID(),
+        clientRequestId: crypto.randomUUID(),
+        expectedStateVersion: 0,
+      })
+      .catch(() => undefined);
   }
 }

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -765,14 +765,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
    */
   private readonly deletedConversationIds = new Set<string>();
   /**
-   * Deletion-in-progress reservation: set before the delete's cancel and
-   * fence wait, cleared when the delete settles (the tombstone takes over
-   * on success). Sends and approvals are rejected while present —
-   * otherwise a successor turn admitted during the fence wait can
-   * dispatch its stream before the DELETE and recreate the actor the
-   * user asked to remove.
+   * Deletion-in-progress reservation: the one in-flight delete operation
+   * per conversation, installed before the delete's cancel and fence wait
+   * and cleared when it settles (the tombstone takes over on success).
+   * Sends and approvals are rejected while present — otherwise a
+   * successor turn admitted during the fence wait can dispatch its stream
+   * before the DELETE and recreate the actor the user asked to remove.
+   * Concurrent deletes coalesce onto the stored promise.
    */
-  private readonly deletingConversationIds = new Set<string>();
+  private readonly deletingConversations = new Map<string, Promise<void>>();
   private listFetchedAt = 0;
 
   async listConversations(): Promise<Conversation[]> {
@@ -829,8 +830,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // the terminal synchronously, so without the reservation a successor
     // send admitted during the fence wait could dispatch its stream before
     // the DELETE and recreate the actor the user asked to remove.
-    this.deletingConversationIds.add(conversationId);
-    try {
+    // Concurrent deletes COALESCE onto the one in-flight operation — a
+    // flag-style reservation is not ownership-safe (an overlapping call's
+    // failure would clear it while the other DELETE is still in flight).
+    const inFlight = this.deletingConversations.get(conversationId);
+    if (inFlight) return inFlight;
+    const operation = (async () => {
       const run = this.running.get(conversationId);
       if (run) this.cancelTurn(conversationId, run);
       // The cancel above may have fired a `:stop`; let its fence commit
@@ -843,10 +848,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // the conversation listed and retryable.
       this.conversations.delete(conversationId);
       this.deletedConversationIds.add(conversationId);
+    })();
+    this.deletingConversations.set(conversationId, operation);
+    try {
+      await operation;
     } finally {
       // On success the tombstone takes over; on failure the conversation
-      // becomes usable (and retryable) again.
-      this.deletingConversationIds.delete(conversationId);
+      // becomes usable (and retryable) again. Only this owner clears the
+      // reservation — coalesced callers returned the shared promise above.
+      this.deletingConversations.delete(conversationId);
     }
   }
 
@@ -907,7 +917,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (!stored) {
       throw new Error("Conversation was not found.");
     }
-    if (this.deletingConversationIds.has(conversationId)) {
+    if (this.deletingConversations.has(conversationId)) {
       throw new Error("This conversation is being deleted.");
     }
     if (
@@ -990,7 +1000,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     approved: boolean,
     onEvent?: (event: TurnEvent) => void,
   ): Promise<TurnHandle | null> {
-    if (this.deletingConversationIds.has(conversationId)) {
+    if (this.deletingConversations.has(conversationId)) {
       throw new Error("This conversation is being deleted.");
     }
     const stored = this.conversations.get(conversationId);

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -81,12 +81,6 @@ const MAX_MESSAGE_CHARS = 32_768;
 // have no deadline the client can impose.
 const STREAM_PROGRESS_TIMEOUT_MS = 120_000;
 
-// How long a follow-up send or delete waits on an in-flight `:stop` before
-// proceeding anyway. Serializing behind the stop keeps a fast follow-up from
-// racing the fence upstream (HTTP request ordering is not guaranteed across
-// connections); the bound keeps a hung stop from wedging the composer.
-const STOP_FENCE_WAIT_MS = 2_000;
-
 // How long a pre-RUN_STARTED cancel keeps the reader alive waiting for the
 // frame that names the server turn. Without it the abort would discard the
 // only chance to learn the turnId, leaving the upstream run uncancellable.
@@ -746,9 +740,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private readonly conversations = new Map<string, StoredConversation>();
   private readonly running = new Map<string, RunningTurn>();
   /**
-   * In-flight `:stop` per conversation. Follow-up sends and the composite
-   * delete serialize behind it (bounded by STOP_FENCE_WAIT_MS) so a fast
-   * next action cannot reach Aevatar before the stop fence commits.
+   * In-flight `:stop` fence per conversation. Follow-up sends and the
+   * composite delete serialize behind it so a fast next action cannot
+   * reach Aevatar before the stop fence commits. Every entry is
+   * self-bounded (stop deadline / pre-start window), so waiters await it
+   * directly.
    */
   private readonly pendingStops = new Map<string, Promise<void>>();
   /**
@@ -1486,6 +1482,10 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // A hung run holds the conversation actor: without a server-side stop
       // the next send fails with ACTIVE_TURN_REQUIRES_STEERING until the
       // run reaches its own terminal. Best-effort, like user cancel.
+      // Pre-RUN_STARTED this is a no-op BY DESIGN: after a full watchdog
+      // period of silence there is no addressable turn identity, and no
+      // announcing frame is coming — unlike a user cancel, which defers
+      // its abort for a bounded window because the frame may be in flight.
       this.requestServerStop(conversationId, run);
       this.closeOpenMessage(conversationId, run);
       this.finalizeActivity(conversationId, run, "failed");
@@ -2719,18 +2719,21 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   /**
-   * Wait (bounded) for this conversation's in-flight `:stop` to be
-   * accepted upstream before the next send or delete goes out. Without
-   * this, a fast follow-up can reach Aevatar ahead of the stop — request
-   * ordering across HTTP connections is not guaranteed — and fail with
-   * ACTIVE_TURN_REQUIRES_STEERING.
+   * Wait for this conversation's in-flight `:stop` fence before the next
+   * send or delete goes out. Without this, a fast follow-up can reach
+   * Aevatar ahead of the stop — request ordering across HTTP connections
+   * is not guaranteed — and fail with ACTIVE_TURN_REQUIRES_STEERING.
+   *
+   * Awaited DIRECTLY, no outer race: every tracked promise is
+   * self-bounded — a real stop by its STOP_REQUEST_DEADLINE_MS abort, a
+   * pre-start placeholder by the PRE_START_STOP_WINDOW_MS expiry (plus,
+   * when RUN_STARTED lands late in the window, the chained stop's own
+   * deadline). An outer bound shorter than the placeholder lifetime would
+   * reopen the exact overtake the fence exists to prevent.
    */
   private async awaitPendingStop(conversationId: string): Promise<void> {
     const pending = this.pendingStops.get(conversationId);
     if (!pending) return;
-    await Promise.race([
-      pending,
-      new Promise<void>((resolve) => setTimeout(resolve, STOP_FENCE_WAIT_MS)),
-    ]);
+    await pending;
   }
 }

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -81,6 +81,17 @@ const MAX_MESSAGE_CHARS = 32_768;
 // have no deadline the client can impose.
 const STREAM_PROGRESS_TIMEOUT_MS = 120_000;
 
+// How long a follow-up send or delete waits on an in-flight `:stop` before
+// proceeding anyway. Serializing behind the stop keeps a fast follow-up from
+// racing the fence upstream (HTTP request ordering is not guaranteed across
+// connections); the bound keeps a hung stop from wedging the composer.
+const STOP_FENCE_WAIT_MS = 2_000;
+
+// How long a pre-RUN_STARTED cancel keeps the reader alive waiting for the
+// frame that names the server turn. Without it the abort would discard the
+// only chance to learn the turnId, leaving the upstream run uncancellable.
+const PRE_START_STOP_WINDOW_MS = 5_000;
+
 // Inline media larger than this (base64 chars ≈ 6 MB decoded) is summarized
 // as text instead of being embedded as a data: URL artifact.
 const MAX_MEDIA_DATA_CHARS = 8_000_000;
@@ -291,6 +302,12 @@ interface RunStepState {
 interface RunningTurn {
   readonly clientRequestId: string;
   turnId: string | null;
+  /**
+   * A cancel landed before RUN_STARTED delivered the server turn id. The
+   * reader stays alive (bounded) so the announcing frame can still arrive;
+   * the RUN_STARTED handler then submits the stop and aborts.
+   */
+  stopPendingStart: boolean;
   turnAnnounced: boolean;
   readonly controller: AbortController;
   readonly onEvent: (event: TurnEvent) => void;
@@ -718,6 +735,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private readonly conversations = new Map<string, StoredConversation>();
   private readonly running = new Map<string, RunningTurn>();
   /**
+   * In-flight `:stop` per conversation. Follow-up sends and the composite
+   * delete serialize behind it (bounded by STOP_FENCE_WAIT_MS) so a fast
+   * next action cannot reach Aevatar before the stop fence commits.
+   */
+  private readonly pendingStops = new Map<string, Promise<void>>();
+  /**
    * Tombstones for server-accepted deletes: the Chat History index is
    * eventually consistent, so stale list/history responses can still carry
    * a row we just deleted. Tombstones are PERMANENT for the transport's
@@ -779,6 +802,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // call retires both upstream surfaces.
     const run = this.running.get(conversationId);
     if (run) this.cancelTurn(conversationId, run);
+    // The cancel above may have fired a `:stop`; let its fence commit before
+    // the actor delete races the still-active work upstream.
+    await this.awaitPendingStop(conversationId);
     await assistantApi.del(
       `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
     );
@@ -1175,6 +1201,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     return {
       clientRequestId: crypto.randomUUID(),
       turnId,
+      stopPendingStart: false,
       turnAnnounced: false,
       controller: new AbortController(),
       onEvent,
@@ -1234,12 +1261,19 @@ export class AevatarAssistantTransport implements AssistantTransport {
     run: RunningTurn,
     prompt: string,
   ): Promise<void> {
+    // Serialize behind a previous turn's in-flight stop so this send cannot
+    // arrive upstream before the fence commits.
+    await this.awaitPendingStop(conversationId);
+
     let finalFailure = {
       code: "network_error",
       message: "The assistant stream could not be reached. Try again.",
     };
 
     for (let attempt = 0; attempt < STREAM_DELIVERY_ATTEMPTS; attempt += 1) {
+      // A cancel can settle the run between attempts (the pre-RUN_STARTED
+      // path defers its abort); a finished run must never re-POST.
+      if (run.finished || run.controller.signal.aborted) return;
       this.resetDeliveryState(run);
       let response: Response;
       try {
@@ -1531,6 +1565,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
           return;
         }
         if (!run.turnId) run.turnId = authoritativeTurnId;
+        if (run.stopPendingStart) {
+          // A cancel landed before this frame named the turn. Deliver the
+          // stop it was waiting on, then drop the connection — the local
+          // turn already settled as cancelled.
+          run.stopPendingStart = false;
+          this.requestServerStop(conversationId, run);
+          run.controller.abort();
+          return;
+        }
         if (!run.turnAnnounced) {
           run.turnAnnounced = true;
           this.emit(conversationId, run, {
@@ -2505,18 +2548,29 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   /**
-   * Stop flow: aborts the SSE fetch, settles the local turn per the PRD
-   * stop-flow — every open block reaches a terminal state (§5.6) — and,
-   * when the server has announced a turn, fires a best-effort `:stop`
+   * Stop flow: settles the local turn per the PRD stop-flow — every open
+   * block reaches a terminal state (§5.6) — and fires a best-effort `:stop`
    * control command so Aevatar commits a stop fence instead of running the
-   * turn to its own terminal. The stop is 202-accepted and asynchronous
-   * upstream; if it fails or never fires, the pre-existing behavior stands
-   * (the run finishes server-side and surfaces on the next history reload).
+   * turn to its own terminal. When the server has already announced the
+   * turn, the fetch aborts immediately and the stop goes out with that
+   * turnId. When cancel lands BEFORE RUN_STARTED, the reader is kept alive
+   * (bounded) so the announcing frame can still deliver the turnId the stop
+   * needs; the RUN_STARTED handler then stops and aborts. The stop is
+   * 202-accepted and asynchronous upstream; if it fails or never fires, the
+   * pre-existing behavior stands (the run finishes server-side and surfaces
+   * on the next history reload).
    */
   private cancelTurn(conversationId: string, run: RunningTurn): void {
     if (run.finished) return;
-    run.controller.abort();
-    this.requestServerStop(conversationId, run);
+    if (run.turnId) {
+      run.controller.abort();
+      this.requestServerStop(conversationId, run);
+    } else {
+      run.stopPendingStart = true;
+      setTimeout(() => {
+        if (!run.controller.signal.aborted) run.controller.abort();
+      }, PRE_START_STOP_WINDOW_MS);
+    }
     this.clearWatchdog(run);
     if (run.currentBlockId) {
       // Cancel runs the SAME projection as a normal message close. Two things
@@ -2590,21 +2644,50 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * contract): a fresh `stopRequestId` per intent keeps the command
    * idempotent upstream, and `expectedStateVersion: 0` skips the
    * optimistic-concurrency fence — the transport does not track actor
-   * state versions. Requires the server-announced `turnId`: before
-   * RUN_STARTED there is no committed turn to address, and aborting the
-   * fetch is the only cancellation available. Failures are swallowed —
-   * stop is an upgrade over the previous client-only cancel, never a new
-   * failure mode.
+   * state versions. Requires the server-announced `turnId` (a
+   * pre-RUN_STARTED cancel defers here via `stopPendingStart`). Failures
+   * are swallowed — stop is an upgrade over the previous client-only
+   * cancel, never a new failure mode — but the in-flight request is
+   * tracked in `pendingStops` so follow-up sends and deletes serialize
+   * behind the fence.
    */
   private requestServerStop(conversationId: string, run: RunningTurn): void {
     if (!run.turnId) return;
-    void assistantApi
-      .post<unknown>(`${ASSISTANT_PREFIX}/conversations/${conversationId}/stop`, {
-        turnId: run.turnId,
-        stopRequestId: crypto.randomUUID(),
-        clientRequestId: crypto.randomUUID(),
-        expectedStateVersion: 0,
-      })
-      .catch(() => undefined);
+    const pending = assistantApi
+      .post<unknown>(
+        `${ASSISTANT_PREFIX}/conversations/${conversationId}/stop`,
+        {
+          turnId: run.turnId,
+          stopRequestId: crypto.randomUUID(),
+          clientRequestId: crypto.randomUUID(),
+          expectedStateVersion: 0,
+        },
+      )
+      .then(
+        () => undefined,
+        () => undefined,
+      );
+    this.pendingStops.set(conversationId, pending);
+    void pending.then(() => {
+      if (this.pendingStops.get(conversationId) === pending) {
+        this.pendingStops.delete(conversationId);
+      }
+    });
+  }
+
+  /**
+   * Wait (bounded) for this conversation's in-flight `:stop` to be
+   * accepted upstream before the next send or delete goes out. Without
+   * this, a fast follow-up can reach Aevatar ahead of the stop — request
+   * ordering across HTTP connections is not guaranteed — and fail with
+   * ACTIVE_TURN_REQUIRES_STEERING.
+   */
+  private async awaitPendingStop(conversationId: string): Promise<void> {
+    const pending = this.pendingStops.get(conversationId);
+    if (!pending) return;
+    await Promise.race([
+      pending,
+      new Promise<void>((resolve) => setTimeout(resolve, STOP_FENCE_WAIT_MS)),
+    ]);
   }
 }

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -308,6 +308,14 @@ interface RunningTurn {
    */
   stopPendingStart: boolean;
   /**
+   * The stream (or continuation) fetch actually left the client. A cancel
+   * before dispatch is purely local: nothing reached upstream, so there is
+   * no turn to stop — and, critically, no pre-start placeholder may be
+   * installed, or it would overwrite an earlier turn's still-pending stop
+   * fence and let a later send overtake it.
+   */
+  streamDispatched: boolean;
+  /**
    * Lifts the placeholder fence a pre-start cancel installed in
    * `pendingStops` — called once the deferred stop settles, or when the
    * pre-start window expires without a turn to stop.
@@ -999,6 +1007,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
 
     let response: Response;
     try {
+      run.streamDispatched = true;
       response = await fetch(
         `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/approve`,
         {
@@ -1209,6 +1218,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       clientRequestId: crypto.randomUUID(),
       turnId,
       stopPendingStart: false,
+      streamDispatched: false,
       turnAnnounced: false,
       controller: new AbortController(),
       onEvent,
@@ -1286,6 +1296,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       try {
         // Hand-rolled fetch (not `apiClient`): the response is an SSE stream,
         // and the endpoint 415s without an explicit JSON content type.
+        run.streamDispatched = true;
         response = await fetch(
           `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/stream`,
           {
@@ -1583,15 +1594,29 @@ export class AevatarAssistantTransport implements AssistantTransport {
           run.stopPendingStart = false;
           const releaseFence = run.resolvePreStartFence;
           run.resolvePreStartFence = undefined;
-          this.requestServerStop(conversationId, run);
-          if (releaseFence) {
-            // The placeholder fence lifts only once the real stop settles,
-            // so a waiter serialized on it cannot overtake the fence commit.
-            void (
-              this.pendingStops.get(conversationId) ?? Promise.resolve()
-            ).then(releaseFence);
+          let stopInstalled = false;
+          try {
+            this.requestServerStop(conversationId, run);
+            stopInstalled = true;
+          } finally {
+            if (releaseFence) {
+              if (stopInstalled) {
+                // The placeholder lifts only once the real stop settles, so
+                // a waiter serialized on it cannot overtake the fence
+                // commit.
+                void (
+                  this.pendingStops.get(conversationId) ?? Promise.resolve()
+                ).then(releaseFence);
+              } else {
+                // The stop never launched (synchronous throw): the map may
+                // still hold the placeholder itself — chaining onto it
+                // would deadlock. Retire it outright.
+                this.pendingStops.delete(conversationId);
+                releaseFence();
+              }
+            }
+            run.controller.abort();
           }
-          run.controller.abort();
           return;
         }
         if (!run.turnAnnounced) {
@@ -2585,6 +2610,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (run.turnId) {
       run.controller.abort();
       this.requestServerStop(conversationId, run);
+    } else if (!run.streamDispatched) {
+      // The stream request never left the client (e.g. the send is still
+      // queued behind an earlier turn's stop fence): nothing reached
+      // upstream, so cancel is purely local. Installing a placeholder here
+      // would OVERWRITE that earlier fence and let a later send overtake
+      // the still-pending stop.
+      run.controller.abort();
     } else {
       run.stopPendingStart = true;
       // Install the fence NOW: the stop request cannot exist until
@@ -2690,6 +2722,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
    */
   private requestServerStop(conversationId: string, run: RunningTurn): void {
     if (!run.turnId) return;
+    // Own deadline: a server that accepts but never answers must not pin
+    // the pendingStops entry (and tax every later send with the full fence
+    // wait). A manual controller instead of AbortSignal.timeout so this
+    // never throws on an environment that lacks the static — the deferred
+    // placeholder release depends on this call not throwing.
+    const deadline = new AbortController();
+    const deadlineTimer = setTimeout(
+      () => deadline.abort(),
+      STOP_REQUEST_DEADLINE_MS,
+    );
     const pending = apiClient<unknown>(
       `${ASSISTANT_PREFIX}/conversations/${conversationId}/stop`,
       {
@@ -2701,14 +2743,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
           expectedStateVersion: 0,
         },
         preserveSessionOn401: true,
-        // Own deadline: a server that accepts but never answers must not
-        // pin the pendingStops entry (and tax every later send with the
-        // full fence wait). The abort settles the promise; cleanup runs.
-        signal: AbortSignal.timeout(STOP_REQUEST_DEADLINE_MS),
+        signal: deadline.signal,
       },
     ).then(
-      () => undefined,
-      () => undefined,
+      () => clearTimeout(deadlineTimer),
+      () => clearTimeout(deadlineTimer),
     );
     this.pendingStops.set(conversationId, pending);
     void pending.then(() => {


### PR DESCRIPTION
## Summary

Brings the assistant chat surface (FE → NyxID BE → Aevatar) into full conformance with the authoritative contract on `aevatarAI/aevatar` branch `feature/integrate` (`docs/canon/nyxid-chat-api.md` + the `agents/Aevatar.GAgents.NyxidChat` host), and hardens the client against the concurrency races an adversarial review loop surfaced. The mandatory `type:"text"` stream discriminator was fixed separately in #1251; this PR delivers everything else.

### Backend — the mount now exposes the complete conversation-control surface

All through the same `forward()`/`execute_proxy` funnel (credential injection, identity propagation, rate limiting, audit), scope always server-derived, mounted human-only:

| New route | Upstream | Notes |
|---|---|---|
| `POST /assistant/conversations/{id}/stop` | `…:stop` | 202-accepted stop fence |
| `POST /assistant/conversations/{id}/steer` | `…:steer` | steering control (no UI consumer yet) |
| `GET /assistant/conversations/{id}/state` | `…/state` | conditional state query; cursors ride the forwarded query string |
| `POST …/turns/{turn}/steps/{step}/retry` | `…:retry` | per-step retry |
| `POST …/turns/{turn}/steps/{step}/skip` | `…:skip` | per-step skip |

Turn/step segments follow the upstream control-identity grammar (≤128 UTF-16 code units, no whitespace/control chars, none of `/ \ ? #`) and are percent-encoded on interpolation; `%` and dot-only segments are documented NyxID narrowings (fail closed at the mount instead of deeper in the proxy's repeat-decode hardening).

### Frontend — cancel is now a real server-side stop, with a fence

`cancelTurn` and the 120s watchdog fire `POST …/stop` (`{turnId, stopRequestId, clientRequestId, expectedStateVersion: 0}`). The hardening that the codex (gpt-5.6-sol) ↔ Fable review loop drove, round by round:

- Follow-up sends, approvals, and the composite delete **serialize behind the in-flight stop fence** so they cannot reach Aevatar before the fence commits (HTTP ordering across connections is not guaranteed).
- A cancel landing **before `RUN_STARTED`** installs a placeholder fence synchronously and defers its abort (bounded) so the announcing frame can still deliver the `turnId` the stop needs; a run whose fetch never dispatched cancels purely locally and leaves any live fence untouched.
- Fence entries are **composed, never replaced** (`trackFence`), every component is self-bounded (stop: 10s deadline; placeholder: 5s window), and the placeholder handoff chains on the raw stop promise so it cannot deadlock.
- Deletes hold a **per-conversation reservation** (installed before any callback-capable work, identity-checked cleanup, concurrent deletes coalesce onto one owned operation, DELETE carries its own 15s deadline) so sends/approvals cannot slip into the delete window and recreate the actor.
- The approval pause deliberately does **not** stop (that turn is waiting server-side for the decision); the watchdog's pre-`RUN_STARTED` abort is documented client-only (after 120s of silence there is no addressable turn).

### Docs

`CHAT_SPEC.md` + `CHAT_ASSISTANT_SPECS.md` cut 6: endpoint tables, the fence design, the corrected stale `sessionId` claim, and the deliberately-deferred surfaces (FE task-frame rendering, steer/retry/skip/state UI, the `GET /api/v1/assistant/actions` registry — default-disabled on the Aevatar side).

## Verification

- **Adversarial review loop**: 8 rounds of codex gpt-5.6-sol review alternating with Fable fixes; every P1/P2 addressed or explicitly documented (see PR comments for the round-by-round evidence). Rounds 6–7 accepted the fence mechanics and the full admission surface except the delete flow, fixed in the final round.
- **Live E2E** (real backend + real `/assistant` page + strict mock enforcing the `feature/integrate` rules — ordinal `type` discriminator, unknown-member rejection, control-identity grammar, single delegation header, EOF-at-terminal): streaming renders live; the Stop button fences the upstream run mid-stream; an immediate follow-up leaves only after the stop 202 and completes; state echoes forwarded cursors; steer/retry/skip answer 202 with strict-valid bodies; `..%2F`-style path escapes die at NyxID with 400.
- **Gates**: backend 4,813 + CLI 1,063 tests, clippy `-D warnings`, fmt; frontend 2,096 tests (10 new fence/stop/delete regression tests), lint 0 errors, full `tsc -b` build. CI green on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)