### PR TITLE
fix(assistant): stop a transcript 404 from killing the new-chat flow

### DIFF
--- a/frontend/src/components/assistant/assistant-sidebar.test.tsx
+++ b/frontend/src/components/assistant/assistant-sidebar.test.tsx
@@ -42,7 +42,6 @@ function renderSidebar() {
       <AssistantSidebar
         conversations={[CONVERSATION]}
         activeConversationId={CONVERSATION.id}
-        creating={false}
         onNewChat={vi.fn()}
         onSelect={onSelect}
         onDelete={onDelete}

--- a/frontend/src/components/assistant/assistant-sidebar.tsx
+++ b/frontend/src/components/assistant/assistant-sidebar.tsx
@@ -153,7 +153,6 @@ export function AssistantSidebar({
   conversations,
   activeConversationId,
   activeView = "chat",
-  creating,
   deletingId,
   onNewChat,
   onSelect,
@@ -162,7 +161,6 @@ export function AssistantSidebar({
   readonly conversations: readonly Conversation[];
   readonly activeConversationId: string | undefined;
   readonly activeView?: "chat" | "plugins" | "approvals";
-  readonly creating: boolean;
   readonly deletingId?: string;
   readonly onNewChat: () => void;
   readonly onSelect: (conversationId: string) => void;
@@ -176,11 +174,12 @@ export function AssistantSidebar({
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="p-2.5">
+        {/* No loading state: "New chat" is navigation only — it issues no
+            requests. The conversation is allocated lazily by the first send. */}
         <Button
           type="button"
           variant="primary"
           className="w-full"
-          isLoading={creating}
           onClick={onNewChat}
         >
           <Plus />

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -12,6 +12,7 @@ import {
 import type { Conversation, ConversationHistory } from "@/types/assistant";
 import {
   assistantKeys,
+  describeHistoryError,
   describeSendFailure,
   describeTransportError,
   useAssistantTurn,
@@ -444,5 +445,109 @@ describe("describeSendFailure", () => {
       new Error("Aevatar did not return a conversation id."),
     );
     expect(description).toBe("Aevatar did not return a conversation id.");
+  });
+});
+
+describe("a failed transcript read never blocks the send", () => {
+  // The send path warms the cache before and after the stream starts. Those
+  // two reads used to share one `Promise.all`, so a rejected transcript read
+  // took the projection — and the send — down with it, and the stream POST
+  // was never issued. Reading history and sending a message target different
+  // upstream surfaces; one must not gate the other.
+  it("still streams the turn when getHistory rejects", async () => {
+    const { Wrapper } = createHarness();
+    vi.spyOn(assistantTransport, "getHistory").mockRejectedValue(
+      new ApiError(404, {
+        error: "not_found",
+        error_code: -1,
+        message: "Not Found",
+      }),
+    );
+    const sendSpy = vi.spyOn(assistantTransport, "sendMessage");
+    // The file has no global mock reset; spies accumulate across tests.
+    sendSpy.mockClear();
+
+    const { result, unmount } = renderHook(
+      () => useSendMessage("conversation-stripe"),
+      { wrapper: Wrapper },
+    );
+
+    let sent: SentMessage | null = null;
+    await act(async () => {
+      const pending = result.current.mutateAsync("Send me anyway.");
+      await vi.advanceTimersByTimeAsync(0);
+      sent = await pending;
+    });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect((sent as SentMessage | null)?.conversationId).toBe(
+      "conversation-stripe",
+    );
+    unmount();
+  });
+
+  it("still streams from the draft empty state, where the read runs FIRST", async () => {
+    // The exact prod failure: "New chat" -> first send -> the conversation is
+    // allocated, then the cache is warmed, then the stream POST fires. With
+    // the read gating the projection, the flow died between allocate and
+    // stream and no `:stream` request was ever issued.
+    const { Wrapper } = createHarness();
+    vi.spyOn(assistantTransport, "getHistory").mockRejectedValue(
+      new ApiError(404, {
+        error: "not_found",
+        error_code: -1,
+        message: "Not Found",
+      }),
+    );
+    const sendSpy = vi.spyOn(assistantTransport, "sendMessage");
+    // The file has no global mock reset; spies accumulate across tests.
+    sendSpy.mockClear();
+
+    const { result, unmount } = renderHook(() => useSendMessage(undefined), {
+      wrapper: Wrapper,
+    });
+
+    let sent: SentMessage | null = null;
+    await act(async () => {
+      const pending = result.current.mutateAsync("First message.");
+      await vi.advanceTimersByTimeAsync(0);
+      sent = await pending;
+    });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect((sent as SentMessage | null)?.conversationId).toBeTruthy();
+    unmount();
+  });
+});
+
+describe("describeHistoryError", () => {
+  it("does not call a not-yet-materialized transcript a failure", () => {
+    expect(
+      describeHistoryError(
+        new ApiError(404, {
+          error: "not_found",
+          error_code: -1,
+          message: "Not Found",
+        }),
+      ),
+    ).toContain("no saved transcript yet");
+  });
+
+  it("names an auth rejection as the backend's, not the session's", () => {
+    expect(
+      describeHistoryError(
+        new ApiError(403, {
+          error: "forbidden",
+          error_code: -1,
+          message: "Forbidden",
+        }),
+      ),
+    ).toContain("chat backend rejected");
+  });
+
+  it("falls back to a plain message for anything else", () => {
+    expect(describeHistoryError(new Error("boom"))).toContain(
+      "Could not load earlier messages",
+    );
   });
 });

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -46,22 +46,42 @@ const APPROVAL_HISTORY_PAGE_SIZE = 20;
 
 const activeHandles = new Map<string, TurnHandle>();
 
+/**
+ * Warm the query cache from the transport. BEST EFFORT, and deliberately
+ * non-throwing.
+ *
+ * This runs on the send path (before and after the stream starts), so a
+ * failure here used to abort the send itself: the two reads shared one
+ * `Promise.all`, and a rejected transcript read took the whole projection —
+ * and its caller — down with it. That is how a transcript 404 stopped the
+ * stream POST from ever being issued.
+ *
+ * Each half now projects independently and a rejection is swallowed: the
+ * cache simply keeps whatever it already had. Failures are NOT hidden from
+ * the user — `useConversation`/`useConversations` run the same reads as real
+ * queries and surface their own error state; this function only declines to
+ * make a cache-warming failure fatal to an unrelated flow.
+ */
 async function projectTransportState(
   queryClient: QueryClient,
   conversationId: string,
 ): Promise<void> {
-  const [history, conversations] = await Promise.all([
+  const [history, conversations] = await Promise.allSettled([
     assistantTransport.getHistory(conversationId),
     assistantTransport.listConversations(),
   ]);
-  queryClient.setQueryData<ConversationHistory>(
-    assistantKeys.history(conversationId),
-    () => history,
-  );
-  queryClient.setQueryData<Conversation[]>(
-    assistantKeys.conversations,
-    () => conversations,
-  );
+  if (history.status === "fulfilled") {
+    queryClient.setQueryData<ConversationHistory>(
+      assistantKeys.history(conversationId),
+      () => history.value,
+    );
+  }
+  if (conversations.status === "fulfilled") {
+    queryClient.setQueryData<Conversation[]>(
+      assistantKeys.conversations,
+      () => conversations.value,
+    );
+  }
   await queryClient.invalidateQueries({ queryKey: assistantKeys.workspace });
 }
 
@@ -176,6 +196,27 @@ export function describeTransportError(error: unknown): {
     message: "Could not load your chats",
     description: "The assistant backend did not respond. Retrying shortly.",
   };
+}
+
+/**
+ * One line for the non-blocking transcript-read notice. Deliberately short:
+ * it renders inline above a working thread, not as a full-page failure.
+ *
+ * A 404 is called out separately because it is not really a fault — the
+ * conversation actor and its chat-history row materialize at different times
+ * upstream, so a conversation with no completed turn has no transcript to
+ * return. Saying "failed" there would be a lie.
+ */
+export function describeHistoryError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 404) {
+      return "This conversation has no saved transcript yet.";
+    }
+    if (error.status === 401 || error.status === 403) {
+      return "The chat backend rejected the request for this transcript.";
+    }
+  }
+  return "Could not load earlier messages in this conversation.";
 }
 
 function useTransportErrorToast(isError: boolean, error: unknown): void {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -4135,3 +4135,51 @@ describe("connect markers survive the PR #2923 wrapped transcript", () => {
     ]);
   });
 });
+
+describe("a conversation with no committed turn has no server transcript", () => {
+  // The two upstream halves materialize at different times: `nyxid-chat`
+  // mints the actor at create, while the `chat-history` row is only written
+  // when a turn reaches a terminal. Aevatar's `HandleGetConversation` maps a
+  // missing read-model document to 404 — NOT to an empty array — so a
+  // freshly created conversation 404s here by design. Treating that as a
+  // failure is what made every new chat dead-end on "Failed to load this
+  // conversation" (observed in prod, 2026-07-28).
+  it("serves an empty transcript when the history row does not exist yet", async () => {
+    // Only the create is routed; stubFetch answers everything else 404.
+    stubFetch(routeCreate);
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    const history = await transport.getHistory(conversation.id);
+
+    expect(history.messages).toEqual([]);
+    expect(history.conversation.id).toBe(CONVERSATION_ID);
+  });
+
+  it("still rejects a 404 for a conversation it has never seen", async () => {
+    stubFetch(routeCreate);
+    const transport = new AevatarAssistantTransport();
+
+    await expect(
+      transport.getHistory("nyxid-chat-never-created"),
+    ).rejects.toThrow();
+  });
+
+  it("still rejects a transient failure on a conversation with no local transcript", async () => {
+    // 5xx is a real read failure, not the not-yet-materialized state — it
+    // must not be dressed up as a legitimately empty chat.
+    stubFetch(routeCreate, (url, init) =>
+      url.startsWith(`${ASSISTANT_BASE}/conversations/`) &&
+      (init?.method ?? "GET") === "GET"
+        ? jsonResponse(
+            { error: "internal", error_code: -1, message: "boom" },
+            500,
+          )
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    await expect(transport.getHistory(conversation.id)).rejects.toThrow();
+  });
+});

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "@/lib/api-client";
+import { ApiError, apiClient } from "@/lib/api-client";
 import {
   AssistantProtocolError,
   AssistantTurnActiveError,
@@ -941,11 +941,27 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // turned the PR #2923 array→`{messages, stateVersion}` change into a
       // blank transcript instead of a visible failure.
       if (error instanceof AssistantProtocolError) throw error;
+      // Nothing local to answer with.
+      if (!existing) throw error;
+      // 404 is the EXPECTED answer for a conversation that has not yet
+      // completed a turn. The two upstream halves materialize at different
+      // times: `nyxid-chat` mints the actor at create, while the
+      // `chat-history` row is only written when a turn reaches a terminal.
+      // Aevatar's `HandleGetConversation` maps a missing read-model document
+      // to 404 — NOT to an empty array — so every brand-new conversation
+      // 404s here, as does the window between a turn's terminal frame and
+      // its history materialization. For a conversation we already hold,
+      // that is "no server transcript yet", and the local mirror is the
+      // truthful answer rather than a failure.
+      const noServerTranscriptYet =
+        error instanceof ApiError && error.status === 404;
       // Transient failures (network, 5xx) may serve the local mirror — but
       // only when it holds a real transcript. A conversation the index
       // merged in carries `EMPTY_TURN_STATE`, and answering with that would
       // dress a failed read as a legitimately empty chat.
-      if (!existing || existing.turnState.messages.length === 0) throw error;
+      if (!noServerTranscriptYet && existing.turnState.messages.length === 0) {
+        throw error;
+      }
       stored = existing;
     }
     // Re-check AFTER the await: a delete completing while the history

--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -21,6 +21,7 @@ const {
     pathname: "/assistant",
     search: {} as Record<string, unknown>,
     conversations: [] as Conversation[],
+    historyError: false,
   },
 }));
 
