### PR TITLE
feat(assistant): full-width chat titles with a hover-revealed row menu

### DIFF
--- a/frontend/src/components/assistant/assistant-shell.tsx
+++ b/frontend/src/components/assistant/assistant-shell.tsx
@@ -35,6 +35,13 @@ export function AssistantShell({
   useEffect(() => {
     if (!mobileSidebarOpen) return;
     function closeOnEscape(event: KeyboardEvent) {
+      // Radix layers opened inside the drawer (the row menu, its delete
+      // confirmation) handle Escape on `document` in the capture phase and
+      // preventDefault, well before this window-level listener. Escape must
+      // dismiss the innermost layer only -- taking the drawer down with it
+      // would unmount that layer's anchor and skip a whole step of the way
+      // back in one keypress.
+      if (event.defaultPrevented) return;
       if (event.key === "Escape") setMobileSidebarOpen(false);
     }
     window.addEventListener("keydown", closeOnEscape);
@@ -159,7 +166,11 @@ export function AssistantShell({
             <div
               className="min-h-0 flex-1"
               onClick={(event) => {
-                if ((event.target as HTMLElement).closest("a,button")) {
+                const target = event.target as HTMLElement;
+                // Menu triggers open something anchored inside the drawer --
+                // closing it would unmount the anchor out from under them.
+                if (target.closest("[data-keep-drawer-open]")) return;
+                if (target.closest("a,button")) {
                   setMobileSidebarOpen(false);
                 }
               }}

--- a/frontend/src/components/assistant/assistant-sidebar.test.tsx
+++ b/frontend/src/components/assistant/assistant-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
@@ -34,13 +34,22 @@ const CONVERSATION: Conversation = {
   last_message_at: "2026-07-20T00:05:00.000Z",
 };
 
-function renderSidebar() {
+const SECOND_CONVERSATION: Conversation = {
+  id: "conv-2",
+  title: "Rotate GitHub token",
+  created_at: "2026-07-19T00:00:00.000Z",
+  last_message_at: "2026-07-19T00:05:00.000Z",
+};
+
+function renderSidebar(
+  onDelete: (id: string) => void | Promise<void> = vi.fn(),
+  conversations: readonly Conversation[] = [CONVERSATION],
+) {
   const onSelect = vi.fn();
-  const onDelete = vi.fn();
   render(
     <TooltipProvider>
       <AssistantSidebar
-        conversations={[CONVERSATION]}
+        conversations={conversations}
         activeConversationId={CONVERSATION.id}
         creating={false}
         onNewChat={vi.fn()}
@@ -53,12 +62,20 @@ function renderSidebar() {
 }
 
 describe("AssistantSidebar conversation rows", () => {
-  it("deletes only after the popover confirm, never on menu open", async () => {
+  it("opens a menu -- not a delete prompt -- and only deletes after confirm", async () => {
     const user = userEvent.setup();
-    const { onDelete } = renderSidebar();
+    const onDelete = vi.fn();
+    renderSidebar(onDelete);
 
     await user.click(screen.getByLabelText("Options for Quarterly digest"));
-    expect(await screen.findByText("Delete this chat?")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /delete/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+    expect(await screen.findByText("Delete chat?")).toBeInTheDocument();
     expect(onDelete).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Delete" }));
@@ -68,15 +85,128 @@ describe("AssistantSidebar conversation rows", () => {
 
   it("cancel closes the confirm without deleting", async () => {
     const user = userEvent.setup();
-    const { onDelete } = renderSidebar();
+    const onDelete = vi.fn();
+    renderSidebar(onDelete);
 
     await user.click(screen.getByLabelText("Options for Quarterly digest"));
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     await waitFor(() => {
-      expect(screen.queryByText("Delete this chat?")).not.toBeInTheDocument();
+      expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
     });
     expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("keeps the confirm open when the delete fails, so it stays retryable", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn().mockRejectedValue(new Error("offline"));
+    renderSidebar(onDelete);
+
+    await user.click(screen.getByLabelText("Options for Quarterly digest"));
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Delete chat?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fire a second delete while the first is in flight", async () => {
+    const user = userEvent.setup();
+    let settle: () => void = () => undefined;
+    const onDelete = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        }),
+    );
+    renderSidebar(onDelete);
+
+    await user.click(screen.getByLabelText("Options for Quarterly digest"));
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+
+    settle();
+    await waitFor(() => {
+      expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
+    });
+  });
+
+  // Dismissal stays available mid-flight, so a request can outlive its own
+  // dialog; landing late it must not close the confirmation for a different
+  // chat that has been opened since.
+  it("a late-landing delete does not close another chat's confirmation", async () => {
+    const user = userEvent.setup();
+    let settleFirst: () => void = () => undefined;
+    const onDelete = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleFirst = resolve;
+        }),
+    );
+    renderSidebar(onDelete, [CONVERSATION, SECOND_CONVERSATION]);
+
+    await user.click(screen.getByLabelText("Options for Quarterly digest"));
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await user.click(screen.getByLabelText("Options for Rotate GitHub token"));
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(/Rotate GitHub token/)).toBeInTheDocument();
+
+    settleFirst();
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+    expect(within(dialog).getByText("Delete chat?")).toBeInTheDocument();
+    expect(within(dialog).getByText(/Rotate GitHub token/)).toBeInTheDocument();
+  });
+
+  // A single pending marker would forget chat A the moment B was submitted,
+  // letting A's still-hung request be fired a second time.
+  it("tracks every in-flight target, not just the most recent one", async () => {
+    const user = userEvent.setup();
+    const settles = new Map<string, () => void>();
+    const onDelete = vi.fn(
+      (id: string) =>
+        new Promise<void>((resolve) => {
+          settles.set(id, resolve);
+        }),
+    );
+    renderSidebar(onDelete, [CONVERSATION, SECOND_CONVERSATION]);
+
+    async function submitDelete(title: string) {
+      await user.click(screen.getByLabelText(`Options for ${title}`));
+      await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+      await user.click(screen.getByRole("button", { name: "Delete" }));
+    }
+
+    await submitDelete("Quarterly digest");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await submitDelete("Rotate GitHub token");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    settles.get(SECOND_CONVERSATION.id)?.();
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(2);
+    });
+
+    // The first request is still hung; re-confirming it must not fire again.
+    await submitDelete("Quarterly digest");
+    expect(onDelete).toHaveBeenCalledTimes(2);
+
+    settles.get(CONVERSATION.id)?.();
+    await waitFor(() => {
+      expect(screen.queryByText("Delete chat?")).not.toBeInTheDocument();
+    });
   });
 
   it("clicking the row body selects the conversation instead of deleting", async () => {

--- a/frontend/src/components/assistant/assistant-sidebar.tsx
+++ b/frontend/src/components/assistant/assistant-sidebar.tsx
@@ -4,30 +4,50 @@ import {
   ChevronRight,
   FileText,
   LayoutGrid,
-  MessageSquare,
   MoreHorizontal,
   Plus,
   Server,
   ShieldCheck,
   SlidersHorizontal,
+  Trash2,
   User,
   type LucideIcon,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useWorkspaceCounts } from "@/hooks/use-assistant";
+import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/stores/auth-store";
 import type { Conversation } from "@/types/assistant";
+
+/**
+ * Titles run to the very end of the column, so whenever the 3-dot is showing
+ * it would otherwise sit on top of the text. Masking the tail (rather than
+ * covering it with a chip) keeps the fade correct on every row background --
+ * default, hover and active are all translucent overlays over `background`,
+ * so no single gradient colour would match all three.
+ */
+const TITLE_FADE =
+  "[mask-image:linear-gradient(to_right,#000_calc(100%_-_2.5rem),transparent)]";
 
 function GroupLabel({ children }: { readonly children: string }) {
   return (
@@ -65,86 +85,83 @@ function ComingSoonItem({
 }
 
 /**
- * One sidebar chat row: the select button plus a hover-revealed 3-dot menu
- * whose popover doubles as the delete confirmation (deleting removes the
- * actor and its history permanently, so a plain one-click delete is too
- * easy to hit by accident). On success the row unmounts with the list; on
- * failure the popover stays open so the action remains retryable.
+ * One sidebar chat row: a full-width select button with the 3-dot menu laid
+ * over its right edge, so the title always gets the whole column and the
+ * trigger only takes space visually once the row is hovered.
+ *
+ * The always-on state is keyed on `(hover: none)`, not on a breakpoint: a
+ * pointer-less device can be any width (an iPad is `md`), and app.css already
+ * force-shows `group-hover:opacity-100` there. Revealing on width instead
+ * would leave a wide tablet with a visible but `pointer-events: none` trigger
+ * whose taps fall through to the title button underneath.
+ *
+ * The menu is a menu -- opening it must never look like a delete prompt --
+ * and its Delete item raises the confirmation instead of deleting outright,
+ * because the conversation and its history go permanently.
  */
 function ConversationRow({
   conversation,
   active,
-  deleting,
   onSelect,
-  onDelete,
+  onRequestDelete,
 }: {
   readonly conversation: Conversation;
   readonly active: boolean;
-  readonly deleting: boolean;
   readonly onSelect: () => void;
-  readonly onDelete: () => void;
+  readonly onRequestDelete: () => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
     <div
-      className={`group relative flex items-center rounded-lg transition-colors ${
-        active ? "bg-overlay-strong" : "hover:bg-overlay"
-      }`}
+      className={cn(
+        "group relative flex items-center rounded-lg transition-colors",
+        active ? "bg-overlay-strong" : "hover:bg-overlay",
+      )}
     >
       <button
         type="button"
         onClick={onSelect}
-        className={`flex min-w-0 flex-1 items-center gap-3 px-3 py-2 text-left text-[13px] transition-colors ${
+        className={cn(
+          "w-full truncate px-3 py-2 text-left text-[13px] transition-colors",
           active
             ? "font-medium text-foreground"
-            : "text-muted-foreground group-hover:text-foreground"
-        }`}
+            : "text-muted-foreground group-hover:text-foreground",
+          "[@media(hover:none)]:[mask-image:linear-gradient(to_right,#000_calc(100%_-_2.5rem),transparent)]",
+          "group-hover:[mask-image:linear-gradient(to_right,#000_calc(100%_-_2.5rem),transparent)]",
+          menuOpen && TITLE_FADE,
+        )}
       >
-        <MessageSquare
-          className={`h-4 w-4 shrink-0 ${active ? "text-nyx-secondary-400" : "text-text-tertiary"}`}
-        />
-        <span className="truncate">{conversation.title}</span>
+        {conversation.title}
       </button>
-      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-        <PopoverTrigger asChild>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
           <button
             type="button"
             aria-label={`Options for ${conversation.title}`}
-            className={`mr-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-text-tertiary transition-opacity hover:bg-overlay-strong hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 ${
-              menuOpen ? "opacity-100" : "opacity-0"
-            }`}
+            data-keep-drawer-open=""
+            className={cn(
+              "absolute right-1 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md text-text-tertiary transition-opacity hover:bg-overlay-strong hover:text-foreground",
+              "pointer-events-none opacity-0",
+              "[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
+              "group-hover:pointer-events-auto group-hover:opacity-100",
+              "focus-visible:pointer-events-auto focus-visible:opacity-100",
+              "data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
+            )}
           >
             <MoreHorizontal className="h-3.5 w-3.5" />
           </button>
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-60 p-3">
-          <p className="text-[13px] font-medium text-foreground">
-            Delete this chat?
-          </p>
-          <p className="mt-1 text-[12px] text-muted-foreground">
-            The conversation and its history are removed permanently.
-          </p>
-          <div className="mt-3 flex justify-end gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setMenuOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              isLoading={deleting}
-              onClick={onDelete}
-            >
-              Delete
-            </Button>
-          </div>
-        </PopoverContent>
-      </Popover>
+        </DropdownMenuTrigger>
+        {/* Above the z-[80] mobile sidebar drawer this can be opened from. */}
+        <DropdownMenuContent align="end" className="z-[90] min-w-[160px]">
+          <DropdownMenuItem
+            onSelect={onRequestDelete}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 aria-hidden="true" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -166,12 +183,48 @@ export function AssistantSidebar({
   readonly deletingId?: string;
   readonly onNewChat: () => void;
   readonly onSelect: (conversationId: string) => void;
-  readonly onDelete: (conversationId: string) => void;
+  readonly onDelete: (conversationId: string) => void | Promise<void>;
 }) {
   const user = useAuthStore((state) => state.user);
   const counts = useWorkspaceCounts();
   const pluginsActive = activeView === "plugins";
   const approvalsActive = activeView === "approvals";
+  const [deleteTarget, setDeleteTarget] = useState<Conversation | undefined>();
+  const [deletePendingIds, setDeletePendingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  // One dialog for the whole list rather than one per row. A rejected delete
+  // has already been said out loud by the caller, so the dialog stays open
+  // and the action remains retryable; a resolved one closes it (the row is
+  // gone from the list by then anyway).
+  //
+  // Dismissal stays available at all times -- `apiClient` has no timeout, so
+  // holding the dialog shut around a hung request would trap the user -- so a
+  // request can outlive the dialog that started it, and several can be in
+  // flight against different chats at once. Hence a set of pending ids rather
+  // than one marker (a scalar would forget chat A the moment B was submitted,
+  // and let A be submitted twice), and hence every read and write below keyed
+  // on the id captured at submit rather than on whatever is open now.
+  async function confirmDelete() {
+    const target = deleteTarget;
+    if (!target || deletePendingIds.has(target.id)) return;
+    setDeletePendingIds((current) => new Set(current).add(target.id));
+    try {
+      await onDelete(target.id);
+      setDeleteTarget((current) =>
+        current?.id === target.id ? undefined : current,
+      );
+    } catch {
+      /* keep the dialog open so Delete can be pressed again */
+    } finally {
+      setDeletePendingIds((current) => {
+        const next = new Set(current);
+        next.delete(target.id);
+        return next;
+      });
+    }
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
@@ -242,9 +295,8 @@ export function AssistantSidebar({
               key={conversation.id}
               conversation={conversation}
               active={conversation.id === activeConversationId}
-              deleting={conversation.id === deletingId}
               onSelect={() => onSelect(conversation.id)}
-              onDelete={() => onDelete(conversation.id)}
+              onRequestDelete={() => setDeleteTarget(conversation)}
             />
           ))}
         </div>
@@ -273,6 +325,48 @@ export function AssistantSidebar({
           </div>
         </div>
       </div>
+
+      <Dialog
+        open={deleteTarget !== undefined}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(undefined);
+        }}
+      >
+        {/* Lifts the panel over the z-[80] mobile sidebar drawer this can be
+            opened from. Dialog's own overlay stays at z-50 and so sits under
+            that drawer, which only shows during the slide transition -- the
+            settled mobile panel is opaque and full-screen. */}
+        <DialogContent className="z-[90] md:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete chat?</DialogTitle>
+            <DialogDescription>
+              &ldquo;{deleteTarget?.title}&rdquo; and its history are removed
+              permanently.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setDeleteTarget(undefined)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              isLoading={
+                deleteTarget !== undefined &&
+                (deletePendingIds.has(deleteTarget.id) ||
+                  deleteTarget.id === deletingId)
+              }
+              onClick={() => void confirmDelete()}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -65,8 +65,9 @@ export function AssistantPage({
 
   // Deleting the URL-addressed conversation must also drop `?c=`, or the
   // stale id lingers in the address bar and re-selects nothing on reload;
-  // selection then falls back to the newest remaining chat. Failures stay
-  // in the row's popover (still open) with the reason said out loud.
+  // selection then falls back to the newest remaining chat. Failures are said
+  // out loud here and re-thrown so the sidebar keeps its confirm dialog open
+  // and the delete stays retryable.
   async function handleDelete(conversationId: string) {
     try {
       await deleteConversation.mutateAsync(conversationId);
@@ -80,6 +81,7 @@ export function AssistantPage({
             ? error.message
             : "The assistant backend did not respond. Try again.",
       });
+      throw error;
     }
   }
 
@@ -118,7 +120,7 @@ export function AssistantPage({
       }
       onNewChat={() => void createNewChat()}
       onSelect={selectConversation}
-      onDelete={(conversationId) => void handleDelete(conversationId)}
+      onDelete={handleDelete}
     />
   );
 


### PR DESCRIPTION
## What

Reworks the assistant sidebar chat rows per feedback:

- **Message icon removed.** It distinguished nothing — there is only one kind of chat today.
- **Titles run the full column width.** The 3-dot no longer reserves layout space; it is laid over the right edge and revealed on hover, keyboard focus, or while its menu is open.
- **The 3-dot opens a menu, not a delete prompt.** A `DropdownMenu` whose destructive `Delete` item raises the confirmation, so opening the menu is never itself destructive.

| | Before | After |
|---|---|---|
| Row | icon + truncated title + reserved 24px gutter | title only, full width |
| 3-dot | invisible but always occupying space | overlaid, revealed on hover |
| 3-dot click | "Delete this chat?" confirm | menu → Delete → confirm |

## Two details worth naming

**The always-on state is keyed on `(hover: none)`, not a breakpoint.** A pointer-less device can be any width (an iPad is `md`), and `app.css:282` already force-shows `group-hover:opacity-100` there. Revealing on width instead left wide tablets with a visible but `pointer-events: none` trigger whose taps fell through to the title button underneath.

**The title tail is masked, not covered by a chip.** Idle, hover and active rows are three different translucent overlays over `background`, so no single gradient colour would match all three. Verified in the built CSS that all three variants emit (with `-webkit-mask-image` auto-prefixed) and that the capability overrides land after the base `opacity-0` / `pointer-events-none` rules.

## Delete lifecycle

The confirmation is lifted to one dialog for the whole list. Dismissal stays available while a delete is in flight — `apiClient` has no timeout, so holding the dialog shut around a hung request would trap the user with no way out but a reload, and `DeleteRouteDialog` sets the house precedent of always-dismissable.

That means requests can outlive their dialog and overlap across chats, so pending state is a **set** of ids and every read/write is keyed on the id captured at submit. A late completion can then neither close a different chat's confirmation nor let its own be submitted twice. Both guards are mutation-tested — reverting either one fails its test.

## Drive-by fixes

Two ways the mobile drawer fought layers opened inside it:

- It closed on any `a`/`button` click, taking the menu's anchor down with it. Now skips `[data-keep-drawer-open]`.
- Its window-level Escape handler fired even after a Radix layer had already handled the key, skipping a whole step back in one press. Now defers on `defaultPrevented` (Radix listens on `document` with `capture: true`, so it always runs first).

## Review

Adversarially reviewed by GPT-5.6-Sol over two rounds. It found four issues; each was independently reproduced before being acted on:

1. **Dead 3-dot on wide touch devices** (fixed) — the original `max-md:` reveal left iPads with a visible, unclickable trigger.
2. **A stale delete could close another chat's confirmation** (fixed) — plus a follow-on where a single pending marker forgot chat A once B was submitted, allowing a duplicate mutation.
3. **Overlay z-index during the dialog's slide transition** — cosmetic, left as-is with the comment corrected to describe it accurately.
4. **Hybrid devices** (Surface / touchscreen laptop) report a hovering primary pointer while also accepting touch, so the dots stay hover-only there. Not actioned: the proposed `any-pointer: coarse` would show the dots permanently on every touchscreen laptop including trackpad users, which is the always-visible behaviour this PR removes. Scope agreed as laptop + mobile.

## Testing

- `npm run build` (the tsc gate) — clean
- `npm run lint` — 0 errors
- Full frontend suite — **1919/1919** passing (run with `--no-file-parallelism`; the shared runner was saturated and produced timeout flakes in unrelated files otherwise)
- `cargo test -p nyxid-cli --test wizard_bundle_freshness` — passing; none of the changed files are wizard bundle inputs, so no bundle rebuild
- 7 sidebar tests, 4 of them new

🤖 Generated with [Claude Code](https://claude.com/claude-code)