### PR TITLE
feat(assistant): route chat turns through the aevatar workflow (studio) engine

### DIFF
--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -30,7 +30,7 @@ use crate::crypto::jwt::{
     MCP_DELEGATION_TOKEN_TTL_SECS, TokenRestrictionClaims, generate_delegated_access_token,
 };
 use crate::errors::{AppError, AppResult};
-use crate::handlers::proxy::execute_proxy;
+use crate::handlers::proxy::execute_admin_proxy;
 use crate::models::downstream_service::DownstreamService;
 use crate::mw::auth::{AuthMethod, AuthUser, PROXY_SCOPE, scope_allows_rest_proxy};
 use crate::services::assistant_service;
@@ -40,6 +40,10 @@ use crate::services::assistant_service;
 const MAX_CREATE_RESPONSE_BYTES: usize = 64 * 1024;
 /// The actor index is bare `{actorId}` rows (~60 bytes each).
 const MAX_INDEX_RESPONSE_BYTES: usize = 512 * 1024;
+/// The chat-history index carries titles and counts per row (~300 bytes
+/// each), and unlike the actor index it is buffered on the user-facing read
+/// path, so it gets its own headroom.
+const MAX_HISTORY_INDEX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
 
 /// Server-initiated upstream request derived from a caller request (the
 /// materialization polls, the history half of the composite delete).
@@ -179,8 +183,14 @@ async fn forward(
     // Addressing the catalog service by id drives the DownstreamService
     // (admin/master-credential) resolution path. Never route by slug here:
     // the slug resolver would prefer a caller-owned `UserService`.
+    //
+    // `execute_admin_proxy` (not `execute_proxy`) because the caller never
+    // named this target: the platform did. Caller-owned routing state must
+    // not decide whether a platform surface works — see its doc comment for
+    // the three inputs it switches off and why the delegation token still
+    // carries the caller's restrictions.
     let mut resolved_slug = String::new();
-    execute_proxy(
+    execute_admin_proxy(
         state,
         auth_user,
         &service.id,
@@ -284,13 +294,43 @@ async fn wait_for_conversation_materialization(
 /// creation targets the `nyxid-chat` actor, while the list is the materialized
 /// history read model, so a freshly created conversation appears here only
 /// after its first completed turn.
+///
+/// That read model is shared with Aevatar's workflow chat, so the rows are
+/// filtered down to `nyxid-chat` actors before they reach the client — see
+/// `assistant_service::filter_chat_history_index`. A body that does not parse,
+/// or whose shape we do not recognise, streams through byte-for-byte: this
+/// route stays shape-agnostic like the transcript route, and a mixed list is
+/// a better failure than an empty one. A body past the buffer cap cannot be
+/// re-streamed once buffering has failed, so it surfaces as an internal error
+/// rather than a silently truncated list.
 pub async fn list_conversations(
     State(state): State<AppState>,
     auth_user: AuthUser,
     request: Request<Body>,
 ) -> AppResult<Response> {
     let path = assistant_service::history_index_path(&auth_user.user_id.to_string());
-    forward(&state, &auth_user, path, request).await
+    let response = forward(&state, &auth_user, path, request).await?;
+    if !response.status().is_success() {
+        return Ok(response);
+    }
+    let (mut parts, body) = response.into_parts();
+    let Ok(bytes) = to_bytes(body, MAX_HISTORY_INDEX_RESPONSE_BYTES).await else {
+        return Err(AppError::Internal(
+            "assistant: conversation index exceeded the buffer cap".to_string(),
+        ));
+    };
+    let Ok(mut index) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(Response::from_parts(parts, Body::from(bytes)));
+    };
+    if !assistant_service::filter_chat_history_index(&mut index) {
+        return Ok(Response::from_parts(parts, Body::from(bytes)));
+    }
+    let Ok(filtered) = serde_json::to_vec(&index) else {
+        return Ok(Response::from_parts(parts, Body::from(bytes)));
+    };
+    // The upstream length no longer describes the body we are sending.
+    parts.headers.remove(header::CONTENT_LENGTH);
+    Ok(Response::from_parts(parts, Body::from(filtered)))
 }
 
 /// `GET /api/v1/assistant/conversations/{id}` -- transcript.
@@ -476,7 +516,20 @@ pub async fn completions(
     .await
 }
 
-/// `POST /api/v1/assistant/workflow-chat` -- ad-hoc workflow chat SSE stream.
+/// Bounds the caller turn body: a 32k-char prompt is ≤128 KiB of UTF-8 plus
+/// JSON escaping headroom.
+const MAX_WORKFLOW_CHAT_REQUEST_BYTES: usize = 256 * 1024;
+
+/// `POST /api/v1/assistant/workflow-chat` -- workflow ("studio") chat turn,
+/// answered as the upstream SSE stream.
+///
+/// The caller body is the typed `WorkflowChatTurnRequest` (prompt +
+/// conversation continuation + idempotency id); the upstream `/api/chat`
+/// body is built server-side with the workflow pinned to `studio` and the
+/// `conversation` object always present, so every turn persists to chat
+/// history and no caller can select another engine or smuggle fields into
+/// Aevatar's strict `HttpChatInput`. Scope comes from the propagated
+/// identity token (Aevatar ignores any body scope).
 ///
 /// Streams Aevatar's raw workflow engine events (`aevatar.raw.observed`
 /// envelopes carrying workflow YAML, system prompts, and kernel state) to the
@@ -488,6 +541,25 @@ pub async fn workflow_chat(
     auth_user: AuthUser,
     request: Request<Body>,
 ) -> AppResult<Response> {
+    let (mut parts, body) = request.into_parts();
+    let bytes = to_bytes(body, MAX_WORKFLOW_CHAT_REQUEST_BYTES)
+        .await
+        .map_err(|_| {
+            AppError::BadRequest("Workflow chat request body is too large.".to_string())
+        })?;
+    let turn: assistant_service::WorkflowChatTurnRequest = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::BadRequest(format!("Invalid workflow chat request: {e}")))?;
+    let upstream = assistant_service::workflow_chat_body(&turn)?;
+    let payload = serde_json::to_vec(&upstream).map_err(|_| {
+        AppError::Internal("assistant: failed to encode the workflow chat body".to_string())
+    })?;
+    // The upstream length is the rebuilt body's, not the caller's.
+    parts.headers.remove(header::CONTENT_LENGTH);
+    parts.headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    let request = Request::from_parts(parts, Body::from(payload));
     forward(
         &state,
         &auth_user,
@@ -498,7 +570,7 @@ pub async fn workflow_chat(
 }
 
 /// `GET /api/v1/assistant/workflow-chat/ws` -- WebSocket twin of the workflow
-/// chat. `execute_proxy` detects the upgrade headers and bridges the socket;
+/// chat. The proxy detects the upgrade headers and bridges the socket;
 /// browser callers authenticate via the session cookie since WebSocket
 /// clients cannot set an `Authorization` header.
 pub async fn workflow_chat_ws(

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -611,6 +611,7 @@ async fn proxy_request_inner(
                         .map(|r| r.org_user_id.clone())
                         .unwrap_or_else(|| user_id_str.clone()),
                 }),
+                TargetMode::CallerAddressed,
                 resolved_slug,
             )
             .await;
@@ -669,6 +670,7 @@ async fn proxy_request_inner(
                     .map(|r| r.org_user_id.clone())
                     .unwrap_or_else(|| user_id_str.clone()),
             }),
+            TargetMode::CallerAddressed,
             resolved_slug,
         )
         .await;
@@ -826,6 +828,7 @@ async fn proxy_request_by_slug_inner(
                         .map(|r| r.org_user_id.clone())
                         .unwrap_or_else(|| user_id_str.clone()),
                 }),
+                TargetMode::CallerAddressed,
                 resolved_slug,
             )
             .await;
@@ -884,6 +887,7 @@ async fn proxy_request_by_slug_inner(
                     .map(|r| r.org_user_id.clone())
                     .unwrap_or_else(|| user_id_str.clone()),
             }),
+            TargetMode::CallerAddressed,
             resolved_slug,
         )
         .await;