@@ -93,7 +94,8 @@ vi.mock("@/hooks/use-assistant", () => ({
         }
       : undefined,
     isLoading: false,
-    isError: false,
+    isError: state.historyError,
+    error: undefined,
   }),
   useAssistantTurn: () => ({ data: null }),
   useCreateConversation: () => ({
@@ -113,6 +115,7 @@ vi.mock("@/hooks/use-assistant", () => ({
   }),
   useWorkspaceCounts: () => ({ data: { artifacts: 0, pendingApprovals: 0 } }),
   describeSendFailure: () => ({ message: "Message not sent", description: "" }),
+  describeHistoryError: () => "This conversation has no saved transcript yet.",
 }));
 
 vi.mock("sonner", () => ({
@@ -139,13 +142,12 @@ beforeEach(() => {
   state.pathname = "/assistant";
   state.search = {};
   state.conversations = [EXISTING];
+  state.historyError = false;
 });
 
 describe("AssistantPage new chat", () => {
-  it("navigates to the draft thread before the actor is provisioned", async () => {
+  it("navigates to the draft thread", async () => {
     const user = userEvent.setup();
-    // Never resolves: the point is that the UI moves without waiting.
-    mockCreateMutateAsync.mockReturnValue(new Promise(() => {}));
     renderPage();
 
     await user.click(screen.getByRole("button", { name: /New chat/ }));
@@ -155,61 +157,35 @@ describe("AssistantPage new chat", () => {
     );
   });
 
-  it("swaps the draft for the conversation id once the create lands", async () => {
+  it("provisions nothing on click — the click is navigation only", async () => {
+    // An empty conversation has no server-side representation: the
+    // chat-history transcript 404s until a turn materializes a row. Creating
+    // the actor here and swapping to `?c=<id>` is what made every new chat
+    // fail its first history read. Allocation belongs to the first send.
     const user = userEvent.setup();
-    mockCreateMutateAsync.mockResolvedValue({ ...EXISTING, id: "conv-new" });
     renderPage();
 
-    // The optimistic navigation is what puts the app in draft; mirror it,
-    // since the router is stubbed.
-    state.search = { draft: true };
     await user.click(screen.getByRole("button", { name: /New chat/ }));
 
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({ search: { c: "conv-new" }, replace: true }),
-      );
-    });
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it("does not yank the user back when they navigated away mid-create", async () => {
+  it("allocates on first send and follows the returned conversation", async () => {
     const user = userEvent.setup();
-    let resolveCreate: (conversation: Conversation) => void = () => {};
-    mockCreateMutateAsync.mockReturnValue(
-      new Promise<Conversation>((resolve) => {
-        resolveCreate = resolve;
-      }),
+    mockSendMutateAsync.mockResolvedValue({ conversationId: "conv-new" });
+    state.search = { draft: true };
+    renderPage();
+
+    await user.type(screen.getByRole("textbox"), "hello");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => {
+      expect(mockSendMutateAsync).toHaveBeenCalledWith("hello");
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ search: { c: "conv-new" } }),
     );
-    renderPage();
-
-    state.search = { draft: true };
-    await user.click(screen.getByRole("button", { name: /New chat/ }));
-    mockNavigate.mockClear();
-
-    // They opened another chat while the actor was still provisioning.
-    state.search = { c: EXISTING.id };
-    resolveCreate({ ...EXISTING, id: "conv-new" });
-
-    await waitFor(() => {
-      expect(mockCreateMutateAsync).toHaveBeenCalled();
-    });
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it("says a failed create out loud instead of stopping silently", async () => {
-    const user = userEvent.setup();
-    mockCreateMutateAsync.mockRejectedValue(new Error("aevatar is down"));
-    renderPage();
-
-    state.search = { draft: true };
-    await user.click(screen.getByRole("button", { name: /New chat/ }));
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith(
-        "Could not start a new chat",
-        expect.objectContaining({ description: "aevatar is down" }),
-      );
-    });
   });
 
   it("renders the empty draft thread rather than falling back to the newest chat", () => {
@@ -217,6 +193,21 @@ describe("AssistantPage new chat", () => {
     renderPage();
 
     expect(screen.getByRole("heading", { name: "New chat" })).toBeInTheDocument();
+  });
+
+  it("reports a failed transcript read without taking the chat away", () => {
+    // Replacing the whole thread with an error hid the composer too, so the
+    // chat looked dead even though sending still works — the turn streams
+    // into the conversation actor, a different surface from the transcript.
+    state.historyError = true;
+    state.search = { c: EXISTING.id };
+    renderPage();
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /no saved transcript yet/i,
+    );
+    // Still usable: the composer is present and the thread still rendered.
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
   it("still falls back to the newest chat when there is no draft", () => {

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useRouter, useRouterState } from "@tanstack/react-router";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { AssistantShell } from "@/components/assistant/assistant-shell";
 import { AssistantSidebar } from "@/components/assistant/assistant-sidebar";
@@ -8,12 +8,12 @@ import { ChatThread } from "@/components/assistant/chat-thread";
 import { ApprovalsView } from "@/components/assistant/approvals-view";
 import { PluginsView } from "@/components/assistant/plugins-view";
 import {
+  describeHistoryError,
   describeSendFailure,
   useAssistantTurn,
   useCancelTurn,
   useConversation,
   useConversations,
-  useCreateConversation,
   useDecideApproval,
   useDeleteConversation,
   useSendMessage,
@@ -27,7 +27,6 @@ export function AssistantPage({
   readonly view?: "chat" | "plugins" | "approvals";
 }) {
   const navigate = useNavigate();
-  const router = useRouter();
   // Two selectors returning primitives rather than one returning an object:
   // a fresh object identity would re-render the page on every router tick.
   const selectedFromSearch = useRouterState({
@@ -73,7 +72,6 @@ export function AssistantPage({
   }, [conversations.data, drafting, selectedFromSearch]);
   const history = useConversation(selectedId);
   const turn = useAssistantTurn(selectedId);
-  const createConversation = useCreateConversation();
   const sendMessage = useSendMessage(selectedId);
   const cancelTurn = useCancelTurn(selectedId);
   const decideApproval = useDecideApproval(selectedId);
@@ -88,43 +86,28 @@ export function AssistantPage({
   }
 
   /**
-   * The click paints the empty thread immediately (`?draft`), then
-   * provisions the actor in the background and swaps in `?c=<id>` once it
-   * lands. Awaiting the create first made the button spin through three
-   * sequential round trips — create, history, list — before anything moved,
-   * and a failure resolved to nothing at all: no navigation, no message,
-   * just a button that stopped spinning.
+   * "New chat" is navigation only — it issues NO requests.
    *
-   * `replace` on the swap keeps Back going where the user came from rather
-   * than to the draft URL of a chat that now exists. The live router read
-   * (not the render-time `drafting`) is deliberate: if they navigated on —
-   * Plugins, another chat, or a send that already claimed this actor — the
-   * late resolve must not yank them back.
+   * An empty conversation has no server-side representation on any upstream
+   * surface: the `chat-history` transcript 404s, the `nyxid-chat` registry
+   * lists ids without titles, and `/state` 404s until the controller commits
+   * something. So there is nothing to fetch and nothing to show that the
+   * client cannot paint itself. Aevatar's own reference client
+   * (`apps/aevatar-console-web`) never calls create either — it allocates the
+   * conversation with the first message.
+   *
+   * Provisioning eagerly here is what broke new chat: the create landed, the
+   * swap to `?c=<id>` re-enabled the history query, and the transcript read
+   * 404'd because no turn had ever materialized a history row. Allocation now
+   * happens lazily on first send via `useSendMessage`'s `createConversationOnce`
+   * single-flight, and `handleSend` navigates to the id it returns — so the
+   * first history read only ever runs against a conversation that has a turn.
    */
-  async function createNewChat() {
+  function createNewChat() {
     void navigate({
       to: "/assistant" as never,
       search: { draft: true } as never,
     });
-    try {
-      const conversation = await createConversation.mutateAsync();
-      const stillDrafting =
-        router.state.location.pathname === "/assistant" &&
-        parseAssistantSearch(
-          router.state.location.search as Record<string, unknown>,
-        ).draft === true;
-      if (stillDrafting) selectConversation(conversation.id, true);
-    } catch (error) {
-      // The draft stays put and the composer's auto-create retries the
-      // provision on first send, so this is a recoverable failure — but an
-      // unsaid one reads as the button being broken.
-      toast.error("Could not start a new chat", {
-        description:
-          error instanceof Error && error.message
-            ? error.message
-            : "The assistant backend did not respond. Send a message to try again.",
-      });
-    }
   }
 
   // Deleting the URL-addressed conversation must also drop `?c=`, or the
@@ -176,7 +159,6 @@ export function AssistantPage({
       conversations={conversations.data ?? []}
       activeConversationId={view === "chat" ? selectedId : undefined}
       activeView={view}
-      creating={createConversation.isPending}
       deletingId={
         deleteConversation.isPending ? deleteConversation.variables : undefined
       }
@@ -197,13 +179,24 @@ export function AssistantPage({
   return (
     <AssistantShell title={title} sidebar={sidebar}>
       <div className="relative flex h-full min-h-0 flex-col bg-background">
+        {/* A failed transcript read is REPORTED, never blocking. It used to
+            replace the whole thread, which also took the composer's context
+            away and made the chat look dead — even though sending still
+            works: the turn streams into the conversation actor, which is a
+            different upstream surface from the chat-history transcript.
+            The notice sits above a still-usable thread and composer. */}
+        {history.isError ? (
+          <div
+            role="status"
+            className="border-b border-border/60 bg-destructive/5 px-6 py-2 text-center text-[12px] text-destructive"
+          >
+            {describeHistoryError(history.error)} You can keep chatting — new
+            messages are unaffected.
+          </div>
+        ) : null}
         {history.isLoading ? (
           <div className="flex flex-1 items-center justify-center text-[12px] text-text-tertiary">
             Loading conversation...
-          </div>
-        ) : history.isError ? (
-          <div className="flex flex-1 items-center justify-center px-6 text-center text-[12px] text-destructive">
-            Failed to load this conversation.
           </div>
         ) : (
           <ChatThread


### PR DESCRIPTION
## The bug

Every new chat dead-ended on **"Failed to load this conversation"**, and the first send never issued its `:stream` request.

Reported trace:
```
POST /api/v1/assistant/conversations                    → 202 {actorId: "nyxid-chat-4d71…"}
GET  /api/v1/assistant/conversations/nyxid-chat-4d71…   → 404   ← flow dies here
```

## Root cause

An upstream shape we assumed away.

A conversation becomes a `nyxid-chat` actor the moment it is created, but its `chat-history` row is only written when a turn reaches a terminal. Aevatar's `HandleGetConversation` maps a missing read-model document to **404 — not to an empty array**. Our `docs/CHAT_SPEC.md` asserted the opposite ("an empty transcript is Aevatar's representation of empty"), so the frontend treated the expected 404 as fatal.

Three independent places turned that into a dead chat:

1. **`createNewChat` eagerly provisioned the actor** and swapped `?draft=true` for `?c=<id>`, re-enabling the history query against a conversation that had never materialized a row. Draft mode existed precisely to prevent this; the eager create re-entered the state it was protecting against.
2. **`projectTransportState` read history and the list in one `Promise.all`**, so a rejected transcript read took the whole projection down. It runs on the send path *before* the stream — which is why the `:stream` POST was never issued. This is the one that actually killed the send.
3. **`history.isError` replaced the entire thread**, taking the composer with it, so the chat looked dead even though sending worked.

## The fix

- **"New chat" is navigation only** — zero requests. Allocation moves to the first send via the existing `createConversationOnce` single-flight. This matches Aevatar's own reference client (`apps/aevatar-console-web`), which never calls create either and allocates with the first message.
- **`projectTransportState` is best-effort** — `Promise.allSettled`, each half projects independently, a rejection is swallowed. Failures are still surfaced: `useConversation`/`useConversations` run the same reads as real queries and own the error state.
- **A failed transcript read is reported, not substituted** — a non-blocking `role="status"` notice above a usable thread and composer.
- **`getHistory` treats a 404 on a conversation the transport already holds** as "no server transcript yet" and serves the local mirror. A 5xx, or a 404 on an unknown id, still throws — the PR #2923 loud-failure property is preserved.
- `describeHistoryError` calls a 404 *"This conversation has no saved transcript yet"* rather than "failed", because it isn't one.

### Network sequence after this change
```
Click "New chat"   → (no requests)
Type + send        → POST /assistant/conversations              202
                   → GET  /assistant/conversations/{id}          404  ← tolerated, flow continues
                   → GET  /assistant/conversations               200
                   → POST /assistant/conversations/{id}/stream   ← now actually fires
```

## Verification

Against prod (`nyx.chrono-ai.fun`, backend `6c1170d7`) with a live session:

| Check | Result |
|---|---|
| Create conversation | 202, correct user scope in `statusUrl` |
| Transcript before any turn | 404 |
| Transcript on a conversation with a completed turn | **200, full content** |

That last row is the one that matters: it confirms the 404 is the not-yet-materialized state, not a broken read.

## Known-unfixed, and not fixable on this side

Two upstream Aevatar failures still prevent a reply. This PR does not claim to fix them; it removes the client-side failure that would otherwise still break the flow once they're resolved.

- **New turns stall.** The task commits one `llm` step at operation `phase: "requested"` and never dispatches it. No content, no terminal frame within 6 minutes — Aevatar's own 5-minute `StreamTerminalTimeout` did not fire either.
- **Existing conversations are unstreamable.** `:stream` into a pre-existing conversation returns `RUN_ERROR / ACTOR_NOT_FOUND`, from the agent-kind split between `nyxid.chat` (`NyxIdChatConversationGAgent`) and `nyxid.chat.legacy` (`NyxIdChatGAgent`).

A separate handoff for the Aevatar team covers both with code citations and wire traces.

### Follow-ups filed mentally, not in this PR
- `docs/CHAT_SPEC.md` §2 still documents the empty-array assumption and should be corrected.
- Our stream watchdog is 120s while Aevatar's terminal deadline is 300s, and keepalives are deliberately excluded as progress — so a slow-but-healthy turn gets client-killed. Worth landing alongside the upstream fix rather than guessing a number now.

## Testing

- **2100 tests / 179 files pass**, lint 0 errors, `npm run build` (the real CI gate) passes.
- 6 new tests. The load-bearing two: `useSendMessage` still calls `sendMessage` when `getHistory` rejects — including from the draft empty state, where the read runs *first*, which is the exact prod path.
- No dependency or lockfile change, so the wizard-bundle freshness gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
