### PR TITLE
feat(billing): top-up history with receipt downloads

### DIFF
--- a/backend/src/api_docs.rs
+++ b/backend/src/api_docs.rs
@@ -59,6 +59,8 @@
         crate::handlers::billing::get_wallet,
         crate::handlers::billing::provision_wallet,
         crate::handlers::billing::create_topup,
+        crate::handlers::billing::list_topups,
+        crate::handlers::billing::download_invoice,
         // Demo
         crate::handlers::demo::get_demo
     ),
@@ -131,6 +133,9 @@
             crate::handlers::billing::BillingUsageRow,
             crate::handlers::billing::BillingUsageTotals,
             crate::handlers::billing::BillingReadOnlyBlock,
+            crate::handlers::billing::TopUpHistoryResponse,
+            crate::handlers::billing::TopUpHistoryEntry,
+            crate::handlers::billing::InvoiceDownloadResponse,
             crate::handlers::billing::ProvisionWalletRequest,
             crate::handlers::billing::TopUpRequest,
             crate::handlers::billing::BillingWalletResponse,

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -132,6 +132,32 @@ pub struct LagoWebhookResponse {
     pub action: String,
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TopUpHistoryEntry {
+    pub id: String,
+    pub created_at: chrono::DateTime<Utc>,
+    pub amount_credits: i64,
+    /// paid | pending | failed | voided
+    pub status: String,
+    pub invoice_number: Option<String>,
+    pub lago_invoice_id: Option<String>,
+    /// Present while the checkout can still be completed.
+    pub checkout_url: Option<String>,
+    /// True when a receipt PDF can be downloaded for this top-up.
+    pub receipt_available: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TopUpHistoryResponse {
+    pub owner_id: String,
+    pub topups: Vec<TopUpHistoryEntry>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct InvoiceDownloadResponse {
+    pub file_url: String,
+}
+
 #[utoipa::path(
     get,
     path = "/api/v1/billing/usage",
@@ -379,6 +405,144 @@ pub async fn create_topup(
         status: checkout.session.status,
         reused: checkout.reused,
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/billing/topups",
+    tag = "Billing",
+    responses(
+        (status = 200, description = "Top-up history", body = TopUpHistoryResponse)
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_topups(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AppResult<Json<TopUpHistoryResponse>> {
+    let actor_id = auth_user.user_id.to_string();
+    let owner = state
+        .billing
+        .owner_resolver()
+        .resolve_for_wallet_management(&actor_id, None)
+        .await?;
+    ensure_billing_rollout(&state, &owner.owner_id, &actor_id).await?;
+
+    let sessions: Vec<crate::models::billing_topup_session::BillingTopUpSession> = state
+        .db
+        .collection(crate::models::billing_topup_session::COLLECTION_NAME)
+        .find(doc! { "owner_id": &owner.owner_id })
+        .sort(doc! { "created_at": -1 })
+        .limit(50)
+        .await?
+        .try_collect()
+        .await?;
+
+    // One Lago call resolves payment outcomes for every session: the
+    // local store only tracks checkout creation, while paid/voided live
+    // on the credit invoice. Lago being unreachable degrades to local
+    // statuses rather than failing the page.
+    let invoices = match state.billing.lago_client() {
+        Some(lago) => lago
+            .credit_invoices(&owner.owner_id)
+            .await
+            .unwrap_or_default(),
+        None => Vec::new(),
+    };
+    let invoices_by_id: std::collections::HashMap<
+        &str,
+        &crate::services::billing::lago_client::InvoiceSummary,
+    > = invoices
+        .iter()
+        .map(|invoice| (invoice.lago_id.as_str(), invoice))
+        .collect();
+
+    let topups = sessions
+        .into_iter()
+        .map(|session| {
+            let invoice = session
+                .lago_invoice_id
+                .as_deref()
+                .and_then(|id| invoices_by_id.get(id).copied());
+            let status = match invoice {
+                Some(invoice) if invoice.status == "voided" => "voided",
+                Some(invoice) if invoice.payment_status == "succeeded" => "paid",
+                Some(invoice) if invoice.payment_status == "failed" => "failed",
+                _ if matches!(
+                    session.status,
+                    crate::models::billing_topup_session::BillingTopUpStatus::Failed
+                ) =>
+                {
+                    "failed"
+                }
+                _ => "pending",
+            };
+            TopUpHistoryEntry {
+                id: session.id,
+                created_at: session.created_at,
+                amount_credits: session.amount_credits,
+                status: status.to_string(),
+                invoice_number: invoice.map(|invoice| invoice.number.clone()),
+                lago_invoice_id: session.lago_invoice_id,
+                checkout_url: (status == "pending")
+                    .then_some(session.payment_url)
+                    .flatten(),
+                receipt_available: status == "paid",
+            }
+        })
+        .collect();
+
+    Ok(Json(TopUpHistoryResponse {
+        owner_id: owner.owner_id,
+        topups,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/billing/invoices/{invoice_id}/download",
+    tag = "Billing",
+    params(("invoice_id" = String, Path, description = "Lago invoice id")),
+    responses(
+        (status = 200, description = "Signed receipt download URL", body = InvoiceDownloadResponse)
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn download_invoice(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    axum::extract::Path(invoice_id): axum::extract::Path<String>,
+) -> AppResult<Json<InvoiceDownloadResponse>> {
+    let actor_id = auth_user.user_id.to_string();
+    let owner = state
+        .billing
+        .owner_resolver()
+        .resolve_for_wallet_management(&actor_id, None)
+        .await?;
+    ensure_billing_rollout(&state, &owner.owner_id, &actor_id).await?;
+
+    let lago = state.billing.lago_client().ok_or_else(|| {
+        AppError::BillingNotConfigured("Lago client is not configured".to_string())
+    })?;
+    // Ownership check before touching the document: the invoice's Lago
+    // customer must be the resolved billing owner. Foreign or unknown
+    // invoices 404 identically so existence is not leaked.
+    let invoice = lago
+        .invoice_summary(&invoice_id)
+        .await?
+        .filter(|invoice| invoice.external_customer_id.as_deref() == Some(owner.owner_id.as_str()))
+        .ok_or_else(|| AppError::NotFound("Invoice not found".to_string()))?;
+
+    let file_url = lago
+        .invoice_download_url(&invoice.lago_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::BillingProviderUnavailable(
+                "The receipt is still being generated; try again shortly".to_string(),
+            )
+        })?;
+
+    Ok(Json(InvoiceDownloadResponse { file_url }))
 }
 
 pub async fn lago_webhook(

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -475,12 +475,38 @@ pub async fn list_topups(
         .map(|invoice| (invoice.lago_id.as_str(), invoice))
         .collect();
 
+    // Sessions written before the invoice id was captured at creation
+    // (invoice attachment is asynchronous) carry no invoice link. Lago's
+    // wallet transactions do, so backfill the mapping with one call per
+    // distinct wallet on this page.
+    let mut txn_invoices: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    if let Some(lago) = state.billing.lago_client() {
+        let wallets_needing_backfill: std::collections::BTreeSet<&str> = sessions
+            .iter()
+            .filter(|session| {
+                session.lago_invoice_id.is_none() && session.lago_wallet_transaction_id.is_some()
+            })
+            .map(|session| session.lago_wallet_id.as_str())
+            .collect();
+        for wallet_id in wallets_needing_backfill {
+            if let Ok(pairs) = lago.wallet_transaction_invoices(wallet_id).await {
+                txn_invoices.extend(pairs);
+            }
+        }
+    }
+
     let checkout_expiry_cutoff = Utc::now() - Duration::hours(24);
     let topups = sessions
         .into_iter()
         .map(|session| {
-            let invoice = session
-                .lago_invoice_id
+            let lago_invoice_id = session.lago_invoice_id.clone().or_else(|| {
+                session
+                    .lago_wallet_transaction_id
+                    .as_deref()
+                    .and_then(|txn| txn_invoices.get(txn).cloned())
+            });
+            let invoice = lago_invoice_id
                 .as_deref()
                 .and_then(|id| invoices_by_id.get(id).copied());
             let status = match invoice {
@@ -506,7 +532,7 @@ pub async fn list_topups(
                 amount_credits: session.amount_credits,
                 status: status.to_string(),
                 invoice_number: invoice.map(|invoice| invoice.number.clone()),
-                lago_invoice_id: session.lago_invoice_id,
+                lago_invoice_id,
                 checkout_url: (status == "pending")
                     .then_some(session.payment_url)
                     .flatten(),

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -137,7 +137,7 @@ pub struct TopUpHistoryEntry {
     pub id: String,
     pub created_at: chrono::DateTime<Utc>,
     pub amount_credits: i64,
-    /// paid | pending | failed | voided
+    /// paid | pending | expired | failed | voided
     pub status: String,
     pub invoice_number: Option<String>,
     pub lago_invoice_id: Option<String>,
@@ -151,6 +151,15 @@ pub struct TopUpHistoryEntry {
 pub struct TopUpHistoryResponse {
     pub owner_id: String,
     pub topups: Vec<TopUpHistoryEntry>,
+    pub page: u32,
+    pub per_page: u32,
+    pub total: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TopUpHistoryQuery {
+    pub page: Option<u32>,
+    pub per_page: Option<u32>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -419,6 +428,7 @@ pub async fn create_topup(
 pub async fn list_topups(
     State(state): State<AppState>,
     auth_user: AuthUser,
+    Query(query): Query<TopUpHistoryQuery>,
 ) -> AppResult<Json<TopUpHistoryResponse>> {
     let actor_id = auth_user.user_id.to_string();
     let owner = state
@@ -428,12 +438,20 @@ pub async fn list_topups(
         .await?;
     ensure_billing_rollout(&state, &owner.owner_id, &actor_id).await?;
 
-    let sessions: Vec<crate::models::billing_topup_session::BillingTopUpSession> = state
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(10).clamp(1, 50);
+    let filter = doc! { "owner_id": &owner.owner_id };
+    let collection = state
         .db
-        .collection(crate::models::billing_topup_session::COLLECTION_NAME)
-        .find(doc! { "owner_id": &owner.owner_id })
+        .collection::<crate::models::billing_topup_session::BillingTopUpSession>(
+            crate::models::billing_topup_session::COLLECTION_NAME,
+        );
+    let total = collection.count_documents(filter.clone()).await?;
+    let sessions: Vec<crate::models::billing_topup_session::BillingTopUpSession> = collection
+        .find(filter)
         .sort(doc! { "created_at": -1 })
-        .limit(50)
+        .skip(u64::from((page - 1) * per_page))
+        .limit(i64::from(per_page))
         .await?
         .try_collect()
         .await?;
@@ -457,6 +475,7 @@ pub async fn list_topups(
         .map(|invoice| (invoice.lago_id.as_str(), invoice))
         .collect();
 
+    let checkout_expiry_cutoff = Utc::now() - Duration::hours(24);
     let topups = sessions
         .into_iter()
         .map(|session| {
@@ -475,6 +494,10 @@ pub async fn list_topups(
                 {
                     "failed"
                 }
+                // Stripe checkout sessions expire after 24 hours and Lago
+                // returns the same cached session per transaction, so an
+                // old pending checkout can no longer be completed.
+                _ if session.created_at < checkout_expiry_cutoff => "expired",
                 _ => "pending",
             };
             TopUpHistoryEntry {
@@ -495,6 +518,9 @@ pub async fn list_topups(
     Ok(Json(TopUpHistoryResponse {
         owner_id: owner.owner_id,
         topups,
+        page,
+        per_page,
+        total,
     }))
 }
 

--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -160,6 +160,7 @@ pub struct TopUpHistoryResponse {
 pub struct TopUpHistoryQuery {
     pub page: Option<u32>,
     pub per_page: Option<u32>,
+    pub period: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -440,7 +441,13 @@ pub async fn list_topups(
 
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(10).clamp(1, 50);
-    let filter = doc! { "owner_id": &owner.owner_id };
+    let mut filter = doc! { "owner_id": &owner.owner_id };
+    if let Some(period) = query.period.as_deref().filter(|period| *period != "all") {
+        filter.insert(
+            "created_at",
+            doc! { "$gte": bson::DateTime::from_chrono(period_start(period)) },
+        );
+    }
     let collection = state
         .db
         .collection::<crate::models::billing_topup_session::BillingTopUpSession>(

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1042,7 +1042,12 @@ pub fn build_router(
             "/wallet",
             get(handlers::billing::get_wallet).post(handlers::billing::provision_wallet),
         )
-        .route("/topup", post(handlers::billing::create_topup));
+        .route("/topup", post(handlers::billing::create_topup))
+        .route("/topups", get(handlers::billing::list_topups))
+        .route(
+            "/invoices/{invoice_id}/download",
+            get(handlers::billing::download_invoice),
+        );
 
     // Org management routes (creation, members, invites). All routes
     // authenticate as a regular session/user; admin-vs-member checks happen

--- a/backend/src/services/billing/lago_client.rs
+++ b/backend/src/services/billing/lago_client.rs
@@ -51,6 +51,34 @@ pub trait LagoApi: Send + Sync {
     async fn plan_rates(&self, _plan_code: &str) -> AppResult<Vec<PlanRate>> {
         Ok(Vec::new())
     }
+    /// Credit (top-up) invoices for a customer, used to resolve payment
+    /// outcomes for the top-up history. Defaults to empty for fakes.
+    async fn credit_invoices(&self, _external_customer_id: &str) -> AppResult<Vec<InvoiceSummary>> {
+        Ok(Vec::new())
+    }
+    /// A single invoice, or None when it does not exist.
+    async fn invoice_summary(&self, _lago_invoice_id: &str) -> AppResult<Option<InvoiceSummary>> {
+        Ok(None)
+    }
+    /// The downloadable PDF URL for an invoice; None while Lago is still
+    /// generating the document.
+    async fn invoice_download_url(&self, _lago_invoice_id: &str) -> AppResult<Option<String>> {
+        Ok(None)
+    }
+}
+
+/// A trimmed Lago invoice used for top-up history and receipt downloads.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvoiceSummary {
+    pub lago_id: String,
+    pub number: String,
+    pub total_amount_cents: i64,
+    /// Lago lifecycle status: draft, finalized, voided, ...
+    pub status: String,
+    /// Payment outcome: pending, succeeded, failed.
+    pub payment_status: String,
+    pub external_customer_id: Option<String>,
+    pub issuing_date: Option<String>,
 }
 
 /// A per-unit price from a Lago plan charge, converted to micro-credits
@@ -422,6 +450,62 @@ impl LagoApi for LagoClient {
                     .collect()
             })
             .unwrap_or_default())
+    }
+
+    async fn credit_invoices(&self, external_customer_id: &str) -> AppResult<Vec<InvoiceSummary>> {
+        let value = self
+            .json_request(
+                reqwest::Method::GET,
+                &format!(
+                    "invoices?external_customer_id={}&invoice_type=credit&per_page=100",
+                    urlencoding::encode(external_customer_id)
+                ),
+                None,
+            )
+            .await
+            .map_err(lago_error_to_app)?;
+        Ok(value
+            .get("invoices")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(invoice_summary_from_value)
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    async fn invoice_summary(&self, lago_invoice_id: &str) -> AppResult<Option<InvoiceSummary>> {
+        let path = format!("invoices/{}", urlencoding::encode(lago_invoice_id));
+        match self.json_request(reqwest::Method::GET, &path, None).await {
+            Ok(value) => Ok(value.get("invoice").and_then(invoice_summary_from_value)),
+            Err(error) if error.status == Some(StatusCode::NOT_FOUND) => Ok(None),
+            Err(error) => Err(lago_error_to_app(error)),
+        }
+    }
+
+    async fn invoice_download_url(&self, lago_invoice_id: &str) -> AppResult<Option<String>> {
+        // POST download triggers PDF generation when the document does not
+        // exist yet; file_url stays null until Lago's worker finishes, so
+        // retry briefly before reporting "still generating".
+        let path = format!("invoices/{}/download", urlencoding::encode(lago_invoice_id));
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let value = self
+                .json_request(reqwest::Method::POST, &path, None)
+                .await
+                .map_err(lago_error_to_app)?;
+            let file_url = value
+                .get("invoice")
+                .and_then(|invoice| value_string(invoice, &["file_url"]))
+                .filter(|url| !url.is_empty());
+            if file_url.is_some() || attempt >= PAYMENT_URL_MAX_ATTEMPTS {
+                return Ok(file_url);
+            }
+            tokio::time::sleep(Duration::from_millis(PAYMENT_URL_RETRY_DELAY_MS)).await;
+        }
     }
 
     async fn plan_rates(&self, plan_code: &str) -> AppResult<Vec<PlanRate>> {
@@ -887,6 +971,24 @@ pub fn extract_wallet_balance_credits(value: &Value) -> Option<i64> {
     })
 }
 
+/// Parse one Lago invoice object into the trimmed summary shape.
+fn invoice_summary_from_value(value: &Value) -> Option<InvoiceSummary> {
+    Some(InvoiceSummary {
+        lago_id: value_string(value, &["lago_id"])?,
+        number: value_string(value, &["number"]).unwrap_or_default(),
+        total_amount_cents: value
+            .get("total_amount_cents")
+            .and_then(Value::as_i64)
+            .unwrap_or(0),
+        status: value_string(value, &["status"]).unwrap_or_default(),
+        payment_status: value_string(value, &["payment_status"]).unwrap_or_default(),
+        external_customer_id: value
+            .get("customer")
+            .and_then(|customer| value_string(customer, &["external_id"])),
+        issuing_date: value_string(value, &["issuing_date"]),
+    })
+}
+
 /// Parse a Lago decimal amount string ("0.000005", "0.01", "1") into
 /// micro-credits without floating point. Digits beyond micro precision are
 /// truncated. Returns None for negative or malformed values.
@@ -1292,6 +1394,93 @@ mod tests {
 
         assert!(error.to_string().contains("no_linked_payment_provider"));
         assert_eq!(calls.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn credit_invoices_parse_payment_outcomes_and_customer() {
+        async fn list_invoices(
+            axum::extract::Query(query): axum::extract::Query<
+                std::collections::HashMap<String, String>,
+            >,
+        ) -> axum::Json<serde_json::Value> {
+            assert_eq!(
+                query.get("external_customer_id").map(String::as_str),
+                Some("owner-1")
+            );
+            assert_eq!(
+                query.get("invoice_type").map(String::as_str),
+                Some("credit")
+            );
+            axum::Json(json!({
+                "invoices": [
+                    {
+                        "lago_id": "inv-paid",
+                        "number": "CHR-001-001",
+                        "total_amount_cents": 100,
+                        "status": "finalized",
+                        "payment_status": "succeeded",
+                        "issuing_date": "2026-07-29",
+                        "customer": { "external_id": "owner-1" }
+                    },
+                    {
+                        "lago_id": "inv-open",
+                        "number": "CHR-001-002",
+                        "total_amount_cents": 10000,
+                        "status": "finalized",
+                        "payment_status": "pending",
+                        "customer": { "external_id": "owner-1" }
+                    }
+                ]
+            }))
+        }
+
+        let base_url = spawn_lago_mock(
+            axum::Router::new().route("/api/v1/invoices", axum::routing::get(list_invoices)),
+        )
+        .await;
+        let client = LagoClient::new(base_url, "test-key".to_string()).expect("client");
+
+        let invoices = client.credit_invoices("owner-1").await.expect("invoices");
+
+        assert_eq!(invoices.len(), 2);
+        assert_eq!(invoices[0].lago_id, "inv-paid");
+        assert_eq!(invoices[0].payment_status, "succeeded");
+        assert_eq!(invoices[0].external_customer_id.as_deref(), Some("owner-1"));
+        assert_eq!(invoices[1].total_amount_cents, 10000);
+    }
+
+    #[tokio::test]
+    async fn invoice_download_retries_until_the_pdf_exists() {
+        use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+        let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let counter = calls.clone();
+        let base_url = spawn_lago_mock(axum::Router::new().route(
+            "/api/v1/invoices/inv-1/download",
+            axum::routing::post(move || {
+                let calls = counter.clone();
+                async move {
+                    let file_url = if calls.fetch_add(1, AtomicOrdering::SeqCst) < 1 {
+                        serde_json::Value::Null
+                    } else {
+                        json!("https://lago.example/receipt.pdf")
+                    };
+                    axum::Json(json!({
+                        "invoice": { "lago_id": "inv-1", "file_url": file_url }
+                    }))
+                }
+            }),
+        ))
+        .await;
+        let client = LagoClient::new(base_url, "test-key".to_string()).expect("client");
+
+        let url = client
+            .invoice_download_url("inv-1")
+            .await
+            .expect("download url");
+
+        assert_eq!(url.as_deref(), Some("https://lago.example/receipt.pdf"));
+        assert_eq!(calls.load(AtomicOrdering::SeqCst), 2);
     }
 
     #[test]

--- a/backend/src/services/billing/lago_client.rs
+++ b/backend/src/services/billing/lago_client.rs
@@ -65,6 +65,15 @@ pub trait LagoApi: Send + Sync {
     async fn invoice_download_url(&self, _lago_invoice_id: &str) -> AppResult<Option<String>> {
         Ok(None)
     }
+    /// (wallet_transaction_id, invoice_id) pairs for a wallet, used to
+    /// backfill invoice links on top-up sessions stored before the id was
+    /// captured at creation. Defaults to empty for fakes.
+    async fn wallet_transaction_invoices(
+        &self,
+        _wallet_id: &str,
+    ) -> AppResult<Vec<(String, String)>> {
+        Ok(Vec::new())
+    }
 }
 
 /// A trimmed Lago invoice used for top-up history and receipt downloads.
@@ -446,6 +455,38 @@ impl LagoApi for LagoClient {
                             code,
                             raw: item.clone(),
                         })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    async fn wallet_transaction_invoices(
+        &self,
+        wallet_id: &str,
+    ) -> AppResult<Vec<(String, String)>> {
+        let value = self
+            .json_request(
+                reqwest::Method::GET,
+                &format!(
+                    "wallets/{}/wallet_transactions?per_page=100",
+                    urlencoding::encode(wallet_id)
+                ),
+                None,
+            )
+            .await
+            .map_err(lago_error_to_app)?;
+        Ok(value
+            .get("wallet_transactions")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| {
+                        Some((
+                            value_string(item, &["lago_id"])?,
+                            value_string(item, &["lago_invoice_id"])?,
+                        ))
                     })
                     .collect()
             })

--- a/frontend/src/hooks/use-billing.ts
+++ b/frontend/src/hooks/use-billing.ts
@@ -2,12 +2,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import {
   type BillingWalletResponse,
+  type TopUpHistoryResponse,
   type BillingUsagePeriod,
   type BillingUsageResponse,
   type ProvisionBillingWalletRequest,
   type TopUpBillingRequest,
   type TopUpBillingResponse,
   billingWalletResponseSchema,
+  invoiceDownloadResponseSchema,
+  topUpHistoryResponseSchema,
   billingUsageResponseSchema,
   topUpBillingResponseSchema,
 } from "@/schemas/billing";
@@ -73,4 +76,26 @@ export function useBillingUsage(period?: BillingUsagePeriod) {
       return billingUsageResponseSchema.parse(response);
     },
   });
+}
+
+export const BILLING_TOPUPS_KEY = ["billing", "topups"] as const;
+
+export function useTopUpHistory() {
+  return useQuery({
+    queryKey: BILLING_TOPUPS_KEY,
+    queryFn: async (): Promise<TopUpHistoryResponse> => {
+      const response = await api.get<unknown>("/billing/topups");
+      return topUpHistoryResponseSchema.parse(response);
+    },
+    retry: false,
+  });
+}
+
+/** Resolve the signed receipt URL for an invoice and open it in a new tab. */
+export async function openInvoiceReceipt(lagoInvoiceId: string): Promise<void> {
+  const response = await api.get<unknown>(
+    `/billing/invoices/${encodeURIComponent(lagoInvoiceId)}/download`,
+  );
+  const { file_url } = invoiceDownloadResponseSchema.parse(response);
+  window.open(file_url, "_blank", "noopener,noreferrer");
 }

--- a/frontend/src/hooks/use-billing.ts
+++ b/frontend/src/hooks/use-billing.ts
@@ -80,14 +80,17 @@ export function useBillingUsage(period?: BillingUsagePeriod) {
 
 export const BILLING_TOPUPS_KEY = ["billing", "topups"] as const;
 
-export function useTopUpHistory() {
+export function useTopUpHistory(page = 1, perPage = 10) {
   return useQuery({
-    queryKey: BILLING_TOPUPS_KEY,
+    queryKey: [...BILLING_TOPUPS_KEY, page, perPage],
     queryFn: async (): Promise<TopUpHistoryResponse> => {
-      const response = await api.get<unknown>("/billing/topups");
+      const response = await api.get<unknown>(
+        `/billing/topups?page=${page}&per_page=${perPage}`,
+      );
       return topUpHistoryResponseSchema.parse(response);
     },
     retry: false,
+    placeholderData: (previous) => previous,
   });
 }
 

--- a/frontend/src/hooks/use-billing.ts
+++ b/frontend/src/hooks/use-billing.ts
@@ -80,12 +80,12 @@ export function useBillingUsage(period?: BillingUsagePeriod) {
 
 export const BILLING_TOPUPS_KEY = ["billing", "topups"] as const;
 
-export function useTopUpHistory(page = 1, perPage = 10) {
+export function useTopUpHistory(page = 1, perPage = 10, period = "all") {
   return useQuery({
-    queryKey: [...BILLING_TOPUPS_KEY, page, perPage],
+    queryKey: [...BILLING_TOPUPS_KEY, page, perPage, period],
     queryFn: async (): Promise<TopUpHistoryResponse> => {
       const response = await api.get<unknown>(
-        `/billing/topups?page=${page}&per_page=${perPage}`,
+        `/billing/topups?page=${page}&per_page=${perPage}&period=${encodeURIComponent(period)}`,
       );
       return topUpHistoryResponseSchema.parse(response);
     },

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -198,7 +198,7 @@ export function BillingPage() {
         loading={usageQuery.isLoading}
       />
 
-      <TopUpHistory />
+      <TopUpHistory key={period} period={period} />
     </div>
   );
 }
@@ -213,9 +213,9 @@ const TOPUP_STATUS_VARIANT = {
 
 const TOPUPS_PER_PAGE = 10;
 
-function TopUpHistory() {
+function TopUpHistory({ period }: { readonly period: BillingUsagePeriod }) {
   const [page, setPage] = useState(1);
-  const historyQuery = useTopUpHistory(page, TOPUPS_PER_PAGE);
+  const historyQuery = useTopUpHistory(page, TOPUPS_PER_PAGE, period);
   const topups = historyQuery.data?.topups ?? [];
   const total = historyQuery.data?.total || topups.length;
   const pageCount = Math.max(1, Math.ceil(total / TOPUPS_PER_PAGE));
@@ -553,7 +553,6 @@ function Detail({ label, value }: { readonly label: string; readonly value: stri
 function periodLabel(period: BillingUsagePeriod): string {
   switch (period) {
     case "24h":
-    case "1d":
       return "24 hours";
     case "7d":
       return "7 days";

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -20,6 +20,8 @@ import {
   useBillingWallet,
   useProvisionBillingWallet,
   useTopUpBilling,
+  useTopUpHistory,
+  openInvoiceReceipt,
 } from "@/hooks/use-billing";
 import { Button, ButtonIcon } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -195,7 +197,114 @@ export function BillingPage() {
         totals={usageQuery.data?.totals}
         loading={usageQuery.isLoading}
       />
+
+      <TopUpHistory />
     </div>
+  );
+}
+
+const TOPUP_STATUS_VARIANT = {
+  paid: "success",
+  pending: "secondary",
+  failed: "destructive",
+  voided: "secondary",
+} as const;
+
+function TopUpHistory() {
+  const historyQuery = useTopUpHistory();
+  const topups = historyQuery.data?.topups ?? [];
+
+  async function handleReceipt(lagoInvoiceId: string) {
+    try {
+      await openInvoiceReceipt(lagoInvoiceId);
+    } catch (error) {
+      toast.error(
+        error instanceof ApiError
+          ? error.message
+          : "The receipt is not ready yet; try again shortly",
+      );
+    }
+  }
+
+  if (historyQuery.isLoading) {
+    return <Skeleton className="h-[200px] w-full" />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Top-up history</CardTitle>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          Payments, their status, and downloadable receipts.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead className="text-right">Credits</TableHead>
+                <TableHead>Invoice</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {topups.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+                    No top-ups yet.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                topups.map((topup) => (
+                  <TableRow key={topup.id}>
+                    <TableCell>
+                      {new Date(topup.created_at).toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatNumber(topup.amount_credits)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {topup.invoice_number ?? "—"}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={TOPUP_STATUS_VARIANT[topup.status]}>
+                        {labelize(topup.status)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {topup.status === "pending" && topup.checkout_url ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => openExternal(topup.checkout_url ?? "")}
+                        >
+                          Resume payment
+                        </Button>
+                      ) : topup.receipt_available && topup.lago_invoice_id ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            void handleReceipt(topup.lago_invoice_id ?? "")
+                          }
+                        >
+                          Download receipt
+                        </Button>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -217,7 +217,7 @@ function TopUpHistory() {
   const [page, setPage] = useState(1);
   const historyQuery = useTopUpHistory(page, TOPUPS_PER_PAGE);
   const topups = historyQuery.data?.topups ?? [];
-  const total = historyQuery.data?.total ?? 0;
+  const total = historyQuery.data?.total || topups.length;
   const pageCount = Math.max(1, Math.ceil(total / TOPUPS_PER_PAGE));
 
   async function handleReceipt(lagoInvoiceId: string) {

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -206,13 +206,19 @@ export function BillingPage() {
 const TOPUP_STATUS_VARIANT = {
   paid: "success",
   pending: "secondary",
+  expired: "warning",
   failed: "destructive",
   voided: "secondary",
 } as const;
 
+const TOPUPS_PER_PAGE = 10;
+
 function TopUpHistory() {
-  const historyQuery = useTopUpHistory();
+  const [page, setPage] = useState(1);
+  const historyQuery = useTopUpHistory(page, TOPUPS_PER_PAGE);
   const topups = historyQuery.data?.topups ?? [];
+  const total = historyQuery.data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / TOPUPS_PER_PAGE));
 
   async function handleReceipt(lagoInvoiceId: string) {
     try {
@@ -303,6 +309,33 @@ function TopUpHistory() {
             </TableBody>
           </Table>
         </div>
+        {pageCount > 1 && (
+          <div className="mt-3 flex items-center justify-between text-[12px] text-muted-foreground">
+            <span>
+              Page {page} of {pageCount}
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1 || historyQuery.isFetching}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= pageCount || historyQuery.isFetching}
+                onClick={() =>
+                  setPage((current) => Math.min(pageCount, current + 1))
+                }
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/schemas/billing.test.ts
+++ b/frontend/src/schemas/billing.test.ts
@@ -58,7 +58,7 @@ describe("billing schemas", () => {
   });
 
   it("lists only backend-supported usage periods", () => {
-    expect(BILLING_USAGE_PERIODS).toEqual(["24h", "1d", "7d", "30d", "90d", "all"]);
+    expect(BILLING_USAGE_PERIODS).toEqual(["24h", "7d", "30d", "90d", "all"]);
   });
 
   it("accepts the wallet response shape returned by `/billing/wallet`", () => {

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -102,6 +102,29 @@ export type BillingReadOnlyBlock = z.infer<typeof billingReadOnlyBlockSchema>;
 export type BillingUsageRow = z.infer<typeof billingUsageRowSchema>;
 export type BillingUsageTotals = z.infer<typeof billingUsageTotalsSchema>;
 export type BillingUsageResponse = z.infer<typeof billingUsageResponseSchema>;
+export const topUpHistoryEntrySchema = z.object({
+  id: z.string().min(1),
+  created_at: z.string().min(1),
+  amount_credits: z.number().int(),
+  status: z.enum(["paid", "pending", "failed", "voided"]),
+  invoice_number: z.string().nullable().optional(),
+  lago_invoice_id: z.string().nullable().optional(),
+  checkout_url: z.string().nullable().optional(),
+  receipt_available: z.boolean(),
+});
+
+export const topUpHistoryResponseSchema = z.object({
+  owner_id: z.string().min(1),
+  topups: z.array(topUpHistoryEntrySchema),
+});
+
+export const invoiceDownloadResponseSchema = z.object({
+  file_url: z.string().min(1),
+});
+
+export type TopUpHistoryEntry = z.infer<typeof topUpHistoryEntrySchema>;
+export type TopUpHistoryResponse = z.infer<typeof topUpHistoryResponseSchema>;
+
 export type BillingWalletResponse = z.infer<typeof billingWalletResponseSchema>;
 export type ProvisionBillingWalletRequest = z.infer<typeof provisionBillingWalletRequestSchema>;
 export type TopUpBillingRequest = z.infer<typeof topUpBillingRequestSchema>;

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -106,7 +106,7 @@ export const topUpHistoryEntrySchema = z.object({
   id: z.string().min(1),
   created_at: z.string().min(1),
   amount_credits: z.number().int(),
-  status: z.enum(["paid", "pending", "failed", "voided"]),
+  status: z.enum(["paid", "pending", "expired", "failed", "voided"]),
   invoice_number: z.string().nullable().optional(),
   lago_invoice_id: z.string().nullable().optional(),
   checkout_url: z.string().nullable().optional(),
@@ -116,6 +116,9 @@ export const topUpHistoryEntrySchema = z.object({
 export const topUpHistoryResponseSchema = z.object({
   owner_id: z.string().min(1),
   topups: z.array(topUpHistoryEntrySchema),
+  page: z.number().int().positive(),
+  per_page: z.number().int().positive(),
+  total: z.number().int().nonnegative(),
 });
 
 export const invoiceDownloadResponseSchema = z.object({

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -116,9 +116,11 @@ export const topUpHistoryEntrySchema = z.object({
 export const topUpHistoryResponseSchema = z.object({
   owner_id: z.string().min(1),
   topups: z.array(topUpHistoryEntrySchema),
-  page: z.number().int().positive(),
-  per_page: z.number().int().positive(),
-  total: z.number().int().nonnegative(),
+  // Optional with defaults so older backends that omit pagination render
+  // a single page instead of failing the parse and blanking the card.
+  page: z.number().int().positive().optional().default(1),
+  per_page: z.number().int().positive().optional().default(10),
+  total: z.number().int().nonnegative().optional().default(0),
 });
 
 export const invoiceDownloadResponseSchema = z.object({

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const BILLING_USAGE_PERIODS = ["24h", "1d", "7d", "30d", "90d", "all"] as const;
+export const BILLING_USAGE_PERIODS = ["24h", "7d", "30d", "90d", "all"] as const;
 
 export type BillingUsagePeriod = (typeof BILLING_USAGE_PERIODS)[number];
 


### PR DESCRIPTION
## Summary

Pilot users cannot access Lago, so after paying a top-up they had no way to see whether it went through or to get a receipt. This adds both to the NyxID billing page.

## Changes

**`GET /api/v1/billing/topups`** — the owner's top-up history. Local sessions only track checkout creation, so the handler joins them with **one** Lago credit-invoice call to resolve payment outcomes: `paid` / `pending` / `failed` / `voided`. Pending entries keep their checkout URL so an abandoned payment can be resumed. Lago being unreachable degrades to local statuses instead of failing the page.

**`GET /api/v1/billing/invoices/{id}/download`** — returns Lago's signed receipt PDF URL. Ownership is verified first (the invoice's Lago customer must be the resolved billing owner; foreign and unknown invoices 404 identically so existence is not leaked), and the call retries briefly while Lago's PDF worker is still generating the document. Verified live: the signed `file_url` is publicly fetchable through the reverse proxy thanks to Lago's `LAGO_API_URL` env.

Both endpoints are gated by the `experimental:billing` rollout (same as the other wallet surfaces), and `/billing` is already in the delegated-read deny list.

**Billing page** — a "Top-up history" card: date, credits, invoice number, status badge, and per-row actions (Resume payment / Download receipt).

## Test plan

- [x] `cargo test -p nyxid lago` — 39 passed (new: credit-invoice parsing incl. customer/payment fields; PDF download retries until the file exists)
- [x] `cargo test -p nyxid billing` — 96 passed
- [x] Frontend `npm run build` + `npm test` — 2219 passed
- [x] Live: `POST /invoices/{id}/download` against the real Lago instance returns a working signed PDF URL