@@ -955,6 +959,60 @@ pub(crate) async fn execute_proxy(
         path,
         request,
         None,
+        TargetMode::CallerAddressed,
+        resolved_slug,
+    )
+    .await
+}
+
+/// How the proxy target was chosen, which decides whether caller-owned
+/// routing state applies to it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TargetMode {
+    /// The caller named the service (`/proxy/{id}`, `/proxy/s/{slug}`, LLM
+    /// gateway, MCP). Caller state governs: scoped-token service allowlist,
+    /// personal node pins, personal connection state.
+    CallerAddressed,
+    /// The server chose the service for a platform surface and the caller
+    /// could not have named anything else (assistant chat pass-through).
+    AdminManaged,
+}
+
+/// Execute a proxy request against a **server-chosen** platform service.
+///
+/// Same data plane as [`execute_proxy`] -- identity propagation, delegation
+/// token, approvals, audit, billing, streaming -- with the caller-state
+/// resolution deliberately switched off, because none of it can apply to a
+/// target the caller never named:
+///
+/// - the scoped-token service allowlist is not consulted. Those lists hold
+///   `UserService` ids, so an admin catalog row can never appear in one:
+///   leaving the gate on made every restricted token (every OAuth access
+///   token minted with `resource`/`allowed_service_ids`, e.g. the Aevatar
+///   console's) fail the assistant surface with `api_key_scope_forbidden`,
+///   with no grant a user could add to fix it. This does **not** widen what
+///   the run can reach: the delegation token this path mints still inherits
+///   the caller's restrictions verbatim
+///   (`TokenRestrictionClaims::from_auth_user`), so a restricted caller's
+///   assistant run stays restricted on every callback into NyxID.
+/// - personal node pins and personal connection state are not consulted
+///   (see `proxy_service::resolve_admin_proxy_target`).
+pub(crate) async fn execute_admin_proxy(
+    state: &AppState,
+    auth_user: &AuthUser,
+    service_id: &str,
+    path: &str,
+    request: Request<Body>,
+    resolved_slug: &mut String,
+) -> AppResult<Response> {
+    execute_proxy_inner(
+        state,
+        auth_user,
+        service_id,
+        path,
+        request,
+        None,
+        TargetMode::AdminManaged,
         resolved_slug,
     )
     .await
@@ -1244,8 +1302,14 @@ async fn preflight_proxy_deny_before_resolution(
 /// Inner proxy execution with optional pre-resolved target from UserService path.
 ///
 /// When `pre_resolved` is `Some`, the target and node routing are already known
-/// (from `resolve_proxy_target_from_user_service`). When `None`, falls back to
-/// the original DownstreamService resolution.
+/// (from `resolve_proxy_target_from_user_service`). When `None`, resolution
+/// follows `target_mode`: caller-addressed requests fall back to the original
+/// DownstreamService path, server-chosen platform targets resolve the admin
+/// row alone (see [`execute_admin_proxy`]).
+// One argument over the lint's threshold: every parameter is a distinct
+// security-relevant input to resolution, and bundling them into a struct
+// would only move the same fields behind one more indirection.
+#[allow(clippy::too_many_arguments)]
 async fn execute_proxy_inner(
     state: &AppState,
     auth_user: &AuthUser,
@@ -1253,6 +1317,7 @@ async fn execute_proxy_inner(
     path: &str,
     request: Request<Body>,
     pre_resolved: Option<PreResolved>,
+    target_mode: TargetMode,
     resolved_slug: &mut String,
 ) -> AppResult<Response> {
     let downstream_cancellation = request_cancellation(&request);
@@ -1444,6 +1509,26 @@ async fn execute_proxy_inner(
             pre.master_credential,
             pre.user_service_id,
             required,
+            catalog_service_slug,
+        )
+    } else if target_mode == TargetMode::AdminManaged {
+        // Server-chosen platform target: resolve the admin row alone, with
+        // no caller-owned routing state. See `execute_admin_proxy`.
+        let target = proxy_service::resolve_admin_proxy_target(
+            &state.db,
+            &state.encryption_keys,
+            service_id,
+        )
+        .await?;
+        let catalog_service_slug = Some(target.service.slug.clone());
+        let has_server_credential = true;
+        (
+            None,
+            target,
+            has_server_credential,
+            true,
+            None,
+            false,
             catalog_service_slug,
         )
     } else {
@@ -7607,6 +7692,325 @@ mod proxy_resolution_integration_tests {
         assert!(
             matches!(err, AppError::ApiKeyScopeForbidden(_)),
             "expected scope denial after resolution, got: {err}"
+        );
+        server.abort();
+    }
+
+    /// Seed an admin-managed platform service (the shape the assistant chat
+    /// pass-through targets: internal, no user credential, master/no auth).
+    async fn insert_platform_service(
+        db: &mongodb::Database,
+        slug: &str,
+        base_url: &str,
+    ) -> crate::models::downstream_service::DownstreamService {
+        let mut service = crate::models::downstream_service::test_helpers::dummy_service();
+        service.id = Uuid::new_v4().to_string();
+        service.slug = slug.to_string();
+        service.name = slug.to_string();
+        service.base_url = base_url.to_string();
+        service.service_category = "internal".to_string();
+        service.requires_user_credential = false;
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_one(service.clone())
+        .await
+        .unwrap();
+        service
+    }
+
+    /// A restricted token's `allowed_service_ids` holds `UserService` ids, so
+    /// an admin catalog row can never be listed in one. Gating the platform
+    /// surface on that list therefore denied every restricted caller with no
+    /// grant that could fix it (observed on prod: OAuth access tokens minted
+    /// with `resource`/`allowed_service_ids` got `api_key_scope_forbidden` on
+    /// every `/api/v1/assistant/*` call). The admin-managed mode drops that
+    /// gate; the caller-addressed mode keeps it.
+    #[tokio::test]
+    async fn admin_managed_target_admits_a_scoped_token_the_caller_path_rejects() {
+        let Some(db) = connect_test_database("proxy_admin_target_scope").await else {
+            eprintln!("skipping proxy integration test: no local MongoDB available");
+            return;
+        };
+
+        let (base_url, server) = start_downstream().await;
+        let user_id = Uuid::new_v4().to_string();
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .unwrap();
+        let service = insert_platform_service(&db, "platform-assistant", &base_url).await;
+
+        let state = test_app_state(db.clone());
+        let mut auth = access_token_auth(&user_id);
+        auth.allow_all_services = false;
+        // A UserService id the caller really was granted — still never the
+        // catalog row the platform resolves.
+        auth.allowed_service_ids = vec![Uuid::new_v4().to_string()];
+
+        let mut caller_slug = String::new();
+        let err = super::execute_proxy(
+            &state,
+            &auth,
+            &service.id,
+            "status",
+            proxy_request("/assistant/conversations"),
+            &mut caller_slug,
+        )
+        .await
+        .expect_err("caller-addressed mode must keep enforcing the allowlist");
+        assert!(
+            matches!(err, AppError::ApiKeyScopeForbidden(_)),
+            "expected scope denial on the caller-addressed path, got: {err}"
+        );
+
+        let mut admin_slug = String::new();
+        let response = super::execute_admin_proxy(
+            &state,
+            &auth,
+            &service.id,
+            "status",
+            proxy_request("/assistant/conversations"),
+            &mut admin_slug,
+        )
+        .await
+        .expect("admin-managed mode must admit a restricted caller");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(admin_slug, service.slug);
+        server.abort();
+    }
+
+    /// "Works for everyone but me": a user who once connected the same
+    /// catalog service personally and then disconnected it was refused by the
+    /// platform surface they never connected. The admin-managed mode does not
+    /// read the caller's connection row at all.
+    #[tokio::test]
+    async fn admin_managed_target_ignores_a_disconnected_personal_connection() {
+        let Some(db) = connect_test_database("proxy_admin_target_disconnected").await else {
+            eprintln!("skipping proxy integration test: no local MongoDB available");
+            return;
+        };
+
+        let (base_url, server) = start_downstream().await;
+        let user_id = Uuid::new_v4().to_string();
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .unwrap();
+        let service = insert_platform_service(&db, "platform-assistant-2", &base_url).await;
+        let now = chrono::Utc::now();
+        db.collection::<crate::models::user_service_connection::UserServiceConnection>(
+            crate::models::user_service_connection::COLLECTION_NAME,
+        )
+        .insert_one(
+            crate::models::user_service_connection::UserServiceConnection {
+                id: Uuid::new_v4().to_string(),
+                user_id: user_id.clone(),
+                service_id: service.id.clone(),
+                credential_encrypted: None,
+                credential_type: None,
+                credential_label: None,
+                metadata: None,
+                is_active: false,
+                created_at: now,
+                updated_at: now,
+            },
+        )
+        .await
+        .unwrap();
+
+        let state = test_app_state(db.clone());
+        let auth = access_token_auth(&user_id);
+
+        let mut caller_slug = String::new();
+        let err = super::execute_proxy(
+            &state,
+            &auth,
+            &service.id,
+            "status",
+            proxy_request("/assistant/conversations"),
+            &mut caller_slug,
+        )
+        .await
+        .expect_err("caller-addressed mode must keep honoring the disconnect");
+        assert!(
+            matches!(err, AppError::Forbidden(_)),
+            "expected a disconnect denial on the caller-addressed path, got: {err}"
+        );
+
+        let mut admin_slug = String::new();
+        let response = super::execute_admin_proxy(
+            &state,
+            &auth,
+            &service.id,
+            "status",
+            proxy_request("/assistant/conversations"),
+            &mut admin_slug,
+        )
+        .await
+        .expect("admin-managed mode must ignore the personal disconnect");
+        assert_eq!(response.status(), StatusCode::OK);
+        server.abort();
+    }
+
+    /// A `requires_user_credential` row cannot back a platform surface: it is
+    /// a provisioning fault, and must not degrade into a caller-facing error.
+    #[tokio::test]
+    async fn admin_managed_target_rejects_a_user_credential_service_as_internal() {
+        let Some(db) = connect_test_database("proxy_admin_target_user_cred").await else {
+            eprintln!("skipping proxy integration test: no local MongoDB available");
+            return;
+        };
+
+        let (base_url, server) = start_downstream().await;
+        let user_id = Uuid::new_v4().to_string();
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .unwrap();
+        let mut service = insert_platform_service(&db, "platform-needs-cred", &base_url).await;
+        service.requires_user_credential = true;
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .replace_one(doc! { "_id": &service.id }, &service)
+        .await
+        .unwrap();
+
+        let state = test_app_state(db.clone());
+        let mut admin_slug = String::new();
+        let err = super::execute_admin_proxy(
+            &state,
+            &access_token_auth(&user_id),
+            &service.id,
+            "status",
+            proxy_request("/assistant/conversations"),
+            &mut admin_slug,
+        )
+        .await
+        .expect_err("a user-credential row must not back a platform surface");
+        assert!(
+            matches!(err, AppError::Internal(_)),
+            "expected a provisioning fault, got: {err}"
+        );
+        server.abort();
+    }
+
+    /// End-to-end through the real assistant handler: the caller's typed
+    /// workflow-chat body is rebuilt into the pinned `studio` body, and the
+    /// upstream request carries the injected identity material with NO
+    /// caller `Authorization` — the exact wire shape Aevatar's `/api/chat`
+    /// authenticates (`NyxIdIdentityAssertionAuthentication` forwards the
+    /// Bearer scheme to the identity-assertion handler only when
+    /// `Authorization` is absent, and a malformed one 400s the whole turn).
+    #[tokio::test]
+    async fn workflow_chat_handler_rebuilds_the_body_for_the_admin_service() {
+        use std::sync::Mutex as StdMutex;
+
+        let Some(db) = connect_test_database("assistant_workflow_chat").await else {
+            eprintln!("skipping proxy integration test: no local MongoDB available");
+            return;
+        };
+
+        type Captured = (String, Vec<u8>, axum::http::HeaderMap);
+        let captured: std::sync::Arc<StdMutex<Option<Captured>>> =
+            std::sync::Arc::new(StdMutex::new(None));
+        let sink = captured.clone();
+        let app = Router::new().route(
+            "/{*path}",
+            axum::routing::post(move |request: Request<Body>| {
+                let sink = sink.clone();
+                async move {
+                    let (parts, body) = request.into_parts();
+                    let bytes = axum::body::to_bytes(body, 1024 * 1024).await.unwrap();
+                    *sink.lock().unwrap() =
+                        Some((parts.uri.path().to_string(), bytes.to_vec(), parts.headers));
+                    axum::Json(serde_json::json!({ "ok": true }))
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind workflow-chat downstream listener");
+        let addr = listener.local_addr().expect("downstream listener addr");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve workflow-chat downstream");
+        });
+
+        let user_id = Uuid::new_v4().to_string();
+        db.collection::<crate::models::user::User>(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .unwrap();
+        // The assistant resolves by slug: this must be the `aevatar` row,
+        // configured like the deployed contract (identity JWT + injected
+        // delegation token, no Bearer forwarding).
+        let mut service = crate::models::downstream_service::test_helpers::dummy_service();
+        service.id = Uuid::new_v4().to_string();
+        service.slug = crate::services::assistant_service::AEVATAR_SLUG.to_string();
+        service.name = "Aevatar".to_string();
+        service.base_url = format!("http://{addr}");
+        service.service_category = "internal".to_string();
+        service.requires_user_credential = false;
+        service.identity_propagation_mode = "jwt".to_string();
+        service.identity_jwt_audience = Some("urn:aevatar:api".to_string());
+        service.inject_delegation_token = true;
+        service.delegation_token_scope = "proxy:*".to_string();
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_one(service.clone())
+        .await
+        .unwrap();
+
+        let state = test_app_state(db.clone());
+        let auth = access_token_auth(&user_id);
+
+        let mut request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/v1/assistant/workflow-chat")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"prompt":"hi there"}"#))
+            .expect("build workflow chat request");
+        request.extensions_mut().insert(
+            crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
+                crate::services::billing::BillingIngress::Proxy,
+            ),
+        );
+
+        let response =
+            crate::handlers::assistant::workflow_chat(axum::extract::State(state), auth, request)
+                .await
+                .expect("workflow chat handler must forward");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let (path, body, headers) = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("downstream must have received the turn");
+        assert_eq!(path, "/api/chat");
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["workflow"], "studio");
+        assert_eq!(body["prompt"], "hi there");
+        assert!(body["conversation"]["conversationId"].is_null());
+        assert!(
+            body["commandId"].as_str().is_some_and(|id| !id.is_empty()),
+            "a server-minted commandId must be present"
+        );
+        assert!(
+            headers.get(axum::http::header::AUTHORIZATION).is_none(),
+            "no caller Authorization may reach /api/chat (a malformed one 400s upstream)"
+        );
+        assert!(
+            headers.get("x-nyxid-identity-token").is_some(),
+            "the identity assertion authenticates the request upstream"
+        );
+        assert!(
+            headers.get("x-nyxid-delegation-token").is_some(),
+            "the delegation token is the workflow tool credential"
         );
         server.abort();
     }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -88,6 +88,48 @@ pub fn history_index_path(user_id: &str) -> String {
     format!("api/scopes/{user_id}/chat-history")
 }
 
+/// Actor-id prefix of a `nyxid-chat` conversation (upstream
+/// `NyxIdChatServiceDefaults.ActorIdPrefix`; ids are `nyxid-chat-{guid:N}`).
+const NYXID_CHAT_ACTOR_PREFIX: &str = "nyxid-chat-";
+
+/// Conversation-id prefix of a workflow-chat conversation (upstream
+/// `ChatHistoryActorIds.CreateConversationId`; ids are `chatc-{hash[..32]}`).
+const WORKFLOW_CHAT_CONVERSATION_PREFIX: &str = "chatc-";
+
+/// Drop chat-history rows this surface cannot address.
+///
+/// `chat-history` is a **shared** read model. Two families in it are ours:
+/// `nyxid-chat-…` conversation actors (turns via `:stream`) and `chatc-…`
+/// workflow-chat conversations (turns via `POST /assistant/workflow-chat`,
+/// continued with `conversation.conversationId`). Anything else in the index
+/// belongs to another product surface and is dropped, keeping the client
+/// honest about what it can address: every id this route returns is a valid
+/// target for its family's turn route, the transcript route, and delete.
+///
+/// Shape-tolerant by design — an index that is not `{"conversations": [...]}`
+/// (or a row without a string `id`) is returned untouched, matching the
+/// deploy-independence posture of the transcript route.
+pub fn filter_chat_history_index(index: &mut serde_json::Value) -> bool {
+    let Some(rows) = index
+        .get_mut("conversations")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return false;
+    };
+    let before = rows.len();
+    rows.retain(|row| {
+        row.get("id")
+            .and_then(serde_json::Value::as_str)
+            // Keep unknown-shaped rows: a row we cannot classify is not
+            // evidence that it belongs to another surface.
+            .is_none_or(|id| {
+                id.starts_with(NYXID_CHAT_ACTOR_PREFIX)
+                    || id.starts_with(WORKFLOW_CHAT_CONVERSATION_PREFIX)
+            })
+    });
+    rows.len() != before
+}
+
 /// `chat-history/conversations/{id}` -- transcript read.
 pub fn history_path(user_id: &str, conversation_id: &str) -> AppResult<String> {
     validate_conversation_id(conversation_id)?;
@@ -223,6 +265,110 @@ pub fn workflow_chat_path() -> String {
     "api/chat".to_string()
 }
 
+/// The one workflow the assistant surface may start. Pinned server-side:
+/// Aevatar's `/api/chat` runs whatever catalog workflow the body names
+/// (`direct`, `auto`, `auto_review`, file-loaded definitions, …), and which
+/// engine backs the platform chat is a platform decision, not a caller input.
+pub const WORKFLOW_CHAT_WORKFLOW: &str = "studio";
+
+/// Matches the client cap in `aevatar-transport.ts` (`MAX_MESSAGE_CHARS`).
+const WORKFLOW_CHAT_PROMPT_MAX_CHARS: usize = 32_768;
+
+/// The caller half of the workflow-chat turn contract. Everything else in
+/// Aevatar's `HttpChatInput` (workflow selection, inline YAML, llmControl,
+/// toolContext, metadata, headers) is deliberately not expressible here.
+///
+/// `deny_unknown_fields` keeps client drift loud: Aevatar rejects unknown
+/// body members (`JsonUnmappedMemberHandling.Disallow`), and a field that
+/// silently vanished here would surface as a confusing upstream 400 instead.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WorkflowChatTurnRequest {
+    pub prompt: String,
+    /// `chatc-…` conversation to continue; absent starts a new conversation.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
+    /// Chat-history read fence for continuations: the `stateVersion` the
+    /// client last observed. Aevatar requires `> 0` alongside a conversation
+    /// id (`CHAT_HISTORY_RESERVATION_UNAVAILABLE` otherwise).
+    #[serde(default)]
+    pub minimum_state_version: Option<i64>,
+    /// Client idempotency identity for the create/turn (Aevatar replays the
+    /// same conversation/turn for a repeated id, 409s on payload mismatch).
+    #[serde(default)]
+    pub command_id: Option<String>,
+}
+
+/// Opaque client token (command ids): UUID-shaped material only, so nothing
+/// structural or attacker-shaped rides through to the upstream body.
+fn validate_client_token(value: &str, label: &str) -> AppResult<()> {
+    let valid = !value.is_empty()
+        && value.len() <= 64
+        && value.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+    if !valid {
+        return Err(AppError::BadRequest(format!("Invalid {label}.")));
+    }
+    Ok(())
+}
+
+/// Build the upstream `/api/chat` body for a caller turn request.
+///
+/// The `conversation` object is always present: without it Aevatar runs the
+/// turn ephemerally and **persists nothing** to chat history, which would
+/// silently drop the conversation from the sidebar contract. `workflow` is
+/// pinned to [`WORKFLOW_CHAT_WORKFLOW`]. A body `scopeId` is ignored by
+/// Aevatar (trusted scope wins), so none is sent.
+pub fn workflow_chat_body(request: &WorkflowChatTurnRequest) -> AppResult<serde_json::Value> {
+    let prompt = request.prompt.trim();
+    if prompt.is_empty() || request.prompt.chars().count() > WORKFLOW_CHAT_PROMPT_MAX_CHARS {
+        return Err(AppError::BadRequest(format!(
+            "Prompt must contain between 1 and {WORKFLOW_CHAT_PROMPT_MAX_CHARS} characters."
+        )));
+    }
+
+    let conversation = match (&request.conversation_id, request.minimum_state_version) {
+        (None, None) => serde_json::json!({ "conversationId": null }),
+        (None, Some(_)) => {
+            return Err(AppError::BadRequest(
+                "minimumStateVersion requires a conversationId.".to_string(),
+            ));
+        }
+        (Some(id), version) => {
+            validate_conversation_id(id)?;
+            if !id.starts_with(WORKFLOW_CHAT_CONVERSATION_PREFIX) {
+                // A `nyxid-chat-…` actor id is a different surface; failing
+                // fast beats an upstream CONVERSATION_NOT_FOUND after a run
+                // was already admitted.
+                return Err(AppError::BadRequest(
+                    "Only workflow conversations can be continued here.".to_string(),
+                ));
+            }
+            let Some(version) = version.filter(|v| *v > 0) else {
+                return Err(AppError::BadRequest(
+                    "Continuing a conversation requires the last observed minimumStateVersion."
+                        .to_string(),
+                ));
+            };
+            serde_json::json!({ "conversationId": id, "minimumStateVersion": version })
+        }
+    };
+
+    let command_id = match &request.command_id {
+        Some(id) => {
+            validate_client_token(id, "commandId")?;
+            id.clone()
+        }
+        None => uuid::Uuid::new_v4().to_string(),
+    };
+
+    Ok(serde_json::json!({
+        "commandId": command_id,
+        "conversation": conversation,
+        "prompt": request.prompt,
+        "workflow": WORKFLOW_CHAT_WORKFLOW,
+    }))
+}
+
 /// `api/ws/chat` -- WebSocket twin of the workflow chat
 /// (`StartWorkflowChatWebSocket`).
 pub fn workflow_chat_ws_path() -> String {
@@ -283,6 +429,63 @@ mod tests {
 
     const USER: &str = "add69059-bece-4f0e-9559-99cfd10b47eb";
     const CONV: &str = "nyxid-chat-f8369965a444433f92ec50e67ad8ee52";
+
+    /// The chat-history index is shared across product surfaces. Both of
+    /// ours stay — `nyxid-chat-…` actors (turns via `:stream`) and `chatc-…`
+    /// workflow conversations (turns via the workflow-chat route) — while
+    /// rows from any other surface are dropped.
+    #[test]
+    fn history_index_keeps_both_addressable_families() {
+        let mut index = serde_json::json!({
+            "conversations": [
+                { "id": "chatc-650906f30cc985fa341477281303b6de", "title": "workflow chat" },
+                { "id": CONV, "title": "assistant chat", "messageCount": 7 },
+                { "id": "voicec-9c1d3f24a88b41f7", "title": "another product" },
+                { "id": "nyxid-chat-bb78fd3b1d834e6b958f8dbc626cef17", "messageCount": 0 },
+            ]
+        });
+        assert!(filter_chat_history_index(&mut index));
+        let ids: Vec<&str> = index["conversations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "chatc-650906f30cc985fa341477281303b6de",
+                CONV,
+                "nyxid-chat-bb78fd3b1d834e6b958f8dbc626cef17"
+            ]
+        );
+    }
+
+    #[test]
+    fn history_index_filter_reports_no_change_when_every_row_is_addressable() {
+        let mut index = serde_json::json!({
+            "conversations": [{ "id": CONV }, { "id": "chatc-650906f30cc985fa3414" }]
+        });
+        assert!(!filter_chat_history_index(&mut index));
+        assert_eq!(index["conversations"].as_array().unwrap().len(), 2);
+    }
+
+    /// Shape drift must not empty the sidebar: an index we do not recognise,
+    /// or a row without a string id, is left exactly as upstream sent it.
+    #[test]
+    fn history_index_filter_leaves_unknown_shapes_untouched() {
+        let mut array_shaped = serde_json::json!([{ "id": "chatc-1" }]);
+        assert!(!filter_chat_history_index(&mut array_shaped));
+        assert_eq!(array_shaped.as_array().unwrap().len(), 1);
+
+        let mut missing_key = serde_json::json!({ "rows": [{ "id": "chatc-1" }] });
+        assert!(!filter_chat_history_index(&mut missing_key));
+        assert!(missing_key.get("conversations").is_none());
+
+        let mut idless = serde_json::json!({ "conversations": [{ "title": "no id" }] });
+        assert!(!filter_chat_history_index(&mut idless));
+        assert_eq!(idless["conversations"].as_array().unwrap().len(), 1);
+    }
 
     #[test]
     fn builds_the_aevatar_paths_from_the_server_side_scope() {
@@ -405,6 +608,117 @@ mod tests {
             assert!(state_path(USER, bad).is_err());
         }
         assert!(history_path(USER, &"a".repeat(129)).is_err());
+    }
+
+    const WORKFLOW_CONV: &str = "chatc-650906f30cc985fa341477281303b6de";
+
+    fn turn_request(json: serde_json::Value) -> WorkflowChatTurnRequest {
+        serde_json::from_value(json).unwrap()
+    }
+
+    /// The upstream body is server-built end to end: pinned workflow, always
+    /// a `conversation` object (persistence contract), never a `scopeId`.
+    #[test]
+    fn workflow_body_creates_a_conversation_with_the_pinned_workflow() {
+        let body = workflow_chat_body(&turn_request(serde_json::json!({
+            "prompt": "hi",
+            "commandId": "0d4b0a52-3d5f-4d2e-9f10-8f6f9b1c2d3e",
+        })))
+        .unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "commandId": "0d4b0a52-3d5f-4d2e-9f10-8f6f9b1c2d3e",
+                "conversation": { "conversationId": null },
+                "prompt": "hi",
+                "workflow": "studio",
+            })
+        );
+    }
+
+    #[test]
+    fn workflow_body_continues_with_the_observed_state_version() {
+        let body = workflow_chat_body(&turn_request(serde_json::json!({
+            "prompt": "and then?",
+            "conversationId": WORKFLOW_CONV,
+            "minimumStateVersion": 18,
+        })))
+        .unwrap();
+        assert_eq!(body["conversation"]["conversationId"], WORKFLOW_CONV);
+        assert_eq!(body["conversation"]["minimumStateVersion"], 18);
+        assert_eq!(body["workflow"], "studio");
+        // No client commandId: the server mints one (idempotency identity
+        // must always exist for create-replay recovery).
+        assert!(
+            body["commandId"].as_str().is_some_and(|id| !id.is_empty()),
+            "server must mint a commandId"
+        );
+    }
+
+    #[test]
+    fn workflow_body_rejects_out_of_contract_turns() {
+        // Empty / oversized prompt.
+        assert!(workflow_chat_body(&turn_request(serde_json::json!({ "prompt": "  " }))).is_err());
+        assert!(
+            workflow_chat_body(&turn_request(
+                serde_json::json!({ "prompt": "a".repeat(32_769) })
+            ))
+            .is_err()
+        );
+        // Continuation without the read fence (upstream would 503).
+        assert!(
+            workflow_chat_body(&turn_request(serde_json::json!({
+                "prompt": "hi", "conversationId": WORKFLOW_CONV,
+            })))
+            .is_err()
+        );
+        assert!(
+            workflow_chat_body(&turn_request(serde_json::json!({
+                "prompt": "hi", "conversationId": WORKFLOW_CONV, "minimumStateVersion": 0,
+            })))
+            .is_err()
+        );
+        // Fence without a conversation.
+        assert!(
+            workflow_chat_body(&turn_request(serde_json::json!({
+                "prompt": "hi", "minimumStateVersion": 3,
+            })))
+            .is_err()
+        );
+        // A nyxid-chat actor id is the other surface.
+        assert!(
+            workflow_chat_body(&turn_request(serde_json::json!({
+                "prompt": "hi", "conversationId": CONV, "minimumStateVersion": 3,
+            })))
+            .is_err()
+        );
+        // Path-escaping conversation ids and non-token command ids.
+        assert!(
+            workflow_chat_body(&turn_request(serde_json::json!({
+                "prompt": "hi", "conversationId": "chatc-a/b", "minimumStateVersion": 3,
+            })))
+            .is_err()
+        );
+        assert!(
+            workflow_chat_body(&turn_request(serde_json::json!({
+                "prompt": "hi", "commandId": "not a token!",
+            })))
+            .is_err()
+        );
+        // Unknown fields fail loudly instead of silently dropping.
+        assert!(
+            serde_json::from_value::<WorkflowChatTurnRequest>(serde_json::json!({
+                "prompt": "hi", "workflow": "direct",
+            }))
+            .is_err(),
+            "a caller-supplied workflow selection must be rejected"
+        );
+        assert!(
+            serde_json::from_value::<WorkflowChatTurnRequest>(serde_json::json!({
+                "prompt": "hi", "scopeId": "someone-else",
+            }))
+            .is_err()
+        );
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -412,6 +412,104 @@ pub async fn resolve_service_by_slug(
         .ok_or_else(|| AppError::NotFound("Service not found".to_string()))
 }
 
+/// Resolve a platform-owned downstream service with NO caller state.
+///
+/// This backs surfaces where the target is chosen by the server, not named
+/// by the caller (today: the assistant chat pass-through). The caller cannot
+/// address anything else, so every per-user input that the caller-addressed
+/// path consults is deliberately skipped:
+///
+/// - **no `UserServiceConnection` lookup** -- a user who once connected the
+///   same catalog service personally and then disconnected it would otherwise
+///   get `You have disconnected from this service` on a platform surface they
+///   never connected;
+/// - **no gateway-URL override** -- that is a per-user provider concept
+///   (`UserProviderToken.gateway_url`), and a service whose base URL only
+///   exists per user cannot back a platform surface;
+/// - **no per-user credential** -- guarded below: a `requires_user_credential`
+///   service is a provisioning error here, not a caller error.
+///
+/// The credential is the service row's master credential, exactly as the
+/// caller-addressed path resolves it for `service_category = "internal"`.
+pub async fn resolve_admin_proxy_target(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    service_id: &str,
+) -> AppResult<ProxyTarget> {
+    let service = db
+        .collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+        .find_one(doc! { "_id": service_id })
+        .await?
+        .ok_or_else(|| AppError::NotFound("Downstream service not found".to_string()))?;
+
+    // A misconfigured platform row is a server fault, not a caller error:
+    // the caller had no say in which service this is.
+    if !service.is_active {
+        return Err(AppError::Internal(format!(
+            "platform service '{}' is inactive",
+            service.slug
+        )));
+    }
+    if service.service_type != "http" {
+        return Err(AppError::Internal(format!(
+            "platform service '{}' is not an HTTP service",
+            service.slug
+        )));
+    }
+    if service.service_category == "provider" {
+        return Err(AppError::Internal(format!(
+            "platform service '{}' is a provider and cannot be proxied",
+            service.slug
+        )));
+    }
+    if service.requires_user_credential {
+        return Err(AppError::Internal(format!(
+            "platform service '{}' requires a user credential and cannot back a platform surface",
+            service.slug
+        )));
+    }
+
+    let catalog_default_headers = service.default_request_headers.clone().unwrap_or_default();
+    let ws_frame_injections = service.ws_frame_injections.clone();
+
+    if service.auth_method == "none" {
+        return Ok(ProxyTarget {
+            base_url: service.base_url.clone(),
+            auth_method: service.auth_method.clone(),
+            auth_key_name: service.auth_key_name.clone(),
+            credential: String::new(),
+            service,
+            catalog_default_headers,
+            user_service_default_headers: Vec::new(),
+            ws_frame_injections,
+            connection_id: None,
+        });
+    }
+
+    // SEC-M3: raw decrypted bytes stay wrapped so they zero on drop.
+    let decrypted_bytes = Zeroizing::new(
+        encryption_keys
+            .decrypt(&service.credential_encrypted)
+            .await?,
+    );
+    let credential = String::from_utf8((*decrypted_bytes).clone()).map_err(|e| {
+        tracing::error!("Credential UTF-8 decode failed: {e}");
+        AppError::Internal("Failed to decode credential".to_string())
+    })?;
+
+    Ok(ProxyTarget {
+        base_url: service.base_url.clone(),
+        auth_method: service.auth_method.clone(),
+        auth_key_name: service.auth_key_name.clone(),
+        credential,
+        service,
+        catalog_default_headers,
+        user_service_default_headers: Vec::new(),
+        ws_frame_injections,
+        connection_id: None,
+    })
+}
+
 /// Resolve the downstream service and credential for a proxy request.
 ///
 /// Enforces that the user has an active connection. For "connection" services,

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -448,6 +448,35 @@ call: make the product chat call the same engine the Aevatar console uses —
   tools 403 into NyxID and answers degrade instead of crashing — the G9
   decision is still open); a mid-session placeholder URL dies on reload
   (sidebar row recovers it); `workflow-chat/ws` remains dead code.
+- **G18 [P2] Approvals cannot be decided on the workflow surface.** `:approve`
+  addresses a nyxid-chat conversation ACTOR; a workflow run resumes through
+  scope-service `runs/{runId}:resume`, which this mount does not proxy. The
+  card can still RENDER (the workflow mapper emits
+  `aevatar.tool_approval.pending` / `aevatar.human_input.request`), so
+  `decideApproval` fails fast with a legible message pointing at the NyxID
+  Approvals page rather than 404-ing the actor route. Not a regression —
+  G1 already recorded that no approval could be completed from the browser on
+  the actor surface either. Fix = proxy the resume route (new mount entry +
+  `runId`/`stepId` plumbing from the run-context frame) when approvals become
+  a product requirement.
+
+**Compatibility review (2026-07-29, post-implementation).** Every changed
+symbol was traced to its consumers before merge:
+`POST /assistant/workflow-chat` had **no** callers anywhere in the repo (dead
+since the transport-toggle removal), so tightening it to a typed body breaks
+nothing; `execute_proxy`'s two production callers are unchanged and still run
+`TargetMode::CallerAddressed` with every caller-state gate intact; the
+`filter_chat_history_index` widening is additive (a user with only
+`nyxid-chat-` rows sees an identical list); and every workflow-specific branch
+in the transport is gated on `run.protocol === "workflow"` or an id-prefix
+test, so legacy `nyxid-chat-…` conversations stream, cancel, stop, approve,
+reload, and delete exactly as before. The one intended behavior change for
+legacy conversations is that new ones can no longer be *created* — existing
+ones stay fully continuable. On the `AdminManaged` branch, `master_credential`
+and `has_server_credential` are inert (both only matter when a
+`user_service_id` or node route is present, and neither is), so billing
+classification, approvals, audit, identity propagation, and delegation
+injection all behave as on the caller-addressed path.
 
 ### Contract layers dev ships that the FE transport does not speak (2026-07-29)
 

--- a/docs/CHAT_ASSISTANT_SPECS.md
+++ b/docs/CHAT_ASSISTANT_SPECS.md
@@ -321,13 +321,34 @@ none surface as a surprise "next broken leg":**
   responds with SSE. The backend endpoint authenticates; the browser cannot yet
   surface/complete a real approval. Only bites when the assistant performs a
   NyxID-gated write. Fix = the TD-7 protocol-module port.
-- **G2 [P2, TD-1] Caller-state can still divert/deny.** `execute_proxy` still
-  runs per-user node routing and rejects an inactive legacy Aevatar
-  `UserServiceConnection`, so one historical disconnected row = "works for
-  everyone but me". Fix = strict admin-target execution mode.
-- **G3 [P2] Node-routed workflow WS loses the bearer.** `/workflow-chat/ws` via
-  a user node pin: the node WS path has no `caller_token` and never injects the
-  forwarded bearer → 401. Direct WS is fine. Subsumed by G2's strict admin mode.
+- **G2 [P2, TD-1] Caller-state can still divert/deny — FIXED 2026-07-29.**
+  `forward()` now calls `proxy::execute_admin_proxy` (`TargetMode::AdminManaged`)
+  instead of `execute_proxy`, so the platform target resolves through
+  `proxy_service::resolve_admin_proxy_target` with no caller state: no
+  scoped-token service allowlist, no personal node pin, no personal
+  `UserServiceConnection`. The third of those was the live blocker, not just a
+  latent one — see G8.
+- **G8 [P1, FIXED 2026-07-29] Restricted tokens were locked out entirely.** A
+  restricted token's `allowed_service_ids` holds `UserService` ids, so the
+  admin catalog row can never be listed in one; the legacy-branch
+  `allow_all_services` gate therefore 403'd
+  (`api_key_scope_forbidden`, code 9000) **every** OAuth access token minted
+  with `resource`/`allowed_service_ids` on every `/api/v1/assistant/*` call,
+  with no grant a user could add to fix it. Reproduced on prod 2026-07-29 with
+  an Aevatar-console session token: `GET /api/v1/assistant/conversations` → 403,
+  while the same token drove a full `nyxid-chat` turn through
+  `/api/v1/proxy/s/aevatar/...` (its own `UserService` **is** in the list) and a
+  real completion through `/api/v1/proxy/s/chrono-llm-public/chat/completions`.
+  Cookie sessions were never affected (`allow_all_services: true`), which is why
+  the browser surface hid this. The admin-managed mode drops that gate for the
+  server-chosen target only; the delegation token it mints still inherits the
+  caller's restrictions verbatim (`TokenRestrictionClaims::from_auth_user`), so
+  a restricted caller's run stays restricted on every callback into NyxID.
+- **G3 [P2] Node-routed workflow WS loses the bearer — FIXED by G2.**
+  `/workflow-chat/ws` diverted to a user node pin had no `caller_token` and
+  never injected the forwarded bearer → 401. Every assistant handler forwards
+  through `forward()`, so the admin-managed mode resolves the WS twin with
+  `node_route = None`: a personal pin can no longer divert it.
 - **G4 [P2] Long-run callback refresh.** The forwarded delegated token is 300s;
   `/delegation/refresh` expects `act.sub` to be an active `OauthClient`, which
   `"aevatar"` is not, so a run that issues its first callback after 5 min can
@@ -340,6 +361,137 @@ none surface as a surprise "next broken leg":**
   service still resolves a caller `UserService` first then the active catalog
   row — its endpoint + credential provisioning remains a runtime dependency
   (confirm it's an active public/master-credential row, class-equal to aevatar).
+- **G11 [P1, FIXED 2026-07-29; SUPERSEDED same day by the workflow re-point]
+  The conversation list leaked another product's chats.** `chat-history` is a
+  **shared** read model: Aevatar's workflow chat (`POST /api/chat`, what
+  `aevatar-console.aevatar.ai/chat` posts to) writes `chatc-…` rows into the
+  same index that `GET /assistant/conversations` reads. Those ids are not
+  conversation actors — verified on prod 2026-07-29, streaming into one
+  returns `RUN_ERROR ACTOR_NOT_FOUND` — so the sidebar listed the user's
+  console chats and every send into one died. First fixed by filtering to the
+  `nyxid-chat-` actor prefix; the same-day workflow re-point (see "Chat turns
+  re-pointed" below) made `chatc-` rows first-class again, so
+  `assistant_service::filter_chat_history_index` now keeps BOTH families and
+  drops only rows from other product surfaces. Still shape-tolerant: an index
+  we do not recognise streams through byte-for-byte.
+- **G9 [P1, decision needed] Aevatar's NyxID management tools are unreachable
+  through this mount.** Upstream `ExtractNyxIdAccessToken`
+  (`NyxIdChatEndpoints.cs:331`) prefers `X-NyxID-Delegation-Token` over
+  `Authorization`, so every built-in NyxID tool calls NyxID back with the
+  delegation token we inject. `NyxIdApiClient` targets first-party management
+  routes — `/users/me`, `/catalog`, `/keys`, `/user-services`, `/api-keys`,
+  `/nodes`, `/approvals/requests`, `/ssh/{id}/exec` — and all of those live in
+  `api_v1_human_only`, behind `reject_delegated_tokens`. Only `nyxid_proxy`
+  (`/proxy/s/{slug}`) and the LLM gateway are inside `api_v1_delegated`. Net
+  effect: on the Aevatar console (raw user bearer, human-only accepted) the
+  assistant can answer "what do I have connected?"; through `/api/v1/assistant/*`
+  it cannot. This is a deliberate confused-deputy boundary, so widening it is
+  Calvin's call, not a bug fix. Options: (a) keep the boundary and scope chat to
+  proxy/LLM; (b) add a curated **read-only** delegated subset (`GET /users/me`,
+  `/catalog`, `/user-services`, `/keys`, `/nodes`, `/approvals/requests`) with
+  writes still human-only; (c) mint a restricted first-party token instead of a
+  delegation token (previously vetoed: NyxID-audienced ⇒ replayable at NyxID).
+  Note (b) does not pay off until G10 lands upstream — and dev's own answer is
+  neither (a) nor (b): see G12, where the browser executes the action with the
+  user's own session and reports back. Implementing G12 is the aligned path;
+  widening the delegated router is probably the wrong fix.
+- **G10 [P1, UPSTREAM] Effect-capable NyxID tools fail every turn on the
+  `nyxid-chat` surface.** `NyxIdChatTurnOperationExecutor.cs:366-374` fails the
+  run with `NYXID_CHAT_TOOL_RECEIPT_REQUIRED` when a `MayChangeExternalState`
+  tool returns no `AgentToolReceipt`. `NyxIdProxyTool`/`NyxIdRequireServiceTool`
+  emit one via `NyxIdProxyReceiptFactory`; `NyxIdServicesTool` and its siblings
+  return a bare JSON string and never do, and `StreamingToolExecutor`
+  synthesizes a receipt only for `IsError` results — a successful call is left
+  receiptless. Reproduced 2026-07-29 straight at
+  `aevatar-console-backend-api.aevatar.ai` with a raw bearer (no NyxID in the
+  path): `nyxid_services` → step `uncertain` / `may_have_changed` → `RUN_ERROR`.
+  Not fixable from NyxID; needs an Aevatar-side receipt for those tools.
+
+### Chat turns re-pointed to the workflow ("studio") engine (2026-07-29, Calvin's directive)
+
+The nyxid-chat surface's receipt gate (G10) kills every turn that touches a
+default-classified `nyxid_*` tool, and the fix is upstream-owned. Calvin's
+call: make the product chat call the same engine the Aevatar console uses —
+`POST /api/chat`, workflow `studio` — through the pass-through. Implemented:
+
+- **Backend.** `POST /api/v1/assistant/workflow-chat` no longer forwards the
+  caller body verbatim: it parses a typed `WorkflowChatTurnRequest`
+  (`prompt`, optional `conversationId` + `minimumStateVersion`, optional
+  `commandId`; `deny_unknown_fields`) and builds Aevatar's strict
+  `HttpChatInput` server-side — `workflow` pinned to `studio`
+  (`assistant_service::WORKFLOW_CHAT_WORKFLOW`), `conversation` object always
+  present (without it Aevatar persists nothing), no `scopeId` (trusted scope
+  wins upstream anyway). Continuations require the client's last observed
+  `stateVersion` (Aevatar's read fence; `> 0` or 400 here, 503 upstream).
+  Auth: `/api/chat` accepts the injected `X-NyxID-Identity-Token` via the
+  global JwtBearer forward selector when no `Authorization` is present
+  (verified on `feature/integrate`: `NyxIdIdentityAssertionAuthentication.cs`,
+  `ChatEndpointsInternalTests.HandleChat_ShouldUseDelegationCredentialAndAuthenticatedScope`);
+  the delegation token becomes the tool credential
+  (`WorkflowCallerCredentialExtractor`, Authorization-first, delegation
+  fallback).
+- **Frontend.** Transport routes by conversation-id family: `chatc-…` (and
+  the client-local `workflow-pending-…` placeholder) → workflow route;
+  legacy `nyxid-chat-…` → the AG-UI `:stream` route, unchanged.
+  `createConversation` is client-local; the first turn's
+  `aevatar.chat.context` frame delivers the server `chatc-…` id, which the
+  transport aliases over the placeholder (URL keeps the placeholder for the
+  session; a reload lists the server row). `stateVersion` is captured from
+  `chat.context` and the wrapped transcript read. Workflow frame semantics:
+  pre-`runStarted` CUSTOM context frames are legal, `runStarted.runId` is run
+  identity (not the turn id), `runFinished.result.output` renders when
+  nothing streamed, trailing `stateSnapshot`/`raw.observed` after the
+  terminal are tolerated. No `:stop` on this surface — cancel is client-side
+  only (run control lives on scope-service `runs/{runId}:stop`, not proxied).
+- **Known limits, deliberate:** G9 applies unchanged on this path (the tool
+  credential is still the delegation token, so `nyxid_status`-class account
+  tools 403 into NyxID and answers degrade instead of crashing — the G9
+  decision is still open); a mid-session placeholder URL dies on reload
+  (sidebar row recovers it); `workflow-chat/ws` remains dead code.
+
+### Contract layers dev ships that the FE transport does not speak (2026-07-29)
+
+Endpoints, request bodies, and the v1 frame vocabulary all match (verified
+live). What our `aevatar-transport.ts` has not caught up with is everything
+`feature/integrate` added on top:
+
+- **G13 Task/step progress.** `CUSTOM nyxid.task.snapshot` +
+  `nyxid.task.step.changed` are the run ledger now: ordered steps with
+  `kind`, `status`, human `description`, `externalEffect`, and per-step
+  `availableActions`. `aevatar.step.request` / `aevatar.step.completed` (which
+  we do handle) are no longer emitted, so the activity card is built only from
+  `TOOL_CALL_START/END` and shows raw tool names instead of the committed plan.
+- **G14 Control plane unused.** `GET …/state` is the contract's reconnect
+  surface (every control 202 returns its `stateUrl`), and `:steer`,
+  `steps/{id}:retry`, `steps/{id}:skip` are live. NyxID proxies all four; the
+  FE calls none of them — only `:stream`, `:approve`, `:stop`, transcript,
+  list, delete. A dropped stream cannot be recovered by polling state, and
+  `availableActions` never reaches the UI.
+- **G12 Assistant actions registry (schema v4).** `CUSTOM nyxid.action.request`
+  asks the **browser** to perform a caller-owned NyxID action (v1 wire payload:
+  `service.connect`, catalog or custom) and the client answers on the same
+  `:stream` route with `type:"action.continue"`, `originTurnId`, and
+  `actions: [{actionRequestId, originTurnId, disposition, resource,
+  safeMessage}]` where disposition ∈ completed | declined | failed | cancelled
+  | expired. Registry: `NyxIdAssistantActionRegistry.cs` (service.connect,
+  service.reauthorize, key.create/rotate, node.*, service_account.*,
+  developer_app.*, account.mfa_setup …). Unimplemented end to end — the FE
+  drops the frame and NyxID's `:stream` handler never sees the continuation
+  shape. This is the upstream answer to G9: privileged NyxID work is done by
+  the browser with the user's own session, not by Aevatar with a delegation
+  token.
+- **G15 Frame sequencing ignored.** Dev stamps every frame with `sequence`;
+  the transport never reads it, so it cannot detect gaps or re-order.
+- **G16 Dead vocabulary retained.** The transport still handles
+  `aevatar.step.*`, `aevatar.tool_approval.pending`,
+  `aevatar.human_input.request`, `aevatar.workflow.waiting_signal`,
+  `aevatar.raw.observed`, `demo.conversation.context`, `STEP_STARTED/FINISHED`,
+  `RUN_STOPPED`, and typed `AUTHORIZATION_REQUIRED` — none are emitted by dev's
+  `NyxIdChatSseWriter`. Harmless, but it is not the current contract.
+- **G17 Narrow blocker allowlist.** The connect card only renders for
+  `reasonCode` ∈ {`NYXID_SERVICE_NOT_CONNECTED`, `NYXID_UNAUTHORIZED`}. Dev's
+  code path emits `NYXID_UNAUTHORIZED`, but `NyxIdRequireServiceTool` passes a
+  model-supplied code through, so an unexpected value silently drops the card.
 
 ## Enable-ready (proven, awaiting a decision — not blocked on code)
 
@@ -526,13 +678,16 @@ harness).**
 Good-to-have items consciously deferred on 2026-07-17; default owner = BE engineer
 unless noted. Each item: what, risk, trigger.
 
-- **TD-1 — Admin-path isolation leak (F1).** `execute_proxy` still runs caller-state
-  resolution even for catalog-id addressing: a personal node pin
-  (`resolve_node_route`) or an inactive `UserServiceConnection` ("You have
-  disconnected from this service", `proxy_service.rs:~460`) changes or breaks
-  assistant traffic for that one user. Fix: strict admin-target execution mode that
-  bypasses UserService / node routing / legacy connections. Trigger: before GA, or
-  the first "chat works for everyone but me" report.
+- **TD-1 — Admin-path isolation leak (F1) — CLOSED 2026-07-29.** Shipped as
+  `proxy::execute_admin_proxy` / `TargetMode::AdminManaged` +
+  `proxy_service::resolve_admin_proxy_target`, wired into
+  `handlers::assistant::forward`, so no caller state (scoped-token allowlist,
+  personal node pin, personal `UserServiceConnection`) reaches a server-chosen
+  platform target. Caller-addressed proxy routes are unchanged and still
+  enforce all three. Tests:
+  `admin_managed_target_admits_a_scoped_token_the_caller_path_rejects`,
+  `admin_managed_target_ignores_a_disconnected_personal_connection`,
+  `admin_managed_target_rejects_a_user_credential_service_as_internal`.
 - **TD-2 — Scope smuggling (F4, F5, F6).** (a) `/assistant/workflow-chat` forwards
   the body verbatim — a caller can send `scopeId` / `chatHistory.conversationId`;
   identity-JWT generation failures log and continue. (b) The WS twin bridges frames

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -4498,3 +4498,22 @@ describe("workflow chat turns (studio engine)", () => {
     ).rejects.toThrow("Conversation was not found.");
   });
 });
+
+describe("workflow conversations fail approvals honestly", () => {
+  // `:approve` addresses a nyxid-chat ACTOR; a workflow run resumes through
+  // `runs/{runId}:resume`, which the mount does not proxy. The card can
+  // still render (the workflow mapper emits `aevatar.tool_approval.pending`),
+  // so the decision must fail with a legible message instead of a 404.
+  it("refuses to post the actor approve route for a chatc conversation", async () => {
+    const mock = stubFetch();
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    await expect(
+      transport.decideApproval(conversation.id, "block-1", true),
+    ).rejects.toThrow(/Approvals cannot be decided from this chat yet/);
+    expect(
+      mock.mock.calls.some(([input]) => String(input).endsWith("/approve")),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -10,7 +10,7 @@ import capturedHistory from "@/lib/assistant/__fixtures__/aevatar-chat-history.j
 import capturedStream from "@/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse?raw";
 import { useAuthStore } from "@/stores/auth-store";
 import type { User } from "@/types/api";
-import type { ContentBlock, TurnEvent } from "@/types/assistant";
+import type { ContentBlock, Conversation, TurnEvent } from "@/types/assistant";
 
 const USER_ID = "add69059-bece-4f0e-9559-99cfd10b47eb";
 const CONVERSATION_ID = "nyxid-chat-f8369965a444433f92ec50e67ad8ee52";
@@ -101,10 +101,51 @@ function stubFetch(...routes: FetchRoute[]): ReturnType<typeof vi.fn> {
   return mock;
 }
 
-const routeCreate: FetchRoute = (url, init) =>
-  url === `${ASSISTANT_BASE}/conversations` && init?.method === "POST"
-    ? jsonResponse({ status: "accepted", actorId: CONVERSATION_ID })
-    : undefined;
+// `createConversation` is client-local now (new chats are workflow
+// conversations created server-side by their first turn), so the legacy
+// `nyxid-chat-…` actor conversations these AG-UI tests exercise are seeded
+// the only way they still arrive: through the Chat History index. The
+// helper stubs one list fetch, seeds `CONVERSATION_ID`, then restores the
+// test's own fetch stub and the list-fetch throttle.
+async function seedActorConversation(
+  transport: AevatarAssistantTransport,
+): Promise<Conversation> {
+  const active = globalThis.fetch;
+  vi.stubGlobal("fetch", (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (
+      url === `${ASSISTANT_BASE}/conversations` &&
+      (init?.method ?? "GET") === "GET"
+    ) {
+      return Promise.resolve(
+        jsonResponse({
+          conversations: [
+            {
+              id: CONVERSATION_ID,
+              title: "Seeded conversation",
+              updatedAt: "2026-07-29T00:00:00.000Z",
+            },
+          ],
+        }),
+      );
+    }
+    return active(input, init);
+  });
+  try {
+    // The seed must reach the wire even when the test already listed
+    // within the throttle window.
+    (transport as unknown as { listFetchedAt: number }).listFetchedAt = 0;
+    const conversations = await transport.listConversations();
+    const seeded = conversations.find((c) => c.id === CONVERSATION_ID);
+    if (!seeded) throw new Error("seed conversation did not merge");
+    return seeded;
+  } finally {
+    vi.stubGlobal("fetch", active);
+    // Reset the list throttle so tests that assert list behavior still
+    // reach their own stubs.
+    (transport as unknown as { listFetchedAt: number }).listFetchedAt = 0;
+  }
+}
 
 function routeStream(frames: unknown[]): FetchRoute {
   return (url, init) =>
@@ -152,9 +193,9 @@ afterEach(() => {
 
 describe("AevatarAssistantTransport", () => {
   it("adapts the observed AG-UI stream into the PRD turn-event sequence", async () => {
-    stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    stubFetch(routeStream(OBSERVED_FRAMES));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Say hello in five words.");
 
@@ -188,9 +229,9 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("serves the streamed transcript from the local mirror during and after the turn", async () => {
-    stubFetch(routeCreate, routeStream(OBSERVED_FRAMES), routeHistory([]));
+    stubFetch(routeStream(OBSERVED_FRAMES), routeHistory([]));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Say hello in five words.");
 
     // Server history is empty (materialization lag) — the keep-max guard
@@ -294,9 +335,9 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("uses RUN_STARTED.turnId as the authoritative handle and event identity", async () => {
-    stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    stubFetch(routeStream(OBSERVED_FRAMES));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events: TurnEvent[] = [];
     let resolveDone: () => void = () => {};
@@ -370,9 +411,9 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("keeps a streaming conversation's live title over stale index metadata", async () => {
-    stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    stubFetch(routeStream(OBSERVED_FRAMES));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     // Start a turn but don't await it, so the conversation is mid-flight.
     const inflight = collectTurn(transport, "Draft the launch note");
 
@@ -386,9 +427,9 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("rejects a concurrent send while a turn is active", async () => {
-    stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    stubFetch(routeStream(OBSERVED_FRAMES));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const first = collectTurn(transport, "First message");
     expect(() => {
@@ -399,7 +440,6 @@ describe("AevatarAssistantTransport", () => {
 
   it("maps RUN_ERROR to a failed turn", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -409,7 +449,7 @@ describe("AevatarAssistantTransport", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -426,13 +466,13 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("fails the turn when the stream endpoint rejects the request", async () => {
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? jsonResponse({ error: "turn_active" }, 409)
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -448,7 +488,7 @@ describe("AevatarAssistantTransport", () => {
   it("surfaces the pre-stream error envelope instead of a bare status", async () => {
     // Errors before the SSE stream starts are a JSON `{code, message}`
     // envelope (Chat History contract) — the turn error must carry it.
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? jsonResponse(
             { code: "UPSTREAM_TIMEOUT", message: "Aevatar timed out." },
@@ -457,7 +497,7 @@ describe("AevatarAssistantTransport", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -469,13 +509,13 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("gives a stream 401 an auth-specific message, not a bare status", async () => {
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? jsonResponse({ error: "unauthorized" }, 401)
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -491,11 +531,10 @@ describe("AevatarAssistantTransport", () => {
     // RUN_ERROR. That is not a success (the reference client marks it
     // "closed"); the partial text must still settle into the transcript.
     stubFetch(
-      routeCreate,
       routeStream([OBSERVED_FRAMES[0], OBSERVED_FRAMES[1], OBSERVED_FRAMES[2]]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -513,7 +552,7 @@ describe("AevatarAssistantTransport", () => {
   });
 
   it("fails duplicate terminal frames delivered in separate chunks", async () => {
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? chunkedSseResponse([
             [
@@ -530,7 +569,7 @@ describe("AevatarAssistantTransport", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -547,7 +586,7 @@ describe("AevatarAssistantTransport", () => {
       .join("");
     // The capture ends right after the last data line — no blank line.
     const body = `${terminatedFrames}data: ${JSON.stringify({ type: "RUN_FINISHED" })}`;
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? new Response(body, {
             status: 200,
@@ -556,7 +595,7 @@ describe("AevatarAssistantTransport", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -582,7 +621,7 @@ describe("AevatarAssistantTransport", () => {
         );
       },
     });
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? new Response(openStream, {
             status: 200,
@@ -591,7 +630,7 @@ describe("AevatarAssistantTransport", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events: TurnEvent[] = [];
     const done = new Promise<void>((resolve) => {
@@ -646,7 +685,6 @@ describe("AevatarAssistantTransport", () => {
     const stopBodies: Array<Record<string, unknown>> = [];
     let streamClientRequestId: string | undefined;
     stubFetch(
-      routeCreate,
       (url, init) => {
         if (
           url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/stop` &&
@@ -673,7 +711,7 @@ describe("AevatarAssistantTransport", () => {
       },
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await new Promise<void>((resolve) => {
       const handle = transport.sendMessage(
@@ -705,7 +743,7 @@ describe("AevatarAssistantTransport", () => {
     // the local settle — PRE_START_STOP_WINDOW_MS — in case the announcing
     // frame is still in flight; see the next test for that path.)
     const silentStream = new ReadableStream<Uint8Array>({ start() {} });
-    const fetchMock = stubFetch(routeCreate, (url, init) =>
+    const fetchMock = stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? new Response(silentStream, {
             status: 200,
@@ -714,7 +752,7 @@ describe("AevatarAssistantTransport", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await new Promise<void>((resolve) => {
       const handle = transport.sendMessage(
@@ -749,7 +787,6 @@ describe("AevatarAssistantTransport", () => {
     });
     const stopBodies: Array<Record<string, unknown>> = [];
     stubFetch(
-      routeCreate,
       (url, init) => {
         if (url.endsWith("/stop") && init?.method === "POST") {
           stopBodies.push(
@@ -768,7 +805,7 @@ describe("AevatarAssistantTransport", () => {
           : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events: TurnEvent[] = [];
     const handle = transport.sendMessage(CONVERSATION_ID, "Hello", (event) =>
@@ -841,7 +878,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const handle = transport.sendMessage(CONVERSATION_ID, "First", () => {});
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -918,7 +955,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const handle = transport.sendMessage(CONVERSATION_ID, "First", () => {});
     await new Promise((resolve) => setTimeout(resolve, 10));
@@ -1007,7 +1044,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     // Turn A: streams, gets its turnId, cancelled → stop A held pending.
     await new Promise<void>((resolve) => {
@@ -1102,7 +1139,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await new Promise<void>((resolve) => {
       const handle = transport.sendMessage(CONVERSATION_ID, "Turn A", (e) => {
@@ -1182,7 +1219,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     let deleteStarted = false;
     let reentrantSendError: string | null = null;
@@ -1255,7 +1292,7 @@ describe("AevatarAssistantTransport", () => {
       );
       vi.stubGlobal("fetch", mock);
       const transport = new AevatarAssistantTransport();
-      await transport.createConversation();
+      await seedActorConversation(transport);
 
       const firstOutcome = transport
         .deleteConversation(CONVERSATION_ID)
@@ -1301,7 +1338,6 @@ describe("AevatarAssistantTransport", () => {
     // never invokes the comparator, which is why single-conversation
     // smoke tests missed it.)
     stubFetch(
-      routeCreate,
       (url, init) =>
         url === `${ASSISTANT_BASE}/conversations` &&
         (init?.method ?? "GET") === "GET"
@@ -1336,7 +1372,7 @@ describe("AevatarAssistantTransport", () => {
     }
 
     // A send with multiple rows in the mirror must still complete.
-    await transport.createConversation();
+    await seedActorConversation(transport);
     const events = await collectTurn(transport, "Does sending still work?");
     expect(events[events.length - 1]?.event).toBe("turn.completed");
   });
@@ -1372,7 +1408,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const first = transport.deleteConversation(CONVERSATION_ID);
     const second = transport.deleteConversation(CONVERSATION_ID);
@@ -1461,7 +1497,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     // Turn 1 parks an actionable approval card at EOF.
     const turn1 = await collectTurn(transport, "Post the digest");
@@ -1554,7 +1590,7 @@ describe("AevatarAssistantTransport", () => {
     );
     vi.stubGlobal("fetch", mock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await new Promise<void>((resolve) => {
       const handle = transport.sendMessage(
@@ -1600,7 +1636,6 @@ describe("AevatarAssistantTransport", () => {
       },
     });
     stubFetch(
-      routeCreate,
       (url, init) =>
         url.endsWith("/stop") && init?.method === "POST"
           ? jsonResponse(
@@ -1617,7 +1652,7 @@ describe("AevatarAssistantTransport", () => {
           : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events: TurnEvent[] = [];
     await new Promise<void>((resolve) => {
@@ -1662,9 +1697,9 @@ describe("AevatarAssistantTransport", () => {
     // transport must not depend on the client-side user at all (PRD
     // decision 4). Regression guard against reintroducing a scope segment.
     useAuthStore.getState().setUser(null);
-    const fetchMock = stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    const fetchMock = stubFetch(routeStream(OBSERVED_FRAMES));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello there");
 
@@ -1690,9 +1725,9 @@ describe("AevatarAssistantTransport", () => {
       init?.method === "DELETE"
         ? jsonResponse({})
         : undefined;
-    const fetchMock = stubFetch(routeCreate, routeIndex, routeDelete);
+    const fetchMock = stubFetch(routeIndex, routeDelete);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     expect(await transport.listConversations()).toHaveLength(1);
 
     await transport.deleteConversation(CONVERSATION_ID);
@@ -1720,9 +1755,9 @@ describe("AevatarAssistantTransport", () => {
             502,
           )
         : undefined;
-    stubFetch(routeCreate, routeIndex, routeDeleteFailure);
+    stubFetch(routeIndex, routeDeleteFailure);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await expect(
       transport.deleteConversation(CONVERSATION_ID),
@@ -1756,7 +1791,7 @@ describe("AevatarAssistantTransport", () => {
       init?.method === "DELETE"
         ? jsonResponse({})
         : undefined;
-    stubFetch(routeCreate, routeDelete, (url, init) =>
+    stubFetch(routeDelete, (url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? new Response(openStream, {
             status: 200,
@@ -1765,7 +1800,7 @@ describe("AevatarAssistantTransport", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events: TurnEvent[] = [];
     let deletion: Promise<void> | null = null;
@@ -1819,7 +1854,7 @@ describe("captured production wire shapes", () => {
         controller.close();
       },
     });
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? new Response(trickle, {
             status: 200,
@@ -1828,7 +1863,7 @@ describe("captured production wire shapes", () => {
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(
       transport,
@@ -1953,9 +1988,9 @@ describe("captured production wire shapes", () => {
   );
 
   it("sends the exact request shape the aevatar stream endpoint requires", async () => {
-    const fetchMock = stubFetch(routeCreate, routeStream(OBSERVED_FRAMES));
+    const fetchMock = stubFetch(routeStream(OBSERVED_FRAMES));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await collectTurn(transport, "Hello there");
 
@@ -1999,7 +2034,6 @@ describe("captured production wire shapes", () => {
 
   it("uses a new clientRequestId for each logical turn across reprojection", async () => {
     const fetchMock = stubFetch(
-      routeCreate,
       routeStream(OBSERVED_FRAMES),
       (url, init) =>
         url === `${ASSISTANT_BASE}/conversations` &&
@@ -2031,7 +2065,7 @@ describe("captured production wire shapes", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await collectTurn(transport, "First turn");
     // Post-turn reprojection: server history (equal length) replaces the
@@ -2076,7 +2110,7 @@ describe("captured production wire shapes", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Retry this delivery");
 
@@ -2109,7 +2143,7 @@ describe("captured production wire shapes", () => {
 
   it("retries a successful stream response that has no body", async () => {
     let streamAttempts = 0;
-    const fetchMock = stubFetch(routeCreate, (url, init) => {
+    const fetchMock = stubFetch((url, init) => {
       if (!url.endsWith("/stream") || init?.method !== "POST") return undefined;
       streamAttempts += 1;
       return streamAttempts === 1
@@ -2120,7 +2154,7 @@ describe("captured production wire shapes", () => {
         : sseResponse(OBSERVED_FRAMES);
     });
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Retry the empty delivery");
 
@@ -2173,7 +2207,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("maps TOOL_CALL_START/END onto a run step ledger", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID, actorId: CONVERSATION_ID },
         {
@@ -2192,7 +2225,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Search skills");
 
@@ -2238,7 +2271,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("keeps policy-denied tool failures ordinary without a connect card", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2262,7 +2294,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Open a PR");
 
@@ -2282,7 +2314,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("ignores generic and unclassified authorization signals", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2311,7 +2342,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Summarize PRs");
 
@@ -2337,7 +2368,6 @@ describe("live AG-UI frame taxonomy", () => {
       },
     };
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         authorizationFrame,
@@ -2350,7 +2380,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Summarize my PRs");
 
@@ -2378,7 +2408,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("maps a genuinely disconnected service by its canonical slug", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2400,7 +2429,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Post to Lark");
 
@@ -2420,7 +2449,7 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("starts a new logical turn after a blocked delivery", async () => {
     let delivery = 0;
-    const fetchMock = stubFetch(routeCreate, (url, init) => {
+    const fetchMock = stubFetch((url, init) => {
       if (!url.endsWith("/stream") || init?.method !== "POST") return undefined;
       delivery += 1;
       return delivery === 1
@@ -2449,7 +2478,7 @@ describe("live AG-UI frame taxonomy", () => {
           ]);
     });
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const blocked = await collectTurn(transport, "Read a private repository");
     const completed = await collectTurn(transport, "Continue after reconnect");
@@ -2474,7 +2503,6 @@ describe("live AG-UI frame taxonomy", () => {
     // The upstream may close the idle stream while the human gate is open
     // (PRD §3.4); that is a pause, not a truncated run.
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2488,7 +2516,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Post the digest");
 
@@ -2523,7 +2551,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("streams the approve endpoint's SSE continuation as a follow-on turn", async () => {
     const fetchMock = stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2549,7 +2576,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     const firstTurn = await collectTurn(transport, "Post the digest");
     const lastFirstCursor = firstTurn[firstTurn.length - 1]?.cursor ?? 0;
     const history = await transport.getHistory(CONVERSATION_ID);
@@ -2611,7 +2638,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("fails closed when an approval continuation ends without a terminal frame", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2635,7 +2661,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Run an approved action");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
@@ -2669,7 +2695,6 @@ describe("live AG-UI frame taxonomy", () => {
     // active-turn guard and interleave two streams into one reducer.
     let releaseApprove: () => void = () => {};
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2680,7 +2705,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Do the thing");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
@@ -2725,7 +2750,6 @@ describe("live AG-UI frame taxonomy", () => {
     // Codex P2: TOOL_CALL_START directly followed by TOOL_APPROVAL_REQUEST
     // (no toolCallId on the frame) must park the step, not spin forever.
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2739,7 +2763,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Post it");
 
@@ -2760,7 +2784,6 @@ describe("live AG-UI frame taxonomy", () => {
     // list response must not resurrect a server-accepted delete.
     let listCalls = 0;
     stubFetch(
-      routeCreate,
       (url, init) =>
         url === `${ASSISTANT_BASE}/conversations` &&
         (init?.method ?? "GET") === "GET"
@@ -2779,7 +2802,7 @@ describe("live AG-UI frame taxonomy", () => {
           : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await transport.deleteConversation(CONVERSATION_ID);
 
@@ -2790,7 +2813,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("settles immediately when the approve endpoint acks with JSON", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2802,7 +2824,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Do the thing");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
@@ -2836,7 +2858,6 @@ describe("live AG-UI frame taxonomy", () => {
     // step; deciding must flip it (approved → done/completed) so the
     // transient activity line doesn't show a stale approval clock forever.
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2855,7 +2876,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Post it");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
@@ -2889,7 +2910,6 @@ describe("live AG-UI frame taxonomy", () => {
     // approval_request_id — deciding one card must not settle a step gated
     // on a different pending approval, and the ledger stays parked.
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2916,7 +2936,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Two gated actions");
     const history = await transport.getHistory(CONVERSATION_ID);
     const cardB = history.messages
@@ -2959,7 +2979,6 @@ describe("live AG-UI frame taxonomy", () => {
     // Second-pass codex P2: a terminal run must not carry a non-terminal
     // step — RUN_ERROR after an approval request skips the waiting step.
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -2977,7 +2996,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Post it");
 
@@ -2994,7 +3013,6 @@ describe("live AG-UI frame taxonomy", () => {
     // Second-pass codex P2: history hydration must honor tombstones — a
     // projection racing the delete must not write the row back.
     stubFetch(
-      routeCreate,
       routeHistory([
         { id: "h-user", role: "user", content: "hi", timestamp: 1 },
       ]),
@@ -3010,7 +3028,7 @@ describe("live AG-UI frame taxonomy", () => {
           : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     await transport.deleteConversation(CONVERSATION_ID);
 
@@ -3027,7 +3045,6 @@ describe("live AG-UI frame taxonomy", () => {
     // fallback.
     let releaseHistory: () => void = () => {};
     stubFetch(
-      routeCreate,
       routeStream(OBSERVED_FRAMES),
       (url, init) =>
         url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}` &&
@@ -3048,7 +3065,7 @@ describe("live AG-UI frame taxonomy", () => {
       },
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Say hello in five words.");
 
     const baseFetch = fetch;
@@ -3130,7 +3147,6 @@ describe("live AG-UI frame taxonomy", () => {
     // Second-pass codex P2: Stop works during the pre-header window via the
     // transport-level cancel (the caller holds no handle yet).
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3141,7 +3157,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Do it");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
@@ -3186,7 +3202,6 @@ describe("live AG-UI frame taxonomy", () => {
     // (its toast) and settle the turn with a NULL error so the generic
     // reply-failed toast cannot double-fire.
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3201,7 +3216,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     await collectTurn(transport, "Do it");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
@@ -3237,7 +3252,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("mines a raw.observed completion for steps and fallback text, never reasoning", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3282,7 +3296,7 @@ describe("live AG-UI frame taxonomy", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Search and finish");
 
@@ -3305,7 +3319,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("treats RUN_STOPPED as a terminal stop, not a truncated stream", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3320,7 +3333,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Do something long");
 
@@ -3338,7 +3351,6 @@ describe("live AG-UI frame taxonomy", () => {
     // body-keyed terminal frame falling through to UNKNOWN would leave the
     // turn looking truncated when it actually completed.
     stubFetch(
-      routeCreate,
       routeStream([
         { runStarted: { turnId: TURN_ID, actorId: CONVERSATION_ID } },
         { textMessageStart: { messageId: "m-1", role: "assistant" } },
@@ -3350,7 +3362,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -3376,7 +3388,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("maps top-level STEP_STARTED/STEP_FINISHED onto the run ledger", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         { type: "STEP_STARTED", stepStarted: { stepName: "collect" } },
@@ -3388,7 +3399,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Run the workflow");
 
@@ -3404,7 +3415,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("maps workflow step customs onto the run ledger", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3425,7 +3435,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Plan it");
 
@@ -3441,7 +3451,6 @@ describe("live AG-UI frame taxonomy", () => {
 
   it("embeds MEDIA_CONTENT as a data-URL artifact block", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3456,7 +3465,7 @@ describe("live AG-UI frame taxonomy", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Chart it");
 
@@ -3486,7 +3495,7 @@ describe("live AG-UI frame taxonomy", () => {
           push({ type: "RUN_STARTED", turnId: TURN_ID });
         },
       });
-      stubFetch(routeCreate, (url, init) =>
+      stubFetch((url, init) =>
         url.endsWith("/stream") && init?.method === "POST"
           ? new Response(openStream, {
               status: 200,
@@ -3495,7 +3504,7 @@ describe("live AG-UI frame taxonomy", () => {
           : undefined,
       );
       const transport = new AevatarAssistantTransport();
-      await transport.createConversation();
+      await seedActorConversation(transport);
 
       const events: TurnEvent[] = [];
       const done = new Promise<void>((resolve) => {
@@ -3540,7 +3549,7 @@ describe("live AG-UI frame taxonomy", () => {
           push({ type: "RUN_STARTED", turnId: TURN_ID });
         },
       });
-      stubFetch(routeCreate, (url, init) =>
+      stubFetch((url, init) =>
         url.endsWith("/stream") && init?.method === "POST"
           ? new Response(openStream, {
               status: 200,
@@ -3549,7 +3558,7 @@ describe("live AG-UI frame taxonomy", () => {
           : undefined,
       );
       const transport = new AevatarAssistantTransport();
-      await transport.createConversation();
+      await seedActorConversation(transport);
 
       const events: TurnEvent[] = [];
       const done = new Promise<void>((resolve) => {
@@ -3627,7 +3636,6 @@ describe("redaction and tool summaries", () => {
 
   it("redacts credentials from RUN_ERROR messages before they render", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3641,7 +3649,7 @@ describe("redaction and tool summaries", () => {
       ]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Hello");
 
@@ -3798,7 +3806,6 @@ describe("connect markers in assistant messages", () => {
 
   it("emits a card from the live stream and keeps the encoding out of prose", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID, actorId: CONVERSATION_ID },
         { type: "TEXT_MESSAGE_START", textMessageStart: { messageId: "m9" } },
@@ -3813,7 +3820,7 @@ describe("connect markers in assistant messages", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "Summarise my merged PRs");
 
@@ -3838,7 +3845,6 @@ describe("connect markers in assistant messages", () => {
 
   it("withholds a half-written marker while it streams", async () => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID, actorId: CONVERSATION_ID },
         { type: "TEXT_MESSAGE_START", textMessageStart: { messageId: "m9" } },
@@ -3861,7 +3867,7 @@ describe("connect markers in assistant messages", () => {
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
 
     const events = await collectTurn(transport, "go");
 
@@ -3937,7 +3943,6 @@ describe("live/history convergence for connect markers", () => {
     ),
   )("%s", async (_label, content, chunkSize) => {
     stubFetch(
-      routeCreate,
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID, actorId: CONVERSATION_ID },
         { type: "TEXT_MESSAGE_START", textMessageStart: { messageId: "mX" } },
@@ -3951,7 +3956,7 @@ describe("live/history convergence for connect markers", () => {
       routeHistory([]),
     );
     const liveTransport = new AevatarAssistantTransport();
-    await liveTransport.createConversation();
+    await seedActorConversation(liveTransport);
     const events = await collectTurn(liveTransport, "go");
 
     // Final state of every block this message produced, in emission order.
@@ -4032,9 +4037,9 @@ describe("cancel runs the same projection as a normal close", () => {
   async function cancelAfterDeltas(
     deltas: readonly string[],
   ): Promise<TurnEvent[]> {
-    stubFetch(routeCreate, hangingStream(deltas), routeHistory([]));
+    stubFetch(hangingStream(deltas), routeHistory([]));
     const transport = new AevatarAssistantTransport();
-    await transport.createConversation();
+    await seedActorConversation(transport);
     const events: TurnEvent[] = [];
     let seen = 0;
     await new Promise<void>((resolve) => {
@@ -4146,9 +4151,9 @@ describe("a conversation with no committed turn has no server transcript", () =>
   // conversation" (observed in prod, 2026-07-28).
   it("serves an empty transcript when the history row does not exist yet", async () => {
     // Only the create is routed; stubFetch answers everything else 404.
-    stubFetch(routeCreate);
+    stubFetch();
     const transport = new AevatarAssistantTransport();
-    const conversation = await transport.createConversation();
+    const conversation = await seedActorConversation(transport);
 
     const history = await transport.getHistory(conversation.id);
 
@@ -4157,7 +4162,7 @@ describe("a conversation with no committed turn has no server transcript", () =>
   });
 
   it("still rejects a 404 for a conversation it has never seen", async () => {
-    stubFetch(routeCreate);
+    stubFetch();
     const transport = new AevatarAssistantTransport();
 
     await expect(
@@ -4168,7 +4173,7 @@ describe("a conversation with no committed turn has no server transcript", () =>
   it("still rejects a transient failure on a conversation with no local transcript", async () => {
     // 5xx is a real read failure, not the not-yet-materialized state — it
     // must not be dressed up as a legitimately empty chat.
-    stubFetch(routeCreate, (url, init) =>
+    stubFetch((url, init) =>
       url.startsWith(`${ASSISTANT_BASE}/conversations/`) &&
       (init?.method ?? "GET") === "GET"
         ? jsonResponse(
@@ -4178,8 +4183,318 @@ describe("a conversation with no committed turn has no server transcript", () =>
         : undefined,
     );
     const transport = new AevatarAssistantTransport();
-    const conversation = await transport.createConversation();
+    const conversation = await seedActorConversation(transport);
 
     await expect(transport.getHistory(conversation.id)).rejects.toThrow();
+  });
+});
+
+describe("workflow chat turns (studio engine)", () => {
+  // New conversations run on Aevatar's workflow chat through the typed
+  // `POST /api/v1/assistant/workflow-chat` pass-through. The frame shapes
+  // below mirror the live `/api/chat` capture (2026-07-29): body-keyed
+  // protobuf-JSON envelopes, `aevatar.chat.context` first, trailing
+  // `stateSnapshot` after the terminal.
+  const WORKFLOW_URL = "/api/v1/assistant/workflow-chat";
+  const WORKFLOW_CONVERSATION = "chatc-8bd999c402fb37d60cdcd81e3b78cfd";
+  const WORKFLOW_TURN = "turn-d619940adcd817c4aeb5d1c3e57f1ca5";
+  const RUN_ACTOR = "workflow-definition:studio:run:43bfe86961b44fc2a6422d0b";
+
+  function workflowContextFrame(stateVersion: string): unknown {
+    return {
+      timestamp: "1785297207163",
+      custom: {
+        name: "aevatar.chat.context",
+        payload: {
+          "@type":
+            "type.googleapis.com/aevatar.workflow.runs.WorkflowChatContextPayload",
+          scopeId: USER_ID,
+          conversationId: WORKFLOW_CONVERSATION,
+          turnId: WORKFLOW_TURN,
+          stateVersion,
+        },
+      },
+    };
+  }
+
+  const WORKFLOW_PREAMBLE = [
+    workflowContextFrame("3"),
+    {
+      custom: {
+        name: "aevatar.run.context",
+        payload: {
+          "@type":
+            "type.googleapis.com/aevatar.workflow.runs.WorkflowRunContextPayload",
+          actorId: RUN_ACTOR,
+          workflowName: "studio",
+          commandId: "00e6f0aa-8670-4405-9911-7903a6616cbd",
+        },
+      },
+    },
+    { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+    { stepStarted: { stepName: "reply" } },
+  ];
+
+  const WORKFLOW_TAIL = [
+    { stepFinished: { stepName: "reply" } },
+    { usage: {} },
+    {
+      runFinished: {
+        threadId: RUN_ACTOR,
+        result: {
+          "@type":
+            "type.googleapis.com/aevatar.workflow.runs.WorkflowRunResultPayload",
+          output: "Here's what's available on your NyxID account.",
+        },
+      },
+    },
+    { stateSnapshot: { snapshot: { actorId: RUN_ACTOR } } },
+  ];
+
+  function routeWorkflow(frames: unknown[]): FetchRoute {
+    return (url, init) =>
+      url === WORKFLOW_URL && init?.method === "POST"
+        ? sseResponse(frames)
+        : undefined;
+  }
+
+  function collectWorkflowTurn(
+    transport: AevatarAssistantTransport,
+    conversationId: string,
+    content: string,
+  ): Promise<TurnEvent[]> {
+    return new Promise((resolve, reject) => {
+      const events: TurnEvent[] = [];
+      try {
+        transport.sendMessage(conversationId, content, (event) => {
+          events.push(event);
+          if (event.event === "turn.completed") resolve(events);
+        });
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  it("creates conversations locally and runs the first turn through the workflow route", async () => {
+    const mock = stubFetch(
+      routeWorkflow([
+        ...WORKFLOW_PREAMBLE,
+        { textMessageStart: { messageId: "wm-1" } },
+        {
+          textMessageContent: {
+            delta: "Here's what's available on your NyxID account.",
+          },
+        },
+        { textMessageEnd: {} },
+        ...WORKFLOW_TAIL,
+      ]),
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+    expect(conversation.id.startsWith("workflow-pending-")).toBe(true);
+    // Create is client-local: nothing goes to the wire until the send.
+    expect(mock).not.toHaveBeenCalled();
+
+    const events = await collectWorkflowTurn(transport, conversation.id, "hi");
+
+    const turnCall = mock.mock.calls.find(
+      ([input]) => String(input) === WORKFLOW_URL,
+    );
+    expect(turnCall).toBeDefined();
+    const body = JSON.parse(String(turnCall?.[1]?.body)) as Record<
+      string,
+      unknown
+    >;
+    // First turn = create intent: no conversation id, but an idempotency
+    // command id the retry loop can replay.
+    expect(body["conversationId"]).toBeUndefined();
+    expect(typeof body["commandId"]).toBe("string");
+    expect(body["prompt"]).toBe("hi");
+
+    const terminal = events[events.length - 1];
+    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
+      "completed",
+    );
+    const completed = events.find((event) => event.event === "block.completed");
+    expect(completed?.event === "block.completed" && completed.block).toEqual({
+      type: "text",
+      block_id: "wm-1-text",
+      text: "Here's what's available on your NyxID account.",
+    });
+
+    // `aevatar.chat.context` aliased the placeholder to the server id: the
+    // conversation now reports the `chatc-…` id through either address.
+    const history = await transport.getHistory(conversation.id);
+    expect(history.conversation.id).toBe(WORKFLOW_CONVERSATION);
+    expect(history.messages.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders the run result when nothing streamed as text", async () => {
+    stubFetch(routeWorkflow([...WORKFLOW_PREAMBLE, ...WORKFLOW_TAIL]));
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    const events = await collectWorkflowTurn(transport, conversation.id, "hi");
+
+    const textBlocks = events.filter(
+      (event) =>
+        event.event === "block.completed" && event.block.type === "text",
+    );
+    expect(
+      textBlocks.some(
+        (event) =>
+          event.event === "block.completed" &&
+          event.block.type === "text" &&
+          event.block.text ===
+            "Here's what's available on your NyxID account.",
+      ),
+    ).toBe(true);
+    expect(events[events.length - 1]?.event).toBe("turn.completed");
+  });
+
+  it("continues the conversation with the observed stateVersion and a fresh commandId", async () => {
+    const mock = stubFetch(
+      routeWorkflow([
+        ...WORKFLOW_PREAMBLE,
+        { textMessageStart: { messageId: "wm-1" } },
+        { textMessageContent: { delta: "First." } },
+        { textMessageEnd: {} },
+        ...WORKFLOW_TAIL,
+      ]),
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+    await collectWorkflowTurn(transport, conversation.id, "first");
+    await collectWorkflowTurn(transport, conversation.id, "second");
+
+    const turnBodies = mock.mock.calls
+      .filter(([input]) => String(input) === WORKFLOW_URL)
+      .map(
+        ([, init]) =>
+          JSON.parse(String(init?.body)) as Record<string, unknown>,
+      );
+    expect(turnBodies).toHaveLength(2);
+    expect(turnBodies[0]?.["conversationId"]).toBeUndefined();
+    // The follow-up addresses the server conversation with the read fence
+    // from the first turn's chat.context (stateVersion "3").
+    expect(turnBodies[1]?.["conversationId"]).toBe(WORKFLOW_CONVERSATION);
+    expect(turnBodies[1]?.["minimumStateVersion"]).toBe(3);
+    expect(turnBodies[1]?.["commandId"]).not.toBe(
+      turnBodies[0]?.["commandId"],
+    );
+  });
+
+  it("maps runError to a failed turn with its upstream code", async () => {
+    stubFetch(
+      routeWorkflow([
+        ...WORKFLOW_PREAMBLE,
+        { runError: { code: "WORKFLOW_FAILED", message: "engine died" } },
+      ]),
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    const events = await collectWorkflowTurn(transport, conversation.id, "hi");
+
+    const terminal = events[events.length - 1];
+    expect(
+      terminal?.event === "turn.completed" && {
+        status: terminal.status,
+        code: terminal.error?.code,
+      },
+    ).toEqual({ status: "failed", code: "WORKFLOW_FAILED" });
+  });
+
+  it("cancels client-side without posting the actor surface's :stop", async () => {
+    const encoder = new TextEncoder();
+    let preambleSent = false;
+    const mock = stubFetch((url, init) => {
+      if (url === WORKFLOW_URL && init?.method === "POST") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (!preambleSent) {
+                preambleSent = true;
+                controller.enqueue(
+                  encoder.encode(
+                    WORKFLOW_PREAMBLE.map(
+                      (frame) => `data: ${JSON.stringify(frame)}\n\n`,
+                    ).join(""),
+                  ),
+                );
+                return;
+              }
+              // Hang: the run is still executing server-side.
+              return new Promise<never>(() => {});
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return undefined;
+    });
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    const events: TurnEvent[] = [];
+    const terminal = new Promise<void>((resolve) => {
+      const handle = transport.sendMessage(
+        conversation.id,
+        "hi",
+        (event) => {
+          events.push(event);
+          if (event.event === "turn.completed") resolve();
+          if (event.event === "turn.status" && event.status === "running") {
+            handle.cancel();
+          }
+        },
+      );
+    });
+    await terminal;
+
+    expect(
+      events.some(
+        (event) =>
+          event.event === "turn.completed" && event.status === "cancelled",
+      ),
+    ).toBe(true);
+    expect(
+      mock.mock.calls.some(([input]) => String(input).endsWith("/stop")),
+    ).toBe(false);
+  });
+
+  it("deletes an aliased conversation through its server id", async () => {
+    const mock = stubFetch(
+      routeWorkflow([
+        ...WORKFLOW_PREAMBLE,
+        { textMessageStart: { messageId: "wm-1" } },
+        { textMessageContent: { delta: "First." } },
+        { textMessageEnd: {} },
+        ...WORKFLOW_TAIL,
+      ]),
+      (_url, init) =>
+        init?.method === "DELETE" ? jsonResponse({}) : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+    await collectWorkflowTurn(transport, conversation.id, "first");
+
+    await transport.deleteConversation(conversation.id);
+
+    expect(
+      mock.mock.calls.some(
+        ([input, init]) =>
+          String(input) ===
+            `${ASSISTANT_BASE}/conversations/${WORKFLOW_CONVERSATION}` &&
+          init?.method === "DELETE",
+      ),
+    ).toBe(true);
+    await expect(transport.getHistory(conversation.id)).rejects.toThrow(
+      "Conversation was not found.",
+    );
+    await expect(
+      transport.getHistory(WORKFLOW_CONVERSATION),
+    ).rejects.toThrow("Conversation was not found.");
   });
 });

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1177,8 +1177,19 @@ export class AevatarAssistantTransport implements AssistantTransport {
     approved: boolean,
     onEvent?: (event: TurnEvent) => void,
   ): Promise<TurnHandle | null> {
+    conversationId = this.canonicalConversationId(conversationId);
     if (this.deletingConversations.has(conversationId)) {
       throw new Error("This conversation is being deleted.");
+    }
+    // `:approve` addresses a nyxid-chat conversation ACTOR. A workflow run
+    // resumes through `runs/{runId}:resume`, which this mount does not
+    // proxy — posting the actor route with a `chatc-…` id would 404 with a
+    // misleading message. Fail honestly instead: the gate is real, we just
+    // cannot decide it from here yet.
+    if (isWorkflowConversationId(conversationId)) {
+      throw new Error(
+        "Approvals cannot be decided from this chat yet. Approve the request in NyxID (Approvals) and send your message again.",
+      );
     }
     const stored = this.conversations.get(conversationId);
     const card = stored?.turnState.messages

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -73,6 +73,31 @@ const assistantApi = {
 // network round-trip per streamed token.
 const CONVERSATION_LIST_TTL_MS = 5_000;
 
+// New chats run on Aevatar's workflow ("studio") chat engine through NyxID's
+// typed pass-through; legacy `nyxid-chat-…` actor conversations keep the
+// AG-UI `:stream` route so their transcripts stay continuable. Routing is by
+// conversation-id family.
+const WORKFLOW_CHAT_URL = "/api/v1/assistant/workflow-chat";
+
+// Server conversation ids minted by the workflow chat's history reservation
+// (`chatc-{hash[..32]}`).
+const WORKFLOW_CONVERSATION_PREFIX = "chatc-";
+
+// Client-local id for a workflow conversation that has not reached the
+// server yet. The server id arrives in the first turn's
+// `aevatar.chat.context` frame, which aliases this id to it; a reload
+// forgets the placeholder and lists the server row instead.
+const PENDING_WORKFLOW_CONVERSATION_PREFIX = "workflow-pending-";
+
+function isWorkflowConversationId(id: string): boolean {
+  return (
+    id.startsWith(WORKFLOW_CONVERSATION_PREFIX) ||
+    id.startsWith(PENDING_WORKFLOW_CONVERSATION_PREFIX)
+  );
+}
+
+const SERVER_CONVERSATION_ID_PATTERN = /^chatc-[A-Za-z0-9_-]{1,120}$/;
+
 const MAX_MESSAGE_CHARS = 32_768;
 
 // Reference-client parity (nyxid-chat BFF `DEMO_STREAM_PROGRESS_TIMEOUT_MS`):
@@ -198,6 +223,8 @@ interface AgUiFrame {
   readonly runFinished?: {
     readonly runId?: string;
     readonly status?: string;
+    /** Workflow chat terminal payload (`WorkflowRunResultPayload`). */
+    readonly result?: { readonly output?: string };
   };
   readonly runStopped?: { readonly reason?: string };
   readonly runError?: { readonly code?: string; readonly message?: string };
@@ -206,6 +233,17 @@ interface AgUiFrame {
     readonly stepName?: string;
     readonly success?: boolean;
   };
+  /** Workflow chat post-terminal projection snapshot; never rendered. */
+  readonly stateSnapshot?: unknown;
+}
+
+/** `custom aevatar.chat.context` — first frame of a workflow chat turn. */
+interface WorkflowChatContextPayload {
+  readonly scopeId?: string;
+  readonly conversationId?: string;
+  readonly turnId?: string;
+  /** Protobuf int64: rendered as a JSON string. */
+  readonly stateVersion?: string | number;
 }
 
 /** Batched completion inside `aevatar.raw.observed` (reference `protocol.js`). */
@@ -268,10 +306,6 @@ interface AevatarConversationListResponse {
   readonly conversations?: readonly AevatarHistoryIndexEntry[];
 }
 
-interface AevatarCreateConversationResponse {
-  readonly actorId?: string;
-}
-
 interface AevatarHistoryEntry {
   readonly id?: string;
   readonly role?: string;
@@ -294,23 +328,34 @@ interface AevatarHistoryEntry {
  * REMOVE the array branch once every supported Aevatar environment is
  * confirmed on the wrapped contract — not after a single prod probe.
  *
- * `stateVersion` is deliberately **ignored** — not read, not validated, not
- * stored. It is the continuation watermark for `POST /api/chat`, and NyxID's
- * production transport is `nyxid-chat/…:stream`, which has no such parameter.
- * Storing an unread watermark would be state nobody maintains
- * (`mergeIndexEntry` rebuilds `StoredConversation` and would silently drop
- * it), and *requiring* it would turn a field with zero consumers into an
- * outage. Acceptance is therefore keyed only on array-valued `messages`.
- * `stateVersion` becomes load-bearing only if the transport migrates to
- * `/api/chat`.
+ * `stateVersion` is the workflow-chat continuation watermark: continuing a
+ * `chatc-…` conversation requires the last observed value as
+ * `minimumStateVersion` (Aevatar's chat-history read fence). It is captured
+ * when present and never required — legacy-array responses simply leave the
+ * stored watermark unchanged.
  */
 type AevatarHistoryResponse =
   | readonly AevatarHistoryEntry[]
   | { readonly messages?: unknown; readonly stateVersion?: unknown };
 
+/** The wrapped shape's watermark, when the response carries a usable one. */
+function historyStateVersion(body: AevatarHistoryResponse): number | undefined {
+  if (Array.isArray(body)) return undefined;
+  const raw = (body as { readonly stateVersion?: unknown }).stateVersion;
+  const parsed =
+    typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 interface StoredConversation {
   conversation: Conversation;
   turnState: TurnReducerState;
+  /**
+   * Workflow-chat continuation watermark (`chatc-…` conversations only):
+   * the last `stateVersion` observed from the transcript read or the
+   * turn's `aevatar.chat.context` frame.
+   */
+  stateVersion?: number;
 }
 
 interface RunStepState {
@@ -325,6 +370,15 @@ interface RunStepState {
 
 interface RunningTurn {
   readonly clientRequestId: string;
+  /**
+   * Which turn surface this run speaks: `actor` = nyxid-chat AG-UI
+   * `:stream`, `workflow` = the studio workflow chat. Chosen from the
+   * conversation-id family at send time; gates the frame-ordering rules
+   * (`aevatar.chat.context` precedes `runStarted` on workflow streams,
+   * trailing `stateSnapshot` follows the terminal) and disables the
+   * `:stop` control, which only the actor surface serves.
+   */
+  readonly protocol: "actor" | "workflow";
   turnId: string | null;
   /**
    * A cancel landed before RUN_STARTED delivered the server turn id. The
@@ -799,7 +853,19 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * Concurrent deletes coalesce onto the stored promise.
    */
   private readonly deletingConversations = new Map<string, Promise<void>>();
+  /**
+   * Placeholder → server id, written when a new workflow conversation's
+   * first turn delivers its `aevatar.chat.context` frame. Public methods
+   * resolve through this so a page still addressing the placeholder (the
+   * URL keeps it for the session) reaches the server-backed entry.
+   */
+  private readonly conversationAliases = new Map<string, string>();
   private listFetchedAt = 0;
+
+  /** Follow a placeholder alias to the server conversation id, if any. */
+  private canonicalConversationId(conversationId: string): string {
+    return this.conversationAliases.get(conversationId) ?? conversationId;
+  }
 
   async listConversations(): Promise<Conversation[]> {
     const now = Date.now();
@@ -816,33 +882,40 @@ export class AevatarAssistantTransport implements AssistantTransport {
         if (id) this.mergeIndexEntry(id, entry);
       }
     }
-    return [...this.conversations.values()]
-      .map((stored) => stored.conversation)
-      .sort((a, b) =>
-        // Timestamps are normalized to ISO strings at the index boundary;
-        // String() keeps a stray non-string from crashing the whole list
-        // (ISO strings order identically either way).
-        String(b.last_message_at).localeCompare(String(a.last_message_at)),
-      );
+    // An aliased conversation is stored under both its placeholder key and
+    // its server id (`conversation.id` is the server id for both), so the
+    // list dedupes by id — preferring the entry stored under its own id,
+    // which is the one `mergeIndexEntry`/`loadHistory` keep fresh.
+    const byId = new Map<string, Conversation>();
+    for (const [key, stored] of this.conversations) {
+      const conversation = stored.conversation;
+      if (!byId.has(conversation.id) || key === conversation.id) {
+        byId.set(conversation.id, conversation);
+      }
+    }
+    return [...byId.values()].sort((a, b) =>
+      // Timestamps are normalized to ISO strings at the index boundary;
+      // String() keeps a stray non-string from crashing the whole list
+      // (ISO strings order identically either way).
+      String(b.last_message_at).localeCompare(String(a.last_message_at)),
+    );
   }
 
   async createConversation(): Promise<Conversation> {
-    const response = await assistantApi.post<AevatarCreateConversationResponse>(
-      `${ASSISTANT_PREFIX}/conversations`,
-      {},
-    );
-    const id = response.actorId;
-    if (!id) {
-      throw new Error("Aevatar did not return a conversation id.");
-    }
+    // New chats run on the workflow surface, where the conversation is
+    // created server-side by the FIRST turn's chat-history reservation
+    // (`conversation.conversationId: null` in the turn body) — there is no
+    // separate create call. Until that turn's `aevatar.chat.context` frame
+    // delivers the server `chatc-…` id, the conversation exists only under
+    // this client-local placeholder id; the frame aliases it in place.
     const createdAt = new Date().toISOString();
     const conversation: Conversation = {
-      id,
+      id: `${PENDING_WORKFLOW_CONVERSATION_PREFIX}${crypto.randomUUID()}`,
       title: "New chat",
       created_at: createdAt,
       last_message_at: createdAt,
     };
-    this.conversations.set(id, {
+    this.conversations.set(conversation.id, {
       conversation,
       turnState: EMPTY_TURN_STATE,
     });
@@ -850,6 +923,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   async deleteConversation(conversationId: string): Promise<void> {
+    const requestedId = conversationId;
+    conversationId = this.canonicalConversationId(conversationId);
     // A turn still streaming into the conversation must not keep painting
     // a transcript that is about to disappear: cancel first, matching the
     // reference client's abort-then-delete order. The server side is the
@@ -871,8 +946,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // already see the deletion guard — otherwise it can admit a send (or
     // a second delete) into the exact window the reservation closes.
     const operation = Promise.resolve().then(async () => {
-      const run = this.running.get(conversationId);
-      if (run) this.cancelTurn(conversationId, run);
+      // A first-turn workflow run is keyed under the placeholder id the
+      // send used; the same conversation is addressable through both.
+      for (const key of [requestedId, conversationId]) {
+        const run = this.running.get(key);
+        if (run) {
+          this.cancelTurn(key, run);
+          break;
+        }
+      }
       // The cancel above may have fired a `:stop`; let its fence commit
       // before the actor delete races the still-active work upstream.
       await this.awaitPendingStop(conversationId);
@@ -896,9 +978,17 @@ export class AevatarAssistantTransport implements AssistantTransport {
         clearTimeout(deadlineTimer);
       }
       // Local removal only after the server accepted: a failed delete keeps
-      // the conversation listed and retryable.
+      // the conversation listed and retryable. A placeholder that aliased
+      // to this conversation is tombstoned with it, so neither address can
+      // resurrect the row.
       this.conversations.delete(conversationId);
       this.deletedConversationIds.add(conversationId);
+      for (const [placeholder, target] of this.conversationAliases) {
+        if (target === conversationId) {
+          this.conversations.delete(placeholder);
+          this.deletedConversationIds.add(placeholder);
+        }
+      }
     });
     this.deletingConversations.set(conversationId, operation);
     try {
@@ -914,6 +1004,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   async getHistory(conversationId: string): Promise<ConversationHistory> {
+    conversationId = this.canonicalConversationId(conversationId);
     if (this.deletedConversationIds.has(conversationId)) {
       throw new Error("Conversation was not found.");
     }
@@ -982,6 +1073,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
     content: string,
     onEvent: (event: TurnEvent) => void,
   ): TurnHandle {
+    const requestedId = conversationId;
+    conversationId = this.canonicalConversationId(conversationId);
     const stored = this.conversations.get(conversationId);
     if (!stored) {
       throw new Error("Conversation was not found.");
@@ -991,6 +1084,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
     if (
       this.running.has(conversationId) ||
+      this.running.has(requestedId) ||
       isTurnActive(stored.turnState.activeTurn?.status)
     ) {
       throw new AssistantTurnActiveError();
@@ -1031,7 +1125,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
       last_message_at: createdAt,
     };
 
-    const run = this.newRun(onEvent);
+    const run = this.newRun(
+      onEvent,
+      null,
+      isWorkflowConversationId(conversationId) ? "workflow" : "actor",
+    );
     this.running.set(conversationId, run);
     void this.streamTurn(conversationId, run, normalized);
     return {
@@ -1051,8 +1149,18 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * Stop needs a transport-level lookup to abort a hung request).
    */
   cancelActiveTurn(conversationId: string): void {
-    const run = this.running.get(conversationId);
-    if (run) this.cancelTurn(conversationId, run);
+    // A first-turn workflow run is keyed under the placeholder id the send
+    // used; check both addresses and cancel under the run's own key.
+    for (const key of [
+      conversationId,
+      this.canonicalConversationId(conversationId),
+    ]) {
+      const run = this.running.get(key);
+      if (run) {
+        this.cancelTurn(key, run);
+        return;
+      }
+    }
   }
 
   /**
@@ -1277,6 +1385,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     this.conversations.set(id, {
       conversation,
       turnState: existing?.turnState ?? EMPTY_TURN_STATE,
+      stateVersion: existing?.stateVersion,
     });
   }
 
@@ -1297,6 +1406,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
     const messages = entries
       .map((entry, index) => historyEntryToMessage(entry, index))
       .filter((message): message is AssistantMessage => message !== null);
+    // The watermark is fresher than any stored one even when the transcript
+    // below keeps the local mirror (keep-max), so capture it first.
+    const freshStateVersion = historyStateVersion(body);
+    if (existing && freshStateVersion !== undefined) {
+      existing.stateVersion = freshStateVersion;
+    }
     // Keep-max guard: immediately after a turn completes, the server-side
     // materialization can briefly lag the local mirror. Never replace a
     // richer local transcript with a shorter server one.
@@ -1322,6 +1437,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
         activeTurn: existing?.turnState.activeTurn ?? null,
         lastCursor: existing?.turnState.lastCursor ?? 0,
       },
+      stateVersion: freshStateVersion ?? existing?.stateVersion,
     };
     this.conversations.set(conversationId, stored);
     return stored;
@@ -1330,9 +1446,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private newRun(
     onEvent: (event: TurnEvent) => void,
     turnId: string | null = null,
+    protocol: "actor" | "workflow" = "actor",
   ): RunningTurn {
     return {
       clientRequestId: crypto.randomUUID(),
+      protocol,
       turnId,
       stopPendingStart: false,
       streamDispatched: false,
@@ -1390,6 +1508,39 @@ export class AevatarAssistantTransport implements AssistantTransport {
     run.onEvent(event);
   }
 
+  /**
+   * Caller half of the workflow-chat turn contract (`WorkflowChatTurnRequest`
+   * server-side; NyxID builds the strict upstream `/api/chat` body from it).
+   * A `chatc-…` conversation continues with the last observed `stateVersion`
+   * as the read fence; a placeholder (or missing) id starts a new
+   * conversation. `commandId` is the run's idempotency identity — the retry
+   * loop replays it so a dropped first delivery resumes the same
+   * conversation/turn instead of minting a second one.
+   */
+  private workflowTurnBody(
+    conversationId: string,
+    run: RunningTurn,
+    prompt: string,
+  ): string {
+    const stored = this.conversations.get(conversationId);
+    const serverId = stored?.conversation.id;
+    if (serverId && serverId.startsWith(WORKFLOW_CONVERSATION_PREFIX)) {
+      return JSON.stringify({
+        prompt,
+        conversationId: serverId,
+        // The fence only requires the projection to have REACHED the
+        // version, so the floor of 1 (a conversation that exists has
+        // version ≥ 1) keeps a missing watermark from blocking the turn.
+        minimumStateVersion:
+          stored.stateVersion && stored.stateVersion > 0
+            ? stored.stateVersion
+            : 1,
+        commandId: run.clientRequestId,
+      });
+    }
+    return JSON.stringify({ prompt, commandId: run.clientRequestId });
+  }
+
   private async streamTurn(
     conversationId: string,
     run: RunningTurn,
@@ -1404,6 +1555,28 @@ export class AevatarAssistantTransport implements AssistantTransport {
       message: "The assistant stream could not be reached. Try again.",
     };
 
+    // Computed ONCE: a retry must replay the identical body — the workflow
+    // surface's create-replay recovery is keyed on (scope, commandId) with a
+    // request fingerprint, and a body that changed between attempts would
+    // 409 instead of resuming the same conversation/turn.
+    const target =
+      run.protocol === "workflow"
+        ? {
+            url: WORKFLOW_CHAT_URL,
+            body: this.workflowTurnBody(conversationId, run, prompt),
+          }
+        : {
+            url: `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/stream`,
+            body: JSON.stringify({
+              prompt,
+              clientRequestId: run.clientRequestId,
+              // Aevatar NyxIdChatEndpoints.Streaming.cs:58 uses an ordinal
+              // discriminator comparison, so a normal turn requires this
+              // exact lowercase value.
+              type: "text",
+            }),
+          };
+
     for (let attempt = 0; attempt < STREAM_DELIVERY_ATTEMPTS; attempt += 1) {
       // A cancel can settle the run between attempts (the pre-RUN_STARTED
       // path defers its abort); a finished run must never re-POST.
@@ -1414,26 +1587,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
         // Hand-rolled fetch (not `apiClient`): the response is an SSE stream,
         // and the endpoint 415s without an explicit JSON content type.
         run.streamDispatched = true;
-        response = await fetch(
-          `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/stream`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "text/event-stream",
-            },
-            credentials: "include",
-            body: JSON.stringify({
-              prompt,
-              clientRequestId: run.clientRequestId,
-              // Aevatar NyxIdChatEndpoints.Streaming.cs:58 uses an ordinal
-              // discriminator comparison, so a normal turn requires this
-              // exact lowercase value.
-              type: "text",
-            }),
-            signal: run.controller.signal,
+        response = await fetch(target.url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
           },
-        );
+          credentials: "include",
+          body: target.body,
+          signal: run.controller.signal,
+        });
       } catch {
         // The cancel path aborts the fetch after emitting its own terminal
         // events; an abort here is not a failure.
@@ -1666,6 +1829,10 @@ export class AevatarAssistantTransport implements AssistantTransport {
       type !== "RUN_ERROR" &&
       type !== "RUN_STOPPED"
     ) {
+      // The workflow stream legitimately trails its terminal with the
+      // projection snapshot and late `aevatar.raw.observed` envelopes;
+      // they are not renderable and not an ordering fault.
+      if (run.protocol === "workflow") return;
       run.deliveryProtocolError = {
         code: "stream_protocol_error",
         message: "The assistant stream sent data after its terminal frame.",
@@ -1674,15 +1841,28 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
 
     if (type !== "RUN_STARTED" && !isKeepalive && !run.deliveryStarted) {
-      run.deliveryProtocolError ??= {
-        code: "stream_protocol_error",
-        message: "The assistant stream sent data before identifying the turn.",
-      };
-      return;
+      // Workflow streams open with `custom aevatar.chat.context` (which
+      // starts the delivery below) and `custom aevatar.run.context` BEFORE
+      // `runStarted` — pre-start CUSTOM frames are the contract there, not
+      // a fault.
+      if (run.protocol !== "workflow" || type !== "CUSTOM") {
+        run.deliveryProtocolError ??= {
+          code: "stream_protocol_error",
+          message:
+            "The assistant stream sent data before identifying the turn.",
+        };
+        return;
+      }
     }
 
     switch (type) {
       case "RUN_STARTED": {
+        if (run.protocol === "workflow" && run.deliveryStarted) {
+          // `aevatar.chat.context` already identified the turn; this frame
+          // only contributes the run actor identity (`runId`), which the
+          // workflow surface uses for run-level control, not as a turn id.
+          return;
+        }
         const authoritativeTurnId = safeTurnId(
           frame.turnId ?? frame.runStarted?.turnId ?? frame.runStarted?.runId,
         );
@@ -1858,6 +2038,18 @@ export class AevatarAssistantTransport implements AssistantTransport {
           };
           return;
         }
+        // Workflow terminal payload: when nothing streamed (no text deltas
+        // and no `RoleChatSessionCompletedEvent` mined en route), the run
+        // result is the only carrier of the assistant's reply.
+        const output = frame.runFinished?.result?.output;
+        if (
+          run.protocol === "workflow" &&
+          !run.sawText &&
+          typeof output === "string" &&
+          output.trim()
+        ) {
+          this.emitStaticText(conversationId, run, output);
+        }
         this.recordDeliveryTerminal(run, {
           kind: "finished",
           status: status === "blocked" ? "blocked" : "completed",
@@ -1888,6 +2080,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
         );
         return;
       }
+      case "STATE_SNAPSHOT":
+        // Workflow projection state; telemetry only, never rendered.
+        return;
       case "CUSTOM": {
         this.handleCustomFrame(conversationId, run, frame.custom ?? {});
         return;
@@ -1924,6 +2119,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (frame.authorizationRequired) return "AUTHORIZATION_REQUIRED";
     if (frame.usage) return "USAGE";
     if (frame.mediaContent) return "MEDIA_CONTENT";
+    if (frame.stateSnapshot) return "STATE_SNAPSHOT";
     if (frame.custom) return "CUSTOM";
     return "UNKNOWN";
   }
@@ -1989,6 +2185,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
           });
         }
         return;
+      case "aevatar.chat.context":
+        this.applyWorkflowChatContext(
+          conversationId,
+          run,
+          payload as WorkflowChatContextPayload,
+        );
+        return;
       case "aevatar.run.context":
       case "demo.conversation.context":
         // Correlation ids only; nothing renders.
@@ -2008,6 +2211,62 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * step ledger, the final content as fallback text when nothing streamed,
    * and the model name. `reasoningContent` is never read.
    */
+  /**
+   * First frame of a workflow-chat turn: the chat-history reservation's
+   * identity. Starts the delivery (the turn id lives here, not in
+   * `runStarted`), records the continuation watermark, and — on a new
+   * conversation's first turn — aliases the client placeholder id to the
+   * server `chatc-…` id so every later address reaches the server-backed
+   * conversation.
+   */
+  private applyWorkflowChatContext(
+    conversationId: string,
+    run: RunningTurn,
+    payload: WorkflowChatContextPayload,
+  ): void {
+    if (run.protocol !== "workflow") return;
+
+    const stored = this.conversations.get(conversationId);
+    const serverId =
+      typeof payload.conversationId === "string" &&
+      SERVER_CONVERSATION_ID_PATTERN.test(payload.conversationId)
+        ? payload.conversationId
+        : null;
+    if (stored && serverId && stored.conversation.id !== serverId) {
+      stored.conversation = { ...stored.conversation, id: serverId };
+      this.conversations.set(serverId, stored);
+      this.conversationAliases.set(conversationId, serverId);
+    }
+
+    const rawVersion = payload.stateVersion;
+    const stateVersion =
+      typeof rawVersion === "number" ? rawVersion : Number(rawVersion);
+    if (stored && Number.isFinite(stateVersion) && stateVersion > 0) {
+      stored.stateVersion = stateVersion;
+    }
+
+    if (run.deliveryStarted) return;
+    const turnId = safeTurnId(payload.turnId);
+    if (!turnId) {
+      run.deliveryProtocolError = {
+        code: "stream_protocol_error",
+        message: "The assistant stream did not provide a valid turn id.",
+      };
+      return;
+    }
+    run.deliveryStarted = true;
+    run.turnId ??= turnId;
+    if (!run.turnAnnounced) {
+      run.turnAnnounced = true;
+      this.emit(conversationId, run, {
+        cursor: this.nextCursor(run),
+        event: "turn.status",
+        turn_id: turnId,
+        status: "running",
+      });
+    }
+  }
+
   private applyObservedCompletion(
     conversationId: string,
     run: RunningTurn,
@@ -2725,12 +2984,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (run.turnId) {
       run.controller.abort();
       this.requestServerStop(conversationId, run);
-    } else if (!run.streamDispatched) {
+    } else if (!run.streamDispatched || run.protocol === "workflow") {
       // The stream request never left the client (e.g. the send is still
       // queued behind an earlier turn's stop fence): nothing reached
       // upstream, so cancel is purely local. Installing a placeholder here
       // would OVERWRITE that earlier fence and let a later send overtake
       // the still-pending stop.
+      //
+      // Workflow runs take this path unconditionally: the surface has no
+      // `:stop` control, so there is nothing to defer the abort for — the
+      // server run finishes on its own and surfaces on the next reload.
       run.controller.abort();
     } else {
       run.stopPendingStart = true;
@@ -2839,6 +3102,10 @@ export class AevatarAssistantTransport implements AssistantTransport {
     conversationId: string,
     run: RunningTurn,
   ): Promise<void> | null {
+    // The workflow surface has no `:stop` route (run control lives on
+    // scope-service `runs/{runId}:stop`, which this mount does not proxy);
+    // posting the actor-surface stop for a `chatc-…` id would only 404.
+    if (run.protocol === "workflow") return null;
     if (!run.turnId) return null;
     // Own deadline: a server that accepts but never answers must not pin
     // the pendingStops entry (and tax every later send with the full fence


### PR DESCRIPTION
## Why

The nyxid-chat surface fails **every** turn that invokes a default-classified `nyxid_*` tool: Aevatar's `NyxIdChatTurnOperationExecutor` demands an outcome receipt for any `MayChangeExternalState` tool, while `AgentToolReceiptFactory.IsReceiptWorthy` refuses to mint one for those same tools — a deterministic `RUN_ERROR NYXID_CHAT_TOOL_RECEIPT_REQUIRED` ("Sorry, something went wrong") that is not fixable from NyxID. The Aevatar console answers the same prompts fine because it talks to a different engine entirely: `POST /api/chat`, workflow `studio`, which has no receipt gate.

Per Calvin's direction, the product chat now calls that same endpoint through the NyxID pass-through.

## What

**Backend**
- `POST /api/v1/assistant/workflow-chat` no longer forwards the caller body verbatim. It parses a typed `WorkflowChatTurnRequest` (`prompt`, optional `conversationId` + `minimumStateVersion`, optional `commandId`; `deny_unknown_fields`) and builds Aevatar's strict `HttpChatInput` server-side: `workflow` pinned to `studio`, the `conversation` object always present (without it Aevatar persists nothing to chat history), continuations fenced by the client's last observed `stateVersion`, `commandId` as the idempotent replay identity. No caller field reaches the upstream body unvalidated; no scope field is sent (Aevatar's trusted scope wins regardless).
- `filter_chat_history_index` keeps both addressable families now — `nyxid-chat-…` actors (turns via `:stream`) and `chatc-…` workflow conversations (turns via this route) — and still drops rows from other product surfaces.
- Included dependency: `execute_admin_proxy` / `TargetMode::AdminManaged` (TD-1) — server-chosen platform targets resolve with **no caller state** (scoped-token service allowlist, personal node pins, personal connection rows). This also fixes the prod lockout where every resource-restricted OAuth token got `api_key_scope_forbidden` (9000) on every `/api/v1/assistant/*` call with no grant that could fix it.

**Frontend**
- The transport routes turns by conversation-id family: `chatc-…` (and the client-local `workflow-pending-…` placeholder) go to the workflow route; legacy `nyxid-chat-…` conversations keep the AG-UI `:stream` path unchanged, so existing transcripts stay continuable.
- `createConversation` is client-local; the first turn's `aevatar.chat.context` frame delivers the server `chatc-…` id and the transport aliases the placeholder to it (canonical-id resolution on every public method; the list dedupes).
- Workflow frame semantics: pre-`runStarted` context frames are legal, `runStarted.runId` is run identity (not the turn id), `runFinished.result.output` renders when nothing streamed as text, trailing `stateSnapshot`/`raw.observed` after the terminal are tolerated, and cancel is client-side only (`:stop` does not exist on this surface).

## Auth (verified against Aevatar `feature/integrate`)

`/api/chat` authenticates the injected `X-NyxID-Identity-Token` via the global JwtBearer forward selector **when no `Authorization` header is present** — and a malformed `Authorization` fails the whole turn, so the pass-through sends none. The body `scopeId` is ignored in favor of the token subject; the injected `X-NyxID-Delegation-Token` becomes the workflow tool credential.

## Verification

- Backend: 4838 tests, `cargo fmt --check`, `clippy -D warnings` — all green. New integration test drives the real handler against a mock downstream and pins the wire shape: rebuilt studio body, `/api/chat` path, identity + delegation headers, no `Authorization`.
- Frontend: 2112 tests (6 new workflow-turn tests: create/alias, output fallback, continuation fence, `runError`, cancel-without-stop, delete-via-server-id), lint 0 errors, `npm run build` green; wizard bundle untouched (no dep changes, assistant sources not in the manifest).
- Local E2E over real HTTP: local backend + seeded admin row + mock `/api/chat` — cookie-session turn streamed end to end; mock received `{"commandId":…,"conversation":{"conversationId":null},"prompt":…,"workflow":"studio"}` with identity/delegation headers and no `Authorization`; list kept the `chatc-` row and dropped a foreign-surface row.

## Known limits (deliberate, documented in `docs/CHAT_ASSISTANT_SPECS.md`)

- **G9 unchanged:** the workflow tools still hold the delegation token, which NyxID 403s on `/users/me`, `/api-keys`, `/nodes`, `/user-services` by design — account questions now answer *degraded* instead of crashing. Closing that gap (curated read-only delegated subset) is a separate security decision.
- A mid-session URL carrying the placeholder id dies on reload; the sidebar row recovers the conversation.
- G10 (upstream receipt bug) still affects legacy `nyxid-chat-…` conversations; escalation to the Aevatar team is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)