### PR TITLE
fix(assistant): keep sidebar responsive during streaming

### DIFF
--- a/frontend/src/components/assistant/approvals-view.test.tsx
+++ b/frontend/src/components/assistant/approvals-view.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -153,5 +153,48 @@ describe("ApprovalsView", () => {
     expect(
       await screen.findByText("Nothing waiting on you"),
     ).toBeInTheDocument();
+  });
+
+  // A row missing a sort key used to throw out of `Array.sort`, and with no
+  // router error component that unmounted the whole app — sidebar included —
+  // so the page read as "every button is dead" rather than "one row is odd".
+  it("still renders when a row is missing its sort timestamps", async () => {
+    // Order matters: `Array.sort` only throws when the undated row lands on the
+    // left of the comparison, so the undated row must not be first.
+    const undated = request({
+      id: "req-undated",
+      action_description: "Post without an expiry",
+      expires_at: undefined as unknown as string,
+    });
+    const undecided = request({
+      id: "req-undecided",
+      status: "approved",
+      action_description: "Decided at an unknown time",
+      created_at: undefined as unknown as string,
+      decided_at: null,
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.startsWith("/notifications/settings")) {
+        return Promise.resolve({ grant_expiry_days: 7 });
+      }
+      if (url.includes("status=pending")) {
+        return Promise.resolve(listResponse([PENDING, undated]));
+      }
+      return Promise.resolve(listResponse([DECIDED[0]!, undecided]));
+    });
+
+    render(<ApprovalsView />, { wrapper: createWrapper() });
+
+    expect(await screen.findByText("Waiting on you")).toBeInTheDocument();
+    expect(screen.getByText("Post without an expiry")).toBeInTheDocument();
+    expect(
+      screen.getByText("Post the drafted summary to #payments-oncall"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findAllByText("Decided at an unknown time"),
+    ).toHaveLength(2);
+    const historyRows = within(screen.getByRole("table")).getAllByRole("row");
+    expect(historyRows[1]).toHaveTextContent("Rotate the deploy key");
+    expect(historyRows[2]).toHaveTextContent("Decided at an unknown time");
   });
 });

--- a/frontend/src/components/assistant/approvals-view.tsx
+++ b/frontend/src/components/assistant/approvals-view.tsx
@@ -52,6 +52,19 @@ function channelLabel(channel: ApprovalDecisionChannel | null): string {
   }
 }
 
