### PR TITLE
fix(catalog): strip schema validation keywords rejected by aevatar workflow admission (follow-up to #1290/#1291)

### DIFF
--- a/backend/specs/catalog/anthropic.openapi.json
+++ b/backend/specs/catalog/anthropic.openapi.json
@@ -33,7 +33,7 @@
                     "description": "Conversation messages with role and content.",
                     "items": { "type": "object", "additionalProperties": true }
                   },
-                  "max_tokens": { "type": "integer", "minimum": 1 },
+                  "max_tokens": { "type": "integer" },
                   "system": { "description": "Optional system prompt." },
                   "temperature": { "type": "number" }
                 }
@@ -69,7 +69,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/cohere.openapi.json
+++ b/backend/specs/catalog/cohere.openapi.json
@@ -117,7 +117,7 @@
                   "model": { "type": "string", "description": "e.g. rerank-v3.5." },
                   "query": { "type": "string" },
                   "documents": { "type": "array", "items": { "type": "string" } },
-                  "top_n": { "type": "integer", "minimum": 1 }
+                  "top_n": { "type": "integer" }
                 }
               }
             }

--- a/backend/specs/catalog/discord-bot.openapi.json
+++ b/backend/specs/catalog/discord-bot.openapi.json
@@ -46,7 +46,7 @@
             "name": "channel_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           }
         ],
         "responses": {
@@ -77,13 +77,13 @@
             "name": "channel_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "before",
@@ -119,7 +119,7 @@
             "name": "channel_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           }
         ],
         "requestBody": {

--- a/backend/specs/catalog/discord.openapi.json
+++ b/backend/specs/catalog/discord.openapi.json
@@ -46,7 +46,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 200 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "after",

--- a/backend/specs/catalog/facebook.openapi.json
+++ b/backend/specs/catalog/facebook.openapi.json
@@ -61,7 +61,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/firecrawl.openapi.json
+++ b/backend/specs/catalog/firecrawl.openapi.json
@@ -67,8 +67,7 @@
             "required": true,
             "description": "Firecrawl agent task id returned by POST /v2/agent.",
             "schema": {
-              "type": "string",
-              "minLength": 1
+              "type": "string"
             }
           }
         ],
@@ -103,7 +102,6 @@
         "properties": {
           "prompt": {
             "type": "string",
-            "minLength": 1,
             "description": "Natural-language task for the Firecrawl agent."
           },
           "urls": {
@@ -125,7 +123,6 @@
           },
           "maxCredits": {
             "type": "integer",
-            "minimum": 1,
             "description": "Optional maximum credits to spend on the task."
           }
         }

--- a/backend/specs/catalog/github.openapi.json
+++ b/backend/specs/catalog/github.openapi.json
@@ -52,13 +52,13 @@
             "name": "per_page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {
@@ -85,8 +85,8 @@
           "requiresApproval": false
         },
         "parameters": [
-          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } },
-          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } }
+          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string" } }
         ],
         "responses": {
           "200": {
@@ -112,8 +112,8 @@
           "requiresApproval": false
         },
         "parameters": [
-          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } },
-          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } },
+          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string" } },
           {
             "name": "state",
             "in": "query",
@@ -131,13 +131,13 @@
             "name": "per_page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {
@@ -162,8 +162,8 @@
           "requiresApproval": true
         },
         "parameters": [
-          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } },
-          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } }
+          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string" } }
         ],
         "requestBody": {
           "required": true,
@@ -174,7 +174,7 @@
                 "required": ["title"],
                 "additionalProperties": true,
                 "properties": {
-                  "title": { "type": "string", "minLength": 1 },
+                  "title": { "type": "string" },
                   "body": { "type": "string" },
                   "labels": { "type": "array", "items": { "type": "string" } },
                   "assignees": { "type": "array", "items": { "type": "string" } }
@@ -207,9 +207,9 @@
           "requiresApproval": true
         },
         "parameters": [
-          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } },
-          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string", "minLength": 1 } },
-          { "name": "issue_number", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+          { "name": "owner", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "repo", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "issue_number", "in": "path", "required": true, "schema": { "type": "integer" } }
         ],
         "requestBody": {
           "required": true,
@@ -220,7 +220,7 @@
                 "required": ["body"],
                 "additionalProperties": false,
                 "properties": {
-                  "body": { "type": "string", "minLength": 1 }
+                  "body": { "type": "string" }
                 }
               }
             }
@@ -255,19 +255,19 @@
             "in": "query",
             "required": true,
             "description": "Search query using GitHub search syntax.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "per_page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/google-ai.openapi.json
