### PR TITLE
fix(docker): copy backend/specs into the image build for embedded catalog overlays

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,9 +42,11 @@ RUN rm -rf backend/src cloud-auth/src \
     target/release/libnyxid_cloud_auth.* \
     target/release/nyxid-server
 
-# Copy the real source code, build script, and docs (docs are embedded via include_str!)
+# Copy the real source code, build script, docs, and catalog spec overlays
+# (docs and specs are embedded via include_str!)
 COPY backend/src backend/src
 COPY backend/build.rs backend/build.rs
+COPY backend/specs backend/specs
 COPY cloud-auth/src cloud-auth/src
 COPY docs/AI_AGENT_PLAYBOOK.md docs/AI_AGENT_PLAYBOOK.md
 


### PR DESCRIPTION
## Summary

Follow-up to #1291: the `publish-images` backend build failed on main ([run 30605260300](https://github.com/ChronoAIProject/NyxID/actions/runs/30605260300)) because `backend/Dockerfile` copies source paths selectively and never copied the new `backend/specs/` directory that `catalog_spec_registry` embeds via `include_str!` — 22 `No such file or directory` errors. The CI Gate builds from the full checkout, and PR CI does not exercise the Docker build (only main pushes do), so #1291's PR checks were green.

One-line fix: `COPY backend/specs backend/specs` before the release build. `cli/Dockerfile.node` already copies the whole `backend/` tree; `Dockerfile.glama` does not build the backend crate.

## Test plan

- [x] Local `docker build -f backend/Dockerfile .` succeeds with the fix (was failing at the same step as CI)
- [ ] `publish-images` green on main after merge