+/** ISO-8601 comparator that always sorts absent values after present ones. */
+function compareIsoDates(
+  left: string | null | undefined,
+  right: string | null | undefined,
+  direction: "ascending" | "descending",
+): number {
+  if (!left) return right ? 1 : 0;
+  if (!right) return -1;
+  return direction === "ascending"
+    ? left.localeCompare(right)
+    : right.localeCompare(left);
+}
+
 function ServiceCell({ slug }: { readonly slug: string }) {
   return (
     <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
@@ -89,10 +102,12 @@ function PendingSection({
 
   return (
     <>
-      <p className="mb-2.5 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[1.5px] text-text-tertiary">
+      {/* A div, not a p: `Badge` renders a div, which is invalid inside a p and
+          gets reparented by the browser. */}
+      <div className="mb-2.5 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[1.5px] text-text-tertiary">
         Waiting on you
         <Badge variant="warning">{entries.length}</Badge>
-      </p>
+      </div>
       <div className="space-y-5">
         {entries.map((entry) => (
           <div key={entry.requestId}>
@@ -212,11 +227,18 @@ export function ApprovalsView() {
   const decide = useDecideApproval();
 
   // Pending: most urgent (soonest expiry) first. History: newest first.
+  // Both keys are ISO strings the API always sends, but a comparator that
+  // throws takes the whole route down with it (the router unmounts to a blank
+  // page), so one absent timestamp must degrade to "sorts last" instead.
   const pending = [...approvals.pending].sort((a, b) =>
-    a.block.expires_at.localeCompare(b.block.expires_at),
+    compareIsoDates(a.block.expires_at, b.block.expires_at, "ascending"),
   );
   const decided = [...approvals.history].sort((a, b) =>
-    (b.decidedAt ?? b.requestedAt).localeCompare(a.decidedAt ?? a.requestedAt),
+    compareIsoDates(
+      a.decidedAt ?? a.requestedAt,
+      b.decidedAt ?? b.requestedAt,
+      "descending",
+    ),
   );
 
   async function handleDecide(
@@ -243,8 +265,7 @@ export function ApprovalsView() {
         </h1>
         <p className="mt-1 max-w-2xl text-[12px] text-muted-foreground">
           Write actions gated by your NyxID policy wait here for your decision.
-          Deciding here, in Telegram, or on mobile converges to the same
-          result.
+          Deciding here, in Telegram, or on mobile converges to the same result.
         </p>
       </div>
 

--- a/frontend/src/components/shared/app-route-error.tsx
+++ b/frontend/src/components/shared/app-route-error.tsx
@@ -1,0 +1,54 @@
+import { Link, useRouter, type ErrorComponentProps } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { NotFoundPage } from "@/components/shared/not-found-page";
+import { useAuthStore } from "@/stores/auth-store";
+
+/**
+ * Router-wide render-error fallback, wired as `defaultErrorComponent`.
+ *
+ * Without this, TanStack Router's CatchBoundary swallows any render error and
+ * renders *nothing* — the entire app goes blank, including chrome the user
+ * needs to navigate away (the assistant sidebar, the dashboard nav). One bad
+ * field in one list then looks like every button in the app is dead. This
+ * keeps the failure scoped: say what happened, and offer a way out.
+ *
+ * Reuses the empty-state visual language of `NotFoundPage` (DESIGN.md) so the
+ * two failure surfaces read as one system.
+ */
+export function AppRouteError({ error, reset }: ErrorComponentProps) {
+  const router = useRouter();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  // `reset` clears the boundary; `invalidate` re-runs the route's loaders so a
+  // retry refetches instead of replaying the same failed render.
+  function retry() {
+    reset();
+    void router.invalidate();
+  }
+
+  return (
+    <NotFoundPage
+      code="Error"
+      title="Something broke on this page"
+      description={
+        import.meta.env.DEV && error instanceof Error && error.message
+          ? error.message
+          : "This part of the app hit an unexpected error. Your data is safe — try again, or head back and come at it from another angle."
+      }
+      action={
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button type="button" variant="primary" onClick={retry}>
+            Try again
+          </Button>
+          <Button asChild variant="secondary">
+            {isAuthenticated ? (
+              <Link to="/dashboard">Back to dashboard</Link>
+            ) : (
+              <Link to="/">Go to homepage</Link>
+            )}
+          </Button>
+        </div>
+      }
+    />
+  );
+}

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -355,6 +355,74 @@ describe("assistant hooks", () => {
     queryClient.clear();
   });
 
+  it("coalesces bursty stream frames before projecting them into React", async () => {
+    const { queryClient, Wrapper } = createHarness();
+    const historySpy = vi.spyOn(assistantTransport, "getHistory");
+    let emit: Parameters<typeof assistantTransport.sendMessage>[2] | undefined;
+    const sendSpy = vi
+      .spyOn(assistantTransport, "sendMessage")
+      .mockImplementation((_conversationId, _content, onEvent) => {
+        emit = onEvent;
+        for (let cursor = 1; cursor <= 250; cursor += 1) {
+          onEvent({
+            cursor,
+            event: "block.delta",
+            block_id: "streaming-text",
+            text: "x",
+          });
+        }
+        return { turnId: "turn-burst", cancel: () => {} };
+      });
+    const { result, unmount } = renderHook(
+      () => ({ send: useSendMessage("conversation-stripe") }),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await result.current.send.mutateAsync("Bursty response.");
+    });
+    // Ignore the send mutation's intentional immediate projection. The 250
+    // stream callbacks above must produce only one additional projection.
+    historySpy.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(49);
+    });
+    expect(historySpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(historySpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      emit?.({
+        cursor: 251,
+        event: "block.delta",
+        block_id: "streaming-text",
+        text: "final",
+      });
+      emit?.({
+        cursor: 252,
+        event: "turn.completed",
+        turn_id: "turn-burst",
+        status: "completed",
+        error: null,
+      });
+    });
+    // Terminal events bypass the interval so Stop/send state cannot linger.
+    expect(historySpy).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(historySpy).toHaveBeenCalledTimes(2);
+
+    sendSpy.mockRestore();
+    historySpy.mockRestore();
+    unmount();
+    queryClient.clear();
+  });
+
   it("rejects a concurrent send without disturbing the active turn", async () => {
     const { queryClient, Wrapper } = createHarness();
     const { result, unmount } = renderHook(

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -49,6 +49,10 @@ const PENDING_APPROVALS_PAGE_SIZE = 50;
 const APPROVAL_HISTORY_PAGE_SIZE = 20;
 const STREAM_START_DEADLINE_MS = 8_000;
 const PROJECTION_DEADLINE_MS = 5_000;
+// Streaming events update the transport mirror synchronously. Projecting that
+// mirror into React Query at most twenty times per second keeps Markdown-heavy
+// active threads from starving sidebar navigation on the main thread.
+const STREAM_PROJECTION_INTERVAL_MS = 50;
 
 const activeHandles = new Map<string, TurnHandle>();
 const episodeOwners = new WeakMap<QueryClient, Map<string, symbol>>();
@@ -426,6 +430,7 @@ function createTurnEventPump(
   let hasReceivedEvent = false;
   let startExpired = false;
   let startDeadline: ReturnType<typeof setTimeout> | undefined;
+  let projectionTimer: ReturnType<typeof setTimeout> | undefined;
   const ownsEpisode = () => owners.get(targetId) === owner;
   const clearStartDeadline = () => {
     if (startDeadline !== undefined) {
@@ -439,6 +444,34 @@ function createTurnEventPump(
       assistantKeys.episode(targetId),
       () => ({ open, printed, projecting: projections > 0 }),
     );
+  };
+  const clearProjectionTimer = () => {
+    if (projectionTimer !== undefined) {
+      clearTimeout(projectionTimer);
+      projectionTimer = undefined;
+    }
+  };
+  const project = () => {
+    projectionTimer = undefined;
+    if (!ownsEpisode()) return;
+    projections += 1;
+    publish();
+    // A delete can race a cancel-driven projection, in which case the history
+    // read legitimately rejects for the tombstoned id.
+    void projectTransportState(queryClient, targetId)
+      .catch(() => undefined)
+      .finally(() => {
+        projections -= 1;
+        publish();
+      });
+  };
+  const scheduleProjection = (immediate = false) => {
+    if (immediate) {
+      clearProjectionTimer();
+      project();
+      return;
+    }
+    projectionTimer ??= setTimeout(project, STREAM_PROJECTION_INTERVAL_MS);
   };
   owners.set(targetId, owner);
   publish();
@@ -497,22 +530,10 @@ function createTurnEventPump(
         });
       }
     }
-    // Counted, and published, because this projection is the work the thread
-    // would otherwise have to guess the duration of: the terminal status is
-    // delivered synchronously above while the content it refers to arrives
-    // through this read. Reporting "the turn printed nothing" before it settles
-    // is how a turn that DID answer gets called an error.
-    projections += 1;
-    publish();
-    // Swallow projection failures: after a delete races a cancel-driven
-    // event, the history read legitimately rejects (tombstoned id) and
-    // must not surface as an unhandled rejection.
-    projectTransportState(queryClient, targetId)
-      .catch(() => undefined)
-      .finally(() => {
-        projections -= 1;
-        publish();
-      });
+    // Intermediate token/tool frames can share one UI projection. A terminal
+    // event flushes immediately so the composer and episode state settle with
+    // no extra interval of latency.
+    scheduleProjection(event.event === "turn.completed");
   };
 
   return {
@@ -521,6 +542,7 @@ function createTurnEventPump(
     expired: () => startExpired,
     restorePrevious: () => {
       clearStartDeadline();
+      clearProjectionTimer();
       if (!ownsEpisode()) return;
       if (previousOwner) {
         owners.set(targetId, previousOwner);
@@ -534,6 +556,7 @@ function createTurnEventPump(
     },
     disown: () => {
       clearStartDeadline();
+      clearProjectionTimer();
       if (!ownsEpisode()) return;
       owners.delete(targetId);
       queryClient.setQueryData<TurnEpisode | null>(

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -11,7 +11,12 @@ import {
   renderableText,
   splitConnectMarkers,
 } from "@/lib/assistant/connect-fence";
-import { drainSseBuffer, flushSseBuffer } from "@/lib/assistant/sse";
+import {
+  chatStreamClient,
+  type ChatStreamCompletionResult,
+  type ChatStreamRequestHandle,
+} from "@/lib/assistant/chat-stream-worker-client";
+import type { ChatStreamFrame } from "@/lib/assistant/chat-stream-worker-protocol";
 import {
   actionReportSchema,
   assistantActionRequestSchema,
@@ -1284,26 +1289,23 @@ export class AevatarAssistantTransport implements AssistantTransport {
       return null;
     }
 
-    let response: Response;
-    try {
-      run.streamDispatched = true;
-      response = await fetch(
-        `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/approve`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "text/event-stream",
-          },
-          credentials: "include",
-          body: JSON.stringify({
-            requestId: card.approval_request_id,
-            approved,
-          }),
-          signal: run.controller.signal,
-        },
-      );
-    } catch (error) {
+    const stream = this.startChatStream(
+      conversationId,
+      run,
+      `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/approve`,
+      JSON.stringify({
+        requestId: card.approval_request_id,
+        approved,
+      }),
+    );
+    const response = await stream.headers;
+    if (response.kind === "cancelled") {
+      // cancelTurn already emitted the terminal events when the user stopped
+      // this request before response headers arrived.
+      this.finishTurn(conversationId, run, "cancelled", null);
+      throw new AssistantTurnCancelledError();
+    }
+    if (response.kind === "network_error") {
       const aborted = run.controller.signal.aborted;
       // cancelTurn may already have settled the run; finishTurn is a no-op
       // then. The card was never flipped, so the decision stays retryable.
@@ -1316,11 +1318,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
         aborted ? "cancelled" : "failed",
         null,
       );
-      throw aborted ? new AssistantTurnCancelledError() : error;
+      throw aborted
+        ? new AssistantTurnCancelledError()
+        : new Error(response.message);
     }
-    if (!response.ok) {
-      const bodyText = await response.text().catch(() => "");
-      const failure = streamStartError(response.status, bodyText);
+    if (response.kind === "http_error") {
+      const failure = streamStartError(response.status, response.body);
       // Null turn error for the same single-toast reason as above.
       this.finishTurn(conversationId, run, "failed", null);
       throw new Error(failure.message);
@@ -1381,14 +1384,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
       });
     }
 
-    const contentType = response.headers.get("content-type") ?? "";
-    if (response.body && contentType.includes("text/event-stream")) {
-      void this.consumeApprovalContinuation(conversationId, run, response);
+    if (response.contentType.includes("text/event-stream")) {
+      void this.consumeApprovalContinuation(conversationId, run, stream);
     } else {
       // Older backend acknowledging with JSON: nothing further will stream,
       // and there is no live continuation for the caller to hold a handle
       // to — returning one would let a stale entry linger in the caller's
       // handle registry after this turn already completed.
+      stream.cancel();
       this.finishTurn(conversationId, run, "completed", null);
       return null;
     }
@@ -2001,11 +2004,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
       run.protocol === "workflow"
         ? {
             url: WORKFLOW_CHAT_URL,
-            body: this.workflowTurnBody(conversationId, run, prompt),
+            bodyText: this.workflowTurnBody(conversationId, run, prompt),
           }
         : {
             url: `/api/v1${ASSISTANT_PREFIX}/conversations/${conversationId}/stream`,
-            body: JSON.stringify({
+            bodyText: JSON.stringify({
               // Aevatar NyxIdChatEndpoints.Streaming.cs:58 uses an ordinal
               // discriminator comparison, so a normal turn requires this
               // exact lowercase value.
@@ -2020,56 +2023,33 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // path defers its abort); a finished run must never re-POST.
       if (run.finished || run.controller.signal.aborted) return;
       this.resetDeliveryState(run);
-      let response: Response;
-      try {
-        // Hand-rolled fetch (not `apiClient`): the response is an SSE stream,
-        // and the endpoint 415s without an explicit JSON content type.
-        run.streamDispatched = true;
-        response = await fetch(target.url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "text/event-stream",
-          },
-          credentials: "include",
-          body: target.body,
-          signal: run.controller.signal,
-        });
-      } catch {
-        // The cancel path aborts the fetch after emitting its own terminal
-        // events; an abort here is not a failure.
+      const stream = this.startChatStream(
+        conversationId,
+        run,
+        target.url,
+        target.bodyText,
+      );
+      const response = await stream.headers;
+
+      if (response.kind === "cancelled") return;
+      if (response.kind === "network_error") {
         if (run.finished || run.controller.signal.aborted) return;
+        finalFailure = { code: response.code, message: response.message };
         if (attempt + 1 < STREAM_DELIVERY_ATTEMPTS) continue;
         break;
       }
-
-      if (!response.ok) {
+      if (response.kind === "http_error") {
         if (
           RETRYABLE_STREAM_STATUSES.has(response.status) &&
           attempt + 1 < STREAM_DELIVERY_ATTEMPTS
         ) {
-          await response.body?.cancel().catch(() => undefined);
           continue;
         }
-        const bodyText = await response.text().catch(() => "");
-        finalFailure = streamStartError(response.status, bodyText);
+        finalFailure = streamStartError(response.status, response.body);
         break;
       }
 
-      if (!response.body) {
-        finalFailure = {
-          code: "stream_closed",
-          message: "The assistant stream closed before it started.",
-        };
-        if (attempt + 1 < STREAM_DELIVERY_ATTEMPTS) continue;
-        break;
-      }
-
-      const result = await this.consumeTurnStream(
-        conversationId,
-        run,
-        response,
-      );
+      const result = await this.consumeTurnStream(conversationId, run, stream);
       if (result.kind === "settled" || run.finished) return;
       finalFailure = result.error;
       if (
@@ -2102,50 +2082,41 @@ export class AevatarAssistantTransport implements AssistantTransport {
       message:
         "The action report could not be delivered. It will be retried after the next turn.",
     };
+    // This DTO is already rebuilt from the strict allowlist in
+    // buildActionContinueBody; no card or model object is spread here.
+    const bodyText = JSON.stringify(body);
 
     for (let attempt = 0; attempt < STREAM_DELIVERY_ATTEMPTS; attempt += 1) {
       if (run.finished || run.controller.signal.aborted) return;
       this.resetDeliveryState(run);
-      let response: Response;
-      try {
-        run.streamDispatched = true;
-        response = await fetch(
-          `/api/v1${ASSISTANT_PREFIX}/conversations/${encodeURIComponent(actorId)}/stream`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "text/event-stream",
-            },
-            credentials: "include",
-            // This DTO is already rebuilt from the strict allowlist in
-            // buildActionContinueBody; no card or model object is spread here.
-            body: JSON.stringify(body),
-            signal: run.controller.signal,
-          },
-        );
-      } catch {
+      const stream = this.startChatStream(
+        conversationId,
+        run,
+        `/api/v1${ASSISTANT_PREFIX}/conversations/${encodeURIComponent(actorId)}/stream`,
+        bodyText,
+      );
+      const response = await stream.headers;
+
+      if (response.kind === "cancelled") return;
+      if (response.kind === "network_error") {
         if (run.finished || run.controller.signal.aborted) return;
+        finalFailure = { ...finalFailure, code: response.code };
         if (attempt + 1 < STREAM_DELIVERY_ATTEMPTS) continue;
         break;
       }
-
-      if (!response.ok) {
+      if (response.kind === "http_error") {
         if (
           RETRYABLE_STREAM_STATUSES.has(response.status) &&
           attempt + 1 < STREAM_DELIVERY_ATTEMPTS
         ) {
-          await response.body?.cancel().catch(() => undefined);
           continue;
         }
-        const bodyText = await response.text().catch(() => "");
-        finalFailure = streamStartError(response.status, bodyText);
+        finalFailure = streamStartError(response.status, response.body);
         break;
       }
 
-      const contentType = response.headers.get("content-type") ?? "";
-      if (!contentType.includes("text/event-stream")) {
-        await response.body?.cancel().catch(() => undefined);
+      if (!response.contentType.includes("text/event-stream")) {
+        stream.cancel();
         finalFailure = {
           code: "stream_protocol_error",
           message:
@@ -2153,22 +2124,19 @@ export class AevatarAssistantTransport implements AssistantTransport {
         };
         break;
       }
-      if (!response.body) {
-        finalFailure = {
-          code: "stream_closed",
-          message: "The action continuation closed before it started.",
-        };
-        if (attempt + 1 < STREAM_DELIVERY_ATTEMPTS) continue;
-        break;
-      }
 
-      const result = await this.consumeTurnStream(
-        conversationId,
-        run,
-        response,
-      );
+      const result = await this.consumeTurnStream(conversationId, run, stream);
       if (result.kind === "settled" || run.finished) return;
-      finalFailure = result.error;
+      finalFailure =
+        result.error.code === "stream_closed"
+          ? {
+              code: "stream_closed",
+              message: "The action continuation closed before it started.",
+            }
+          : result.error.code === "network_error" ||
+              result.error.code === "worker_error"
+            ? { ...finalFailure, code: result.error.code }
+            : result.error;
       if (
         result.kind === "retryable" &&
         attempt + 1 < STREAM_DELIVERY_ATTEMPTS
@@ -2186,55 +2154,28 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   /**
-   * Shared SSE consumption for the original turn stream and the approval
-   * continuation stream: same framing, same adapter, same watchdog and
-   * truncation semantics.
+   * Shared completion handling for initial turns, approval continuations, and
+   * action continuations. Fetch, UTF-8 decoding, SSE framing, JSON parsing,
+   * and bounded batching happen in the stream worker (or inline fallback).
    */
   private async consumeTurnStream(
     conversationId: string,
     run: RunningTurn,
-    response: Response,
+    stream: ChatStreamRequestHandle,
   ): Promise<StreamConsumptionResult> {
-    if (!response.body) {
-      return {
-        kind: "retryable",
-        error: {
-          code: "stream_closed",
-          message: "The assistant stream closed before it started.",
-        },
-      };
-    }
     try {
       this.armWatchdog(conversationId, run);
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      readLoop: for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const { payloads, rest } = drainSseBuffer(buffer);
-        buffer = rest;
-        for (const payload of payloads) {
-          this.handleAgUiFrame(conversationId, run, payload);
-          if (run.finished) return { kind: "settled" };
-          if (run.deliveryProtocolError) break readLoop;
-        }
-      }
-      if (!run.deliveryProtocolError) {
-        // The final frame may arrive without a trailing blank line; flush it
-        // before judging how the stream ended.
-        buffer += decoder.decode();
-        for (const payload of flushSseBuffer(buffer)) {
-          this.handleAgUiFrame(conversationId, run, payload);
-          if (run.finished) return { kind: "settled" };
-          if (run.deliveryProtocolError) break;
-        }
+      const completion = await stream.completion;
+      if (run.finished || run.controller.signal.aborted) {
+        return { kind: "settled" };
       }
 
       if (run.deliveryProtocolError) {
-        await reader.cancel().catch(() => undefined);
+        stream.cancel();
         return { kind: "protocol_error", error: run.deliveryProtocolError };
+      }
+      if (completion.kind !== "complete") {
+        return this.streamCompletionFailure(completion);
       }
       if (run.deliveryTerminal) {
         this.settleDeliveryTerminal(conversationId, run, run.deliveryTerminal);
@@ -2265,17 +2206,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
             "The stream ended before the assistant finished. The reply may be incomplete; it will appear in full once the conversation reloads.",
         },
       };
-    } catch {
-      if (run.finished || run.controller.signal.aborted) {
-        return { kind: "settled" };
-      }
-      return {
-        kind: "retryable",
-        error: {
-          code: "network_error",
-          message: "The assistant stream was interrupted. Try again.",
-        },
-      };
     } finally {
       this.clearWatchdog(run);
     }
@@ -2284,13 +2214,54 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private async consumeApprovalContinuation(
     conversationId: string,
     run: RunningTurn,
-    response: Response,
+    stream: ChatStreamRequestHandle,
   ): Promise<void> {
-    const result = await this.consumeTurnStream(conversationId, run, response);
+    const result = await this.consumeTurnStream(conversationId, run, stream);
     if (result.kind === "settled" || run.finished) return;
     this.closeOpenMessage(conversationId, run);
     this.finalizeActivity(conversationId, run, "failed");
     this.finishTurn(conversationId, run, "failed", result.error);
+  }
+
+  private startChatStream(
+    conversationId: string,
+    run: RunningTurn,
+    url: string,
+    bodyText: string,
+  ): ChatStreamRequestHandle {
+    let stream: ChatStreamRequestHandle | null = null;
+    run.streamDispatched = true;
+    stream = chatStreamClient.start({
+      url,
+      bodyText,
+      signal: run.controller.signal,
+      onFrames: (frames) => {
+        for (const frame of frames) {
+          this.handleAgUiFrame(conversationId, run, frame);
+          if (run.finished || run.deliveryProtocolError) {
+            if (run.deliveryProtocolError) stream?.cancel();
+            break;
+          }
+        }
+      },
+    });
+    return stream;
+  }
+
+  private streamCompletionFailure(
+    completion: Exclude<ChatStreamCompletionResult, { kind: "complete" }>,
+  ): StreamConsumptionResult {
+    if (completion.kind === "cancelled") return { kind: "settled" };
+    if (completion.kind === "http_error") {
+      return {
+        kind: "retryable",
+        error: streamStartError(completion.status, completion.body),
+      };
+    }
+    return {
+      kind: "retryable",
+      error: { code: completion.code, message: completion.message },
+    };
   }
 
   private resetDeliveryState(run: RunningTurn): void {
@@ -2343,14 +2314,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private handleAgUiFrame(
     conversationId: string,
     run: RunningTurn,
-    payload: string,
+    payload: ChatStreamFrame,
   ): void {
-    let frame: AgUiFrame;
-    try {
-      frame = JSON.parse(payload) as AgUiFrame;
-    } catch {
-      return;
-    }
+    const frame = payload as AgUiFrame;
     if (typeof frame !== "object" || frame === null) return;
 
     const type = this.frameType(frame);

--- a/frontend/src/lib/assistant/chat-stream-parser.test.ts
+++ b/frontend/src/lib/assistant/chat-stream-parser.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { ChatStreamParser } from "./chat-stream-parser";
+
+const encoder = new TextEncoder();
+
+describe("ChatStreamParser", () => {
+  it("preserves frame order across UTF-8 and SSE chunk boundaries", () => {
+    const parser = new ChatStreamParser();
+    const source = [
+      'data: {"type":"RUN_STARTED","turnId":"turn-1"}\n\n',
+      'data: {"type":"TEXT_MESSAGE_CONTENT","textMessageContent":{"delta":"hé"}}\n\n',
+    ].join("");
+    const bytes = encoder.encode(source);
+    const split = bytes.indexOf(0xc3) + 1;
+
+    expect(parser.push(bytes.slice(0, split))).toEqual([
+      { type: "RUN_STARTED", turnId: "turn-1" },
+    ]);
+    expect(parser.push(bytes.slice(split))).toEqual([
+      {
+        type: "TEXT_MESSAGE_CONTENT",
+        textMessageContent: { delta: "hé" },
+      },
+    ]);
+    expect(parser.finish()).toEqual([]);
+  });
+
+  it("flushes a final frame without a trailing SSE separator", () => {
+    const parser = new ChatStreamParser();
+
+    expect(
+      parser.push(encoder.encode('data: {"type":"RUN_FINISHED"}')),
+    ).toEqual([]);
+    expect(parser.finish()).toEqual([{ type: "RUN_FINISHED" }]);
+  });
+
+  it("drops malformed and non-object payloads without dropping valid frames", () => {
+    const parser = new ChatStreamParser();
+    const frames = parser.push(
+      encoder.encode(
+        [
+          "data: not-json",
+          "",
+          "data: []",
+          "",
+          'data: {"type":"RUN_STARTED","turnId":"turn-2"}',
+          "",
+          "",
+        ].join("\n"),
+      ),
+    );
+
+    expect(frames).toEqual([{ type: "RUN_STARTED", turnId: "turn-2" }]);
+  });
+});

--- a/frontend/src/lib/assistant/chat-stream-parser.ts
+++ b/frontend/src/lib/assistant/chat-stream-parser.ts
@@ -1,0 +1,44 @@
+import { drainSseBuffer, flushSseBuffer } from "@/lib/assistant/sse";
+import type { ChatStreamFrame } from "@/lib/assistant/chat-stream-worker-protocol";
+
+function parseFrame(payload: string): ChatStreamFrame | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as ChatStreamFrame;
+}
+
+function parsePayloads(payloads: readonly string[]): ChatStreamFrame[] {
+  const frames: ChatStreamFrame[] = [];
+  for (const payload of payloads) {
+    const frame = parseFrame(payload);
+    if (frame) frames.push(frame);
+  }
+  return frames;
+}
+
+/** Incremental UTF-8/SSE parser shared by the worker and inline fallback. */
+export class ChatStreamParser {
+  private readonly decoder = new TextDecoder();
+  private buffer = "";
+
+  push(value: Uint8Array): ChatStreamFrame[] {
+    this.buffer += this.decoder.decode(value, { stream: true });
+    const { payloads, rest } = drainSseBuffer(this.buffer);
+    this.buffer = rest;
+    return parsePayloads(payloads);
+  }
+
+  finish(): ChatStreamFrame[] {
+    this.buffer += this.decoder.decode();
+    const frames = parsePayloads(flushSseBuffer(this.buffer));
+    this.buffer = "";
+    return frames;
+  }
+}

--- a/frontend/src/lib/assistant/chat-stream-worker-client.test.ts
+++ b/frontend/src/lib/assistant/chat-stream-worker-client.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatStreamWorkerClient } from "./chat-stream-worker-client";
+import type {
+  ChatStreamWorkerCommand,
+  ChatStreamWorkerMessage,
+} from "./chat-stream-worker-protocol";
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent<ChatStreamWorkerMessage>) => void) | null =
+    null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  onmessageerror: ((event: MessageEvent) => void) | null = null;
+  readonly messages: ChatStreamWorkerCommand[] = [];
+  readonly terminate = vi.fn();
+
+  postMessage(message: ChatStreamWorkerCommand): void {
+    this.messages.push(message);
+  }
+
+  emit(message: ChatStreamWorkerMessage): void {
+    this.onmessage?.({
+      data: message,
+    } as MessageEvent<ChatStreamWorkerMessage>);
+  }
+
+  crash(): void {
+    this.onerror?.({ preventDefault: vi.fn() } as unknown as ErrorEvent);
+  }
+}
+
+function asWorker(worker: FakeWorker): Worker {
+  return worker as unknown as Worker;
+}
+
+function requestId(worker: FakeWorker): string {
+  const start = worker.messages.find(
+    (message) => message.type === "stream.start",
+  );
+  if (!start) throw new Error("Worker did not receive stream.start");
+  return start.requestId;
+}
+
+describe("ChatStreamWorkerClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("delivers ordered frame batches and completion from one worker request", async () => {
+    const worker = new FakeWorker();
+    const client = new ChatStreamWorkerClient(() => asWorker(worker));
+    const controller = new AbortController();
+    const delivered: unknown[] = [];
+
+    const stream = client.start({
+      url: "/api/v1/assistant/conversations/chat-1/stream",
+      bodyText: '{"prompt":"hello"}',
+      signal: controller.signal,
+      onFrames: (frames) => delivered.push(...frames),
+    });
+    const id = requestId(worker);
+    worker.emit({
+      type: "stream.response",
+      requestId: id,
+      status: 200,
+      contentType: "text/event-stream",
+    });
+    worker.emit({
+      type: "stream.batch",
+      requestId: id,
+      frames: [{ type: "RUN_STARTED" }, { type: "TEXT_MESSAGE_START" }],
+    });
+    worker.emit({
+      type: "stream.complete",
+      requestId: id,
+      frames: [{ type: "RUN_FINISHED" }],
+    });
+
+    await expect(stream.headers).resolves.toEqual({
+      kind: "response",
+      status: 200,
+      contentType: "text/event-stream",
+    });
+    await expect(stream.completion).resolves.toEqual({ kind: "complete" });
+    expect(delivered).toEqual([
+      { type: "RUN_STARTED" },
+      { type: "TEXT_MESSAGE_START" },
+      { type: "RUN_FINISHED" },
+    ]);
+  });
+
+  it("cancels the matching worker request when its AbortSignal fires", async () => {
+    const worker = new FakeWorker();
+    const client = new ChatStreamWorkerClient(() => asWorker(worker));
+    const controller = new AbortController();
+    const stream = client.start({
+      url: "/stream",
+      bodyText: "{}",
+      signal: controller.signal,
+      onFrames: () => {},
+    });
+    const id = requestId(worker);
+
+    controller.abort();
+
+    expect(worker.messages.at(-1)).toEqual({
+      type: "stream.cancel",
+      requestId: id,
+    });
+    await expect(stream.headers).resolves.toEqual({ kind: "cancelled" });
+    await expect(stream.completion).resolves.toEqual({ kind: "cancelled" });
+  });
+
+  it("falls back inline after a worker fails before its first message", async () => {
+    const worker = new FakeWorker();
+    const factory = vi
+      .fn<() => Worker | null>()
+      .mockReturnValue(asWorker(worker));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response('data: {"type":"RUN_FINISHED"}\n\n', {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+    const client = new ChatStreamWorkerClient(factory);
+    const firstStream = client.start({
+      url: "/stream/worker",
+      bodyText: "{}",
+      signal: new AbortController().signal,
+      onFrames: () => {},
+    });
+
+    worker.crash();
+    await expect(firstStream.completion).resolves.toMatchObject({
+      kind: "network_error",
+      code: "worker_error",
+    });
+
+    const delivered: unknown[] = [];
+    const fallbackStream = client.start({
+      url: "/stream/inline",
+      bodyText: "{}",
+      signal: new AbortController().signal,
+      onFrames: (frames) => delivered.push(...frames),
+    });
+    await expect(fallbackStream.completion).resolves.toEqual({
+      kind: "complete",
+    });
+    expect(factory).toHaveBeenCalledOnce();
+    expect(delivered).toEqual([{ type: "RUN_FINISHED" }]);
+  });
+
+  it("creates a fresh worker after an established worker crashes", async () => {
+    const first = new FakeWorker();
+    const second = new FakeWorker();
+    const factory = vi
+      .fn<() => Worker | null>()
+      .mockReturnValueOnce(asWorker(first))
+      .mockReturnValueOnce(asWorker(second));
+    const client = new ChatStreamWorkerClient(factory);
+    const firstController = new AbortController();
+    const firstStream = client.start({
+      url: "/stream/one",
+      bodyText: "{}",
+      signal: firstController.signal,
+      onFrames: () => {},
+    });
+
+    first.emit({
+      type: "stream.response",
+      requestId: requestId(first),
+      status: 200,
+      contentType: "text/event-stream",
+    });
+    first.crash();
+
+    await expect(firstStream.completion).resolves.toMatchObject({
+      kind: "network_error",
+      code: "worker_error",
+    });
+    expect(first.terminate).toHaveBeenCalledOnce();
+
+    const secondController = new AbortController();
+    const secondStream = client.start({
+      url: "/stream/two",
+      bodyText: "{}",
+      signal: secondController.signal,
+      onFrames: () => {},
+    });
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(second.messages[0]).toMatchObject({
+      type: "stream.start",
+      url: "/stream/two",
+    });
+    // A duplicate late error from the retired worker must not tear down its
+    // replacement or settle the replacement's requests.
+    first.crash();
+    expect(second.terminate).not.toHaveBeenCalled();
+    secondController.abort();
+    await expect(secondStream.completion).resolves.toEqual({
+      kind: "cancelled",
+    });
+  });
+
+  it("cancels the inline reader when frame delivery throws", async () => {
+    const cancel = vi.fn();
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"type":"RUN_STARTED"}\n\n'));
+      },
+      cancel,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+    const client = new ChatStreamWorkerClient(() => null);
+    const stream = client.start({
+      url: "/stream",
+      bodyText: "{}",
+      signal: new AbortController().signal,
+      onFrames: () => {
+        throw new Error("adapter failed");
+      },
+    });
+
+    await expect(stream.completion).resolves.toMatchObject({
+      kind: "network_error",
+      code: "worker_error",
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/lib/assistant/chat-stream-worker-client.ts
+++ b/frontend/src/lib/assistant/chat-stream-worker-client.ts
@@ -1,0 +1,365 @@
+import { ChatStreamParser } from "@/lib/assistant/chat-stream-parser";
+import {
+  CHAT_STREAM_MAX_ERROR_BODY_CHARS,
+  type ChatStreamFrame,
+  type ChatStreamWorkerCommand,
+  type ChatStreamWorkerMessage,
+} from "@/lib/assistant/chat-stream-worker-protocol";
+
+export type ChatStreamHeadersResult =
+  | {
+      readonly kind: "response";
+      readonly status: number;
+      readonly contentType: string;
+    }
+  | {
+      readonly kind: "http_error";
+      readonly status: number;
+      readonly body: string;
+    }
+  | {
+      readonly kind: "network_error";
+      readonly code: "network_error" | "stream_closed" | "worker_error";
+      readonly message: string;
+    }
+  | { readonly kind: "cancelled" };
+
+export type ChatStreamCompletionResult =
+  | { readonly kind: "complete" }
+  | Exclude<ChatStreamHeadersResult, { kind: "response" }>;
+
+export interface ChatStreamRequest {
+  readonly url: string;
+  readonly bodyText: string;
+  readonly signal: AbortSignal;
+  readonly onFrames: (frames: readonly ChatStreamFrame[]) => void;
+}
+
+export interface ChatStreamRequestHandle {
+  readonly headers: Promise<ChatStreamHeadersResult>;
+  readonly completion: Promise<ChatStreamCompletionResult>;
+  cancel(): void;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+interface PendingRequest {
+  readonly headers: Deferred<ChatStreamHeadersResult>;
+  readonly completion: Deferred<ChatStreamCompletionResult>;
+  readonly onFrames: (frames: readonly ChatStreamFrame[]) => void;
+  readonly removeAbortListener: () => void;
+  settled: boolean;
+}
+
+type WorkerFactory = () => Worker | null;
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: (value) => resolvePromise?.(value) };
+}
+
+function createModuleWorker(): Worker | null {
+  if (typeof Worker === "undefined" || import.meta.env.MODE === "test") {
+    return null;
+  }
+  try {
+    return new Worker(new URL("./chat-stream.worker.ts", import.meta.url), {
+      type: "module",
+      name: "nyxid-assistant-stream",
+    });
+  } catch {
+    return null;
+  }
+}
+
+function networkFailure(
+  code: "network_error" | "stream_closed" | "worker_error",
+  message: string,
+): Extract<ChatStreamHeadersResult, { kind: "network_error" }> {
+  return { kind: "network_error", code, message };
+}
+
+export class ChatStreamWorkerClient {
+  private worker: Worker | null = null;
+  private workerReady = false;
+  private workerUnavailable = false;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly workerFactory: WorkerFactory;
+
+  constructor(workerFactory: WorkerFactory = createModuleWorker) {
+    this.workerFactory = workerFactory;
+  }
+
+  start(request: ChatStreamRequest): ChatStreamRequestHandle {
+    const worker = this.getWorker();
+    return worker
+      ? this.startWorkerRequest(worker, request)
+      : this.startInline(request);
+  }
+
+  private getWorker(): Worker | null {
+    if (this.workerUnavailable) return null;
+    if (this.worker) return this.worker;
+    const worker = this.workerFactory();
+    if (!worker) return null;
+    worker.onmessage = (event: MessageEvent<ChatStreamWorkerMessage>) => {
+      if (this.worker !== worker) return;
+      this.workerReady = true;
+      this.handleWorkerMessage(event.data);
+    };
+    worker.onerror = (event) => {
+      event.preventDefault();
+      this.failWorker(worker);
+    };
+    worker.onmessageerror = () => {
+      this.failWorker(worker);
+    };
+    this.workerReady = false;
+    this.worker = worker;
+    return worker;
+  }
+
+  private startWorkerRequest(
+    worker: Worker,
+    request: ChatStreamRequest,
+  ): ChatStreamRequestHandle {
+    const requestId = crypto.randomUUID();
+    const headers = deferred<ChatStreamHeadersResult>();
+    const completion = deferred<ChatStreamCompletionResult>();
+    const cancel = () => {
+      const pending = this.pending.get(requestId);
+      if (!pending || pending.settled) return;
+      try {
+        worker.postMessage({
+          type: "stream.cancel",
+          requestId,
+        } satisfies ChatStreamWorkerCommand);
+      } catch {
+        // The local request still settles below. A failed/terminated worker
+        // will be replaced on the next stream start.
+      }
+      this.settleRequest(requestId, { kind: "cancelled" });
+    };
+    const onAbort = () => cancel();
+    request.signal.addEventListener("abort", onAbort, { once: true });
+    this.pending.set(requestId, {
+      headers,
+      completion,
+      onFrames: request.onFrames,
+      removeAbortListener: () =>
+        request.signal.removeEventListener("abort", onAbort),
+      settled: false,
+    });
+
+    if (request.signal.aborted) {
+      cancel();
+    } else {
+      try {
+        worker.postMessage({
+          type: "stream.start",
+          requestId,
+          url: request.url,
+          bodyText: request.bodyText,
+        } satisfies ChatStreamWorkerCommand);
+      } catch {
+        this.failWorker(worker);
+      }
+    }
+    return { headers: headers.promise, completion: completion.promise, cancel };
+  }
+
+  private handleWorkerMessage(message: ChatStreamWorkerMessage): void {
+    const request = this.pending.get(message.requestId);
+    if (!request || request.settled) return;
+    switch (message.type) {
+      case "stream.response":
+        request.headers.resolve({
+          kind: "response",
+          status: message.status,
+          contentType: message.contentType,
+        });
+        return;
+      case "stream.batch":
+        this.deliverFrames(message.requestId, request, message.frames);
+        return;
+      case "stream.complete":
+        if (!this.deliverFrames(message.requestId, request, message.frames))
+          return;
+        this.settleRequest(message.requestId, { kind: "complete" });
+        return;
+      case "stream.http_error":
+        this.settleRequest(message.requestId, {
+          kind: "http_error",
+          status: message.status,
+          body: message.body,
+        });
+        return;
+      case "stream.network_error":
+        this.settleRequest(
+          message.requestId,
+          networkFailure(message.code, message.message),
+        );
+        return;
+      case "stream.cancelled":
+        this.settleRequest(message.requestId, { kind: "cancelled" });
+    }
+  }
+
+  private deliverFrames(
+    requestId: string,
+    request: PendingRequest,
+    frames: readonly ChatStreamFrame[],
+  ): boolean {
+    if (frames.length === 0) return true;
+    try {
+      request.onFrames(frames);
+      return true;
+    } catch {
+      this.worker?.postMessage({
+        type: "stream.cancel",
+        requestId,
+      } satisfies ChatStreamWorkerCommand);
+      this.settleRequest(
+        requestId,
+        networkFailure(
+          "worker_error",
+          "The assistant stream could not be processed. Try again.",
+        ),
+      );
+      return false;
+    }
+  }
+
+  private settleRequest(
+    requestId: string,
+    result: ChatStreamCompletionResult,
+  ): void {
+    const request = this.pending.get(requestId);
+    if (!request || request.settled) return;
+    request.settled = true;
+    request.removeAbortListener();
+    if (result.kind !== "complete") request.headers.resolve(result);
+    request.completion.resolve(result);
+    this.pending.delete(requestId);
+  }
+
+  private failWorker(failedWorker: Worker): void {
+    if (this.worker !== failedWorker) return;
+    if (!this.workerReady) this.workerUnavailable = true;
+    this.worker = null;
+    this.workerReady = false;
+    failedWorker.terminate();
+    const failure = networkFailure(
+      "worker_error",
+      "The assistant stream worker stopped unexpectedly. Try again.",
+    );
+    for (const requestId of [...this.pending.keys()]) {
+      this.settleRequest(requestId, failure);
+    }
+  }
+
+  private startInline(request: ChatStreamRequest): ChatStreamRequestHandle {
+    const headers = deferred<ChatStreamHeadersResult>();
+    const completion = deferred<ChatStreamCompletionResult>();
+    const controller = new AbortController();
+    const cancel = () => controller.abort();
+    const onAbort = () => cancel();
+    request.signal.addEventListener("abort", onAbort, { once: true });
+    if (request.signal.aborted) cancel();
+
+    void (async () => {
+      let headersSettled = false;
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+      const settle = (result: ChatStreamCompletionResult) => {
+        request.signal.removeEventListener("abort", onAbort);
+        if (!headersSettled && result.kind !== "complete")
+          headers.resolve(result);
+        completion.resolve(result);
+      };
+      const deliverFrames = async (
+        frames: readonly ChatStreamFrame[],
+      ): Promise<boolean> => {
+        if (frames.length === 0) return true;
+        try {
+          request.onFrames(frames);
+          return true;
+        } catch {
+          await reader?.cancel().catch(() => undefined);
+          settle(
+            networkFailure(
+              "worker_error",
+              "The assistant stream could not be processed. Try again.",
+            ),
+          );
+          return false;
+        }
+      };
+      try {
+        const response = await fetch(request.url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+          },
+          credentials: "include",
+          body: request.bodyText,
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          const body = (await response.text().catch(() => "")).slice(
+            0,
+            CHAT_STREAM_MAX_ERROR_BODY_CHARS,
+          );
+          settle({ kind: "http_error", status: response.status, body });
+          return;
+        }
+        headersSettled = true;
+        headers.resolve({
+          kind: "response",
+          status: response.status,
+          contentType: response.headers.get("content-type") ?? "",
+        });
+        if (!response.body) {
+          settle(
+            networkFailure(
+              "stream_closed",
+              "The assistant stream closed before it started.",
+            ),
+          );
+          return;
+        }
+
+        const parser = new ChatStreamParser();
+        reader = response.body.getReader();
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const frames = parser.push(value);
+          if (!(await deliverFrames(frames))) return;
+        }
+        const finalFrames = parser.finish();
+        if (!(await deliverFrames(finalFrames))) return;
+        settle({ kind: "complete" });
+      } catch {
+        settle(
+          controller.signal.aborted
+            ? { kind: "cancelled" }
+            : networkFailure(
+                "network_error",
+                "The assistant stream was interrupted. Try again.",
+              ),
+        );
+      }
+    })();
+
+    return { headers: headers.promise, completion: completion.promise, cancel };
+  }
+}
+
+export const chatStreamClient = new ChatStreamWorkerClient();

--- a/frontend/src/lib/assistant/chat-stream-worker-protocol.ts
+++ b/frontend/src/lib/assistant/chat-stream-worker-protocol.ts
@@ -1,0 +1,68 @@
+export const CHAT_STREAM_BATCH_INTERVAL_MS = 50;
+export const CHAT_STREAM_MAX_BATCH_FRAMES = 256;
+export const CHAT_STREAM_MAX_ERROR_BODY_CHARS = 65_536;
+
+export type ChatStreamFrame = Record<string, unknown>;
+
+export type ChatStreamWorkerCommand =
+  | {
+      readonly type: "stream.start";
+      readonly requestId: string;
+      readonly url: string;
+      readonly bodyText: string;
+    }
+  | {
+      readonly type: "stream.cancel";
+      readonly requestId: string;
+    };
+
+export type ChatStreamWorkerMessage =
+  | {
+      readonly type: "stream.response";
+      readonly requestId: string;
+      readonly status: number;
+      readonly contentType: string;
+    }
+  | {
+      readonly type: "stream.batch";
+      readonly requestId: string;
+      readonly frames: readonly ChatStreamFrame[];
+    }
+  | {
+      readonly type: "stream.complete";
+      readonly requestId: string;
+      readonly frames: readonly ChatStreamFrame[];
+    }
+  | {
+      readonly type: "stream.http_error";
+      readonly requestId: string;
+      readonly status: number;
+      readonly body: string;
+    }
+  | {
+      readonly type: "stream.network_error";
+      readonly requestId: string;
+      readonly code: "network_error" | "stream_closed" | "worker_error";
+      readonly message: string;
+    }
+  | {
+      readonly type: "stream.cancelled";
+      readonly requestId: string;
+    };
+
+export function isTerminalChatStreamFrame(frame: ChatStreamFrame): boolean {
+  const explicitType = frame["type"];
+  if (typeof explicitType === "string") {
+    const normalized = explicitType.toUpperCase();
+    if (
+      normalized === "RUN_FINISHED" ||
+      normalized === "RUN_ERROR" ||
+      normalized === "RUN_STOPPED"
+    ) {
+      return true;
+    }
+  }
+  return Boolean(
+    frame["runFinished"] ?? frame["runError"] ?? frame["runStopped"],
+  );
+}

--- a/frontend/src/lib/assistant/chat-stream.worker.test.ts
+++ b/frontend/src/lib/assistant/chat-stream.worker.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ChatStreamWorkerCommand,
+  ChatStreamWorkerMessage,
+} from "./chat-stream-worker-protocol";
+
+interface TestWorkerScope {
+  onmessage: ((event: MessageEvent<ChatStreamWorkerCommand>) => void) | null;
+  postMessage: ReturnType<
+    typeof vi.fn<(message: ChatStreamWorkerMessage) => void>
+  >;
+}
+
+async function installWorker(): Promise<TestWorkerScope> {
+  const scope: TestWorkerScope = {
+    onmessage: null,
+    postMessage: vi.fn<(message: ChatStreamWorkerMessage) => void>(),
+  };
+  vi.stubGlobal("self", scope);
+  vi.resetModules();
+  await import("./chat-stream.worker");
+  return scope;
+}
+
+function send(scope: TestWorkerScope, command: ChatStreamWorkerCommand): void {
+  scope.onmessage?.({ data: command } as MessageEvent<ChatStreamWorkerCommand>);
+}
+
+function messages(scope: TestWorkerScope): ChatStreamWorkerMessage[] {
+  return scope.postMessage.mock.calls.map(([message]) => message);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("chat stream worker", () => {
+  it("batches ordered frames and flushes them within the bounded interval", async () => {
+    const encoder = new TextEncoder();
+    let push: (value: Uint8Array) => void = (value) => {
+      void value;
+    };
+    let close: () => void = () => undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        push = (value) => controller.enqueue(value);
+        close = () => controller.close();
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+    const scope = await installWorker();
+    send(scope, {
+      type: "stream.start",
+      requestId: "request-batch",
+      url: "/stream",
+      bodyText: '{"prompt":"hello"}',
+    });
+    await vi.waitFor(() => {
+      expect(messages(scope)[0]).toMatchObject({ type: "stream.response" });
+    });
+
+    push(
+      encoder.encode(
+        [
+          'data: {"type":"RUN_STARTED","turnId":"turn-1"}',
+          "",
+          'data: {"type":"TEXT_MESSAGE_START"}',
+          "",
+          "",
+        ].join("\n"),
+      ),
+    );
+
+    await vi.waitFor(() => {
+      const batch = messages(scope).find(
+        (message) => message.type === "stream.batch",
+      );
+      expect(batch?.type === "stream.batch" && batch.frames).toEqual([
+        { type: "RUN_STARTED", turnId: "turn-1" },
+        { type: "TEXT_MESSAGE_START" },
+      ]);
+    });
+    push(encoder.encode('data: {"type":"RUN_FINISHED"}\n\n'));
+    await vi.waitFor(() => {
+      const batches = messages(scope).filter(
+        (message) => message.type === "stream.batch",
+      );
+      expect(batches[1]).toMatchObject({
+        frames: [{ type: "RUN_FINISHED" }],
+      });
+    });
+    close();
+    await vi.waitFor(() => {
+      expect(
+        messages(scope).some((message) => message.type === "stream.complete"),
+      ).toBe(true);
+    });
+  });
+
+  it("keeps each posted batch within the maximum frame count", async () => {
+    const frames = Array.from({ length: 600 }, (_, index) => ({
+      type: "TEXT_MESSAGE_CONTENT",
+      textMessageContent: { delta: String(index) },
+    }));
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            frames
+              .map(
+                (frame, index) =>
+                  `data: ${JSON.stringify(frame)}${index + 1 < frames.length ? "\n\n" : ""}`,
+              )
+              .join(""),
+          ),
+        );
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+    const scope = await installWorker();
+    send(scope, {
+      type: "stream.start",
+      requestId: "request-bounded",
+      url: "/stream",
+      bodyText: "{}",
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        messages(scope).some((message) => message.type === "stream.complete"),
+      ).toBe(true);
+    });
+    const frameMessages = messages(scope).filter(
+      (message) =>
+        message.type === "stream.batch" || message.type === "stream.complete",
+    );
+    expect(frameMessages.every((message) => message.frames.length <= 256)).toBe(
+      true,
+    );
+    expect(
+      frameMessages.reduce(
+        (total, message) => total + message.frames.length,
+        0,
+      ),
+    ).toBe(600);
+  });
+
+  it("preserves a final frame without an SSE separator", async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"type":"RUN_STARTED","turnId":"turn-2"}\n\n' +
+              'data: {"type":"RUN_FINISHED"}',
+          ),
+        );
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+    const scope = await installWorker();
+    send(scope, {
+      type: "stream.start",
+      requestId: "request-terminal",
+      url: "/stream",
+      bodyText: "{}",
+    });
+
+    await vi.waitFor(() => {
+      const complete = messages(scope).find(
+        (message) => message.type === "stream.complete",
+      );
+      expect(complete?.type === "stream.complete" && complete.frames).toEqual([
+        { type: "RUN_STARTED", turnId: "turn-2" },
+        { type: "RUN_FINISHED" },
+      ]);
+    });
+    expect(
+      messages(scope).some((message) => message.type === "stream.batch"),
+    ).toBe(false);
+  });
+
+  it("returns typed HTTP and network failures", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('{"code":"UPSTREAM_DOWN"}', { status: 502 }),
+      )
+      .mockRejectedValueOnce(new TypeError("connection reset"));
+    vi.stubGlobal("fetch", fetchMock);
+    const scope = await installWorker();
+    send(scope, {
+      type: "stream.start",
+      requestId: "request-http",
+      url: "/stream",
+      bodyText: "{}",
+    });
+    send(scope, {
+      type: "stream.start",
+      requestId: "request-network",
+      url: "/stream",
+      bodyText: "{}",
+    });
+
+    await vi.waitFor(() => {
+      expect(messages(scope)).toEqual(
+        expect.arrayContaining([
+          {
+            type: "stream.http_error",
+            requestId: "request-http",
+            status: 502,
+            body: '{"code":"UPSTREAM_DOWN"}',
+          },
+          {
+            type: "stream.network_error",
+            requestId: "request-network",
+            code: "network_error",
+            message: "The assistant stream was interrupted. Try again.",
+          },
+        ]),
+      );
+    });
+  });
+
+  it("aborts only the matching in-flight request", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        capturedSignal = init?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        });
+      }),
+    );
+    const scope = await installWorker();
+    send(scope, {
+      type: "stream.start",
+      requestId: "request-cancel",
+      url: "/stream",
+      bodyText: "{}",
+    });
+    await vi.waitFor(() => expect(capturedSignal).toBeDefined());
+
+    send(scope, { type: "stream.cancel", requestId: "request-cancel" });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(messages(scope)).toContainEqual({
+        type: "stream.cancelled",
+        requestId: "request-cancel",
+      });
+    });
+  });
+});

--- a/frontend/src/lib/assistant/chat-stream.worker.ts
+++ b/frontend/src/lib/assistant/chat-stream.worker.ts
@@ -1,0 +1,185 @@
+import { ChatStreamParser } from "@/lib/assistant/chat-stream-parser";
+import {
+  CHAT_STREAM_BATCH_INTERVAL_MS,
+  CHAT_STREAM_MAX_BATCH_FRAMES,
+  CHAT_STREAM_MAX_ERROR_BODY_CHARS,
+  isTerminalChatStreamFrame,
+  type ChatStreamFrame,
+  type ChatStreamWorkerCommand,
+  type ChatStreamWorkerMessage,
+} from "@/lib/assistant/chat-stream-worker-protocol";
+
+interface ActiveWorkerRequest {
+  readonly controller: AbortController;
+  frames: ChatStreamFrame[];
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+interface WorkerScope {
+  onmessage: ((event: MessageEvent<ChatStreamWorkerCommand>) => void) | null;
+  postMessage(message: ChatStreamWorkerMessage): void;
+}
+
+const workerScope = self as unknown as WorkerScope;
+const activeRequests = new Map<string, ActiveWorkerRequest>();
+
+function post(message: ChatStreamWorkerMessage): void {
+  workerScope.postMessage(message);
+}
+
+function clearBatchTimer(request: ActiveWorkerRequest): void {
+  if (request.timer === null) return;
+  clearTimeout(request.timer);
+  request.timer = null;
+}
+
+function flushBatch(requestId: string, request: ActiveWorkerRequest): void {
+  clearBatchTimer(request);
+  if (request.frames.length === 0) return;
+  const frames = request.frames;
+  request.frames = [];
+  post({ type: "stream.batch", requestId, frames });
+}
+
+function enqueueFrames(
+  requestId: string,
+  request: ActiveWorkerRequest,
+  frames: readonly ChatStreamFrame[],
+): void {
+  if (frames.length === 0) return;
+  for (const frame of frames) {
+    request.frames.push(frame);
+    if (
+      request.frames.length >= CHAT_STREAM_MAX_BATCH_FRAMES ||
+      isTerminalChatStreamFrame(frame)
+    ) {
+      flushBatch(requestId, request);
+    }
+  }
+  if (request.frames.length === 0) return;
+  request.timer ??= setTimeout(() => {
+    if (activeRequests.get(requestId) === request) {
+      flushBatch(requestId, request);
+    }
+  }, CHAT_STREAM_BATCH_INTERVAL_MS);
+}
+
+function completeRequest(
+  requestId: string,
+  request: ActiveWorkerRequest,
+  frames: readonly ChatStreamFrame[],
+): void {
+  clearBatchTimer(request);
+  request.frames.push(...frames);
+  while (request.frames.length > CHAT_STREAM_MAX_BATCH_FRAMES) {
+    post({
+      type: "stream.batch",
+      requestId,
+      frames: request.frames.splice(0, CHAT_STREAM_MAX_BATCH_FRAMES),
+    });
+  }
+  const finalFrames = request.frames;
+  request.frames = [];
+  post({ type: "stream.complete", requestId, frames: finalFrames });
+}
+
+async function runRequest(
+  command: Extract<ChatStreamWorkerCommand, { type: "stream.start" }>,
+  request: ActiveWorkerRequest,
+): Promise<void> {
+  const { requestId } = command;
+  try {
+    const response = await fetch(command.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      credentials: "include",
+      body: command.bodyText,
+      signal: request.controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = (await response.text().catch(() => "")).slice(
+        0,
+        CHAT_STREAM_MAX_ERROR_BODY_CHARS,
+      );
+      post({
+        type: "stream.http_error",
+        requestId,
+        status: response.status,
+        body,
+      });
+      return;
+    }
+
+    post({
+      type: "stream.response",
+      requestId,
+      status: response.status,
+      contentType: response.headers.get("content-type") ?? "",
+    });
+
+    if (!response.body) {
+      post({
+        type: "stream.network_error",
+        requestId,
+        code: "stream_closed",
+        message: "The assistant stream closed before it started.",
+      });
+      return;
+    }
+
+    const parser = new ChatStreamParser();
+    const reader = response.body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      enqueueFrames(requestId, request, parser.push(value));
+    }
+    completeRequest(requestId, request, parser.finish());
+  } catch {
+    post(
+      request.controller.signal.aborted
+        ? { type: "stream.cancelled", requestId }
+        : {
+            type: "stream.network_error",
+            requestId,
+            code: "network_error",
+            message: "The assistant stream was interrupted. Try again.",
+          },
+    );
+  } finally {
+    clearBatchTimer(request);
+    if (activeRequests.get(requestId) === request) {
+      activeRequests.delete(requestId);
+    }
+  }
+}
+
+workerScope.onmessage = (event) => {
+  const command = event.data;
+  if (command.type === "stream.cancel") {
+    const request = activeRequests.get(command.requestId);
+    if (request) {
+      clearBatchTimer(request);
+      request.controller.abort();
+      activeRequests.delete(command.requestId);
+    }
+    return;
+  }
+
+  const previous = activeRequests.get(command.requestId);
+  if (previous) {
+    clearBatchTimer(previous);
+    previous.controller.abort();
+  }
+  const request: ActiveWorkerRequest = {
+    controller: new AbortController(),
+    frames: [],
+    timer: null,
+  };
+  activeRequests.set(command.requestId, request);
+  void runRequest(command, request);
+};

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -513,8 +513,25 @@ const MOCK_NOTIFICATION_SETTINGS = {
 };
 
 // ── Approval Requests ──
+// Every row carries `expires_at`, matching the required backend response
+// field. Consumers sort on it, so omitting it makes mock mode diverge from
+// production and can crash the Approvals view.
 const MOCK_APPROVAL_REQUESTS = {
   requests: [
+    {
+      id: "ar-0000",
+      service_name: "Lark", service_slug: "lark-bot",
+      requester_type: "api_key", requester_label: "claude-code-agent",
+      operation_summary: "POST /im/v1/messages",
+      action_description: "Post the drafted summary to #payments-oncall",
+      tool_name: null, tool_call_id: null, tool_arguments: null,
+      is_destructive: false, approval_mode: "per_request" as const,
+      status: "pending" as const,
+      created_at: new Date(Date.now() - 60_000).toISOString(),
+      decided_at: null,
+      expires_at: new Date(Date.now() + 14 * 60_000).toISOString(),
+      decision_channel: null,
+    },
     {
       id: "ar-0001",
       service_name: "OpenAI", service_slug: "openai",
@@ -525,6 +542,7 @@ const MOCK_APPROVAL_REQUESTS = {
       is_destructive: false, approval_mode: "per_request" as const,
       status: "approved" as const,
       created_at: "2026-05-06T14:20:00Z", decided_at: "2026-05-06T14:20:05Z",
+      expires_at: "2026-05-06T14:25:00Z",
       decision_channel: "telegram",
     },
     {
@@ -537,6 +555,7 @@ const MOCK_APPROVAL_REQUESTS = {
       is_destructive: true, approval_mode: "per_request" as const,
       status: "rejected" as const,
       created_at: "2026-05-05T18:00:00Z", decided_at: "2026-05-05T18:01:30Z",
+      expires_at: "2026-05-05T18:05:00Z",
       decision_channel: "push",
     },
     {
@@ -549,10 +568,11 @@ const MOCK_APPROVAL_REQUESTS = {
       is_destructive: false, approval_mode: "grant" as const,
       status: "approved" as const,
       created_at: "2026-05-04T10:00:00Z", decided_at: "2026-05-04T10:00:12Z",
+      expires_at: "2026-05-04T10:05:00Z",
       decision_channel: "telegram",
     },
   ],
-  total: 3, page: 1, per_page: 20,
+  total: 4, page: 1, per_page: 20,
 };
 
 // ── Approval Grants ──
@@ -1407,7 +1427,11 @@ const MOCK_FULL_CATALOG = (() => {
 })();
 
 // ── Dynamic endpoint resolver ──
-type MockHandler = (path: string) => unknown | undefined;
+// `path` is query-stripped so anchored endpoint patterns keep matching.
+type MockHandler = (
+  path: string,
+  params: URLSearchParams,
+) => unknown | undefined;
 
 const MOCK_HANDLERS: MockHandler[] = [
   // User
@@ -1485,7 +1509,17 @@ const MOCK_HANDLERS: MockHandler[] = [
   (p) => p.match(/^\/notifications\/telegram/) ? { link_code: "MOCK-LINK-CODE", bot_username: "nyxid_approvals_bot", expires_in_secs: 600 } : undefined,
 
   // Approvals
-  (p) => p.match(/^\/approvals\/requests/) ? MOCK_APPROVAL_REQUESTS : undefined,
+  // The real handler filters by status server-side; the assistant view relies
+  // on that behavior and deliberately does not re-filter the response.
+  (p, params) => {
+    if (!p.match(/^\/approvals\/requests/)) return undefined;
+    const status = params.get("status");
+    if (!status) return MOCK_APPROVAL_REQUESTS;
+    const requests = MOCK_APPROVAL_REQUESTS.requests.filter(
+      (request) => request.status === status,
+    );
+    return { ...MOCK_APPROVAL_REQUESTS, requests, total: requests.length };
+  },
   (p) => p.match(/^\/approvals\/grants/) ? MOCK_APPROVAL_GRANTS : undefined,
   (p) => p.match(/^\/approvals\/service-configs/) ? MOCK_SERVICE_APPROVAL_CONFIGS : undefined,
 
@@ -1664,10 +1698,11 @@ export function getMockResponse(
   body?: unknown,
 ): unknown | undefined {
   const [path = endpoint, query = ""] = endpoint.split("?", 2);
+  const params = new URLSearchParams(query);
   if (
     method === "GET" &&
     path === "/catalog" &&
-    new URLSearchParams(query).get("include_all") === "true"
+    params.get("include_all") === "true"
   ) {
     return { entries: MOCK_FULL_CATALOG };
   }
@@ -1701,7 +1736,7 @@ export function getMockResponse(
     };
   }
   for (const handler of MOCK_HANDLERS) {
-    const result = handler(path);
+    const result = handler(path, params);
     if (result !== undefined) return result;
   }
   return undefined;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toast";
 import { ChunkErrorBoundary } from "@/components/chunk-error-boundary";
 import { AppNotFound } from "@/components/shared/app-not-found";
+import { AppRouteError } from "@/components/shared/app-route-error";
 import { AuthLayout } from "@/components/layout/auth-layout";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { BillingRouteGuard } from "@/components/billing-route-guard";
@@ -908,6 +909,10 @@ export const router = createRouter({
   routeTree,
   defaultPreload: "intent",
   defaultNotFoundComponent: AppNotFound,
+  // Without an error component the router's CatchBoundary renders nothing on a
+  // render error, blanking the whole app — nav chrome included — so a single
+  // broken view reads as "every button is dead".
+  defaultErrorComponent: AppRouteError,
 });
 
 declare module "@tanstack/react-router" {


### PR DESCRIPTION
## Summary

The LHS links were correctly wired. The active-conversation failure was caused by main-thread starvation: each streamed token was decoded, parsed, reduced, projected through React Query, and rendered synchronously, so navigation input could be delayed or appear dead while a busy turn was active.

- Move authenticated fetch, UTF-8/SSE framing, JSON parsing, and ordered bounded batching into a module Web Worker.
- Coalesce transport-to-React projection to one update per 50 ms, with immediate terminal flushes.
- Use the shared stream client for initial actor/workflow turns, approval continuations, and action-report continuations while preserving stop fences, idempotent request bodies, retries, and cancellation.
- Fall back inline when workers are unavailable or fail to boot; isolate cancellation per request and replace workers after runtime crashes.
- Harden Approvals mock/query behavior and missing-date ordering, and add a route-level error component so view failures cannot blank the navigation shell.

## Verification

- `npx vitest run src/lib/assistant src/hooks/use-assistant.test.tsx src/components/assistant`: 26 files, 431 tests passed.
- `npx tsc -b`: passed.
- `npm run lint`: passed with 0 errors and 23 existing warnings.
- `npm run build`: passed; emitted the dedicated `chat-stream.worker` production asset.
- `git diff --check origin/rollup-chat-20260730...HEAD`: passed.
- Browser stress run with about 6,000 frames over six seconds: Plugins navigated in 145 ms, Approvals in 121 ms, and Studio in 179 ms; Studio remained on `/dashboard`. No page errors were observed.

## Adversarial review

Opus 5 reviewed worker boot fallback, cancellation and reader cleanup, batch bounds at EOF, and missing-date ordering. After the findings were addressed, the final verdict was: **No material findings. Ship.**