### PR TITLE
fix(assistant): preserve live action cards across history materialization

### DIFF
--- a/frontend/src/hooks/use-assistant.aevatar.test.tsx
+++ b/frontend/src/hooks/use-assistant.aevatar.test.tsx
@@ -1,0 +1,484 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSendMessage, assistantKeys } from "@/hooks/use-assistant";
+import { AevatarAssistantTransport } from "@/lib/assistant/aevatar-transport";
+import {
+  chatStreamClient,
+  type ChatStreamRequest,
+  type ChatStreamRequestHandle,
+} from "@/lib/assistant/chat-stream-worker-client";
+import type { ChatStreamFrame } from "@/lib/assistant/chat-stream-worker-protocol";
+import { assistantTransport } from "@/lib/assistant/transport";
+import type {
+  ConversationHistory,
+  TurnEpisode,
+  TurnEvent,
+} from "@/types/assistant";
+
+const SERVER_CONVERSATION = "chatc-8bd999c402fb37d60cdcd81e3b78cfd";
+const TURN_ID = "turn-d619940adcd817c4aeb5d1c3e57f1ca5";
+const RUN_ACTOR = "workflow-definition:studio:run:probe";
+const HISTORY_URL = `/api/v1/assistant/conversations/${SERVER_CONVERSATION}`;
+
+type HistoryMode = "missing" | "materialized";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function serverHistory(assistantText: string) {
+  return {
+    messages: [
+      {
+        id: `${TURN_ID}:user`,
+        role: "user",
+        content: "Connect GitHub",
+        timestamp: 1785297207000,
+        turnId: TURN_ID,
+      },
+      {
+        id: `${TURN_ID}:assistant`,
+        role: "assistant",
+        content: assistantText,
+        timestamp: 1785297208000,
+        turnId: TURN_ID,
+        status: "blocked",
+      },
+    ],
+    stateVersion: 4,
+  };
+}
+
+function workflowContextFrame(): ChatStreamFrame {
+  return {
+    custom: {
+      name: "aevatar.chat.context",
+      payload: {
+        "@type":
+          "type.googleapis.com/aevatar.workflow.runs.WorkflowChatContextPayload",
+        scopeId: "user-probe",
+        conversationId: SERVER_CONVERSATION,
+        turnId: TURN_ID,
+        stateVersion: "3",
+      },
+    },
+  };
+}
+
+function actionRequestFrame(): ChatStreamFrame {
+  return {
+    type: "CUSTOM",
+    custom: {
+      name: "nyxid.action.request",
+      payload: {
+        schemaVersion: 4,
+        actorId: "nyxid-chat-workflow-action-probe",
+        originTurnId: TURN_ID,
+        taskId: "task-probe",
+        stepId: "step-probe",
+        actionRequestId: "action-probe",
+        action: "service.connect",
+        params: {
+          catalogService: {
+            serviceSlug: "api-github",
+            requestedScopes: ["repo"],
+          },
+        },
+      },
+    },
+  };
+}
+
+function hasActionCard(history: ConversationHistory | undefined): boolean {
+  return (
+    history?.messages.some((message) =>
+      message.blocks.some((block) => block.type === "action_card"),
+    ) ?? false
+  );
+}
+
+function createHarness() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, Wrapper };
+}
+
+interface ManualStream {
+  request: ChatStreamRequest | null;
+  emit(frames: readonly ChatStreamFrame[]): void;
+  finish(): void;
+}
+
+function installManualStream(): ManualStream {
+  let request: ChatStreamRequest | null = null;
+  let settle: ((result: { readonly kind: "complete" }) => void) | undefined;
+  vi.spyOn(chatStreamClient, "start").mockImplementation((nextRequest) => {
+    request = nextRequest;
+    const completion = new Promise<{ readonly kind: "complete" }>((resolve) => {
+      settle = resolve;
+    });
+    return {
+      headers: Promise.resolve({
+        kind: "response",
+        status: 200,
+        contentType: "text/event-stream",
+      }),
+      completion,
+      cancel: vi.fn(),
+    } satisfies ChatStreamRequestHandle;
+  });
+  return {
+    get request() {
+      return request;
+    },
+    emit(frames) {
+      if (!request) throw new Error("The workflow stream has not started.");
+      request.onFrames(frames);
+    },
+    finish() {
+      if (!settle) throw new Error("The workflow stream has not started.");
+      settle({ kind: "complete" });
+    },
+  };
+}
+
+function bindHookTransport(
+  transport: AevatarAssistantTransport,
+  observedEvents: TurnEvent[],
+): void {
+  vi.spyOn(assistantTransport, "getHistory").mockImplementation((id) =>
+    transport.getHistory(id),
+  );
+  vi.spyOn(assistantTransport, "listConversations").mockImplementation(() =>
+    transport.listConversations(),
+  );
+  vi.spyOn(assistantTransport, "sendMessage").mockImplementation(
+    (id, content, onEvent) =>
+      transport.sendMessage(id, content, (event) => {
+        observedEvents.push(event);
+        onEvent(event);
+      }),
+  );
+  vi.spyOn(assistantTransport, "cancelActiveTurn").mockImplementation((id) =>
+    transport.cancelActiveTurn(id),
+  );
+}
+
+interface ProbeSession {
+  readonly transport: AevatarAssistantTransport;
+  readonly placeholderId: string;
+  readonly stream: ManualStream;
+  readonly queryClient: QueryClient;
+  readonly observedEvents: TurnEvent[];
+  readonly cacheSawCardWhileRunning: () => boolean;
+  readonly advanceHistoryClock: (milliseconds: number) => void;
+  readonly setHistoryMode: (mode: HistoryMode) => void;
+  readonly setServerAssistantText: (text: string) => void;
+  readonly unmount: () => void;
+}
+
+async function startProbe(): Promise<ProbeSession> {
+  let historyMode: HistoryMode = "missing";
+  let serverAssistantText =
+    "Complete the requested action in NyxID, then continue this conversation.";
+  let now = Date.parse("2026-07-31T13:00:00.000Z");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url === "/api/v1/assistant/conversations" &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        return Promise.resolve(jsonResponse({ conversations: [] }));
+      }
+      if (url === HISTORY_URL && (init?.method ?? "GET") === "GET") {
+        return Promise.resolve(
+          historyMode === "missing"
+            ? jsonResponse(
+                { error: "not_found", error_code: -1, message: "404" },
+                404,
+              )
+            : jsonResponse(serverHistory(serverAssistantText)),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(
+          { error: "not_found", error_code: -1, message: "404" },
+          404,
+        ),
+      );
+    }),
+  );
+
+  const transport = new AevatarAssistantTransport(() => now);
+  const conversation = await transport.createConversation();
+  const observedEvents: TurnEvent[] = [];
+  bindHookTransport(transport, observedEvents);
+  const stream = installManualStream();
+  const { queryClient, Wrapper } = createHarness();
+  let cacheSawCardWhileRunning = false;
+  const unsubscribe = queryClient.getQueryCache().subscribe(() => {
+    const history = queryClient.getQueryData<ConversationHistory>(
+      assistantKeys.history(conversation.id),
+    );
+    const terminalSeen = observedEvents.some(
+      (event) => event.event === "turn.completed",
+    );
+    if (!terminalSeen && hasActionCard(history)) {
+      cacheSawCardWhileRunning = true;
+    }
+  });
+  const hook = renderHook(() => useSendMessage(conversation.id), {
+    wrapper: Wrapper,
+  });
+
+  await act(async () => {
+    await hook.result.current.mutateAsync("Connect GitHub");
+  });
+  await vi.waitFor(() => expect(stream.request).not.toBeNull());
+
+  return {
+    transport,
+    placeholderId: conversation.id,
+    stream,
+    queryClient,
+    observedEvents,
+    cacheSawCardWhileRunning: () => cacheSawCardWhileRunning,
+    advanceHistoryClock: (milliseconds) => {
+      now += milliseconds;
+    },
+    setHistoryMode: (mode) => {
+      historyMode = mode;
+    },
+    setServerAssistantText: (text) => {
+      serverAssistantText = text;
+    },
+    unmount: () => {
+      unsubscribe();
+      hook.unmount();
+      queryClient.clear();
+    },
+  };
+}
+
+async function finishAndWait(session: ProbeSession): Promise<void> {
+  await act(async () => {
+    session.stream.finish();
+  });
+  await vi.waitFor(() => {
+    expect(
+      session.observedEvents.some(
+        (event) => event.event === "turn.completed",
+      ),
+    ).toBe(true);
+  });
+  await vi.waitFor(() => {
+    const episode = session.queryClient.getQueryData<TurnEpisode | null>(
+      assistantKeys.episode(session.placeholderId),
+    );
+    expect(episode?.projecting).toBe(false);
+  });
+}
+
+async function switchRead(session: ProbeSession): Promise<ConversationHistory> {
+  session.queryClient.removeQueries({
+    queryKey: assistantKeys.history(session.placeholderId),
+  });
+  const history = await session.transport.getHistory(session.placeholderId);
+  session.queryClient.setQueryData(
+    assistantKeys.history(session.placeholderId),
+    history,
+  );
+  return history;
+}
+
+function mirrorMintedCard(events: readonly TurnEvent[]): boolean {
+  return events.some(
+    (event) =>
+      event.event === "block.started" && event.block.type === "action_card",
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("workflow action-card projection probes", () => {
+  it("S1 preserves a card when streamed text makes the local transcript longer", async () => {
+    const session = await startProbe();
+    session.stream.emit([
+      workflowContextFrame(),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      { textMessageStart: { messageId: "message-s1", role: "assistant" } },
+      {
+        textMessageContent: {
+          messageId: "message-s1",
+          delta: "Connect GitHub to continue.",
+        },
+      },
+      { textMessageEnd: { messageId: "message-s1" } },
+      actionRequestFrame(),
+      { runFinished: { threadId: RUN_ACTOR, status: "completed" } },
+    ]);
+    session.setHistoryMode("materialized");
+    await finishAndWait(session);
+
+    expect(mirrorMintedCard(session.observedEvents)).toBe(true);
+    expect(session.cacheSawCardWhileRunning()).toBe(false);
+    expect(
+      hasActionCard(
+        session.queryClient.getQueryData(
+          assistantKeys.history(session.placeholderId),
+        ),
+      ),
+    ).toBe(true);
+    const withinGrace = await switchRead(session);
+    expect(hasActionCard(withinGrace)).toBe(true);
+    expect(withinGrace.messages.map((message) => message.id)).not.toContain(
+      `${TURN_ID}:assistant`,
+    );
+    session.unmount();
+  });
+
+  it("S2 preserves a card-only blocked turn while adopting materialized text after grace", async () => {
+    const session = await startProbe();
+    session.stream.emit([
+      workflowContextFrame(),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      actionRequestFrame(),
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
+    session.setHistoryMode("materialized");
+    await finishAndWait(session);
+
+    expect(mirrorMintedCard(session.observedEvents)).toBe(true);
+    expect(session.cacheSawCardWhileRunning()).toBe(false);
+    expect(
+      hasActionCard(
+        session.queryClient.getQueryData(
+          assistantKeys.history(session.placeholderId),
+        ),
+      ),
+    ).toBe(true);
+    const withinGrace = await switchRead(session);
+    expect(hasActionCard(withinGrace)).toBe(true);
+    expect(withinGrace.messages.map((message) => message.id)).not.toContain(
+      `${TURN_ID}:assistant`,
+    );
+
+    session.advanceHistoryClock(15_001);
+    const materialized = await switchRead(session);
+    expect(hasActionCard(materialized)).toBe(true);
+    expect(materialized.messages.map((message) => message.id)).toContain(
+      `${TURN_ID}:assistant`,
+    );
+    expect(
+      materialized.messages.find(
+        (message) => message.id === `${TURN_ID}:assistant`,
+      ),
+    ).toMatchObject({ turnId: TURN_ID, status: "blocked" });
+
+    session.setServerAssistantText("The server transcript caught up.");
+    const converged = await switchRead(session);
+    expect(hasActionCard(converged)).toBe(true);
+    expect(
+      converged.messages
+        .flatMap((message) => message.blocks)
+        .find((block) => block.block_id === `${TURN_ID}:assistant-text`),
+    ).toMatchObject({
+      type: "text",
+      text: "The server transcript caught up.",
+    });
+    session.unmount();
+  });
+
+  it("S3 keeps a card through a terminal 404 and later materialization", async () => {
+    const session = await startProbe();
+    session.stream.emit([
+      workflowContextFrame(),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      actionRequestFrame(),
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
+    await finishAndWait(session);
+
+    expect(mirrorMintedCard(session.observedEvents)).toBe(true);
+    expect(
+      hasActionCard(
+        session.queryClient.getQueryData(
+          assistantKeys.history(session.placeholderId),
+        ),
+      ),
+    ).toBe(true);
+    session.setHistoryMode("materialized");
+    expect(hasActionCard(await switchRead(session))).toBe(true);
+    session.advanceHistoryClock(15_001);
+    expect(hasActionCard(await switchRead(session))).toBe(true);
+    session.unmount();
+  });
+
+  it.each(["completed", "blocked"] as const)(
+    "S4 discards an action request after a %s terminal",
+    async (status) => {
+      const session = await startProbe();
+      session.stream.emit([
+        workflowContextFrame(),
+        { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+        { runFinished: { threadId: RUN_ACTOR, status } },
+        actionRequestFrame(),
+      ]);
+      session.setHistoryMode("materialized");
+      await finishAndWait(session);
+
+      expect(mirrorMintedCard(session.observedEvents)).toBe(false);
+      expect(
+        hasActionCard(
+          session.queryClient.getQueryData(
+            assistantKeys.history(session.placeholderId),
+          ),
+        ),
+      ).toBe(false);
+      expect(hasActionCard(await switchRead(session))).toBe(false);
+      session.unmount();
+    },
+  );
+
+  it("S5 preserves the upstream empty text shell around an action terminal", async () => {
+    const session = await startProbe();
+    session.stream.emit([
+      workflowContextFrame(),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      { textMessageStart: { messageId: TURN_ID, role: "assistant" } },
+      actionRequestFrame(),
+      { textMessageEnd: { messageId: TURN_ID } },
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
+    session.setHistoryMode("materialized");
+    await finishAndWait(session);
+
+    expect(mirrorMintedCard(session.observedEvents)).toBe(true);
+    expect(
+      hasActionCard(
+        session.queryClient.getQueryData(
+          assistantKeys.history(session.placeholderId),
+        ),
+      ),
+    ).toBe(true);
+    expect(hasActionCard(await switchRead(session))).toBe(true);
+    session.unmount();
+  });
+});

--- a/frontend/src/hooks/use-assistant.aevatar.test.tsx
+++ b/frontend/src/hooks/use-assistant.aevatar.test.tsx
@@ -19,10 +19,20 @@ import type {
 
 const SERVER_CONVERSATION = "chatc-8bd999c402fb37d60cdcd81e3b78cfd";
 const TURN_ID = "turn-d619940adcd817c4aeb5d1c3e57f1ca5";
+const SECOND_TURN_ID = "turn-261a6458c9b647e99d91a99697115385";
 const RUN_ACTOR = "workflow-definition:studio:run:probe";
 const HISTORY_URL = `/api/v1/assistant/conversations/${SERVER_CONVERSATION}`;
 
 type HistoryMode = "missing" | "materialized";
+
+interface ServerHistoryMessage {
+  readonly id: string;
+  readonly role: "user" | "assistant";
+  readonly content: string;
+  readonly timestamp: number;
+  readonly turnId: string;
+  readonly status?: "blocked";
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -31,30 +41,42 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function serverHistory(assistantText: string) {
+function serverTurnMessages(
+  turnId: string,
+  userText: string,
+  assistantText: string,
+  timestamp: number,
+): readonly ServerHistoryMessage[] {
+  return [
+    {
+      id: `${turnId}:user`,
+      role: "user",
+      content: userText,
+      timestamp,
+      turnId,
+    },
+    {
+      id: `${turnId}:assistant`,
+      role: "assistant",
+      content: assistantText,
+      timestamp: timestamp + 1_000,
+      turnId,
+      status: "blocked",
+    },
+  ];
+}
+
+function serverHistory(messages: readonly ServerHistoryMessage[]) {
   return {
-    messages: [
-      {
-        id: `${TURN_ID}:user`,
-        role: "user",
-        content: "Connect GitHub",
-        timestamp: 1785297207000,
-        turnId: TURN_ID,
-      },
-      {
-        id: `${TURN_ID}:assistant`,
-        role: "assistant",
-        content: assistantText,
-        timestamp: 1785297208000,
-        turnId: TURN_ID,
-        status: "blocked",
-      },
-    ],
+    messages,
     stateVersion: 4,
   };
 }
 
-function workflowContextFrame(): ChatStreamFrame {
+function workflowContextFrame(
+  turnId = TURN_ID,
+  stateVersion = 3,
+): ChatStreamFrame {
   return {
     custom: {
       name: "aevatar.chat.context",
@@ -63,14 +85,18 @@ function workflowContextFrame(): ChatStreamFrame {
           "type.googleapis.com/aevatar.workflow.runs.WorkflowChatContextPayload",
         scopeId: "user-probe",
         conversationId: SERVER_CONVERSATION,
-        turnId: TURN_ID,
-        stateVersion: "3",
+        turnId,
+        stateVersion: String(stateVersion),
       },
     },
   };
 }
 
-function actionRequestFrame(): ChatStreamFrame {
+function actionRequestFrame(
+  turnId = TURN_ID,
+  actionRequestId = `action-${turnId}`,
+  serviceSlug = "api-github",
+): ChatStreamFrame {
   return {
     type: "CUSTOM",
     custom: {
@@ -78,14 +104,14 @@ function actionRequestFrame(): ChatStreamFrame {
       payload: {
         schemaVersion: 4,
         actorId: "nyxid-chat-workflow-action-probe",
-        originTurnId: TURN_ID,
-        taskId: "task-probe",
-        stepId: "step-probe",
-        actionRequestId: "action-probe",
+        originTurnId: turnId,
+        taskId: `task-${turnId}`,
+        stepId: `step-${turnId}`,
+        actionRequestId,
         action: "service.connect",
         params: {
           catalogService: {
-            serviceSlug: "api-github",
+            serviceSlug,
             requestedScopes: ["repo"],
           },
         },
@@ -117,6 +143,7 @@ function createHarness() {
 
 interface ManualStream {
   request: ChatStreamRequest | null;
+  readonly startCount: number;
   emit(frames: readonly ChatStreamFrame[]): void;
   finish(): void;
 }
@@ -124,7 +151,9 @@ interface ManualStream {
 function installManualStream(): ManualStream {
   let request: ChatStreamRequest | null = null;
   let settle: ((result: { readonly kind: "complete" }) => void) | undefined;
+  let startCount = 0;
   vi.spyOn(chatStreamClient, "start").mockImplementation((nextRequest) => {
+    startCount += 1;
     request = nextRequest;
     const completion = new Promise<{ readonly kind: "complete" }>((resolve) => {
       settle = resolve;
@@ -143,13 +172,18 @@ function installManualStream(): ManualStream {
     get request() {
       return request;
     },
+    get startCount() {
+      return startCount;
+    },
     emit(frames) {
       if (!request) throw new Error("The workflow stream has not started.");
       request.onFrames(frames);
     },
     finish() {
       if (!settle) throw new Error("The workflow stream has not started.");
-      settle({ kind: "complete" });
+      const finish = settle;
+      settle = undefined;
+      finish({ kind: "complete" });
     },
   };
 }
@@ -184,15 +218,23 @@ interface ProbeSession {
   readonly observedEvents: TurnEvent[];
   readonly cacheSawCardWhileRunning: () => boolean;
   readonly advanceHistoryClock: (milliseconds: number) => void;
+  readonly send: (content: string) => Promise<void>;
   readonly setHistoryMode: (mode: HistoryMode) => void;
+  readonly setServerMessages: (
+    messages: readonly ServerHistoryMessage[],
+  ) => void;
   readonly setServerAssistantText: (text: string) => void;
   readonly unmount: () => void;
 }
 
 async function startProbe(): Promise<ProbeSession> {
   let historyMode: HistoryMode = "missing";
-  let serverAssistantText =
-    "Complete the requested action in NyxID, then continue this conversation.";
+  let serverMessages = serverTurnMessages(
+    TURN_ID,
+    "Connect GitHub",
+    "Complete the requested action in NyxID, then continue this conversation.",
+    1785297207000,
+  );
   let now = Date.parse("2026-07-31T13:00:00.000Z");
   vi.stubGlobal(
     "fetch",
@@ -211,7 +253,7 @@ async function startProbe(): Promise<ProbeSession> {
                 { error: "not_found", error_code: -1, message: "404" },
                 404,
               )
-            : jsonResponse(serverHistory(serverAssistantText)),
+            : jsonResponse(serverHistory(serverMessages)),
         );
       }
       return Promise.resolve(
@@ -244,11 +286,17 @@ async function startProbe(): Promise<ProbeSession> {
   const hook = renderHook(() => useSendMessage(conversation.id), {
     wrapper: Wrapper,
   });
+  const send = async (content: string) => {
+    const previousStartCount = stream.startCount;
+    await act(async () => {
+      await hook.result.current.mutateAsync(content);
+    });
+    await vi.waitFor(() =>
+      expect(stream.startCount).toBe(previousStartCount + 1),
+    );
+  };
 
-  await act(async () => {
-    await hook.result.current.mutateAsync("Connect GitHub");
-  });
-  await vi.waitFor(() => expect(stream.request).not.toBeNull());
+  await send("Connect GitHub");
 
   return {
     transport,
@@ -260,11 +308,19 @@ async function startProbe(): Promise<ProbeSession> {
     advanceHistoryClock: (milliseconds) => {
       now += milliseconds;
     },
+    send,
     setHistoryMode: (mode) => {
       historyMode = mode;
     },
+    setServerMessages: (messages) => {
+      serverMessages = [...messages];
+    },
     setServerAssistantText: (text) => {
-      serverAssistantText = text;
+      serverMessages = serverMessages.map((message) =>
+        message.id === `${TURN_ID}:assistant`
+          ? { ...message, content: text }
+          : message,
+      );
     },
     unmount: () => {
       unsubscribe();
@@ -274,16 +330,19 @@ async function startProbe(): Promise<ProbeSession> {
   };
 }
 
-async function finishAndWait(session: ProbeSession): Promise<void> {
+async function finishAndWait(
+  session: ProbeSession,
+  completedTurnCount = 1,
+): Promise<void> {
   await act(async () => {
     session.stream.finish();
   });
   await vi.waitFor(() => {
     expect(
-      session.observedEvents.some(
+      session.observedEvents.filter(
         (event) => event.event === "turn.completed",
       ),
-    ).toBe(true);
+    ).toHaveLength(completedTurnCount);
   });
   await vi.waitFor(() => {
     const episode = session.queryClient.getQueryData<TurnEpisode | null>(
@@ -312,6 +371,32 @@ function mirrorMintedCard(events: readonly TurnEvent[]): boolean {
   );
 }
 
+function actionActivityMessageIds(events: readonly TurnEvent[]): string[] {
+  return events.flatMap((event) =>
+    event.event === "block.started" && event.block.type === "action_card"
+      ? [event.message_id]
+      : [],
+  );
+}
+
+function actionCardBlockIds(history: ConversationHistory): string[] {
+  return history.messages.flatMap((message) =>
+    message.blocks.flatMap((block) =>
+      block.type === "action_card" ? [block.block_id] : [],
+    ),
+  );
+}
+
+function onlyActionActivityMessageId(events: readonly TurnEvent[]): string {
+  const ids = actionActivityMessageIds(events);
+  if (ids.length !== 1 || !ids[0]) {
+    throw new Error(
+      `Expected one action activity message, received ${ids.length}.`,
+    );
+  }
+  return ids[0];
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -332,9 +417,11 @@ describe("workflow action-card projection probes", () => {
       },
       { textMessageEnd: { messageId: "message-s1" } },
       actionRequestFrame(),
-      { runFinished: { threadId: RUN_ACTOR, status: "completed" } },
     ]);
     session.setHistoryMode("materialized");
+    session.stream.emit([
+      { runFinished: { threadId: RUN_ACTOR, status: "completed" } },
+    ]);
     await finishAndWait(session);
 
     expect(mirrorMintedCard(session.observedEvents)).toBe(true);
@@ -346,45 +433,59 @@ describe("workflow action-card projection probes", () => {
         ),
       ),
     ).toBe(true);
+    const activityMessageId = onlyActionActivityMessageId(
+      session.observedEvents,
+    );
     const withinGrace = await switchRead(session);
     expect(hasActionCard(withinGrace)).toBe(true);
     expect(withinGrace.messages.map((message) => message.id)).not.toContain(
       `${TURN_ID}:assistant`,
     );
+    expect(withinGrace.messages.at(-1)?.id).toBe(activityMessageId);
     session.unmount();
   });
 
-  it("S2 preserves a card-only blocked turn while adopting materialized text after grace", async () => {
+  it("S2 preserves a card-only blocked turn while adopting materialized text in turn order", async () => {
     const session = await startProbe();
     session.stream.emit([
       workflowContextFrame(),
       { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
       actionRequestFrame(),
-      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
     ]);
     session.setHistoryMode("materialized");
+    session.stream.emit([
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
     await finishAndWait(session);
 
+    const activityMessageId = onlyActionActivityMessageId(
+      session.observedEvents,
+    );
+    const expectedOrder = [
+      `${TURN_ID}:user`,
+      `${TURN_ID}:assistant`,
+      activityMessageId,
+    ];
     expect(mirrorMintedCard(session.observedEvents)).toBe(true);
     expect(session.cacheSawCardWhileRunning()).toBe(false);
-    expect(
-      hasActionCard(
-        session.queryClient.getQueryData(
-          assistantKeys.history(session.placeholderId),
-        ),
-      ),
-    ).toBe(true);
+    const projected = session.queryClient.getQueryData<ConversationHistory>(
+      assistantKeys.history(session.placeholderId),
+    );
+    expect(hasActionCard(projected)).toBe(true);
+    expect(projected?.messages.map((message) => message.id)).toEqual(
+      expectedOrder,
+    );
     const withinGrace = await switchRead(session);
     expect(hasActionCard(withinGrace)).toBe(true);
-    expect(withinGrace.messages.map((message) => message.id)).not.toContain(
-      `${TURN_ID}:assistant`,
+    expect(withinGrace.messages.map((message) => message.id)).toEqual(
+      expectedOrder,
     );
 
     session.advanceHistoryClock(15_001);
     const materialized = await switchRead(session);
     expect(hasActionCard(materialized)).toBe(true);
-    expect(materialized.messages.map((message) => message.id)).toContain(
-      `${TURN_ID}:assistant`,
+    expect(materialized.messages.map((message) => message.id)).toEqual(
+      expectedOrder,
     );
     expect(
       materialized.messages.find(
@@ -395,6 +496,9 @@ describe("workflow action-card projection probes", () => {
     session.setServerAssistantText("The server transcript caught up.");
     const converged = await switchRead(session);
     expect(hasActionCard(converged)).toBe(true);
+    expect(converged.messages.map((message) => message.id)).toEqual(
+      expectedOrder,
+    );
     expect(
       converged.messages
         .flatMap((message) => message.blocks)
@@ -403,6 +507,152 @@ describe("workflow action-card projection probes", () => {
       type: "text",
       text: "The server transcript caught up.",
     });
+    session.unmount();
+  });
+
+  it("anchors two card-only blocked turns after their own server rows", async () => {
+    const firstTurnMessages = serverTurnMessages(
+      TURN_ID,
+      "Connect GitHub",
+      "GitHub needs your confirmation.",
+      1785297207000,
+    );
+    const secondTurnMessages = serverTurnMessages(
+      SECOND_TURN_ID,
+      "Connect Slack",
+      "Slack needs your confirmation.",
+      1785297210000,
+    );
+    const session = await startProbe();
+    session.stream.emit([
+      workflowContextFrame(),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      actionRequestFrame(),
+    ]);
+    session.setServerMessages(firstTurnMessages);
+    session.setHistoryMode("materialized");
+    session.stream.emit([
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
+    await finishAndWait(session);
+
+    const firstActivityMessageId = onlyActionActivityMessageId(
+      session.observedEvents,
+    );
+    expect(
+      (await switchRead(session)).messages.map((message) => message.id),
+    ).toEqual([
+      `${TURN_ID}:user`,
+      `${TURN_ID}:assistant`,
+      firstActivityMessageId,
+    ]);
+
+    await session.send("Connect Slack");
+    session.stream.emit([
+      workflowContextFrame(SECOND_TURN_ID, 5),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      actionRequestFrame(
+        SECOND_TURN_ID,
+        `action-${SECOND_TURN_ID}`,
+        "api-slack",
+      ),
+    ]);
+    session.setServerMessages([...firstTurnMessages, ...secondTurnMessages]);
+    session.stream.emit([
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
+    await finishAndWait(session, 2);
+
+    const activityMessageIds = actionActivityMessageIds(session.observedEvents);
+    expect(activityMessageIds).toHaveLength(2);
+    const secondActivityMessageId = activityMessageIds[1];
+    if (!secondActivityMessageId) {
+      throw new Error("Expected a second action activity message.");
+    }
+    const expectedOrder = [
+      `${TURN_ID}:user`,
+      `${TURN_ID}:assistant`,
+      firstActivityMessageId,
+      `${SECOND_TURN_ID}:user`,
+      `${SECOND_TURN_ID}:assistant`,
+      secondActivityMessageId,
+    ];
+    const withinGrace = await switchRead(session);
+    expect(withinGrace.messages.map((message) => message.id)).toEqual(
+      expectedOrder,
+    );
+    expect(withinGrace.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "assistant",
+      "user",
+      "assistant",
+      "assistant",
+    ]);
+
+    session.advanceHistoryClock(15_001);
+    const postGrace = await switchRead(session);
+    expect(postGrace.messages.map((message) => message.id)).toEqual(
+      expectedOrder,
+    );
+    expect(actionCardBlockIds(postGrace)).toHaveLength(2);
+    session.unmount();
+  });
+
+  it("appends an activity for an unmaterialized turn, then moves it to its turn anchor", async () => {
+    const priorTurnId = "turn-prior-materialized";
+    const priorTurnMessages = serverTurnMessages(
+      priorTurnId,
+      "Earlier question",
+      "Earlier answer",
+      1785297200000,
+    );
+    const currentTurnMessages = serverTurnMessages(
+      TURN_ID,
+      "Connect GitHub",
+      "GitHub needs your confirmation.",
+      1785297207000,
+    );
+    const session = await startProbe();
+    session.stream.emit([
+      workflowContextFrame(),
+      { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+      actionRequestFrame(),
+    ]);
+    session.setServerMessages(priorTurnMessages);
+    session.setHistoryMode("materialized");
+    session.stream.emit([
+      { runFinished: { threadId: RUN_ACTOR, status: "blocked" } },
+    ]);
+    await finishAndWait(session);
+
+    const activityMessageId = onlyActionActivityMessageId(
+      session.observedEvents,
+    );
+    const firstRead = await switchRead(session);
+    const [actionBlockId] = actionCardBlockIds(firstRead);
+    if (!actionBlockId) throw new Error("Expected an action-card block.");
+    expect(firstRead.messages.map((message) => message.id)).toEqual([
+      `${priorTurnId}:user`,
+      `${priorTurnId}:assistant`,
+      activityMessageId,
+    ]);
+
+    session.setServerMessages([...priorTurnMessages, ...currentTurnMessages]);
+    const materialized = await switchRead(session);
+    expect(materialized.messages.map((message) => message.id)).toEqual([
+      `${priorTurnId}:user`,
+      `${priorTurnId}:assistant`,
+      `${TURN_ID}:user`,
+      `${TURN_ID}:assistant`,
+      activityMessageId,
+    ]);
+    expect(actionCardBlockIds(materialized)).toEqual([actionBlockId]);
+    expect(
+      materialized.messages.filter(
+        (message) => message.id === activityMessageId,
+      ),
+    ).toHaveLength(1);
     session.unmount();
   });
 

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -120,6 +120,11 @@ const assistantApi = {
 // network round-trip per streamed token.
 const CONVERSATION_LIST_TTL_MS = 5_000;
 
+// Chat History materializes after the stream terminal. Keep the exact live
+// transcript briefly so an equal-length stale read cannot replace optimistic
+// identities before the authoritative turn is visible.
+const HISTORY_MATERIALIZATION_GRACE_MS = 15_000;
+
 // New chats run on Aevatar's Workflow Studio chat engine: the turn body
 // carries `workflow: "studio"`, which is the only thing that selects that
 // engine upstream. Aevatar's `/api/chat` dispatches on the PRESENCE of a
@@ -409,6 +414,52 @@ function historyStateVersion(body: AevatarHistoryResponse): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function structuredBlockCount(messages: readonly AssistantMessage[]): number {
+  return messages.reduce(
+    (count, message) =>
+      count + message.blocks.filter((block) => block.type !== "text").length,
+    0,
+  );
+}
+
+function hasStructuredBlocks(message: AssistantMessage): boolean {
+  return message.blocks.some((block) => block.type !== "text");
+}
+
+/**
+ * History v4 is text-only until `/state` card rehydration ships. Reinsert each
+ * client-owned activity message after the same number of text messages that
+ * preceded it live, while the server projection supplies text, ids, and turn
+ * status. This keeps typed block ids/order stable without pinning stale text.
+ */
+function preserveLocalStructuredMessages(
+  serverMessages: readonly AssistantMessage[],
+  localMessages: readonly AssistantMessage[],
+): AssistantMessage[] {
+  const buckets = Array.from(
+    { length: serverMessages.length + 1 },
+    () => [] as AssistantMessage[],
+  );
+  const serverMessageIds = new Set(serverMessages.map((message) => message.id));
+  let precedingTextMessages = 0;
+  for (const message of localMessages) {
+    if (!hasStructuredBlocks(message)) {
+      precedingTextMessages += 1;
+      continue;
+    }
+    if (serverMessageIds.has(message.id)) continue;
+    buckets[Math.min(precedingTextMessages, serverMessages.length)]?.push(
+      message,
+    );
+  }
+
+  const merged: AssistantMessage[] = [...(buckets[0] ?? [])];
+  serverMessages.forEach((message, index) => {
+    merged.push(message, ...(buckets[index + 1] ?? []));
+  });
+  return merged;
+}
+
 interface StoredConversation {
   conversation: Conversation;
   turnState: TurnReducerState;
@@ -418,6 +469,8 @@ interface StoredConversation {
    * A fixed-size hash keeps the per-id retention bounded.
    */
   actionRequestFingerprints: Map<string, string>;
+  /** Epoch milliseconds of the latest turn.completed applied to this mirror. */
+  lastLocalTurnCompletedAt?: number;
   /**
    * Workflow-chat continuation watermark (`chatc-…` conversations only):
    * the last `stateVersion` observed from the transcript read or the
@@ -1007,7 +1060,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * the server-backed entry.
    */
   private readonly conversationAliases = new Map<string, string>();
+  private readonly now: () => number;
   private listFetchedAt = 0;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
 
   /** Follow a placeholder alias to the server conversation id, if any. */
   private canonicalConversationId(conversationId: string): string {
@@ -2054,6 +2112,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       turnState: existing?.turnState ?? EMPTY_TURN_STATE,
       actionRequestFingerprints:
         existing?.actionRequestFingerprints ?? new Map(),
+      lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion: existing?.stateVersion,
       sessionId: existing?.sessionId,
     });
@@ -2082,14 +2141,39 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (existing && freshStateVersion !== undefined) {
       existing.stateVersion = freshStateVersion;
     }
-    // Keep-max guard: immediately after a turn completes, the server-side
-    // materialization can briefly lag the local mirror. Never replace a
-    // richer local transcript with a shorter server one.
-    if (existing && existing.turnState.messages.length > messages.length) {
+    const localMessages = existing?.turnState.messages ?? [];
+    const localStructuredBlocks = structuredBlockCount(localMessages);
+    const serverStructuredBlocks = structuredBlockCount(messages);
+    const serverLacksLocalStructure =
+      localStructuredBlocks > serverStructuredBlocks;
+    // Structured activity messages are not part of the text-only History v4
+    // transcript. Exclude them from keep-max's length comparison or their
+    // permanent retention would also permanently pin optimistic text ids.
+    const comparableLocalMessageCount = serverLacksLocalStructure
+      ? localMessages.filter((message) => !hasStructuredBlocks(message)).length
+      : localMessages.length;
+    if (existing && comparableLocalMessageCount > messages.length) {
       return existing;
     }
-    const first = messages[0];
-    const last = messages[messages.length - 1];
+    const withinMaterializationGrace =
+      existing?.lastLocalTurnCompletedAt !== undefined &&
+      this.now() - existing.lastLocalTurnCompletedAt <=
+        HISTORY_MATERIALIZATION_GRACE_MS;
+    if (
+      existing &&
+      serverLacksLocalStructure &&
+      (localMessages.length === messages.length ||
+        comparableLocalMessageCount === messages.length) &&
+      withinMaterializationGrace
+    ) {
+      return existing;
+    }
+    const projectedMessages =
+      existing && serverLacksLocalStructure
+        ? preserveLocalStructuredMessages(messages, localMessages)
+        : messages;
+    const first = projectedMessages[0];
+    const last = projectedMessages[projectedMessages.length - 1];
     const nowIso = new Date().toISOString();
     const conversation: Conversation = {
       id: conversationId,
@@ -2103,12 +2187,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
     const stored: StoredConversation = {
       conversation,
       turnState: {
-        messages,
+        messages: projectedMessages,
         activeTurn: existing?.turnState.activeTurn ?? null,
         lastCursor: existing?.turnState.lastCursor ?? 0,
       },
       actionRequestFingerprints:
         existing?.actionRequestFingerprints ?? new Map(),
+      lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion: freshStateVersion ?? existing?.stateVersion,
       sessionId: existing?.sessionId,
     };
@@ -2170,6 +2255,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     const stored = this.conversations.get(conversationId);
     if (stored) {
       stored.turnState = applyTurnEvent(stored.turnState, event);
+      if (event.event === "turn.completed") {
+        stored.lastLocalTurnCompletedAt = this.now();
+      }
       stored.conversation = {
         ...stored.conversation,
         last_message_at: new Date().toISOString(),

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -428,29 +428,35 @@ function hasStructuredBlocks(message: AssistantMessage): boolean {
 
 /**
  * History v4 is text-only until `/state` card rehydration ships. Reinsert each
- * client-owned activity message after the same number of text messages that
- * preceded it live, while the server projection supplies text, ids, and turn
- * status. This keeps typed block ids/order stable without pinning stale text.
+ * client-owned activity message after the last server row from its turn while
+ * the server projection supplies text, ids, and turn status. This keeps typed
+ * block ids/order stable without pinning stale text.
  */
 function preserveLocalStructuredMessages(
   serverMessages: readonly AssistantMessage[],
   localMessages: readonly AssistantMessage[],
+  activityMessageTurnIds: ReadonlyMap<string, string | null>,
 ): AssistantMessage[] {
   const buckets = Array.from(
     { length: serverMessages.length + 1 },
     () => [] as AssistantMessage[],
   );
   const serverMessageIds = new Set(serverMessages.map((message) => message.id));
-  let precedingTextMessages = 0;
+  const lastServerIndexByTurnId = new Map<string, number>();
+  serverMessages.forEach((message, index) => {
+    if (message.turnId) lastServerIndexByTurnId.set(message.turnId, index);
+  });
+
   for (const message of localMessages) {
-    if (!hasStructuredBlocks(message)) {
-      precedingTextMessages += 1;
-      continue;
-    }
+    if (!hasStructuredBlocks(message)) continue;
     if (serverMessageIds.has(message.id)) continue;
-    buckets[Math.min(precedingTextMessages, serverMessages.length)]?.push(
-      message,
-    );
+    const turnId = activityMessageTurnIds.get(message.id);
+    const serverIndex = turnId
+      ? lastServerIndexByTurnId.get(turnId)
+      : undefined;
+    const insertionIndex =
+      serverIndex === undefined ? serverMessages.length : serverIndex + 1;
+    buckets[insertionIndex]?.push(message);
   }
 
   const merged: AssistantMessage[] = [...(buckets[0] ?? [])];
@@ -469,6 +475,8 @@ interface StoredConversation {
    * A fixed-size hash keeps the per-id retention bounded.
    */
   actionRequestFingerprints: Map<string, string>;
+  /** Server turn ownership for client-only activity messages. */
+  activityMessageTurnIds: Map<string, string | null>;
   /** Epoch milliseconds of the latest turn.completed applied to this mirror. */
   lastLocalTurnCompletedAt?: number;
   /**
@@ -1124,6 +1132,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       conversation,
       turnState: EMPTY_TURN_STATE,
       actionRequestFingerprints: new Map(),
+      activityMessageTurnIds: new Map(),
     });
     return conversation;
   }
@@ -2112,6 +2121,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       turnState: existing?.turnState ?? EMPTY_TURN_STATE,
       actionRequestFingerprints:
         existing?.actionRequestFingerprints ?? new Map(),
+      activityMessageTurnIds: existing?.activityMessageTurnIds ?? new Map(),
       lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion: existing?.stateVersion,
       sessionId: existing?.sessionId,
@@ -2162,15 +2172,18 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (
       existing &&
       serverLacksLocalStructure &&
-      (localMessages.length === messages.length ||
-        comparableLocalMessageCount === messages.length) &&
+      comparableLocalMessageCount === messages.length &&
       withinMaterializationGrace
     ) {
       return existing;
     }
     const projectedMessages =
       existing && serverLacksLocalStructure
-        ? preserveLocalStructuredMessages(messages, localMessages)
+        ? preserveLocalStructuredMessages(
+            messages,
+            localMessages,
+            existing.activityMessageTurnIds,
+          )
         : messages;
     const first = projectedMessages[0];
     const last = projectedMessages[projectedMessages.length - 1];
@@ -2193,6 +2206,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       },
       actionRequestFingerprints:
         existing?.actionRequestFingerprints ?? new Map(),
+      activityMessageTurnIds: existing?.activityMessageTurnIds ?? new Map(),
       lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion: freshStateVersion ?? existing?.stateVersion,
       sessionId: existing?.sessionId,
@@ -2254,8 +2268,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
     let drainActions = false;
     const stored = this.conversations.get(conversationId);
     if (stored) {
-      stored.turnState = applyTurnEvent(stored.turnState, event);
-      if (event.event === "turn.completed") {
+      const previousTurnState = stored.turnState;
+      const nextTurnState = applyTurnEvent(previousTurnState, event);
+      stored.turnState = nextTurnState;
+      if (
+        event.event === "turn.completed" &&
+        nextTurnState !== previousTurnState &&
+        run.streamDispatched
+      ) {
         stored.lastLocalTurnCompletedAt = this.now();
       }
       stored.conversation = {
@@ -3283,6 +3303,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (run.activityMessageId) return run.activityMessageId;
     const messageId = newId("assistant-activity");
     run.activityMessageId = messageId;
+    this.conversations
+      .get(conversationId)
+      ?.activityMessageTurnIds.set(messageId, run.turnId);
     this.emit(conversationId, run, {
       cursor: this.nextCursor(run),
       event: "message.started",


### PR DESCRIPTION
## Problem

Rich cards (v4 action cards) were not reliably visible during/after a live assistant reply — the reported symptom was cards appearing only after switching conversations.

## Confirmed mechanism (reproduced against the real transport + pump + QueryClient stack)

A card-only `blocked` turn — exactly the shape Aevatar produces for browser actions (`nyxid.action.request` → empty text shell → `RUN_FINISHED status=blocked`, with the blocked explanation written as an assistant history row) — leaves the local mirror at `[optimistic user, activity(action_card)]` while the server materializes `[user, blocked explanation]`. Equal message counts defeated the strict `>` keep-max guard in `loadHistory`, so the text-only server read **replaced the mirror at the terminal flush and erased the only copy of the card**. History is text-only on the v4 contract (no card can ever be re-minted from it; `/state` rehydration is an open item), so the wipe was unrecoverable.

Post-terminal frame ordering (S4) was ruled out against Aevatar `origin/dev` (`NyxIdChatConversationAguiFrameBuilder.cs`: action frames always precede terminals), so the post-terminal discard guard is intentionally unchanged.

## Fix (frontend-only, `aevatar-transport.ts`)

- **Structured messages are never surrendered to a text-only server read.** Client-owned activity messages (action/approval/connect/run blocks) are excluded from the keep-max length comparison and re-inserted after server adoption, anchored by **turnId** (transport-private `activityMessageTurnIds` map recorded at activity-message creation; server rows matched via their own `turnId`). Canonical merged order: *user → server explanation → card*, each card under its own turn. Not-yet-materialized turns append the card at the end and relocate it to its anchor on a later read without id churn or duplication.
- **15 s materialization grace window** (`HISTORY_MATERIALIZATION_GRACE_MS`, keyed off the last locally-applied dispatched `turn.completed`): within it, an equal-count text-only read keeps the exact live mirror (optimistic ids intact); after it, server text/ids/turnIds/status/errors are adopted on every read — no permanent pinning.
- Injectable clock on the transport for deterministic tests; timestamp only stamped when the reducer accepted the terminal and the stream actually dispatched.

## Verification

- New probe/regression suite `use-assistant.aevatar.test.tsx` drives the real `AevatarAssistantTransport`, the real `useSendMessage` event pump, and a real TanStack `QueryClient` through the S1–S5 frame/server sequences, with exact message-order assertions (multi-turn, missing-turn relocation, within/post-grace, convergence). The core regression tests fail on the unfixed base.
- Full gate: 2297/2297 tests, `npm run build` (tsc -b), `npm run lint` 0 errors. No dependency, wizard-bundle, parser/worker, reducer-contract, or text-emission changes.
- Adversarially reviewed in two rounds (independent implementation + adversarial execution probes); all confirmed findings addressed.

## Known residuals (out of scope, documented)

- Typed cards remain transport-memory-only until `/state` card rehydration ships (existing open item) — a cold reload still cannot restore them.
- Aevatar's Studio workflow mapper currently has no handler promoting committed NyxID action events to `CUSTOM nyxid.action.request` (falls back to `aevatar.raw.observed`) — upstream gap to reconcile separately.

Squash-merge into the rollup so the rollup → main merge stays a normal merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)