### PR TITLE
fix(evals): move skill-eval fixture bin under the workspace root

### DIFF
--- a/skills/nyxid/evals/run_trigger_evals.rb
+++ b/skills/nyxid/evals/run_trigger_evals.rb
@@ -193,7 +193,10 @@ Dir.mktmpdir("nyxid-openclaw-trigger-evals-") do |tmpdir|
   home_dir = File.join(tmpdir, "home")
   state_dir = File.join(tmpdir, "state")
   workspace_dir = File.join(tmpdir, "workspace")
-  fixture_bin = File.join(tmpdir, "bin")
+  # Must live under the workspace: OpenClaw's sandbox only allows bind-mount
+  # sources beneath its allowed roots (workspace, state/sandboxes) and
+  # rejects sources elsewhere in the temp dir.
+  fixture_bin = File.join(workspace_dir, ".fixture-bin")
   fixture_skill_dir = File.join(workspace_dir, "skills", skill_name)
   FileUtils.mkdir_p([home_dir, state_dir, fixture_bin, fixture_skill_dir])
   FileUtils.cp(skill_path, File.join(fixture_skill_dir, "SKILL.md"))


### PR DESCRIPTION
OpenClaw's sandbox now rejects bind-mount sources outside its allowed roots (`workspace`, `state/sandboxes`); the trigger-eval harness mounted its fixture `bin` from the temp-dir root, so all 12 trigger cases fail infrastructurally on every skills-touching PR (seen on #1293/#1295 heads and main).

One-line move of the fixture bin to `workspace/.fixture-bin`.

Bootstrap note: the evaluate job checks out the **trusted evaluator from the default branch**, so this PR's own "NyxID Skill Trigger Evaluations" check still runs the broken pre-fix harness and stays red — it cannot go green before this lands. The check is not required; after merge, re-running a skills PR's CI re-fires the eval against the fixed harness (verification plan: re-run #1295's CI Gate).