+++ b/backend/specs/catalog/google-ai.openapi.json
@@ -26,7 +26,7 @@
             "in": "path",
             "required": true,
             "description": "Model id, e.g. gemini-2.0-flash.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           }
         ],
         "requestBody": {
@@ -78,7 +78,7 @@
             "name": "pageSize",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "pageToken",

--- a/backend/specs/catalog/google.openapi.json
+++ b/backend/specs/catalog/google.openapi.json
@@ -53,7 +53,7 @@
             "name": "maxResults",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 500 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "pageToken",
@@ -90,7 +90,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "format",
@@ -134,7 +134,7 @@
             "name": "pageSize",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "pageToken",
@@ -185,7 +185,7 @@
             "name": "maxResults",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 2500 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "pageToken",

--- a/backend/specs/catalog/lark-bot.openapi.json
+++ b/backend/specs/catalog/lark-bot.openapi.json
@@ -93,7 +93,7 @@
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",
@@ -131,13 +131,13 @@
             "in": "path",
             "required": true,
             "description": "Bitable app token.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",
@@ -174,13 +174,13 @@
             "name": "app_token",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "table_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "view_id",
@@ -206,7 +206,7 @@
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 500 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",
@@ -244,19 +244,19 @@
             "name": "app_token",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "table_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 500 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",

--- a/backend/specs/catalog/lark.openapi.json
+++ b/backend/specs/catalog/lark.openapi.json
@@ -92,7 +92,7 @@
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",
@@ -130,13 +130,13 @@
             "in": "path",
             "required": true,
             "description": "Bitable app token.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",
@@ -173,13 +173,13 @@
             "name": "app_token",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "table_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "view_id",
@@ -205,7 +205,7 @@
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 500 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",
@@ -243,19 +243,19 @@
             "name": "app_token",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "table_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 500 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "page_token",

--- a/backend/specs/catalog/microsoft-graph.openapi.json
+++ b/backend/specs/catalog/microsoft-graph.openapi.json
@@ -46,7 +46,7 @@
             "name": "$top",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "$filter",
@@ -141,7 +141,7 @@
             "name": "$top",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "$filter",
@@ -184,7 +184,7 @@
             "name": "$top",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/reddit.openapi.json
+++ b/backend/specs/catalog/reddit.openapi.json
@@ -46,13 +46,13 @@
             "name": "subreddit",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "after",
@@ -90,7 +90,7 @@
             "name": "q",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "sort",
@@ -109,7 +109,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/slack.openapi.json
+++ b/backend/specs/catalog/slack.openapi.json
@@ -101,7 +101,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "cursor",
@@ -138,13 +138,13 @@
             "name": "channel",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "cursor",
@@ -188,7 +188,7 @@
             "name": "user",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/spotify.openapi.json
+++ b/backend/specs/catalog/spotify.openapi.json
@@ -46,26 +46,26 @@
             "name": "q",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "type",
             "in": "query",
             "required": true,
             "description": "Comma-separated: album, artist, playlist, track, show, episode, audiobook.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 50 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 0 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {
@@ -96,13 +96,13 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 50 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 0 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/telegram-bot.openapi.json
+++ b/backend/specs/catalog/telegram-bot.openapi.json
@@ -54,7 +54,7 @@
                     "description": "Target chat id or @channelusername.",
                     "type": ["integer", "string"]
                   },
-                  "text": { "type": "string", "minLength": 1 },
+                  "text": { "type": "string" },
                   "parse_mode": {
                     "type": "string",
                     "enum": ["MarkdownV2", "HTML", "Markdown"]
@@ -94,7 +94,7 @@
             "in": "query",
             "required": true,
             "description": "Chat id or @channelusername.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           }
         ],
         "responses": {
@@ -132,13 +132,13 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "timeout",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 0 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/twitch.openapi.json
+++ b/backend/specs/catalog/twitch.openapi.json
@@ -73,7 +73,7 @@
             "name": "first",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "after",
@@ -110,7 +110,7 @@
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "live_only",
@@ -122,7 +122,7 @@
             "name": "first",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100 }
+            "schema": { "type": "integer" }
           }
         ],
         "responses": {

--- a/backend/specs/catalog/twitter.openapi.json
+++ b/backend/specs/catalog/twitter.openapi.json
@@ -56,13 +56,13 @@
             "in": "query",
             "required": true,
             "description": "Search query using X search operators.",
-            "schema": { "type": "string", "minLength": 1 }
+            "schema": { "type": "string" }
           },
           {
             "name": "max_results",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "minimum": 10, "maximum": 100 }
+            "schema": { "type": "integer" }
           },
           {
             "name": "next_token",


### PR DESCRIPTION
## Summary

Follow-up to #1290 / #1291. The overlays shipped in #1291 are live (verified: 45 services in `/api/v1/mcp/config`, `invalid_contract_services` 44 → 12, all `api-lark-bot` instances now publish 5 endpoints) — but binding an aevatar v4 workflow against them still fails, one layer deeper:

```
NYXID_ENDPOINT_SCHEMA_UNSUPPORTED: The endpoint schema is outside the supported workflow contract subset.
```

aevatar's admission proof builder (`NyxIdOperationAdmissionProofBuilder.cs`) accepts only a fixed schema-keyword whitelist — `type, enum, properties, required, items, additionalProperties, title, description, default, example, examples, deprecated` — and drops the whole endpoint on any other keyword (`HasMalformedKeyword`). The #1291 overlays use `minLength` / `minimum` / `maximum`, so 4 of 5 lark-bot endpoints (and equivalents across 17 other overlays: 110 occurrences total) are inadmissible. The #1290 goal — catalog services bindable by aevatar workflows — is therefore still unmet in practice.

## Change

Mechanically strip `minLength` / `minimum` / `maximum` from parameter and body schemas in all 18 affected overlays (78+/81− across single lines; formatting untouched). These keywords are advisory only — the upstream APIs enforce the real limits at runtime — so the change is behavior-neutral for proxying while making every overlay operation admissible.

The alternative (aevatar widening its whitelist) also works but is code + tests + a release on the other side; this is data-only and unblocks immediately. Happy to close this in favor of that route if preferred.

## Verification

- All 22 catalog specs still parse as JSON.
- Whitelist re-scan across all overlays: zero violations remaining except the known residuals below.
- We hold a fully v4-migrated workflow (6 read ops + 1 send op against lark-bot endpoints, opaque endpoint ids) ready to re-bind — we can confirm end-to-end admission within minutes of this deploying.

## Known residuals (left untouched — need semantic decisions, out of scope here)

- `firecrawl.openapi.json`: 3× `$ref` (aevatar rejects unresolved refs)
- `mistral` / `openai` / `telegram-bot`: 4× union `type` arrays (aevatar accepts only single normalized types)

These endpoints remain inadmissible to aevatar until resolved; listing them here so they don't surprise the next consumer.
