### PR TITLE
feat(billing): admin-selectable platform metering unit per service

### DIFF
--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -3115,6 +3115,17 @@ fn platform_metric_for_target(
     target: &proxy_service::ProxyTarget,
     is_connection: bool,
 ) -> BillingMetric {
+    // An admin-selected metric on the service's billing config wins;
+    // the slug/transport heuristic is only the fallback, so billing
+    // classification does not depend on service naming conventions.
+    if let Some(metric) = target
+        .service
+        .billing
+        .as_ref()
+        .and_then(|billing| billing.platform_metric)
+    {
+        return metric;
+    }
     if is_connection || target.service.service_type == "ssh" {
         BillingMetric::Bytes
     } else if target.service.slug.starts_with("llm-") {
@@ -4961,6 +4972,7 @@ mod tests {
     fn token_resale_metered_context(credential_class: CredentialClass) -> MeteredProxyContext {
         let billing = ServiceBilling {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),
@@ -5576,6 +5588,32 @@ mod tests {
             ws_frame_injections: Vec::new(),
             connection_id: None,
         }
+    }
+
+    #[test]
+    fn admin_platform_metric_override_beats_the_slug_heuristic() {
+        // No override: a non-llm slug meters requests.
+        let target = make_target("http://localhost:8080");
+        assert_eq!(
+            super::platform_metric_for_target(&target, false),
+            BillingMetric::Requests
+        );
+
+        // Admin override: an arbitrarily named service meters tokens,
+        // including on the WS/connection path.
+        let mut target = make_target("http://localhost:8080");
+        target.service.billing = Some(ServiceBilling {
+            platform_metric: Some(BillingMetric::Tokens),
+            ..Default::default()
+        });
+        assert_eq!(
+            super::platform_metric_for_target(&target, false),
+            BillingMetric::Tokens
+        );
+        assert_eq!(
+            super::platform_metric_for_target(&target, true),
+            BillingMetric::Tokens
+        );
     }
 
     #[test]

--- a/backend/src/handlers/public_mcp.rs
+++ b/backend/src/handlers/public_mcp.rs
@@ -312,6 +312,7 @@ mod tests {
         billable_svc.slug = "billable-service".to_string();
         billable_svc.billing = Some(ServiceBilling {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/handlers/public_proxy.rs
+++ b/backend/src/handlers/public_proxy.rs
@@ -733,6 +733,7 @@ mod tests {
             let mut service = public_service("pub", "https://example.test", 100);
             service.billing = Some(ServiceBilling {
                 platform_billable: false,
+                platform_metric: None,
                 resale_billable: true,
                 resale_metric: BillingMetric::Tokens,
                 lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/handlers/services.rs
+++ b/backend/src/handlers/services.rs
@@ -1577,6 +1577,7 @@ pub async fn update_service(
         validate_service_billing(body.billing.as_ref())?;
         let next_billing = body.billing.clone().filter(|billing| {
             billing.platform_billable
+                || billing.platform_metric.is_some()
                 || billing.resale_billable
                 || billing.lago_resale_metric_code.is_some()
         });

--- a/backend/src/models/service_billing.rs
+++ b/backend/src/models/service_billing.rs
@@ -17,6 +17,11 @@ pub struct ServiceBilling {
     /// platform-operated services that should bill wallet credits.
     #[serde(default)]
     pub platform_billable: bool,
+    /// Admin-selected platform metering unit. Unset falls back to the
+    /// heuristic (WS/SSH meter bytes, `llm-` slugs meter tokens,
+    /// everything else meters requests).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform_metric: Option<BillingMetric>,
     #[serde(default)]
     pub resale_billable: bool,
     #[serde(default)]
@@ -29,6 +34,7 @@ impl Default for ServiceBilling {
     fn default() -> Self {
         Self {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: false,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: None,
@@ -108,6 +114,7 @@ mod tests {
     fn active_resale_spec_requires_metric_code() {
         let mut billing = ServiceBilling {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Requests,
             lago_resale_metric_code: None,

--- a/backend/src/services/anonymous_endpoint_service.rs
+++ b/backend/src/services/anonymous_endpoint_service.rs
@@ -591,6 +591,7 @@ mod tests {
         let mut service = compatible_service();
         service.billing = Some(crate::models::service_billing::ServiceBilling {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: crate::models::service_billing::BillingMetric::Requests,
             lago_resale_metric_code: Some("resale_requests".to_string()),

--- a/backend/src/services/billing/meter.rs
+++ b/backend/src/services/billing/meter.rs
@@ -517,6 +517,7 @@ mod tests {
 
         let billing = ServiceBilling {
             platform_billable: true,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),
@@ -777,6 +778,7 @@ mod tests {
         create_usage_transaction_index(&db).await;
         let billing = ServiceBilling {
             platform_billable: true,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/backend/src/services/billing/mod.rs
+++ b/backend/src/services/billing/mod.rs
@@ -307,6 +307,7 @@ mod tests {
         let service = BillingService::new(db.clone(), std::sync::Arc::new(test_app_config()));
         let billing = ServiceBilling {
             platform_billable: true,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Requests,
             lago_resale_metric_code: Some("resale_requests".to_string()),
@@ -416,6 +417,7 @@ mod tests {
         let service = BillingService::new_with_lago(db.clone(), Arc::new(config), lago.clone());
         let billable_billing = ServiceBilling {
             platform_billable: true,
+            platform_metric: None,
             ..Default::default()
         };
         let ctx = BillingRouteContext::new(
@@ -562,6 +564,7 @@ mod tests {
         let service = BillingService::new_with_lago(db.clone(), Arc::new(config), lago.clone());
         let billable_billing = ServiceBilling {
             platform_billable: true,
+            platform_metric: None,
             ..Default::default()
         };
         let ctx = BillingRouteContext::new(

--- a/backend/src/services/billing/route_context.rs
+++ b/backend/src/services/billing/route_context.rs
@@ -109,6 +109,7 @@ mod tests {
     fn context_for(credential_class: CredentialClass) -> BillingRouteContext {
         let billing = ServiceBilling {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),
@@ -152,6 +153,7 @@ mod tests {
     fn resale_requires_operator_flag() {
         let billing = ServiceBilling {
             platform_billable: false,
+            platform_metric: None,
             resale_billable: true,
             resale_metric: BillingMetric::Tokens,
             lago_resale_metric_code: Some("resale_tokens".to_string()),

--- a/frontend/src/pages/service-edit.tsx
+++ b/frontend/src/pages/service-edit.tsx
@@ -78,6 +78,7 @@ export function ServiceEditPage() {
       forward_access_token: false,
       inject_delegation_token: false,
       platform_billable: false,
+      platform_metric: "auto" as const,
       delegation_token_scope: "",
       homepage_url: "",
       repository_url: "",
@@ -126,6 +127,9 @@ export function ServiceEditPage() {
         forward_access_token: service.forward_access_token ?? false,
         inject_delegation_token: service.inject_delegation_token ?? false,
         platform_billable: service.billing?.platform_billable ?? false,
+        platform_metric:
+          (service.billing?.platform_metric as UpdateServiceFormData["platform_metric"]) ??
+          "auto",
         delegation_token_scope: service.delegation_token_scope || "llm:proxy",
         homepage_url: service.homepage_url ?? "",
         repository_url: service.repository_url ?? "",
@@ -255,6 +259,10 @@ export function ServiceEditPage() {
                 billing: {
                   ...(service?.billing ?? {}),
                   platform_billable: data.platform_billable ?? false,
+                  platform_metric:
+                    data.platform_metric && data.platform_metric !== "auto"
+                      ? data.platform_metric
+                      : undefined,
                 },
                 ws_frame_injections: data.ws_frame_injections ?? [],
                 ...(defaultRequestHeadersPayload !== undefined
@@ -958,6 +966,38 @@ export function ServiceEditPage() {
                             form.setValue("platform_billable", v)
                           }
                         />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label className="text-[12px] font-normal">
+                          Charge by
+                        </Label>
+                        <Select
+                          value={form.watch("platform_metric") ?? "auto"}
+                          onValueChange={(v) =>
+                            form.setValue(
+                              "platform_metric",
+                              v as UpdateServiceFormData["platform_metric"],
+                            )
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Auto (derived from service)" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="auto">
+                              Auto (derived from service)
+                            </SelectItem>
+                            <SelectItem value="tokens">Tokens</SelectItem>
+                            <SelectItem value="requests">Requests</SelectItem>
+                            <SelectItem value="bytes">Bytes</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <p className="text-xs text-muted-foreground">
+                          The metering unit for platform billing. Auto meters
+                          tokens for llm- services, bytes for SSH and
+                          WebSocket connections, and requests otherwise.
+                        </p>
                       </div>
                     </div>
 

--- a/frontend/src/schemas/services.ts
+++ b/frontend/src/schemas/services.ts
@@ -293,6 +293,7 @@ export const updateServiceSchema = z
     forward_access_token: z.boolean().optional(),
     inject_delegation_token: z.boolean().optional(),
     platform_billable: z.boolean().optional(),
+    platform_metric: z.enum(["auto", "tokens", "requests", "bytes"]).optional(),
     delegation_token_scope: z
       .string()
       .max(200, "Scope must be at most 200 characters")

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -334,6 +334,8 @@ export interface ServiceCapabilities {
 export interface ServiceBilling {
   /** Admin opt-in: only platform_billable services charge wallet credits. */
   readonly platform_billable?: boolean;
+  /** Admin-selected metering unit; unset falls back to the slug heuristic. */
+  readonly platform_metric?: string;
   readonly resale_billable?: boolean;
   readonly resale_metric?: string;
   readonly lago_resale_metric_code?: string | null;


### PR DESCRIPTION
## Summary

The platform billing metric was inferred from naming conventions (`platform_metric_for_target`): WS/SSH meter bytes, slugs starting with `llm-` meter tokens, everything else meters requests. In production this bit immediately — a service named `chrono-llm-public` silently metered **requests** instead of tokens, making it effectively free under a tokens-only plan. Billing classification should be an explicit admin decision, not a side effect of the slug.

## Changes

- `ServiceBilling.platform_metric: Option<BillingMetric>` — admin-selected metering unit. `None` preserves the existing heuristic, so all current services behave identically.
- `platform_metric_for_target` consults the override first (it also wins on the WS/connection path), falling back to the slug/transport heuristic.
- Service update handler keeps a billing config that only sets the metric (previously the empty-config filter would have dropped it).
- Admin service edit page: a "Charge by" selector (Auto / Tokens / Requests / Bytes) in the Billing section; "Auto" omits the field.

## Test plan

- [x] `cargo test -p nyxid proxy` — 362 passed (new: override beats the slug heuristic, including on the connection path; no-override falls back to requests)
- [x] `cargo test -p nyxid billing` — 94 passed
- [x] Frontend `npm run build` + `npm test` — 2183 passed