### PR TITLE
feat(billing): working Lago integration with opt-in platform charging

### DIFF
--- a/backend/src/billing_integration_tests.rs
+++ b/backend/src/billing_integration_tests.rs
@@ -963,12 +963,27 @@ async fn mounted_route_settlement_failure_is_replayed_once_by_reconcile() {
     let owner_id = insert_owner(&db).await;
     let (downstream_url, forwarded_request, release_response, downstream) =
         start_controlled_billing_downstream().await;
+    // Platform charging is opt-in per catalog service, so the recovery
+    // route must resolve to a platform_billable catalog entry for the
+    // wallet hold this test exercises.
+    let mut recovery_catalog = crate::models::downstream_service::test_helpers::dummy_service();
+    recovery_catalog.id = Uuid::new_v4().to_string();
+    recovery_catalog.slug = "billing-recovery-catalog".to_string();
+    recovery_catalog.base_url = downstream_url.clone();
+    recovery_catalog.billing = Some(crate::models::service_billing::ServiceBilling {
+        platform_billable: true,
+        ..Default::default()
+    });
+    db.collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+        .insert_one(&recovery_catalog)
+        .await
+        .expect("insert recovery catalog service");
     let service = insert_route_service(
         &db,
         &owner_id,
         "billing-recovery-route",
         &downstream_url,
-        None,
+        Some(&recovery_catalog.id),
         None,
     )
     .await;
@@ -1951,6 +1966,12 @@ fn billing_service(
 }
 
 fn route_context(case: &CoverageCase, request_id: &str, owner_id: &str) -> BillingRouteContext {
+    // These cases exercise the platform charging gate, which is an admin
+    // opt-in per service.
+    let billing = crate::models::service_billing::ServiceBilling {
+        platform_billable: true,
+        ..Default::default()
+    };
     BillingRouteContext::new(
         case.ingress,
         request_id.to_string(),
@@ -1968,7 +1989,7 @@ fn route_context(case: &CoverageCase, request_id: &str, owner_id: &str) -> Billi
             CredentialClass::NodeManaged
         },
         case.metric,
-        None,
+        Some(&billing),
         false,
     )
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -319,6 +319,10 @@ pub struct AppConfig {
     pub lago_api_key: Option<String>,
     /// Default Lago plan code used when provisioning an owner subscription.
     pub lago_plan_code: String,
+    /// Lago payment provider connection code linked to newly created
+    /// customers so top-up checkout URLs can be generated. Unset skips the
+    /// billing_configuration block on customer creation.
+    pub lago_payment_provider_code: Option<String>,
     /// Lago webhook secret for later phases. Redacted from Debug.
     pub lago_webhook_secret: Option<String>,
     pub billing_reconcile_interval_secs: u64,
@@ -602,6 +606,10 @@ impl std::fmt::Debug for AppConfig {
                 },
             )
             .field("lago_plan_code", &self.lago_plan_code)
+            .field(
+                "lago_payment_provider_code",
+                &self.lago_payment_provider_code,
+            )
             .field(
                 "lago_webhook_secret",
                 if self.lago_webhook_secret.is_some() {
@@ -1030,6 +1038,10 @@ impl AppConfig {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "starter".to_string()),
+            lago_payment_provider_code: env::var("LAGO_PAYMENT_PROVIDER_CODE")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
             lago_webhook_secret: env::var("LAGO_WEBHOOK_SECRET")
                 .ok()
                 .map(|s| s.trim().to_string())
@@ -1410,6 +1422,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -1051,6 +1051,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -227,6 +227,7 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -1209,6 +1209,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -372,6 +372,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -56,6 +56,9 @@ pub struct BillingUsageRow {
     pub bytes: i64,
     pub events: i64,
     pub lago_acked: bool,
+    /// False for usage metered on a service without platform billing:
+    /// observability only, no cost, never pushed to Lago.
+    pub billable: bool,
     pub estimated_credits_micros: Option<i64>,
 }
 
@@ -152,6 +155,10 @@ pub async fn get_usage(
     let mut match_doc = doc! {
         "billing_owner_id": &owner_id,
         "quantity": { "$ne": null },
+        // The billing page shows charged usage only: rows without a wallet
+        // were metered for observability (service not platform_billable)
+        // and never cost anything. Resale rows carry a wallet and stay in.
+        "wallet_id": { "$ne": null },
         "created_at": { "$gte": bson::DateTime::from_chrono(since) },
         "status": { "$in": ["finalized", "dead_letter"] },
     };
@@ -174,6 +181,10 @@ pub async fn get_usage(
                     "lago_metric_code": "$lago_metric_code",
                     "layer": "$layer",
                     "lago_acked": "$lago_acked",
+                    // Rows without a wallet were metered for observability
+                    // only (service not platform_billable); they carry no
+                    // cost and are never pushed to Lago.
+                    "billable": { "$ne": [{ "$ifNull": ["$wallet_id", null] }, null] },
                 },
                 "quantity": { "$sum": "$quantity" },
                 "events": { "$sum": 1 },
@@ -199,9 +210,14 @@ pub async fn get_usage(
             .unwrap_or_default();
         let quantity = doc_i64(&doc, "quantity").unwrap_or(0);
         let lago_metric_code = id_doc.get_str("lago_metric_code").unwrap_or("").to_string();
-        let model_rate = find_rate(&state.db, &lago_metric_code, None).await?;
-        let estimated_credits_micros =
-            model_rate.map(|rate| rate.credits_per_unit_micros.saturating_mul(quantity));
+        let billable = id_doc.get_bool("billable").unwrap_or(false);
+        let estimated_credits_micros = if billable {
+            find_rate(&state.db, &lago_metric_code, None)
+                .await?
+                .map(|rate| rate.credits_per_unit_micros.saturating_mul(quantity))
+        } else {
+            Some(0)
+        };
         rows.push(BillingUsageRow {
             service_slug: id_doc.get_str("service_slug").ok().map(ToString::to_string),
             service_id: id_doc.get_str("service_id").ok().map(ToString::to_string),
@@ -221,6 +237,7 @@ pub async fn get_usage(
             },
             events: doc_i64(&doc, "events").unwrap_or(0),
             lago_acked: id_doc.get_bool("lago_acked").unwrap_or(false),
+            billable,
             estimated_credits_micros,
         });
     }

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -264,6 +264,18 @@ pub async fn get_usage(
     }))
 }
 
+/// Reject wallet surfaces for owners outside the staged billing rollout.
+async fn ensure_billing_rollout(state: &AppState, owner_id: &str, actor_id: &str) -> AppResult<()> {
+    if crate::services::feature_flag_service::billing_rollout_enabled(&state.db, owner_id, actor_id)
+        .await?
+    {
+        return Ok(());
+    }
+    Err(AppError::Forbidden(
+        "Billing is not enabled for this account".to_string(),
+    ))
+}
+
 #[utoipa::path(
     get,
     path = "/api/v1/billing/wallet",
@@ -282,6 +294,7 @@ pub async fn get_wallet(
         .owner_resolver()
         .resolve_for_wallet_management(&auth_user.user_id.to_string(), None)
         .await?;
+    ensure_billing_rollout(&state, &owner.owner_id, &auth_user.user_id.to_string()).await?;
     if let Some(wallet) = state.billing.get_wallet(&owner.owner_id).await? {
         return Ok(Json(BillingWalletResponse::from_wallet(wallet, false)));
     }
@@ -314,6 +327,7 @@ pub async fn provision_wallet(
         .owner_resolver()
         .resolve_for_wallet_management(&actor_id, body.owner_id.as_deref())
         .await?;
+    ensure_billing_rollout(&state, &owner.owner_id, &actor_id).await?;
     let provisioned = state.billing.ensure_wallet(&owner.owner_id).await?;
 
     Ok(Json(BillingWalletResponse::from_wallet(
@@ -343,6 +357,7 @@ pub async fn create_topup(
         .owner_resolver()
         .resolve_for_wallet_management(&actor_id, body.owner_id.as_deref())
         .await?;
+    ensure_billing_rollout(&state, &owner.owner_id, &actor_id).await?;
     let checkout = state
         .billing
         .create_topup_checkout(&owner.owner_id, body.amount_credits, &body.idempotency_key)

--- a/backend/src/handlers/channel_webhooks.rs
+++ b/backend/src/handlers/channel_webhooks.rs
@@ -753,6 +753,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/handlers/llm_gateway.rs
+++ b/backend/src/handlers/llm_gateway.rs
@@ -21,12 +21,19 @@ use crate::services::{
 
 fn llm_credential_class(
     resolved_via_user_service: bool,
+    master_credential: bool,
     target: &proxy_service::ProxyTarget,
 ) -> CredentialClass {
     if target.auth_method == "none" && target.credential.is_empty() {
         CredentialClass::NoAuth
     } else if resolved_via_user_service {
-        CredentialClass::UserOwned
+        // Auto-provisioned UserServices with no user key inject the
+        // catalog master credential; classify by whose key was used.
+        if master_credential {
+            CredentialClass::NyxidManagedMaster
+        } else {
+            CredentialClass::UserOwned
+        }
     } else if !target.service.requires_user_credential && !target.credential.is_empty() {
         CredentialClass::NyxidManagedMaster
     } else {
@@ -280,7 +287,7 @@ pub async fn llm_proxy_request(
     // always None -- and then fall through to the legacy delegation path
     // with the "Provider ... connection required" error, even though the
     // user has a perfectly valid UserService linked by catalog_service_id.
-    let (target, resolved_via_user_service, owner_for_approval) =
+    let (target, resolved_via_user_service, master_credential, owner_for_approval) =
         match proxy_service::resolve_proxy_target_from_user_service(
             &state.db,
             &state.encryption_keys,
@@ -297,7 +304,12 @@ pub async fn llm_proxy_request(
                     .as_ref()
                     .map(|routing| routing.org_user_id.clone())
                     .unwrap_or_else(|| user_id_str.clone());
-                (resolution.target, true, Some(effective_owner))
+                (
+                    resolution.target,
+                    true,
+                    resolution.master_credential,
+                    Some(effective_owner),
+                )
             }
             None => {
                 // Before the legacy fallback, block org viewers whose
@@ -318,7 +330,7 @@ pub async fn llm_proxy_request(
                     &service_id,
                 )
                 .await?;
-                (legacy, false, None)
+                (legacy, false, false, None)
             }
         };
     // Check approval against the owner selected by credential resolution.
@@ -359,7 +371,7 @@ pub async fn llm_proxy_request(
         Some(service.slug.clone()),
         crate::services::billing::NodeIntent::Direct,
         target.auth_method.clone(),
-        llm_credential_class(resolved_via_user_service, &target),
+        llm_credential_class(resolved_via_user_service, master_credential, &target),
         BillingMetric::Tokens,
         target.service.billing.as_ref().or(service.billing.as_ref()),
         state.billing.resale_enabled(),
@@ -634,7 +646,7 @@ pub async fn gateway_request(
     // See `llm_proxy_request` for why we pass `None` as the slug here
     // instead of `provider_slug` -- the URL's provider slug does not
     // match UserService.slug, which is user-chosen at provision time.
-    let (target, resolved_via_user_service) =
+    let (target, resolved_via_user_service, master_credential) =
         match proxy_service::resolve_proxy_target_from_user_service(
             &state.db,
             &state.encryption_keys,
@@ -704,7 +716,7 @@ pub async fn gateway_request(
                         Some(event_data),
                     );
                 }
-                (resolution.target, true)
+                (resolution.target, true, resolution.master_credential)
             }
             None => {
                 let legacy = proxy_service::resolve_proxy_target(
@@ -729,7 +741,7 @@ pub async fn gateway_request(
                         "user_service_id": serde_json::Value::Null,
                     })),
                 );
-                (legacy, false)
+                (legacy, false, false)
             }
         };
 
@@ -771,7 +783,7 @@ pub async fn gateway_request(
         Some(service.slug.clone()),
         crate::services::billing::NodeIntent::Direct,
         target.auth_method.clone(),
-        llm_credential_class(resolved_via_user_service, &target),
+        llm_credential_class(resolved_via_user_service, master_credential, &target),
         BillingMetric::Tokens,
         target.service.billing.as_ref().or(service.billing.as_ref()),
         state.billing.resale_enabled(),

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -229,6 +229,7 @@ struct PreResolved {
     /// The UserService ID for API key scope checks.
     user_service_id: Option<String>,
     has_server_credential: bool,
+    master_credential: bool,
     /// The user_id that owns the resolved UserService. For personal
     /// resolutions this is the actor; for org-routed resolutions this is
     /// the org's user_id. Used to scope NodeServiceBinding fallback
@@ -599,6 +600,7 @@ async fn proxy_request_inner(
                     node_id: resolved.node_id,
                     user_service_id: Some(resolved.user_service_id),
                     has_server_credential: resolved.has_server_credential,
+                    master_credential: resolved.master_credential,
                     effective_owner_id: resolved
                         .org_routing
                         .as_ref()
@@ -656,6 +658,7 @@ async fn proxy_request_inner(
                 node_id: resolved.node_id,
                 user_service_id: Some(resolved.user_service_id),
                 has_server_credential: resolved.has_server_credential,
+                master_credential: resolved.master_credential,
                 effective_owner_id: resolved
                     .org_routing
                     .as_ref()
@@ -812,6 +815,7 @@ async fn proxy_request_by_slug_inner(
                     node_id: resolved.node_id,
                     user_service_id: Some(resolved.user_service_id),
                     has_server_credential: resolved.has_server_credential,
+                    master_credential: resolved.master_credential,
                     effective_owner_id: resolved
                         .org_routing
                         .as_ref()
@@ -869,6 +873,7 @@ async fn proxy_request_by_slug_inner(
                 node_id: resolved.node_id,
                 user_service_id: Some(resolved.user_service_id),
                 has_server_credential: resolved.has_server_credential,
+                master_credential: resolved.master_credential,
                 effective_owner_id: resolved
                     .org_routing
                     .as_ref()
@@ -1293,6 +1298,7 @@ async fn execute_proxy_inner(
         node_route,
         target,
         has_server_credential,
+        master_credential,
         resolved_user_service_id,
         node_routing_required,
         catalog_service_slug,
@@ -1431,6 +1437,7 @@ async fn execute_proxy_inner(
             node_route,
             pre.target,
             pre.has_server_credential,
+            pre.master_credential,
             pre.user_service_id,
             required,
             catalog_service_slug,
@@ -1480,6 +1487,7 @@ async fn execute_proxy_inner(
             node_route,
             target,
             has_server_credential,
+            false,
             resolved_user_service_id,
             node_routing_required,
             catalog_service_slug,
@@ -1512,6 +1520,7 @@ async fn execute_proxy_inner(
         node_route.is_some(),
         agent_override_applied,
         has_server_credential,
+        master_credential,
         &target,
     );
     let is_ws_candidate = is_ws_upgrade_request(&request);
@@ -2747,16 +2756,39 @@ async fn execute_proxy_inner(
             let idle_timeout =
                 std::time::Duration::from_secs(state.config.proxy_stream_idle_timeout_secs);
             let idle_timeout_secs = state.config.proxy_stream_idle_timeout_secs;
+            let is_json_body = downstream_response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|ct| ct.to_ascii_lowercase().starts_with("application/json"));
             let mut upstream_stream = downstream_response.bytes_stream();
             let stream_billing = state.billing.clone();
             let stream_metered = metered.clone();
             let request_len = request_body_len;
+            // Chunked JSON bodies (no Content-Length) stream through this
+            // branch; capture a bounded copy so LLM services settle with the
+            // provider-reported token count instead of the byte estimate.
+            let stream_usage_context = if is_json_body {
+                usage_context.clone()
+            } else {
+                None
+            };
+            let stream_resale_metric = billing_ctx.resale.as_ref().map(|spec| spec.metric);
             let stream = async_stream::stream! {
                 let mut response_len: i64 = 0;
+                let mut captured: Option<Vec<u8>> =
+                    stream_usage_context.as_ref().map(|_| Vec::new());
                 loop {
                     match tokio::time::timeout(idle_timeout, upstream_stream.next()).await {
                         Ok(Some(Ok(bytes))) => {
                             response_len += bytes.len() as i64;
+                            if let Some(buf) = captured.as_mut() {
+                                if buf.len() + bytes.len() <= USAGE_CAPTURE_MAX_BYTES {
+                                    buf.extend_from_slice(&bytes);
+                                } else {
+                                    captured = None;
+                                }
+                            }
                             yield Ok::<_, std::io::Error>(bytes);
                         }
                         Ok(Some(Err(e))) => {
@@ -2782,12 +2814,30 @@ async fn execute_proxy_inner(
                         }
                     }
                 }
+                let mut reported_usage = None;
+                let mut model = None;
+                if let Some(ctx) = stream_usage_context
+                    && let Some(buf) = captured
+                    && let Ok(json) = serde_json::from_slice::<serde_json::Value>(&buf)
+                    && let Some(usage) = llm_usage_service::extract_reported_usage(&json)
+                {
+                    model = ctx.model.clone();
+                    llm_usage_service::log_reported_usage_async(ctx, usage.clone());
+                    reported_usage = Some(usage);
+                }
+                let resale = stream_resale_metric.and_then(|metric| {
+                    resale_usage_from_optional_reported(
+                        metric,
+                        reported_usage.as_ref(),
+                        request_len + response_len,
+                    )
+                });
                 settle_meter_async(
                     stream_billing,
                     stream_metered,
-                    llm_platform_usage(None, request_len + response_len),
-                    None,
-                    None,
+                    llm_platform_usage(reported_usage.as_ref(), request_len + response_len),
+                    resale,
+                    model,
                 )
                 .await;
             };
@@ -2944,6 +2994,7 @@ fn final_credential_class(
     node_route_active: bool,
     agent_override_applied: bool,
     has_server_credential: bool,
+    master_credential: bool,
     target: &proxy_service::ProxyTarget,
 ) -> CredentialClass {
     if node_route_active && !has_server_credential {
@@ -2956,7 +3007,14 @@ fn final_credential_class(
         return CredentialClass::AgentOverrideUserOwned;
     }
     if resolved_user_service_id.is_some() {
-        return CredentialClass::UserOwned;
+        // Auto-provisioned UserServices with no user key inject the
+        // catalog master credential; classify by whose key was used,
+        // not by which resolution path matched.
+        return if master_credential {
+            CredentialClass::NyxidManagedMaster
+        } else {
+            CredentialClass::UserOwned
+        };
     }
     if !target.service.requires_user_credential && !target.credential.is_empty() {
         return CredentialClass::NyxidManagedMaster;
@@ -3164,6 +3222,11 @@ async fn settle_meter_async(
 /// Threshold below which non-error responses are buffered (so small API
 /// responses keep the existing diagnostic-logging path).
 const STREAM_SIZE_THRESHOLD: u64 = 256 * 1024;
+
+/// Cap on the bounded response copy kept for LLM usage extraction when a
+/// chunked JSON body streams through the passthrough branch. Bodies larger
+/// than this fall back to the byte-based token estimate.
+const USAGE_CAPTURE_MAX_BYTES: usize = 2 * 1024 * 1024;
 
 /// Content types that should always be streamed regardless of size.
 const STREAMING_CONTENT_TYPES: &[&str] = &[
@@ -4547,9 +4610,10 @@ mod tests {
         ALLOWED_FORWARD_HEADER_PREFIXES, ALLOWED_FORWARD_HEADERS, ALLOWED_WS_FORWARD_HEADERS,
         ConnectionUsageStats, WsPassthroughGuard, add_websocket_usage_provenance,
         apply_agent_attribution_headers, auth_kind_label, collect_forward_headers_with_prefixes,
-        compose_pre_resolved_node_ids, enforce_node_route_scope, is_chat_completions_proxy_path,
-        is_codex_transport_path, is_ws_upgrade_request, should_enforce_runtime_approval,
-        validate_range_header, websocket_realtime_usage_enabled, websocket_resale_usage,
+        compose_pre_resolved_node_ids, enforce_node_route_scope, final_credential_class,
+        is_chat_completions_proxy_path, is_codex_transport_path, is_ws_upgrade_request,
+        should_enforce_runtime_approval, validate_range_header, websocket_realtime_usage_enabled,
+        websocket_resale_usage,
     };
     use crate::models::service_billing::{BillingMetric, ServiceBilling};
     use crate::models::usage_meter::CredentialClass;
@@ -4799,6 +4863,7 @@ mod tests {
 
     fn token_resale_metered_context(credential_class: CredentialClass) -> MeteredProxyContext {
         let billing = ServiceBilling {
+            platform_billable: false,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),
@@ -5414,6 +5479,25 @@ mod tests {
             ws_frame_injections: Vec::new(),
             connection_id: None,
         }
+    }
+
+    #[test]
+    fn user_service_with_master_credential_classifies_as_master() {
+        let mut target = make_target("http://localhost:8080");
+        target.auth_method = "bearer".to_string();
+        target.credential = "master-key".to_string();
+
+        // Auto-provisioned UserService (no user key) injecting the catalog
+        // master credential: the platform's key, not the user's.
+        assert_eq!(
+            final_credential_class(Some("us-1"), false, false, true, true, &target),
+            CredentialClass::NyxidManagedMaster
+        );
+        // A UserService backed by the user's own key stays user-owned.
+        assert_eq!(
+            final_credential_class(Some("us-1"), false, false, true, false, &target),
+            CredentialClass::UserOwned
+        );
     }
 
     #[test]

--- a/backend/src/handlers/public_mcp.rs
+++ b/backend/src/handlers/public_mcp.rs
@@ -311,6 +311,7 @@ mod tests {
         billable_svc.id = Uuid::new_v4().to_string();
         billable_svc.slug = "billable-service".to_string();
         billable_svc.billing = Some(ServiceBilling {
+            platform_billable: false,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/handlers/public_proxy.rs
+++ b/backend/src/handlers/public_proxy.rs
@@ -732,6 +732,7 @@ mod tests {
             };
             let mut service = public_service("pub", "https://example.test", 100);
             service.billing = Some(ServiceBilling {
+                platform_billable: false,
                 resale_billable: true,
                 resale_metric: BillingMetric::Tokens,
                 lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/handlers/services.rs
+++ b/backend/src/handlers/services.rs
@@ -1575,10 +1575,11 @@ pub async fn update_service(
     let mut next_resale_billable: Option<bool> = None;
     if body.billing.is_some() {
         validate_service_billing(body.billing.as_ref())?;
-        let next_billing = body
-            .billing
-            .clone()
-            .filter(|billing| billing.resale_billable || billing.lago_resale_metric_code.is_some());
+        let next_billing = body.billing.clone().filter(|billing| {
+            billing.platform_billable
+                || billing.resale_billable
+                || billing.lago_resale_metric_code.is_some()
+        });
         next_resale_billable = Some(
             next_billing
                 .as_ref()

--- a/backend/src/handlers/users.rs
+++ b/backend/src/handlers/users.rs
@@ -127,7 +127,11 @@ pub async fn get_me(
             },
         },
         capabilities: UserCapabilitiesResponse {
-            billing_available: state.billing.billing_enabled() && state.billing.lago_configured(),
+            billing_available: state.billing.billing_enabled()
+                && state.billing.lago_configured()
+                && enabled_features
+                    .iter()
+                    .any(|key| key == crate::services::feature_flag_service::BILLING_FLAG_KEY),
             enabled_features,
         },
     }))

--- a/backend/src/models/service_billing.rs
+++ b/backend/src/models/service_billing.rs
@@ -12,6 +12,11 @@ pub enum BillingMetric {
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 pub struct ServiceBilling {
+    /// Opt-in platform-layer charging. Services default to free (metered
+    /// for observability, never charged); admins enable this on the
+    /// platform-operated services that should bill wallet credits.
+    #[serde(default)]
+    pub platform_billable: bool,
     #[serde(default)]
     pub resale_billable: bool,
     #[serde(default)]
@@ -23,6 +28,7 @@ pub struct ServiceBilling {
 impl Default for ServiceBilling {
     fn default() -> Self {
         Self {
+            platform_billable: false,
             resale_billable: false,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: None,
@@ -101,6 +107,7 @@ mod tests {
     #[test]
     fn active_resale_spec_requires_metric_code() {
         let mut billing = ServiceBilling {
+            platform_billable: false,
             resale_billable: true,
             resale_metric: BillingMetric::Requests,
             lago_resale_metric_code: None,

--- a/backend/src/services/anonymous_endpoint_service.rs
+++ b/backend/src/services/anonymous_endpoint_service.rs
@@ -590,6 +590,7 @@ mod tests {
     fn enabled_rules_reject_resale_billing() {
         let mut service = compatible_service();
         service.billing = Some(crate::models::service_billing::ServiceBilling {
+            platform_billable: false,
             resale_billable: true,
             resale_metric: crate::models::service_billing::BillingMetric::Requests,
             lago_resale_metric_code: Some("resale_requests".to_string()),

--- a/backend/src/services/billing/lago_client.rs
+++ b/backend/src/services/billing/lago_client.rs
@@ -42,6 +42,7 @@ pub trait LagoApi: Send + Sync {
 pub struct LagoClient {
     base_url: String,
     api_key: String,
+    payment_provider_code: Option<String>,
     http: reqwest::Client,
 }
 
@@ -69,8 +70,16 @@ impl LagoClient {
         Ok(Self {
             base_url,
             api_key,
+            payment_provider_code: None,
             http,
         })
+    }
+
+    /// Link newly created customers to this Lago payment provider connection
+    /// (a "stripe" connection code) so top-up checkout URLs can be generated.
+    pub fn with_payment_provider_code(mut self, code: Option<String>) -> Self {
+        self.payment_provider_code = code;
+        self
     }
 
     fn url(&self, path: &str) -> String {
@@ -140,13 +149,19 @@ impl LagoApi for LagoClient {
             return Ok(owner.external_customer_id.clone());
         }
 
-        let body = json!({
-            "customer": {
-                "external_id": owner.external_customer_id,
-                "name": owner.name,
-                "email": owner.email,
-            }
+        let mut customer = json!({
+            "external_id": owner.external_customer_id,
+            "name": owner.name,
+            "email": owner.email,
         });
+        if let Some(code) = &self.payment_provider_code {
+            customer["billing_configuration"] = json!({
+                "payment_provider": "stripe",
+                "payment_provider_code": code,
+                "sync_with_provider": true,
+            });
+        }
+        let body = json!({ "customer": customer });
         match self
             .json_request(reqwest::Method::POST, "customers", Some(body))
             .await
@@ -198,6 +213,9 @@ impl LagoApi for LagoClient {
             "wallet": {
                 "external_customer_id": customer_id,
                 "currency": "USD",
+                // Lago requires a credit-to-currency rate on wallet creation;
+                // NyxID credits are denominated 1:1 with the wallet currency.
+                "rate_amount": "1",
             }
         });
         match self
@@ -229,12 +247,14 @@ impl LagoApi for LagoClient {
         let body = json!({
             "wallet_transaction": {
                 "wallet_id": wallet_id,
-                "paid_credits": request.amount_credits,
+                // Lago validates credit amounts as decimal strings and
+                // rejects JSON numbers with invalid_paid_credits.
+                "paid_credits": request.amount_credits.to_string(),
                 // granted_credits are FREE/promotional in Lago and ADDITIVE to
                 // paid_credits. A paid top-up must grant ONLY the purchased
                 // amount, so this is 0; otherwise the customer receives 2N
                 // credits for an N payment. See #1050.
-                "granted_credits": 0,
+                "granted_credits": "0",
                 "external_id": request.external_id,
                 "invoice_requires_successful_payment": true,
             }
@@ -341,7 +361,7 @@ impl LagoApi for LagoClient {
             )
             .await
             .map_err(lago_error_to_app)?;
-        extract_wallet_balance_credits(&value).ok_or_else(|| {
+        extract_active_wallet_balance_credits(&value).ok_or_else(|| {
             AppError::BillingProviderUnavailable(
                 "Lago wallet balance response did not include a balance".to_string(),
             )
@@ -388,7 +408,7 @@ impl LagoClient {
             )
             .await
             .map_err(lago_error_to_app)?;
-        Ok(extract_wallet(&value))
+        Ok(extract_active_wallet(&value))
     }
 
     async fn generate_wallet_transaction_payment_url(
@@ -578,7 +598,15 @@ impl LagoError {
 
     fn from_response(status: StatusCode, json: Value, raw_text: String) -> Self {
         let code = lago_error_code(&json);
-        let message = lago_error_message(&json).unwrap_or(raw_text);
+        // Keep Lago's error_details in the message: a bare "Unprocessable
+        // Entity" hides which field validation failed.
+        let message = match (lago_error_message(&json), json.get("error_details")) {
+            (Some(message), Some(details)) if !details.is_null() => {
+                format!("{message}: {details}")
+            }
+            (Some(message), _) => message,
+            (None, _) => raw_text,
+        };
         let kind = classify_lago_failure(status, code.as_deref(), &json);
         Self {
             status: Some(status),
@@ -589,12 +617,11 @@ impl LagoError {
     }
 
     pub fn is_conflict_like(&self) -> bool {
-        self.status == Some(StatusCode::CONFLICT)
-            || (self.status == Some(StatusCode::UNPROCESSABLE_ENTITY)
-                && matches!(
-                    self.code.as_deref(),
-                    Some("value_already_exist" | "validation_errors")
-                ))
+        // A 422 is a conflict only when classification saw a duplicate
+        // indicator in the body; other validation errors (e.g. a missing
+        // required field) must surface instead of being read back as an
+        // existing resource.
+        self.status == Some(StatusCode::CONFLICT) || self.kind == LagoErrorKind::Duplicate
     }
 }
 
@@ -671,8 +698,11 @@ pub fn extract_wallet_balance_credits(value: &Value) -> Option<i64> {
         json_i64_path(
             wallet,
             &[
-                "credits_balance",
+                // Prefer the ongoing balance: Lago decrements credits_balance
+                // only when a period invoice settles, while ongoing reflects
+                // usage as it accrues — the number a prepaid gate cares about.
                 "credits_ongoing_balance",
+                "credits_balance",
                 "credits_ongoing_usage_balance",
                 "ongoing_balance",
                 "balance_credits",
@@ -680,6 +710,46 @@ pub fn extract_wallet_balance_credits(value: &Value) -> Option<i64> {
             ],
         )
     })
+}
+
+/// Extract the accrued period usage in cents from a Lago current_usage
+/// response (`{"customer_usage": {"total_amount_cents": ...}}`).
+pub fn extract_current_usage_amount_cents(value: &Value) -> Option<i64> {
+    let usage = value.get("customer_usage").unwrap_or(value);
+    usage
+        .get("total_amount_cents")
+        .and_then(json_i64_value)
+        .or_else(|| usage.get("amount_cents").and_then(json_i64_value))
+}
+
+/// Pick the first non-terminated wallet from a Lago wallets list response.
+/// Lago keeps terminated wallets in the collection and may list them before
+/// the active one; wallets without a status field count as active. Returns
+/// None when the response is not a wallets list.
+fn active_wallet_value(value: &Value) -> Option<&Value> {
+    match value.get("wallets") {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter(|item| item.is_object())
+            .find(|item| item.get("status").and_then(Value::as_str) != Some("terminated")),
+        _ => None,
+    }
+}
+
+/// Extract a wallet from a Lago wallets list, skipping terminated entries.
+pub fn extract_active_wallet(value: &Value) -> Option<LagoWallet> {
+    if matches!(value.get("wallets"), Some(Value::Array(_))) {
+        return active_wallet_value(value).and_then(extract_wallet);
+    }
+    extract_wallet(value)
+}
+
+/// Extract a balance from a Lago wallets list, skipping terminated entries.
+pub fn extract_active_wallet_balance_credits(value: &Value) -> Option<i64> {
+    if matches!(value.get("wallets"), Some(Value::Array(_))) {
+        return active_wallet_value(value).and_then(extract_wallet_balance_credits);
+    }
+    extract_wallet_balance_credits(value)
 }
 
 pub fn extract_wallet(value: &Value) -> Option<LagoWallet> {
@@ -896,8 +966,9 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        LagoApi, LagoClient, LagoErrorKind, LagoEvent, LagoEventProperties, OwnerProvisionInput,
-        classify_lago_failure, extract_wallet_balance_credits, subscription_external_id,
+        LagoApi, LagoClient, LagoError, LagoErrorKind, LagoEvent, LagoEventProperties,
+        OwnerProvisionInput, classify_lago_failure, extract_active_wallet,
+        extract_wallet_balance_credits, subscription_external_id,
     };
 
     async fn spawn_lago_mock(app: axum::Router) -> String {
@@ -929,6 +1000,60 @@ mod tests {
             ),
             LagoErrorKind::Duplicate
         );
+    }
+
+    #[test]
+    fn validation_error_without_duplicate_indicator_is_not_conflict_like() {
+        let body = json!({
+            "status": 422,
+            "error": "Unprocessable Entity",
+            "code": "validation_errors",
+            "error_details": { "rate_amount": ["is not a number"] }
+        });
+        let error = LagoError::from_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            body.clone(),
+            body.to_string(),
+        );
+
+        assert!(!error.is_conflict_like());
+    }
+
+    #[test]
+    fn validation_error_with_duplicate_indicator_is_conflict_like() {
+        let body = json!({
+            "status": 422,
+            "error": "Unprocessable Entity",
+            "code": "validation_errors",
+            "error_details": { "external_id": ["value_already_exist"] }
+        });
+        let error = LagoError::from_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            body.clone(),
+            body.to_string(),
+        );
+
+        assert!(error.is_conflict_like());
+    }
+
+    #[test]
+    fn extract_active_wallet_skips_terminated_wallets() {
+        let body = json!({
+            "wallets": [
+                { "lago_id": "w-terminated", "status": "terminated", "credits_balance": "5.0" },
+                { "lago_id": "w-active", "status": "active", "credits_balance": "3.0" }
+            ]
+        });
+
+        let wallet = extract_active_wallet(&body).expect("active wallet");
+        assert_eq!(wallet.id, "w-active");
+
+        let all_terminated = json!({
+            "wallets": [
+                { "lago_id": "w-terminated", "status": "terminated", "credits_balance": "5.0" }
+            ]
+        });
+        assert!(extract_active_wallet(&all_terminated).is_none());
     }
 
     #[test]
@@ -1009,6 +1134,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_customer_links_payment_provider_when_configured() {
+        async fn get_customer() -> axum::http::StatusCode {
+            axum::http::StatusCode::NOT_FOUND
+        }
+
+        async fn create_customer(
+            axum::Json(body): axum::Json<serde_json::Value>,
+        ) -> axum::Json<serde_json::Value> {
+            let billing = &body["customer"]["billing_configuration"];
+            assert_eq!(billing["payment_provider"].as_str(), Some("stripe"));
+            assert_eq!(billing["payment_provider_code"].as_str(), Some("sandbox"));
+            assert_eq!(billing["sync_with_provider"].as_bool(), Some(true));
+            axum::Json(json!({ "customer": { "external_id": "owner-1" } }))
+        }
+
+        let base_url = spawn_lago_mock(
+            axum::Router::new()
+                .route(
+                    "/api/v1/customers/owner-1",
+                    axum::routing::get(get_customer),
+                )
+                .route("/api/v1/customers", axum::routing::post(create_customer)),
+        )
+        .await;
+        let client = LagoClient::new(base_url, "test-key".to_string())
+            .expect("client")
+            .with_payment_provider_code(Some("sandbox".to_string()));
+
+        let customer_id = client
+            .ensure_customer(&OwnerProvisionInput {
+                external_customer_id: "owner-1".to_string(),
+                name: Some("Owner One".to_string()),
+                email: None,
+            })
+            .await
+            .expect("ensure customer");
+
+        assert_eq!(customer_id, "owner-1");
+    }
+
+    #[tokio::test]
     async fn wallet_balance_reads_by_external_customer_id() {
         async fn get_wallet(
             axum::extract::Query(query): axum::extract::Query<
@@ -1047,10 +1213,11 @@ mod tests {
             // Bug #1050: granted_credits are FREE/promotional in Lago, so a paid
             // top-up must grant ONLY the paid amount — granted_credits MUST be 0,
             // otherwise the customer receives 2N credits for an N payment.
-            assert_eq!(wt["paid_credits"].as_i64(), Some(500), "paid_credits");
+            // Amounts are decimal strings: Lago rejects JSON numbers.
+            assert_eq!(wt["paid_credits"].as_str(), Some("500"), "paid_credits");
             assert_eq!(
-                wt["granted_credits"].as_i64(),
-                Some(0),
+                wt["granted_credits"].as_str(),
+                Some("0"),
                 "granted_credits must be 0 for a paid top-up"
             );
             assert_eq!(
@@ -1111,10 +1278,10 @@ mod tests {
             axum::Json(body): axum::Json<serde_json::Value>,
         ) -> axum::Json<serde_json::Value> {
             let wt = &body["wallet_transaction"];
-            assert_eq!(wt["paid_credits"].as_i64(), Some(500), "paid_credits");
+            assert_eq!(wt["paid_credits"].as_str(), Some("500"), "paid_credits");
             assert_eq!(
-                wt["granted_credits"].as_i64(),
-                Some(0),
+                wt["granted_credits"].as_str(),
+                Some("0"),
                 "granted_credits must be 0 for a paid top-up"
             );
             assert_eq!(

--- a/backend/src/services/billing/meter.rs
+++ b/backend/src/services/billing/meter.rs
@@ -516,6 +516,7 @@ mod tests {
             .expect("create transaction id index");
 
         let billing = ServiceBilling {
+            platform_billable: true,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),
@@ -775,6 +776,7 @@ mod tests {
         };
         create_usage_transaction_index(&db).await;
         let billing = ServiceBilling {
+            platform_billable: true,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/services/billing/mod.rs
+++ b/backend/src/services/billing/mod.rs
@@ -156,10 +156,19 @@ impl BillingService {
 
     pub async fn open(&self, ctx: &BillingRouteContext) -> AppResult<MeteredProxyContext> {
         let ctx = if self.config.billing_enabled {
+            // Staged rollout: charging applies only to owners covered by the
+            // billing feature flag. Everyone else is metered for
+            // observability but never charged on either layer.
+            let rollout_enabled = crate::services::feature_flag_service::billing_rollout_enabled(
+                &self.db,
+                &ctx.billing_owner_id,
+                &ctx.actor_user_id,
+            )
+            .await?;
             // Platform charging is an admin opt-in per service: services
             // without billing.platform_billable stay free (metered only),
             // so BYOK and unconfigured services never draw from wallets.
-            let platform_billable = if ctx.service_platform_billable {
+            let platform_billable = if rollout_enabled && ctx.service_platform_billable {
                 self.ensure_wallet_for_charging(&ctx.billing_owner_id)
                     .await?;
                 self.owner_has_chargeable_wallet(&ctx.billing_owner_id)
@@ -167,7 +176,11 @@ impl BillingService {
             } else {
                 false
             };
-            ctx.clone().with_platform_metering(platform_billable)
+            let mut ctx = ctx.clone();
+            if !rollout_enabled {
+                ctx.resale = None;
+            }
+            ctx.with_platform_metering(platform_billable)
         } else {
             ctx.clone()
         };
@@ -509,6 +522,77 @@ mod tests {
         assert!(wallet.is_none(), "free services must not provision wallets");
         assert_eq!(lago.wallet_creates.load(Ordering::SeqCst), 0);
         assert_eq!(row.wallet_id, None, "free services must not hold credits");
+    }
+
+    #[tokio::test]
+    async fn billing_rollout_flag_disabled_skips_charging() {
+        let Some(db) = connect_test_database("billing_rollout_flag_gate").await else {
+            return;
+        };
+        role_service::seed_system_roles(&db)
+            .await
+            .expect("seed roles");
+        insert_platform_rate(&db, 1).await;
+        let owner = crate::services::auth_service::register_user(
+            &db,
+            "wallet-rollout@example.com",
+            "password123",
+            Some("Wallet Rollout"),
+            None,
+            true,
+        )
+        .await
+        .expect("create owner");
+        // Simulate the production default: the rollout flag is off unless a
+        // staff override targets the owner (test builds default it on).
+        crate::services::feature_flag_service::set_platform_override(
+            &db,
+            crate::services::feature_flag_service::BILLING_FLAG_KEY,
+            &crate::services::feature_flag_service::FlagTarget::Global,
+            false,
+            &owner.user_id,
+        )
+        .await
+        .expect("disable billing flag globally");
+
+        let mut config = test_app_config();
+        config.billing_enabled = true;
+        config.lago_plan_code = "starter".to_string();
+        let lago = Arc::new(FakeLago::default());
+        let service = BillingService::new_with_lago(db.clone(), Arc::new(config), lago.clone());
+        let billable_billing = ServiceBilling {
+            platform_billable: true,
+            ..Default::default()
+        };
+        let ctx = BillingRouteContext::new(
+            BillingIngress::Proxy,
+            Uuid::new_v4().to_string(),
+            owner.user_id.clone(),
+            owner.user_id.clone(),
+            None,
+            Some("user-service-1".to_string()),
+            Some("catalog-1".to_string()),
+            Some("service-one".to_string()),
+            NodeIntent::Direct,
+            "bearer".to_string(),
+            CredentialClass::UserOwned,
+            BillingMetric::Requests,
+            Some(&billable_billing),
+            false,
+        );
+
+        service.open(&ctx).await.expect("open metering");
+
+        let wallet = db
+            .collection::<BillingWallet>(crate::models::billing_wallet::COLLECTION_NAME)
+            .find_one(doc! { "owner_id": &owner.user_id })
+            .await
+            .expect("query wallet");
+        assert!(
+            wallet.is_none(),
+            "owners outside the rollout must not be charged even on billable services"
+        );
+        assert_eq!(lago.wallet_creates.load(Ordering::SeqCst), 0);
     }
 
     async fn insert_platform_rate(db: &mongodb::Database, credits: i64) {

--- a/backend/src/services/billing/mod.rs
+++ b/backend/src/services/billing/mod.rs
@@ -34,7 +34,9 @@ impl BillingService {
     pub fn new(db: DbHandle, config: Arc<AppConfig>) -> Self {
         let lago = match (&config.lago_api_url, &config.lago_api_key) {
             (Some(url), Some(key)) => match LagoClient::new(url.clone(), key.clone()) {
-                Ok(client) => Some(Arc::new(client) as Arc<dyn LagoApi>),
+                Ok(client) => Some(Arc::new(
+                    client.with_payment_provider_code(config.lago_payment_provider_code.clone()),
+                ) as Arc<dyn LagoApi>),
                 Err(error) => {
                     tracing::warn!(error = %error, "Lago billing client is not configured");
                     None
@@ -154,11 +156,17 @@ impl BillingService {
 
     pub async fn open(&self, ctx: &BillingRouteContext) -> AppResult<MeteredProxyContext> {
         let ctx = if self.config.billing_enabled {
-            self.ensure_wallet_for_charging(&ctx.billing_owner_id)
-                .await?;
-            let platform_billable = self
-                .owner_has_chargeable_wallet(&ctx.billing_owner_id)
-                .await?;
+            // Platform charging is an admin opt-in per service: services
+            // without billing.platform_billable stay free (metered only),
+            // so BYOK and unconfigured services never draw from wallets.
+            let platform_billable = if ctx.service_platform_billable {
+                self.ensure_wallet_for_charging(&ctx.billing_owner_id)
+                    .await?;
+                self.owner_has_chargeable_wallet(&ctx.billing_owner_id)
+                    .await?
+            } else {
+                false
+            };
             ctx.clone().with_platform_metering(platform_billable)
         } else {
             ctx.clone()
@@ -285,6 +293,7 @@ mod tests {
         insert_wallet(&db, owner_id).await;
         let service = BillingService::new(db.clone(), std::sync::Arc::new(test_app_config()));
         let billing = ServiceBilling {
+            platform_billable: true,
             resale_billable: true,
             resale_metric: BillingMetric::Requests,
             lago_resale_metric_code: Some("resale_requests".to_string()),
@@ -392,6 +401,10 @@ mod tests {
         config.lago_plan_code = "starter".to_string();
         let lago = Arc::new(FakeLago::default());
         let service = BillingService::new_with_lago(db.clone(), Arc::new(config), lago.clone());
+        let billable_billing = ServiceBilling {
+            platform_billable: true,
+            ..Default::default()
+        };
         let ctx = BillingRouteContext::new(
             BillingIngress::Proxy,
             Uuid::new_v4().to_string(),
@@ -405,7 +418,7 @@ mod tests {
             "bearer".to_string(),
             CredentialClass::UserOwned,
             BillingMetric::Requests,
-            None::<&ServiceBilling>,
+            Some(&billable_billing),
             false,
         );
 
@@ -436,6 +449,66 @@ mod tests {
         assert_eq!(lago.wallet_creates.load(Ordering::SeqCst), 1);
         assert_eq!(row.layer, BillingLayer::Platform);
         assert_eq!(row.wallet_id.as_deref(), Some(wallet.id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn service_without_platform_billable_opts_out_of_charging() {
+        let Some(db) = connect_test_database("billing_platform_opt_in").await else {
+            return;
+        };
+        role_service::seed_system_roles(&db)
+            .await
+            .expect("seed roles");
+        insert_platform_rate(&db, 1).await;
+        let owner = crate::services::auth_service::register_user(
+            &db,
+            "wallet-optout@example.com",
+            "password123",
+            Some("Wallet Opt Out"),
+            None,
+            true,
+        )
+        .await
+        .expect("create owner");
+        let mut config = test_app_config();
+        config.billing_enabled = true;
+        config.lago_plan_code = "starter".to_string();
+        let lago = Arc::new(FakeLago::default());
+        let service = BillingService::new_with_lago(db.clone(), Arc::new(config), lago.clone());
+        let ctx = BillingRouteContext::new(
+            BillingIngress::Proxy,
+            Uuid::new_v4().to_string(),
+            owner.user_id.clone(),
+            owner.user_id.clone(),
+            None,
+            Some("user-service-1".to_string()),
+            Some("catalog-1".to_string()),
+            Some("service-one".to_string()),
+            NodeIntent::Direct,
+            "bearer".to_string(),
+            CredentialClass::UserOwned,
+            BillingMetric::Requests,
+            None::<&ServiceBilling>,
+            false,
+        );
+
+        service.open(&ctx).await.expect("open metering");
+
+        let wallet = db
+            .collection::<BillingWallet>(crate::models::billing_wallet::COLLECTION_NAME)
+            .find_one(doc! { "owner_id": &owner.user_id })
+            .await
+            .expect("query wallet");
+        let row = db
+            .collection::<UsageMeterRow>(crate::models::usage_meter::COLLECTION_NAME)
+            .find_one(doc! { "billing_owner_id": &owner.user_id })
+            .await
+            .expect("find usage row")
+            .expect("row exists");
+
+        assert!(wallet.is_none(), "free services must not provision wallets");
+        assert_eq!(lago.wallet_creates.load(Ordering::SeqCst), 0);
+        assert_eq!(row.wallet_id, None, "free services must not hold credits");
     }
 
     async fn insert_platform_rate(db: &mongodb::Database, credits: i64) {

--- a/backend/src/services/billing/mod.rs
+++ b/backend/src/services/billing/mod.rs
@@ -476,7 +476,7 @@ mod tests {
         let owner = crate::services::auth_service::register_user(
             &db,
             "wallet-optout@example.com",
-            "password123",
+            &format!("test-{}", Uuid::new_v4()),
             Some("Wallet Opt Out"),
             None,
             true,
@@ -536,7 +536,7 @@ mod tests {
         let owner = crate::services::auth_service::register_user(
             &db,
             "wallet-rollout@example.com",
-            "password123",
+            &format!("test-{}", Uuid::new_v4()),
             Some("Wallet Rollout"),
             None,
             true,

--- a/backend/src/services/billing/reconcile.rs
+++ b/backend/src/services/billing/reconcile.rs
@@ -8,13 +8,16 @@ use mongodb::options::{FindOneAndUpdateOptions, ReturnDocument};
 
 use crate::config::AppConfig;
 use crate::errors::AppResult;
+use crate::models::billing_wallet::{BillingWallet, COLLECTION_NAME as BILLING_WALLET};
 use crate::models::usage_meter::{COLLECTION_NAME as USAGE_METER, UsageMeterRow};
 
 use super::lago_client::{LagoApi, LagoError, LagoErrorKind, LagoEvent};
 use super::reservation;
+use super::webhook;
 
 const PUSH_GRACE_SECS: i64 = 30;
 const MAX_RECONCILE_PUSH_BATCH: i64 = 100;
+const MAX_WALLET_REFRESH_BATCH: i64 = 100;
 const ACKED_RETENTION_DAYS: i64 = 30;
 
 #[derive(Clone)]
@@ -33,6 +36,7 @@ pub struct ReconcileStats {
     pub abandoned: u64,
     pub recovered_settlements: u64,
     pub drift_alerts: u64,
+    pub wallet_balance_refreshes: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -69,7 +73,71 @@ impl BillingReconciler {
         self.push_unacked(lago.as_ref(), &mut stats).await?;
         self.compare_finalized_usage(lago.as_ref(), &mut stats)
             .await?;
+        self.refresh_wallet_balances(lago.as_ref(), &mut stats)
+            .await?;
         Ok(stats)
+    }
+
+    /// Pull wallet balances from Lago into the local cache. Webhooks are the
+    /// primary balance signal, but deployments Lago cannot reach (or missed
+    /// deliveries) would otherwise never converge.
+    async fn refresh_wallet_balances(
+        &self,
+        lago: &dyn LagoApi,
+        stats: &mut ReconcileStats,
+    ) -> AppResult<()> {
+        let wallets: Vec<BillingWallet> = self
+            .db
+            .collection::<BillingWallet>(BILLING_WALLET)
+            .find(doc! {})
+            .sort(doc! { "balance_synced_at": 1 })
+            .limit(MAX_WALLET_REFRESH_BATCH)
+            .await?
+            .try_collect()
+            .await?;
+
+        for wallet in wallets {
+            match lago.wallet_balance(&wallet.lago_customer_id).await {
+                Ok(balance_credits) => {
+                    // OSS Lago never refreshes credits_ongoing_balance (the
+                    // clock job is premium-gated), so the synced balance
+                    // ignores usage accrued this period until the invoice
+                    // settles. Subtract the period's current_usage ourselves;
+                    // cents convert 1:1 to credits (wallet rate_amount is 1)
+                    // and partial credits round up against availability.
+                    let accrued_credits = match wallet.lago_subscription_id.as_deref() {
+                        Some(subscription_id) => lago
+                            .current_usage(&wallet.lago_customer_id, subscription_id)
+                            .await
+                            .ok()
+                            .and_then(|usage| {
+                                super::lago_client::extract_current_usage_amount_cents(&usage.raw)
+                            })
+                            .map(|cents| (cents.max(0) + 99) / 100)
+                            .unwrap_or(0),
+                        None => 0,
+                    };
+                    if webhook::refresh_wallet_balance(
+                        &self.db,
+                        &wallet.lago_customer_id,
+                        balance_credits.saturating_sub(accrued_credits),
+                    )
+                    .await?
+                    .is_some()
+                    {
+                        stats.wallet_balance_refreshes += 1;
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        owner_id = %wallet.owner_id,
+                        error = %error,
+                        "Billing wallet balance refresh from Lago failed"
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     async fn abandon_unforwarded_reserved(&self) -> AppResult<u64> {
@@ -96,8 +164,26 @@ impl BillingReconciler {
             .try_collect()
             .await?;
 
+        // Events pushed without an external_subscription_id are stored by
+        // Lago but never attached to a subscription's charges, so usage
+        // silently aggregates to zero. Resolve each owner's subscription
+        // from the local wallet, memoized for the batch.
+        let mut subscriptions: BTreeMap<String, Option<String>> = BTreeMap::new();
         for row in rows {
-            let Some(event) = LagoEvent::from_usage_row(&row, None) else {
+            let subscription_id = match subscriptions.get(&row.billing_owner_id) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let resolved = self
+                        .db
+                        .collection::<BillingWallet>(BILLING_WALLET)
+                        .find_one(doc! { "owner_id": &row.billing_owner_id })
+                        .await?
+                        .and_then(|wallet| wallet.lago_subscription_id);
+                    subscriptions.insert(row.billing_owner_id.clone(), resolved.clone());
+                    resolved
+                }
+            };
+            let Some(event) = LagoEvent::from_usage_row(&row, subscription_id) else {
                 mark_dead_letter(
                     &self.db,
                     &row.id,

--- a/backend/src/services/billing/route_context.rs
+++ b/backend/src/services/billing/route_context.rs
@@ -25,6 +25,9 @@ pub struct BillingRouteContext {
     pub credential_class: CredentialClass,
     pub platform_metric: BillingMetric,
     pub resale: Option<ResaleSpec>,
+    /// Admin opt-in from the service's billing config: only services
+    /// explicitly marked platform_billable charge the platform layer.
+    pub(crate) service_platform_billable: bool,
     pub(crate) platform_metered: bool,
     pub(crate) platform_billable: bool,
 }
@@ -54,6 +57,8 @@ impl BillingRouteContext {
                     .filter(|_| credential_class == CredentialClass::NyxidManagedMaster)
             })
             .flatten();
+        let service_platform_billable =
+            service_billing.is_some_and(|billing| billing.platform_billable);
 
         Self {
             ingress,
@@ -69,6 +74,7 @@ impl BillingRouteContext {
             credential_class,
             platform_metric,
             resale,
+            service_platform_billable,
             platform_metered: false,
             platform_billable: false,
         }
@@ -102,6 +108,7 @@ mod tests {
 
     fn context_for(credential_class: CredentialClass) -> BillingRouteContext {
         let billing = ServiceBilling {
+            platform_billable: false,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),
@@ -144,6 +151,7 @@ mod tests {
     #[test]
     fn resale_requires_operator_flag() {
         let billing = ServiceBilling {
+            platform_billable: false,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -1141,6 +1141,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -65,14 +65,37 @@ const AI_ASSISTANT_FLAG: FeatureFlagDef = FeatureFlagDef {
     default_enabled: false,
 };
 
+/// Staged rollout for usage billing: only flagged owners are charged and see
+/// the billing surface, even when `BILLING_ENABLED` and Lago are configured.
+/// Off by default so charging can be piloted on a staff-selected org cohort.
+pub const BILLING_FLAG_KEY: &str = "experimental:billing";
+
 #[cfg(not(test))]
-pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[AI_ASSISTANT_FLAG];
+const BILLING_FLAG: FeatureFlagDef = FeatureFlagDef {
+    key: BILLING_FLAG_KEY,
+    description: "Usage billing and wallet charging (staged rollout).",
+    default_enabled: false,
+};
+
+/// Test builds default the billing flag ON: the billing suites assume
+/// charging is active, and the disabled path is exercised explicitly through
+/// override rows.
+#[cfg(test)]
+const BILLING_FLAG_TEST: FeatureFlagDef = FeatureFlagDef {
+    key: BILLING_FLAG_KEY,
+    description: "Usage billing and wallet charging (staged rollout).",
+    default_enabled: true,
+};
+
+#[cfg(not(test))]
+pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[AI_ASSISTANT_FLAG, BILLING_FLAG];
 
 /// Test builds carry a placeholder flag so the resolution / override pipeline
 /// can exercise multiple definitions alongside the production registry entry.
 #[cfg(test)]
 pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
     AI_ASSISTANT_FLAG,
+    BILLING_FLAG_TEST,
     FeatureFlagDef {
         key: "example_ui",
         description: "Test-only placeholder flag.",
@@ -338,6 +361,27 @@ pub async fn resolve_personal_features(
         &membership_roles,
         user_id,
     ))
+}
+
+/// Whether the billing rollout flag is enabled for a billing owner.
+///
+/// The owner is a person for personal wallets (grant-union resolution, so
+/// members of a flagged org are covered on personal surfaces too) or an org
+/// user id for org wallets (that org's own `user -> role -> org` chain with
+/// the acting member, on top of the platform baseline).
+pub async fn billing_rollout_enabled(
+    db: &mongodb::Database,
+    billing_owner_id: &str,
+    actor_user_id: &str,
+) -> AppResult<bool> {
+    let enabled = if billing_owner_id == actor_user_id {
+        resolve_personal_features(db, billing_owner_id).await?
+    } else {
+        let org = list_overrides(db, billing_owner_id).await?;
+        let global = list_platform_overrides(db).await?;
+        resolve_from_overrides(&global, &org, actor_user_id, OrgRole::Member)
+    };
+    Ok(enabled.iter().any(|key| key == BILLING_FLAG_KEY))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -5743,6 +5743,7 @@ mod tests {
             node_id: None,
             user_service_id: "user-service".to_string(),
             has_server_credential: false,
+            master_credential: false,
             org_routing: org_user_id.map(|org_user_id| proxy_service::OrgRouting {
                 org_user_id: org_user_id.to_string(),
                 member_user_id: actor_user_id.to_string(),

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -693,6 +693,10 @@ pub struct UserServiceResolution {
     pub node_id: Option<String>,
     pub user_service_id: String,
     pub has_server_credential: bool,
+    /// True when the injected credential is the catalog service's master
+    /// credential (auto-provisioned UserService with no user key), not a
+    /// key the user supplied. Drives resale credential classification.
+    pub master_credential: bool,
     /// Set when the resolved UserService was reached via org membership
     /// (the actor has no personal copy). `None` means personal credentials.
     pub org_routing: Option<OrgRouting>,
@@ -1745,6 +1749,7 @@ async fn finish_resolution(
             node_id: user_service.node_id.clone(),
             user_service_id: user_service.id.clone(),
             has_server_credential: true,
+            master_credential: false,
             org_routing,
             pool_selection,
         });
@@ -1794,6 +1799,7 @@ async fn finish_resolution(
             node_id: user_service.node_id.clone(),
             user_service_id: user_service.id.clone(),
             has_server_credential: true,
+            master_credential: true,
             org_routing,
             pool_selection,
         });
@@ -1867,6 +1873,7 @@ async fn finish_resolution(
             node_id: user_service.node_id.clone(),
             user_service_id: user_service.id.clone(),
             has_server_credential,
+            master_credential: false,
             org_routing,
             pool_selection,
         });
@@ -1918,6 +1925,7 @@ async fn finish_resolution(
         node_id: user_service.node_id.clone(),
         user_service_id: user_service.id.clone(),
         has_server_credential: true,
+        master_credential: false,
         org_routing,
         pool_selection,
     })

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -869,6 +869,7 @@ mod tests {
             lago_api_url: None,
             lago_api_key: None,
             lago_plan_code: "starter".to_string(),
+            lago_payment_provider_code: None,
             lago_webhook_secret: None,
             billing_reconcile_interval_secs: 300,
             billing_rate_cache_ttl_secs: 900,

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -392,6 +392,7 @@ pub(crate) fn test_app_config() -> AppConfig {
         lago_api_url: None,
         lago_api_key: None,
         lago_plan_code: "starter".to_string(),
+        lago_payment_provider_code: None,
         lago_webhook_secret: None,
         billing_reconcile_interval_secs: 300,
         billing_rate_cache_ttl_secs: 900,

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -77,6 +77,7 @@ NyxID writes a durable `usage_meter` ledger, can push finalized rows into Lago, 
 | `LAGO_API_URL` | *(empty)* | Lago API URL for the P2 sink. May include or omit `/api/v1`. |
 | `LAGO_API_KEY` | *(empty)* | Lago API bearer key for NyxID-to-Lago calls; redacted from config debug output. |
 | `LAGO_PLAN_CODE` | `starter` | Lago plan code used by owner wallet provisioning/backfill when creating the owner's subscription. |
+| `LAGO_PAYMENT_PROVIDER_CODE` | *(empty)* | Code of the Lago Stripe payment provider connection. When set, newly created Lago customers are linked to it (`sync_with_provider: true`) so `POST /api/v1/billing/topup` can generate checkout URLs. Unset leaves customers unlinked and top-ups fail with `no_linked_payment_provider`; existing customers must be linked manually in the Lago dashboard. |
 | `LAGO_WEBHOOK_SECRET` | *(empty)* | Lago webhook verification secret for `POST /api/v1/webhooks/lago`; redacted from config debug output. Required to accept Lago-originated wallet/subscription updates. |
 | `BILLING_RECONCILE_INTERVAL_SECS` | `300` | Reconcile sweep interval. Set `0` to disable event push/reconcile sweeps. |
 | `BILLING_RATE_CACHE_TTL_SECS` | `900` | Maximum age of a read-only rate used for reservation sizing. A missing or older rate rejects a billable request before forwarding. |

--- a/docs/LAGO_SETUP.md
+++ b/docs/LAGO_SETUP.md
@@ -1,0 +1,132 @@
+# Lago Billing Setup
+
+Practical guide for wiring NyxID's usage billing to a real Lago instance
+(v1.48.x, self-hosted OSS). Companion to `docs/ENV.md` (variable semantics)
+and `docs/USAGE_BILLING_LAGO_SPEC.md` (architecture). Everything in this
+document was validated against a live deployment; the Caveats section lists
+the failure modes that are not obvious from Lago's docs.
+
+## 1. NyxID environment
+
+```bash
+BILLING_ENABLED=true
+LAGO_API_URL=https://billing.example.com/api   # see URL caveat below
+LAGO_API_KEY=<lago api key>
+LAGO_PLAN_CODE=starter                          # must exist in Lago
+LAGO_WEBHOOK_SECRET=<shared secret>             # only useful if Lago can reach NyxID
+LAGO_PAYMENT_PROVIDER_CODE=<stripe connection code>  # enables top-up checkout
+```
+
+URL caveat: `LAGO_API_URL` must point at the Lago **API**, not the dashboard.
+The client appends `/api/v1/` unless the URL already ends in it. Reverse
+proxies that serve the dashboard at the root and strip a leading `/api`
+before forwarding to the API container need the extra prefix (the example
+above resolves to `.../api/api/v1/...`, which is correct for that layout).
+Verify with `curl <LAGO_API_URL>/health` — it must return the Lago API
+version JSON, not HTML.
+
+## 2. Lago-side configuration
+
+1. **Billable metrics** (Settings -> Billable metrics), all SUM over the
+   `quantity` event property:
+   - `platform_tokens`
+   - `platform_requests`
+   - `platform_bytes`
+   - `resale_tokens` / `resale_requests` (only if resale is used)
+
+   Events also carry `model`, `service_code`, and `layer` properties for
+   grouping and charge filters.
+2. **Plan** (code = `LAGO_PLAN_CODE`): monthly, $0 base fee, paid in
+   arrears, with a standard charge per metric you intend to price. Metrics
+   without a charge aggregate but cost nothing.
+3. **Entitlement feature**: create a Feature with code `all_services` and
+   attach it to the plan. The reservation gate requires a subscription
+   entitlement of `*`, `all_services`, or the specific service slug;
+   without one, every billable request fails with 402
+   `plan_entitlement_required` (code 11303).
+4. **Stripe** (for top-ups): connect Stripe under Integrations and note the
+   connection **code** (not the display name) — that is the value for
+   `LAGO_PAYMENT_PROVIDER_CODE`. Set the connection's success redirect URL
+   to `<FRONTEND_URL>/billing` so checkout returns to NyxID.
+5. **Webhooks** (optional): point Lago at
+   `<BASE_URL>/api/v1/webhooks/lago` with `LAGO_WEBHOOK_SECRET`. When Lago
+   cannot reach NyxID (local development), skip this — the reconcile sweep
+   pulls the same state on `BILLING_RECONCILE_INTERVAL_SECS` (default 300s).
+
+Customers created by NyxID are linked to the Stripe connection only when
+`LAGO_PAYMENT_PROVIDER_CODE` is set at creation time. Customers provisioned
+before that must be linked manually (Lago UI: customer -> payment provider).
+
+## 3. Rate cache (required, manual for now)
+
+The reservation gate sizes credit holds from the `billing_rate_cache`
+MongoDB collection. The sweep that should mirror Lago's plan charges is not
+implemented, so rows must be seeded manually and kept "fresh" by a long TTL:
+
+```javascript
+db.billing_rate_cache.insertOne({
+  _id: "platform_tokens:*",
+  lago_metric_code: "platform_tokens",
+  credits_per_unit_micros: NumberLong(5),   // 0.000005 credits per token
+  synced_at: new Date(),
+})
+```
+
+Seed one row per metric you price (unpriced metrics can use `0`, which
+reserves nothing but keeps the gate open). Set
+`BILLING_RATE_CACHE_TTL_SECS` high (e.g. `31536000`); with the default 900s
+the rows go stale in 15 minutes and billable requests are rejected with
+"billing rate cache is stale". Keep `credits_per_unit_micros` in sync with
+the Lago charge price manually. 1 credit = 1 USD (wallets are created with
+`rate_amount: "1"`).
+
+## 4. What gets charged
+
+Charging is **opt-in per catalog service**. Everything is metered for
+observability, but credits are only reserved and Lago events only pushed
+for services whose billing config has `platform_billable: true` (admin
+Services page -> Edit -> Billing, or `PUT /api/v1/services/{id}` with
+`{"billing": {"platform_billable": true}}`).
+
+- User-added keys (BYOK) and custom endpoints are never charged.
+- Token metering applies to `/llm` routes and to proxied services whose
+  slug starts with `llm-`; other services meter requests/bytes.
+- Token counts use the provider-reported `usage` object (Chat Completions
+  and Responses API shapes, JSON and SSE), falling back to bytes/4.
+- The resale layer (charging for the platform's own upstream key at a
+  markup) is separate and additionally gated by `BILLING_RESALE_ENABLED`,
+  `resale_billable` on the service, and a final credential class of
+  `nyxid_managed_master`. See the spec for details.
+
+## 5. OSS Lago limitations
+
+- **Wallet ongoing balance never updates.** Lago's
+  `RefreshWalletsOngoingBalanceJob` is premium-licensed
+  (`return unless License.premium?`); on OSS, `credits_ongoing_balance`
+  stays equal to `credits_balance`, which itself only moves when a period
+  invoice settles. NyxID compensates: the reconcile sweep subtracts the
+  period's `current_usage` (which works on OSS) from the synced balance, so
+  the local balance reflects accrued usage within minutes.
+- **Balances are whole credits.** Sub-credit usage shows in the usage
+  panel's cost column before it moves the balance; availability rounds
+  accrued usage up to whole credits.
+- **Month-end transient**: when the period rolls over, accrued usage resets
+  slightly before the invoice debits the wallet, so the balance can briefly
+  read high until the invoice settles.
+
+## 6. Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Billing provider unavailable: Not Found` on startup backfill | `LAGO_API_URL` points at the dashboard or the wrong path prefix (section 1) |
+| Wallet creation fails with `rate_amount` validation | Lago requires wallet and credit amounts as decimal strings; fixed in the client — update NyxID |
+| 402 `plan_entitlement_required` (11303) on billable requests | Plan has no entitlement feature (section 2.3) |
+| 402 only on some services | Expected: those services have `platform_billable` enabled and the wallet cannot cover the reservation |
+| Top-up fails `no_linked_payment_provider` | Customer not linked to the Stripe connection (section 2.4) |
+| Events visible in Lago but usage aggregates to zero | Events pushed without `external_subscription_id`; fixed in reconcile — update NyxID |
+| Balance never changes | See section 5; also confirm the Lago `clock` scheduler and a worker consuming the `clock` queue are running |
+| Billable requests rejected with stale/missing rate | `billing_rate_cache` row missing or older than `BILLING_RATE_CACHE_TTL_SECS` (section 3) |
+
+Lago error bodies (`error_details`) are surfaced in NyxID's
+`Billing provider unavailable` messages, so backend logs identify the
+failing field directly.

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -17,6 +17,7 @@
  */
 export const FEATURE_FLAG = {
   AI_ASSISTANT: "experimental:ai-assistant",
+  BILLING: "experimental:billing",
 } as const;
 
 type FeatureFlagKey = (typeof FEATURE_FLAG)[keyof typeof FEATURE_FLAG];

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -366,12 +366,18 @@ function UsageSummary({
                     <TableCell>{labelize(row.metric)}</TableCell>
                     <TableCell className="text-right">{formatNumber(row.quantity)}</TableCell>
                     <TableCell className="text-right">
-                      {formatEstimatedCredits(row.estimated_credits_micros)}
+                      {row.billable === false
+                        ? "—"
+                        : formatEstimatedCredits(row.estimated_credits_micros)}
                     </TableCell>
                     <TableCell>
-                      <Badge variant={row.lago_acked ? "success" : "secondary"}>
-                        {row.lago_acked ? "Acked" : "Pending"}
-                      </Badge>
+                      {row.billable === false ? (
+                        <Badge variant="secondary">Free</Badge>
+                      ) : (
+                        <Badge variant={row.lago_acked ? "success" : "secondary"}>
+                          {row.lago_acked ? "Acked" : "Pending"}
+                        </Badge>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))

--- a/frontend/src/pages/service-edit.tsx
+++ b/frontend/src/pages/service-edit.tsx
@@ -77,6 +77,7 @@ export function ServiceEditPage() {
       identity_jwt_audience: "",
       forward_access_token: false,
       inject_delegation_token: false,
+      platform_billable: false,
       delegation_token_scope: "",
       homepage_url: "",
       repository_url: "",
@@ -124,6 +125,7 @@ export function ServiceEditPage() {
         identity_jwt_audience: service.identity_jwt_audience ?? "",
         forward_access_token: service.forward_access_token ?? false,
         inject_delegation_token: service.inject_delegation_token ?? false,
+        platform_billable: service.billing?.platform_billable ?? false,
         delegation_token_scope: service.delegation_token_scope || "llm:proxy",
         homepage_url: service.homepage_url ?? "",
         repository_url: service.repository_url ?? "",
@@ -247,6 +249,12 @@ export function ServiceEditPage() {
                   supports_authoring_via_nyx: data.supports_authoring_via_nyx ?? false,
                   supports_websocket: data.supports_websocket ?? false,
                   supports_streaming: data.supports_streaming ?? false,
+                },
+                // Preserve resale config; the toggle only controls the
+                // platform-layer opt-in.
+                billing: {
+                  ...(service?.billing ?? {}),
+                  platform_billable: data.platform_billable ?? false,
                 },
                 ws_frame_injections: data.ws_frame_injections ?? [],
                 ...(defaultRequestHeadersPayload !== undefined
@@ -918,6 +926,36 @@ export function ServiceEditPage() {
                           }
                           onCheckedChange={(v) =>
                             form.setValue("forward_access_token", v)
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <Separator className="my-2" />
+                    <div className="space-y-4">
+                      <div className="space-y-1">
+                        <h3 className="text-[13px] font-semibold">Billing</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Services are free by default: usage is metered for
+                          observability but never charged. Enable platform
+                          billing to reserve and charge wallet credits for
+                          requests to this service at the plan&apos;s
+                          platform rates.
+                        </p>
+                      </div>
+
+                      <div className="flex items-center justify-between rounded-lg border border-border p-3">
+                        <Label
+                          htmlFor="platform-billable"
+                          className="text-[12px] font-normal"
+                        >
+                          Charge wallet credits (platform billing)
+                        </Label>
+                        <Switch
+                          id="platform-billable"
+                          checked={form.watch("platform_billable") ?? false}
+                          onCheckedChange={(v) =>
+                            form.setValue("platform_billable", v)
                           }
                         />
                       </div>

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -31,6 +31,7 @@ export const billingUsageRowSchema = z.object({
   bytes: z.number().int(),
   events: z.number().int().nonnegative(),
   lago_acked: z.boolean(),
+  billable: z.boolean().optional().default(true),
   estimated_credits_micros: z.number().int().nullable().optional(),
 });
 

--- a/frontend/src/schemas/services.ts
+++ b/frontend/src/schemas/services.ts
@@ -292,6 +292,7 @@ export const updateServiceSchema = z
     identity_jwt_audience: z.string().max(500).optional().or(z.literal("")),
     forward_access_token: z.boolean().optional(),
     inject_delegation_token: z.boolean().optional(),
+    platform_billable: z.boolean().optional(),
     delegation_token_scope: z
       .string()
       .max(200, "Scope must be at most 200 characters")

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -239,6 +239,7 @@ export interface DownstreamService {
   readonly repository_url?: string | null;
   readonly issues_url?: string | null;
   readonly capabilities?: ServiceCapabilities | null;
+  readonly billing?: ServiceBilling | null;
   readonly auth_notes?: string | null;
   readonly known_limitations?: string | null;
   readonly required_permissions?: readonly string[] | null;
@@ -330,6 +331,14 @@ export interface ServiceCapabilities {
   readonly supports_streaming: boolean;
 }
 
+export interface ServiceBilling {
+  /** Admin opt-in: only platform_billable services charge wallet credits. */
+  readonly platform_billable?: boolean;
+  readonly resale_billable?: boolean;
+  readonly resale_metric?: string;
+  readonly lago_resale_metric_code?: string | null;
+}
+
 export interface SshServiceConfig {
   readonly host: string;
   readonly port: number;
@@ -393,6 +402,7 @@ export type UpdateServicePayload =
       readonly repository_url?: string;
       readonly issues_url?: string;
       readonly capabilities?: ServiceCapabilities;
+      readonly billing?: ServiceBilling;
       readonly auth_notes?: string;
       readonly known_limitations?: string;
       readonly required_permissions?: readonly string[];


### PR DESCRIPTION
## Summary

First end-to-end validation of the usage-billing stack against a real Lago instance (v1.48, self-hosted OSS). The Lago client had only ever run against test fakes; this PR fixes every incompatibility found, corrects two billing-accuracy bugs in the proxy, and changes the charging model to admin opt-in per service. Every change was verified live: wallet provisioning, entitlement gating, exact token metering, event aggregation in Lago, Stripe top-up checkout, and balance sync all work end to end.

## Changes

### Lago client compatibility (`db78d7d7`)
- Wallet creation sends the required `rate_amount` (1 credit = 1 USD); top-ups send credit amounts as decimal strings (Lago rejects JSON numbers)
- Lago `error_details` are preserved in error messages (previously a bare "Unprocessable Entity")
- `is_conflict_like` no longer treats every 422 `validation_errors` as "already exists" — real validation failures surface instead of being misread as existing resources
- Wallet lookups and balance reads skip terminated wallets (Lago lists them before active ones)
- Usage events carry `external_subscription_id` — without it Lago stores events but never aggregates them into charges (usage silently reads zero)
- Reconcile sweep now pulls wallet balances (webhooks cannot reach non-public deployments) and subtracts the period's `current_usage` from the synced balance, emulating Lago's premium-gated ongoing-balance job that OSS never runs
- New `LAGO_PAYMENT_PROVIDER_CODE` links created customers to the Stripe connection so top-up checkout URLs can be generated

### Opt-in platform charging (`030545ea`)
- `ServiceBilling.platform_billable` (default false): services are free unless an admin enables charging — metered for observability, but no credit reservation, no wallet provisioning, no Lago push
- BYOK keys and custom endpoints are therefore never charged; the flag lives on the catalog service and flows to user-connected services
- Admin service edit page gains a Billing section with the toggle

### Proxy billing accuracy (`2770896f`)
- Chunked JSON responses (no Content-Length, common behind CDNs) previously billed the bytes/4 estimate (~55% overbilling observed); the streaming branch now captures a bounded copy and settles with provider-reported usage (Chat Completions and Responses API shapes, JSON and SSE)
- Credential classification now reflects whose key was injected: auto-provisioned UserServices with no user key inject the catalog master credential but classified as `user_owned`, which would have exempted UI-connected users from resale charges

### Billing page (`9142a574`)
- Usage rows filtered to charged (wallet-attached) rows; free observability rows no longer display a phantom cost with a permanent "Pending" status

### Docs (`454976d3`)
- `docs/LAGO_SETUP.md`: full setup walkthrough (API URL caveats behind reverse proxies, metrics/plan/entitlement configuration, Stripe linking, manual rate-cache seeding, OSS license limitations) plus a troubleshooting table for every failure mode encountered
- `docs/ENV.md`: `LAGO_PAYMENT_PROVIDER_CODE`

## Known gaps (documented, out of scope)

- The rate-cache sweep from Lago plan config is still unimplemented; rows are seeded manually with a long TTL (LAGO_SETUP.md section 3)
- Resale pricing per credential class is not needed under the opt-in model but noted as a follow-up if per-key pricing is ever required

## Test plan

- [x] `cargo test -p nyxid billing` — 85 passed (includes new tests: opt-out services provision no wallets, conflict narrowing, terminated-wallet skipping, payment-provider linkage, master-credential classification)
- [x] `cargo test -p nyxid proxy` / `llm_gateway` / `mcp` — 356 / 64 / 209 passed
- [x] Frontend `npm run build` + `npm test` — 2078 passed
- [x] Live verification against Lago v1.48: wallet provisioning, 402 entitlement gate, exact token settlement (reported == billed), event aggregation in Lago current_usage, Stripe checkout with paid invoice, balance sync reflecting accrued usage, BYOK service metered free alongside a charged platform service

### Staged rollout flag (`971c7b2d`)

Charging is additionally gated by a new `experimental:billing` feature flag (default off in production) resolved against the **billing owner**: org wallets use the org's own override chain, personal wallets use grant-union so members of a flagged org are covered on personal usage too. Owners outside the rollout are never charged on either layer (still metered), wallet/top-up endpoints return 403, and `billing_available` hides the billing page. Targeting uses the existing platform admin feature-flag API — global, org cohort, or per-user — with no deploy needed. Test builds default the flag on (billing suites assume charging is active); the disabled path is covered by an explicit override test.