### PR TITLE
fix(evals): migrate skill-trigger evaluator from retired GitHub Models to OpenAI

### DIFF
--- a/.github/workflows/skill-trigger-evals.yml
+++ b/.github/workflows/skill-trigger-evals.yml
@@ -75,8 +75,19 @@ jobs:
     permissions:
       actions: read
       contents: read
-      models: read
     steps:
+      # GitHub Models was retired, so the evaluator calls the OpenAI API
+      # with the NYXID_SKILL_EVAL_API_KEY repository secret. Fail with a
+      # clear provisioning message instead of an opaque empty-model run.
+      - name: Require evaluator API key secret
+        env:
+          EVAL_API_KEY: ${{ secrets.NYXID_SKILL_EVAL_API_KEY }}
+        run: |
+          if [ -z "$EVAL_API_KEY" ]; then
+            echo "::error::NYXID_SKILL_EVAL_API_KEY repository secret is not set. Provision an OpenAI API key (used for gpt-4.1-mini trigger evaluations) to run this check."
+            exit 1
+          fi
+
       - name: Check out trusted evaluator
         uses: actions/checkout@v6
         with:
@@ -107,7 +118,7 @@ jobs:
 
       - name: Exercise native OpenClaw skill selection
         env:
-          NYXID_SKILL_EVAL_API_KEY: ${{ github.token }}
+          NYXID_SKILL_EVAL_API_KEY: ${{ secrets.NYXID_SKILL_EVAL_API_KEY }}
           NYXID_SKILL_EVAL_GH_TOKEN: ${{ github.token }}
         run: >-
           ruby skills/nyxid/evals/run_trigger_evals.rb

--- a/skills/nyxid/evals/run_trigger_evals.rb
+++ b/skills/nyxid/evals/run_trigger_evals.rb
@@ -11,9 +11,14 @@ require "yaml"
 MAX_SKILL_BYTES = 256 * 1024
 MAX_CASES_BYTES = 128 * 1024
 GH_AUTH_MARKER = "NYXID_EVAL_GH_AUTH_VERIFIED"
-MODEL_PROVIDER = "github-models"
-MODEL_ID = "openai/gpt-4.1-mini"
+# GitHub Models was retired (inference API returns
+# github_models_retirement_brownout), so the evaluator talks to the OpenAI
+# API directly. NYXID_SKILL_EVAL_BASE_URL overrides the endpoint for any
+# OpenAI-compatible gateway (e.g. a NyxID-brokered proxy in local runs).
+MODEL_PROVIDER = "openai"
+MODEL_ID = "gpt-4.1-mini"
 MODEL_REF = "#{MODEL_PROVIDER}/#{MODEL_ID}"
+MODEL_BASE_URL = ENV.fetch("NYXID_SKILL_EVAL_BASE_URL", "https://api.openai.com/v1")
 
 options = {
   candidate_root: File.expand_path("..", __dir__),
@@ -230,7 +235,7 @@ Dir.mktmpdir("nyxid-openclaw-trigger-evals-") do |tmpdir|
       "mode" => "replace",
       "providers" => {
         MODEL_PROVIDER => {
-          "baseUrl" => "https://models.github.ai/inference",
+          "baseUrl" => MODEL_BASE_URL,
           "apiKey" => "${NYXID_SKILL_EVAL_API_KEY}",
           "api" => "openai-completions",
           "models" => [


### PR DESCRIPTION
## Summary

The skill-trigger evaluator's model backend is gone: GitHub Models returns `github_models_retirement_brownout` and OpenClaw surfaces it as an empty assistant turn, so the agent makes zero tool calls and every trigger case fails regardless of skill content.

Diagnosis (all locally reproduced):
- Same failures with the current SKILL.md **and** the pre-#1218 SKILL.md → not a skill regression.
- Captured agent transcript shows an empty assistant message → model returned nothing.
- Direct `curl` to `models.github.ai/inference` → `github_models_retirement_brownout`.
- The evaluator job had not actually executed in any of the last 100 runs — every recent 'success' was a path-filter skip — so the retirement went unnoticed until today's skills-touching PRs (#1293/#1295/#1296) woke the gate up. The other half of the breakage (sandbox bind-mount policy) was fixed in #1297.

## Change

- Harness: `openai / gpt-4.1-mini` via `api.openai.com/v1` (same model, first-party). `NYXID_SKILL_EVAL_BASE_URL` overrides the endpoint for any OpenAI-compatible gateway (e.g. NyxID-brokered proxy for local runs).
- Workflow: `NYXID_SKILL_EVAL_API_KEY` now comes from the **repository secret** with a fail-fast provisioning message when unset; `models: read` permission dropped. `NYXID_SKILL_EVAL_GH_TOKEN` (the `gh auth` fixture precondition) stays `github.token`.
- Key exposure posture unchanged: the key lives in the host harness process only; agent tool execution runs in the `network: none` docker sandbox without the key in its env.

## Required before this can go green

**Provision the `NYXID_SKILL_EVAL_API_KEY` repository secret** (an OpenAI API key; usage is gpt-4.1-mini, 12 short cases per skills-touching PR — cents per run).

## Validation status

- [x] Harness runs end-to-end locally against an OpenAI-compatible endpoint (via `NYXID_SKILL_EVAL_BASE_URL`); reaches the model, produces transcripts
- [ ] Full 12-case pass pending a usable key: local NyxID-brokered validation hit the org approval flow (request timed out awaiting approval); first CI run after the secret is provisioned validates end-to-end
- [x] This PR's own eval check still runs the pre-migration main harness (trusted-evaluator design) and stays red until merge + secret