### PR TITLE
docs(skills): align Aevatar runtime contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "nyxid",
       "description": "Brokers downstream credentials through the nyxid CLI and bundles synchronized Aevatar platform skills for workflows, teams, services, schedules, channels, and managed Codex.",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "source": "./",
       "author": {
         "name": "ChronoAIProject"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nyxid",
   "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": {
     "name": "ChronoAIProject"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nyxid",
-  "version": "0.7.0",
+  "version": "0.7.3",
   "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
   "author": {
     "name": "ChronoAIProject",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nyxid",
   "displayName": "NyxID",
   "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
-  "version": "0.7.0",
+  "version": "0.7.3",
   "author": {
     "name": "ChronoAIProject",
     "url": "https://github.com/ChronoAIProject"

--- a/skills/aevatar-feasibility-advisor/SKILL.md
+++ b/skills/aevatar-feasibility-advisor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-feasibility-advisor
 description: Use before building when a user asks whether Aevatar can achieve a goal, what prerequisites it has, or why it is unavailable. Triggers include bots and third-party APIs, inbound channels, external HTTP triggers, schedules, service exposure, Agent Profiles and tool ceilings, and bounded managed or private-host codex_exec work. It distinguishes outbound connectors from inbound channels and separates not connected, host-gated, not deployed, and genuinely unsupported outcomes. It chooses managed_sandbox versus private_ssh without promising repository, model, credential, runtime, or deployment capabilities the caller does not control, then routes feasible work to the owning Aevatar skill.
-version: "1.4"
+version: "1.5"
 metadata:
   category: plain
   tag:
@@ -44,14 +44,11 @@ common wrong answer here.
 docs, so it *sounds* available. **Probe the live surface, never a branch or a memory** —
 `GET /api/openapi.json` and check whether the complete route family is advertised.
 
-**Agent Profile is currently the live example.** Owner Profile management (create, edit draft, bind
-exact Ornn skills, validate, publish) is an **owner-managed** capability — an authenticated user
-manages their *own* profile; it is not host-only configuration. But it is **deployment-gated**, and
-today production advertises **no** `agent-profiles` routes at all. So the honest answer to "can I
-give my agent a fixed persona with pinned skills and a hard tool ceiling?" is: *the product models
-exactly that, it is yours to manage rather than the host's, but this deployment does not currently
-expose the contract — here is the probe, and here is what works today instead.* Do not report it as
-host-owned config, and do not report it as impossible.
+Agent Profile management is an **owner-managed** capability — an authenticated user manages their
+own profile; it is not host-only configuration. It remains deployment-gated, so probe the live
+`GET /api/openapi.json` and require the complete `agent-profiles` route family before mutation.
+Do not preserve a historical claim that production lacks or exposes it; the live OpenAPI is the
+only answer for the current deployment.
 
 ## Choose the `codex_exec` target before workflow authoring
 
@@ -89,7 +86,7 @@ Every external capability is brokered by **NyxID**. That single fact drives ever
 
 | Surface | What it gives you | How it's used | Supported set |
 |---|---|---|---|
-| **Connector** (outbound) | Your workflow/agent **calls** a third-party API (read data, post, act) | Raw `nyxid_proxy` requires exact `service_id + slug + path`; an interactive `nyxid_service_operation__*` requires enumerated `user_service_id` plus its emitted schema; a compiled workflow calls `nyxid_proxy` with a copied `capability.nyxid_operation` selector and only admitted runtime values (`path_params/query/headers/body/response_mode`) | Anything in the NyxID **catalog** (see below) — broad |
+| **Connector** (outbound) | Your workflow/agent **calls** a third-party API (read data, post, act) | Raw `nyxid_proxy` requires exact `service_id + slug + path`; current-turn dynamic `nyxid_service_operation__*` tools are retired; a compiled workflow uses exact `capability.nyxid_operation` or typed `capability.nyxid_request` admission | Anything in the live NyxID catalog/inventory — broad |
 | **Channel** (inbound) | A third-party chat platform **delivers user messages to your agent**, which replies **in that platform** | An Aevatar **channel module** + NyxID relay webhook | **Narrow** — only platforms with a built module |
 
 > **The trap:** "I want a Twitter bot." A Twitter *connector* (`api-twitter`) exists, so your
@@ -100,20 +97,18 @@ Every external capability is brokered by **NyxID**. That single fact drives ever
 
 ## Step 0 — Inspect what is actually connectable (don't guess)
 
-You hold a NyxID bearer (`~/.nyxid/access_token`; base in `~/.nyxid/base_url`, e.g.
-`https://nyx.chrono-ai.fun`). Two read-only calls tell you the ground truth — make them with
-the **`curl` binary** (a WAF may 403 Python HTTP clients):
+Use the authenticated NyxID CLI; never read its stored access token or build an Authorization
+header. Two read-only CLI calls tell you the ground truth:
 
 ```bash
-NYX=$(tr -d '\n' < ~/.nyxid/base_url); TOK=$(tr -d '\n' < ~/.nyxid/access_token)
-# What the user already has wired up (slugs you can nyxid_proxy right now):
-curl -s -H "Authorization: Bearer $TOK" "$NYX/api/v1/services"   # -> [{slug,name,...}]
-# What CAN be connected, and exactly how (auth model + setup instructions):
-curl -s -H "Authorization: Bearer $TOK" "$NYX/api/v1/catalog"    # -> {entries:[{slug,auth_method,credential_mode,requires_credential,api_key_instructions,api_key_url,documentation_url,...}]}
+nyxid service list --output json
+nyxid catalog list --output json
 ```
-(Inside an aevatar session with the nyxid MCP, the equivalent is the `nyxid_services` tool,
-`{"action":"list"}`.) **The live catalog is the source of truth — never assert a connector
+(Inside an Aevatar session, use the typed connected-service inventory/management tool actually
+present.) **The live catalog and authoritative `/api/v1/keys` instance inventory are the source of truth — never assert a connector
 exists or doesn't without checking it.** The examples below are illustrative, not a fixed list.
+`/api/v1/user-services` is only a route projection; it cannot prove discovery, readiness, or
+execution authority.
 
 ### Reading a catalog entry (this is the "what's the prerequisite" answer)
 - `requires_credential: true` → the user must connect it before any call works.
@@ -155,7 +150,7 @@ exists or doesn't without checking it.** The examples below are illustrative, no
 | **Publish** a workflow/team as an **invocable service** in-scope | ✅ Yes | Just bind it (`aevatar-service-publisher`). Usable within the user's scope immediately. |
 | An external automation **triggers an existing Aevatar workflow** (e.g. Lark Base row status changed → HTTP request → run member workflow) | ✅ Usually, without service externalExposure | Use the external system's HTTP action to call the NyxID proxy for the existing `aevatar` service with a NyxID API key (`proxy` scope), targeting an explicit `/api/scopes/{scopeId}/members/{memberId}/invoke/...` or `/teams/{teamId}/invoke/...` path. This is an external trigger, not a NyxID connector registration. See `aevatar-service-publisher`. |
 | Have that service **registered as a NyxID-brokered connector** (callable by others/externally) | ⚠️ Host-gated | The **host** must enable external exposure (`GAgentService:ExternalExposure: Enabled=true` + `RegisterAllPublishedServices` or an opt-in policy). You **cannot** turn this on as a client — verify `externalExposure` on the service and, if empty, tell the user to ask the host. |
-| Give an agent a **fixed persona + pinned Ornn skills + an enforced tool ceiling** (an Agent Profile) | ⚠️ Modelled, owner-managed, but **not deployed today** | Probe `GET /api/openapi.json` for the complete `agent-profiles` route family. Absent ⇒ the deployment does not expose it; say so and offer the workflow-instructions version as the interim. Present ⇒ it is **yours** to create/validate/publish via `aevatar-agent-profile-management`, no host action needed for management itself. |
+| Give an agent a **fixed persona + pinned Ornn skills + an enforced tool ceiling** (an Agent Profile) | ⚠️ Modelled, owner-managed, deployment-dependent | Probe `GET /api/openapi.json` for the complete `agent-profiles` route family. Absent means unavailable in this deployment; present means the owner can manage it through `aevatar-agent-profile-management`. |
 | Have a published Profile actually **drive a running agent** | ⚠️ Host-gated, and narrow | Publication is not runtime binding. Only *newly created* NyxID direct conversations admitted by a **host-owned rollout** consume a Profile; existing conversations never hot-upgrade, and workflows/teams/services/schedules/channels/AgentRuns are not consumers at all. |
 | **Schedule** a recurring run (cron) | ⚠️ Yes, with a binding | The scope owner needs a durable **NyxID broker binding** — i.e. an interactive **console** NyxID login, not just a CLI token. Without it, schedule creation 400s ("Authenticated NyxID owner binding is required"). |
 | A service backed by an **arbitrary custom agent / actor type** | ⚠️ Constrained | Member implementations are `workflow`, `script`, or **registered** `gagent` kinds (`GET /api/scopes/gagent-types`). You can't point a service at an arbitrary actor; wrap custom logic in a workflow or script, or use a registered gagent kind. |
@@ -176,6 +171,12 @@ State these plainly when they bite:
 - **`nyxid_proxy` file artifacts cap at 100 MiB.** Bigger downloads aren't feasible that way.
 - **Async settling.** Bindings/deployments/runs are eventually consistent — never promise a
   result from a 2xx alone.
+- **Lark Base has two permission layers.** `bitable:app:readonly` is an application API scope;
+  it does not grant the Bot access to a specific Base document. Lark error `91403` means the
+  Base document ACL denied that application. In the current Base UI, open the Base's `...`/More
+  menu, choose **Add Applications**, and add the exact Bot application used by the selected NyxID
+  UserService with view access for read-only workflows. Do not ask the user to change API scopes
+  when that scope is already enabled, and do not confuse a Base with a spreadsheet file.
 
 ## How to satisfy each prerequisite (what you tell the user to do)
 

--- a/skills/aevatar-platform-map/SKILL.md
+++ b/skills/aevatar-platform-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-platform-map
 description: Entry point, panorama, and router for the Aevatar skill family. Use before building, running, publishing, scheduling, externally triggering, or operating Aevatar resources; configuring an Agent Profile; assessing managed/private codex_exec feasibility and setup; running the canonical Codex readiness proof; authoring a workflow with codex_exec; diagnosing a Codex failure; or deciding which companion skill owns a request. It teaches resource and identity boundaries, NyxID-brokered auth, client REST versus in-session tools, deployment gates, and exact handoffs without treating member, workflow, service, profile, schedule, or Codex capabilities as one lifecycle.
-version: "1.10"
+version: "1.11"
 metadata:
   category: plain
   tag:
@@ -124,9 +124,9 @@ by whichever API you already know:
 |---|---|---|---|
 | An already-bound **Studio Team member** workflow | `scope → team → member` | `aevatar_schedule_member_workflow`, or `/api/scopes/{scopeId}/teams/{teamId}/members/{memberId}/automations` | Dedicated **Agent Key** |
 | An independent **scheduled Ornn skill agent** or **one-shot reminder** | Scheduled agent / catalog actors | `scheduled_agent_creator`, then `agent_builder` | Dedicated **Agent Key** |
-| A **raw service invocation or actor envelope** | Generic platform schedule actor | Generic `/api/schedules` | Typed source; may be a NyxID binding exchange |
+| A typed **service invocation** | Generic platform schedule actor | Generic `/api/schedules` | Typed source; may be a NyxID binding exchange |
 
-Generic `/api/schedules` remains supported, but it is **not** the canonical path for a Team member
+Generic `/api/schedules` remains supported for typed service invocation only; external raw actor/envelope targets are retired and fail closed. It is **not** the canonical path for a Team member
 automation and must not be used as a fallback when the owner is a Team member. `aevatar-scheduler`
 owns the member-automation and generic paths; `aevatar-automation` owns the scheduled skill agent.
 
@@ -146,7 +146,7 @@ through the broker:
 - **Prerequisite (once):** the `aevatar` service must be connected in NyxID. Verify with
   `nyxid proxy discover | grep aevatar`; if absent, `nyxid service add aevatar` (no credential —
   it is an admin-mode system service that resolves the caller via NyxID `/me`).
-- **Every call is** `nyxid proxy request aevatar "<path>" [-m POST -H 'Content-Type: application/json' -d '<json>']`. NyxID injects the
+- **Every call is** `nyxid proxy request aevatar "<path>" [-m POST -d '<json>']`. NyxID injects the
   bearer **and** the scope claim; you never read or send the token yourself. (The broker forwards to
   base URL `https://aevatar-console-backend-api.aevatar.ai`; you only ever pass the `<path>`.)
 - **Resolve your scope once** — `scopeId` is your NyxID subject id:
@@ -191,8 +191,9 @@ target contract through the Codex-specific skills below. Do not invent a REST pa
 Keep these modes separate; they share credentials but not caller-owned fields:
 
 - **Raw one-off HTTP:** call `nyxid_proxy` with exact `service_id + slug + path`; optional fields are `method`, `body`, non-sensitive `headers`, and `response_mode`. Example: `{"service_id":"us-gh-7","slug":"api-github","path":"/user","method":"GET"}`.
-- **Interactive operation:** call the request-local `nyxid_service_operation__*` name emitted by the current catalog. Pass the enumerated `user_service_id` and only fields in that dynamic operation schema; never derive the tool name from a slug.
-- **Compiled workflow operation:** the YAML step calls `nyxid_proxy` and carries a copied `capability.nyxid_operation` selector. Its admission proof owns UserService, slug, operation ID, method, path template, digest, schemas, and response policy. Runtime arguments may contain only admitted `path_params`, `query`, `headers`, `body`, and `response_mode`; never repeat route or proof fields.
+- **Current-turn connected-service tools:** use only the typed tools actually present, such as `nyxid_services`, `nyxid_approvals`, `nyxid_require_service`, and `nyxid_service_inventory`. Retired dynamic `nyxid_service_operation__*` and `nyxid_service_request` tools do not exist; never invent their names.
+- **Compiled published operation:** the YAML step calls `nyxid_proxy` and carries an exact copied `capability.nyxid_operation` selector. Its admission proof owns UserService, slug, operation ID, method, path template, digest, schemas, and response policy. Runtime arguments may contain only admitted `path_params`, `query`, `headers`, `body`, and `response_mode`; never repeat route or proof fields.
+- **Compiled authored request:** `capability.nyxid_request` carries a typed HTTP request contract and exact UserService selection from authoritative `/api/v1/keys`. Binding requires authenticated confirmation/grant for the current request-contract digest and risk. `/api/v1/user-services`, draft save, and preview success are not execution authority.
 - **Studio member:** call `aevatar_invoke_member` with `{"member_id":"m-alpha","payload":{"prompt":"hello"}}`; `endpoint_id` is optional and defaults to `chat`. Never substitute a draft `workflowId` or `publishedServiceId` for `member_id`.
 
 For managed `codex_exec`, normal execution is credential-read-only. Explicitly `POST /api/managed-codex/credential` to provision/reconcile, then read `GET /api/managed-codex/credential` and proceed only when `execution_ready=true` and `execution_readiness_reason=ready`; lifecycle `status=active` alone is insufficient. Do not retry the canary expecting normal execution to repair credentials. Preserve the deadline chain: chrono 180s < Aevatar managed request 300s < NyxID/ingress at least 315s < NyxID client 330s < workflow canary at least 360s.
@@ -214,7 +215,7 @@ For managed `codex_exec`, normal execution is credential-read-only. Explicitly `
 | **Publish** a member/team **as a service** and **register it to NyxID**; verify it | `aevatar-service-publisher` | `/api/scopes/{id}/binding`, `/api/services/*`, `/members/{id}/published-service` |
 | Run a **Team member workflow** on a schedule (dedicated Agent Key) | `aevatar-scheduler` | `aevatar_schedule_member_workflow` / `/api/scopes/{id}/teams/{teamId}/members/{memberId}/automations` |
 | Run an independent **scheduled skill agent** or one-shot reminder | `aevatar-automation` | `scheduled_agent_creator`, then `agent_builder` |
-| Run a **raw service invocation** on a cron (generic platform schedule) | `aevatar-scheduler` | `/api/schedules`, `:run-now`, `:enable`, `:disable` |
+| Run a typed **service invocation** on a cron (generic platform schedule) | `aevatar-scheduler` | `/api/schedules`, `:run-now`, `:enable`, `:disable` |
 | Trigger an existing workflow from an external HTTP sender such as **Lark Base** | `aevatar-feasibility-advisor` first, then `aevatar-service-publisher` | NyxID `/api/v1/proxy/s/aevatar/api/scopes/{scopeId}/members/{memberId}/invoke/...`, host-managed `/api/workflow-webhooks/{routeKey}` if configured |
 | **Invoke**, watch **runs**, observe | (this map + service-publisher's invoke section) | `/invoke/{endpointId}`, `/runs/*`, `/api/workflow/observatory/*` |
 

--- a/skills/aevatar-scheduler/SKILL.md
+++ b/skills/aevatar-scheduler/SKILL.md
@@ -1,15 +1,7 @@
 ---
 name: aevatar-scheduler
-description: >-
-  Use when a user wants to schedule or manage recurring Aevatar work, preview cron, run now, pause
-  or resume, reauthorize, delete an automation, or diagnose scheduled token_expired failures.
-  Route by owner first: a bound Studio Team member workflow uses aevatar_schedule_member_workflow
-  or the member automations API and a dedicated Agent Key; an independent Ornn skill agent or
-  reminder uses aevatar-automation; generic /api/schedules is only for raw service invocations or
-  actor envelopes. Covers preflight, 202 admission-only semantics, credentialSourceKind-aware
-  triage, and Agent Key, NyxID, and Vault lifecycle. Publish callable members or services first
-  with aevatar-service-publisher.
-version: "1.8"
+description: Create and manage recurring Aevatar runs and route to the correct scheduling resource. Use for cron, recurring Team member workflows, scheduled skill agents, typed service invocations, pause/resume, run-now, reauthorization, deletion, or credential triage. Team member automation uses its dedicated route and Agent Key; generic schedules accept typed service invocation only. External raw actor/envelope schedules are retired and must fail closed.
+version: "1.9"
 metadata:
   category: plain
   tag:
@@ -35,10 +27,10 @@ APIs. Pick before you call anything; using the wrong one is not a shortcut, it i
 |---|---|---|---|
 | An already-bound **Studio Team member** workflow | `scope → team → member` | `aevatar_schedule_member_workflow`, or REST `/api/scopes/{scopeId}/teams/{teamId}/members/{memberId}/automations` | **Dedicated Agent Key** |
 | An independent **scheduled Ornn skill agent** or a **one-shot reminder** | Scheduled agent / catalog actors | `scheduled_agent_creator`, then `agent_builder` — see `aevatar-automation` | **Dedicated Agent Key** |
-| A **raw service invocation or actor envelope** | Generic platform schedule actor | Generic `/api/schedules` — the rest of this skill | Typed source; may be a NyxID binding exchange |
+| A typed **service invocation** | Generic platform schedule actor | Generic `/api/schedules` — the rest of this skill | Typed source; may be a NyxID binding exchange |
 
 **If the owner is a Team member, the canonical path is the member automation route — not generic
-`/api/schedules`.** Generic `/api/schedules` is a platform-level resource for raw invocations. It
+`/api/schedules`.** Generic `/api/schedules` is a platform-level resource for typed service invocations. It
 is supported, but it is *not* a fallback for Team member automation, and reaching for it because
 you already know its shape is the most common mistake here.
 
@@ -141,10 +133,11 @@ credential source with different lifetime semantics.
 
 ---
 
-## Generic platform schedule (`/api/schedules`)
+## Generic typed-service schedule (`/api/schedules`)
 
-Everything below is the **generic** resource: a raw service invocation or actor envelope. Use it
-when that is genuinely what the user wants — not as a fallback for a Team member.
+Everything below is the **generic** typed service-invocation resource. External callers cannot
+schedule a raw actor `EventEnvelope`; that target is retired and rejected. Never use an envelope
+as a fallback for a Team member.
 
 You create a **schedule** that fires a published service on a cron expression,
 authenticated as **you** (the scope owner) through NyxID. Publish the service first
@@ -180,8 +173,9 @@ aev "api/scopes/$scopeId/services" \
   | jq '.[] | {tenantId, appId, namespace, serviceId, defaultServingRevisionId, invokeReady,
                endpoints: [.endpoints[] | {endpointId, requestTypeUrl}]}'
 ```
-- **identity** — the 4-tuple `{tenantId, appId, namespace, serviceId}`. For a workflow
-  member the `serviceId` is `member-<memberId>`.
+- **identity** — copy the explicit 4-tuple `{tenantId, appId, namespace, serviceId}` from the
+  service read model or member `published-service` association. Never derive `serviceId` from
+  `memberId`, a prefix, route position, or string equality.
 - **endpointId** + **payloadTypeUrl** — from `endpoints[]` (`payloadTypeUrl` = the
   endpoint's `requestTypeUrl`). A workflow member's default endpoint is `chat` with
   `type.googleapis.com/aevatar.ai.ChatRequestEvent`.
@@ -214,14 +208,9 @@ binding fails fast at create with one of:
 > HTTP 400 — "Authenticated NyxID owner binding is required for scope owner schedule auth…"
 > HTTP 400 — "NyxID binding was revoked for the scheduled subject. (Parameter 'configuration')"
 
-**Diagnose before re-logging in** — the binding lives on the NyxID side, so check it directly:
-```bash
-NYX=$(tr -d '\n' < ~/.nyxid/base_url); TOK=$(tr -d '\n' < ~/.nyxid/access_token)
-curl -s -H "Authorization: Bearer $TOK" "$NYX/api/v1/users/me/broker-bindings" \
-  | jq -r '.bindings[] | "\(.client_name)  scopes=\(.scopes|join(","))  last_used=\(.last_used_at)"'
-```
-A non-revoked `aevatar` binding with the `proxy` scope means NyxID is healthy and the fault
-is Aevatar-side (it can be pinned to a stale binding). A **clean** console re-login (fully
+Diagnose from the typed create/preflight error and the Aevatar read model. Never read a stored
+access token, construct an Authorization header, or call NyxID/Aevatar directly with `curl`.
+A **clean** console re-login (fully
 logged out first) refreshes a revoked binding — finalize replaces it on the revoked/stale
 probe path — so that usually clears it; an SSO-cached login may not re-run finalize.
 
@@ -231,16 +220,11 @@ Tracked at **aevatarAI/aevatar#2491** — do not promise a CLI-only way to creat
 `scopeOwnerNyxId` schedule until it lands.
 
 ### CLI-only alternative: skip the Aevatar scheduler entirely
-For a recurring run **without the browser console**, don't use `scopeOwnerNyxId` scheduling
-at all. The published service is already invocable — drive it from an **external timer**
-(cron, `launchd`, a node) that hits the invoke endpoint with a **non-expiring NyxID API key**
-(`nyxid api-key create --scopes proxy`; export as `NYXID_ACCESS_TOKEN`). No broker binding,
-no console:
-```bash
-NYXID_ACCESS_TOKEN="$KEY" nyxid proxy request aevatar \
-  "api/scopes/$scopeId/members/$memberId/invoke/chat:stream" -m POST --stream \
-  -H 'Content-Type: application/json' -d '{"prompt":"poll"}'
-```
+For a recurring run **without the browser console**, don't use `scopeOwnerNyxId` scheduling.
+An explicitly authorized external timer may invoke the already-published member/team endpoint
+through NyxID using a dedicated minimum-authority API key kept in that timer's secret manager.
+Never print the key, put it in workflow YAML, export it into a shared shell history, or expose it
+in diagnostics.
 The member invoke endpoint carries `scopeId` in its path, so it runs even though a bare API
 key reports `scopeResolved:false` on the generic `api/studio/context` call. The same pattern
 works for **event-driven external triggers** such as Lark Base automation's "send HTTP request"
@@ -307,7 +291,7 @@ aev "api/schedules" -m POST -d "{
   \"timezone\": \"Asia/Shanghai\",
   \"enabled\": true,
   \"serviceInvocation\": {
-    \"identity\": { \"tenantId\": \"$scopeId\", \"appId\": \"default\", \"namespace\": \"default\", \"serviceId\": \"member-<memberId>\" },
+    \"identity\": { \"tenantId\": \"<from-service-contract>\", \"appId\": \"<from-service-contract>\", \"namespace\": \"<from-service-contract>\", \"serviceId\": \"<published-service-id-from-contract>\" },
     \"endpointId\": \"chat\",
     \"payloadTypeUrl\": \"type.googleapis.com/aevatar.ai.ChatRequestEvent\",
     \"payloadJson\": $(jq -nc '{prompt:"do the thing"} | tojson'),
@@ -318,8 +302,8 @@ aev "api/schedules" -m POST -d "{
 ```
 
 `ScheduledDispatchConfigurationHttpRequest`: `cronExpression` (required); `displayName?`,
-`timezone?`, `enabled` (default true), `headers?` (string map), and **exactly one** target:
-`serviceInvocation` (above) or `envelope` (a raw actor `EventEnvelope` — advanced).
+`timezone?`, `enabled` (default true), `headers?` (string map), and exactly one
+`serviceInvocation` target. Any external `envelope` target must be rejected.
 
 > **`payloadJson` requires `revisionId`.** If you supply `payloadJson` without a
 > `revisionId` (and the service has no *active* serving revision), creation fails with

--- a/skills/aevatar-service-publisher/SKILL.md
+++ b/skills/aevatar-service-publisher/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-service-publisher
 description: Publish an Aevatar member, team, or workflow as an invocable service and (host permitting) register it with NyxID, then verify, invoke, or wire external HTTP triggers such as Lark Base automation — all over the REST API. Use when a user wants to "publish/bind a service", "expose my workflow/team as a service", "register it with NyxID", "make it callable", "get the service slug/URL", "invoke my service", "let Lark Base call my workflow", "trigger this workflow from an external webhook", or "version/deploy/roll out a service". It covers the simple scope binding, reading back a member's published service, the full account-level service lifecycle (revision → publish → deploy → rollout), how to confirm the NyxID registration (slug + status), how to invoke an endpoint, and how to distinguish direct NyxID proxy triggering from host-gated externalExposure. Build the team/member first with the team-builder skill.
-version: "1.5"
+version: "1.6"
 metadata:
   category: plain
   tag:
@@ -62,15 +62,13 @@ reusable NyxID connector/slug for other callers."
 
 ## Path A — A member you already bound (from team-builder)
 
-A bound member **already has a published service** — binding it was the publish. The
-`published-service` endpoint only returns ids; the real detail (endpoints, readiness,
-NyxID exposure) lives in the scope services list:
+A bound member **already has an explicit published-service association**. Read it first, then
+use the returned `publishedServiceId` to select the service read model. Never derive a service
+identity from `memberId`, a `member-` prefix, route position, or string equality:
 ```bash
-# minimal: publishedServiceId + key
-aev "api/scopes/$scopeId/members/$memberId/published-service" | jq .
-# full: identity, endpoints, serving revision, invokeReady, externalExposure
-aev "api/scopes/$scopeId/services" \
-  | jq '.[] | select(.serviceId=="member-'"$memberId"'")
+publishedServiceId=$(aev "api/scopes/$scopeId/members/$memberId/published-service" | jq -r .publishedServiceId)
+aev "api/scopes/$scopeId/services" | jq --arg serviceId "$publishedServiceId" '
+      .[] | select(.serviceId==$serviceId)
         | {serviceId, defaultServingRevisionId, invokeReady, invokeReadinessStatus,
            endpoints: [.endpoints[] | {endpointId, requestTypeUrl}], externalExposure}'
 ```
@@ -148,13 +146,14 @@ The endpoint contract tells you the path, readiness, and a ready-to-run curl exa
 aev "api/scopes/$scopeId/members/$memberId/endpoints/chat/contract" \
   | jq '{invokePath, canInvoke:.invocationReadiness.canInvoke, curlExample}'
 ```
-The reliable smoke test is the **streaming** path (`…/invoke/{endpointId}:stream`, SSE),
-which accepts the `{"prompt":"…"}` shorthand and returns workflow-run frames ending in a
-`runFinished` event with the result:
+The streaming path (`…/invoke/{endpointId}:stream`, SSE) accepts the `{"prompt":"…"}` shorthand.
+An opened stream or accepted receipt is not success. Follow the same run to terminal completion,
+then read run detail/audit and require completed status, `lastSuccess=true`, expected non-empty
+step output, non-empty final output, and no failed audit step:
 ```bash
 aev "api/scopes/$scopeId/members/$memberId/invoke/chat:stream" -m POST --stream \
   -d '{"prompt":"smoke test"}'
-# look for:  data: {... "runFinished": { "result": { "output": "..." } } }
+# retain the returned run identity privately, then read its detail and audit
 ```
 The **non-streaming** `…/invoke/{endpointId}` expects the full typed envelope (it rejects a
 bare `{prompt}` with 400 "payloadTypeUrl is required") — prefer `:stream` for a quick check.
@@ -176,8 +175,9 @@ Aevatar inbound chat channel.
 
 ### Direct NyxID proxy trigger
 
-Create a non-expiring NyxID API key with `proxy` scope and store it as the external
-system's secret:
+Create a dedicated NyxID API key with the minimum required proxy authority and store it only in
+the external system's secret manager. Never print, log, paste into workflow YAML, or return the
+secret value in chat:
 
 ```bash
 nyxid api-key create --name "lark-base-aevatar-trigger" --scopes proxy
@@ -187,7 +187,7 @@ Then configure the external HTTP action as:
 
 ```http
 POST https://nyx-api.chrono-ai.fun/api/v1/proxy/s/aevatar/api/scopes/{scopeId}/members/{memberId}/invoke/chat:stream
-Authorization: Bearer <NYXID_API_KEY>
+Authorization: Bearer [secret configured in the external system]
 Content-Type: application/json
 Accept: text/event-stream
 
@@ -210,6 +210,12 @@ Trade-offs:
   serving revision has a descriptor). A bare `{ "prompt": "..." }` is invalid.
 - If the external tool cannot set headers, cannot keep secrets safely, cannot tolerate SSE,
   or cannot build the typed envelope, use an adapter path below instead of forcing it.
+
+For Lark Base, `bitable:app:readonly` is only an application API scope. The exact Base document
+must also grant the selected Bot application access. Error `91403` is a document ACL denial, not
+evidence that the API scope is missing. In the current Base UI, open `...`/More, choose **Add
+Applications**, and add the exact Bot application used by the selected NyxID UserService; view
+access is enough for a read-only workflow.
 
 ### Adapter path
 

--- a/skills/aevatar-team-builder/SKILL.md
+++ b/skills/aevatar-team-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-team-builder
 description: Build an Aevatar agent team and its members over the REST API. Use when a user wants to "create a team", "add a member", "make a workflow member / script member / gagent member", "set the team's entry point", or "assemble agents into a team". It creates the team, creates members whose implementation is a workflow (most common), a script, or a hosted gagent, binds each member's concrete implementation (the workflow YAML is attached here), waits for the async binding to succeed, and sets the team entry member. Author the workflow YAML first with the workflow-authoring skill; publish the result as a service with the service-publisher skill.
-version: "1.3"
+version: "1.4"
 metadata:
   category: plain
   tag:
@@ -29,17 +29,16 @@ output is an invocable team. Publishing it as a NyxID service is a separate step
 # token. A raw curl to the aevatar backend with ~/.nyxid/access_token resolves NO scope
 # (scopeResolved:false) and the stored token expires — it is not a usable path.
 # Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-# NyxID treats `-d` as raw bytes, so declare JSON explicitly; Aevatar rejects writes without it.
-aev() { nyxid proxy request aevatar "$@" -H 'Content-Type: application/json'; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
+aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
 scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 ```
 
 > **`jq` is only for convenience** — any JSON reader works (replace `| jq -r .scopeId` with
 > `| python3 -c 'import sys,json;print(json.load(sys.stdin)["scopeId"])'`). All calls go through the
 > NyxID broker (`nyxid proxy request aevatar`), which injects your `scope_id` claim and
-> auto-refreshes the token. And because the create/bind calls are async and can occasionally return
-> a **transient empty body**, always read the response status/JSON back — retry once on an empty
-> body — rather than assuming success.
+> auto-refreshes the token. Create and bind calls are mutations: an empty body or lost response is
+> an uncertain outcome, not permission to retry. Reconcile through the corresponding member/team/
+> binding-run read model or an idempotency key before deciding whether another mutation is safe.
 
 Member implementation kinds are the lowercase strings **`workflow`**, **`script`**,
 **`gagent`**.
@@ -60,7 +59,7 @@ implementation (the workflow + its YAML) is attached in Step 3. Passing a forwar
 `workflowId` that does not exist yet returns **HTTP 500**.
 
 ```bash
-wfId="my-workflow"   # the id you will bind in Step 3 (pick a stable kebab-case id)
+wfId="wf-my-workflow"   # workflow draft identity; it is not the member or published-service id
 memberId=$(aev "api/scopes/$scopeId/members" -m POST -d "{
   \"displayName\": \"My Workflow Member\",
   \"implementationKind\": \"workflow\",
@@ -74,13 +73,21 @@ assigned a `publishedServiceId`; its `implementationRef` stays `null` until Step
 it in. (Verified: omitting `implementationRef` returns 201; sending it with a not-yet-bound
 `workflowId` returns 500.)
 
+Keep all three identities distinct: the response `memberId` owns Team authority, `wfId` names the
+workflow draft/definition, and `publishedServiceId` is the callable runtime identity. Only explicit
+contracts may translate between them; never derive one from another. Use visibly different shapes
+in fixtures and examples.
+
 - **script / gagent members** are created the same way — just set `implementationKind`
   to `"script"` or `"gagent"`. Discover valid gagent kinds with `GET /api/scopes/gagent-types`.
   The concrete `scriptId` / `agentKind` is supplied in the Step 3 binding, not here.
 
 ## Step 3 — Bind the member's implementation (attach the YAML)
 
-This is where the real implementation lands. It starts an **async binding run**.
+This is where the real implementation lands. It starts an **async binding run**. A successful bind
+commits workflow/revision identity and the capability admission plan together; a later run must
+preserve all three. If execution fails, do not create another binding/run until run detail and audit
+identify the first failed boundary.
 
 ```bash
 # Author the YAML first with aevatar-workflow-authoring; pass it inline.

--- a/skills/aevatar-triage/SKILL.md
+++ b/skills/aevatar-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-triage
 description: Use after an Aevatar workflow, codex_exec call, schedule, channel, connector, skill, Agent Profile, or control-plane request fails or behaves unexpectedly. It applies when the agent must attribute the first broken boundary across Aevatar, NyxID, Ornn, chrono-sandbox/gVisor, the managed runner, or private SSH; distinguish credential sources and deployment gaps; preserve sanitized evidence; determine defect versus usage; or draft an issue for explicit user confirmation. Never use it to guess a root cause from one error string or auto-file.
-version: "1.6"
+version: "1.7"
 metadata:
   category: plain
   tag:
@@ -133,8 +133,8 @@ running **image tag / commit**, pod age + `restartCount`, and the **time window*
 (live logs rotate fast, so an old window may already be gone). Missing ids are themselves a finding.
 
 **First, rule out the cheap local causes** before blaming a layer: your own **expired / missing
-credential** (a blanket `401` is often just your own stale token, not a platform bug — refresh it
-and retry) and a **stale local checkout** (the code you're about to read may be behind what's
+credential** (a blanket `401` is often just your own stale token, not a platform bug — refresh it,
+then retry only a safe/idempotent read) and a **stale local checkout** (the code you're about to read may be behind what's
 deployed).
 
 ## Step 2 — Attribute to a layer (trace the request path, eliminate)
@@ -145,8 +145,8 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 
 | Symptom | Most likely layer | Disambiguating evidence to gather |
 |---|---|---|
-| `401` / `403` on a connector/tool call | **NyxID** (auth/vault) | is the `slug` in `GET {NYX}/api/v1/services`? token expired? OAuth scope present? |
-| "credential not found" / connector slug missing | **NyxID** (vault / not connected) | catalog vs services; was it ever connected for *this* identity? |
+| `401` / `403` on a connector/tool call | **Aevatar -> NyxID -> provider auth chain** | Did caller credential enter the run, reach the executor, select the exact UserService/route, and remain authorized downstream? Establish the first missing boundary; do not assign the layer from status alone. |
+| "credential not found" / connector slug missing | **NyxID** (vault / not connected) | Compare catalog with authoritative `/api/v1/keys` for this caller. `/api/v1/user-services` is only a route projection and cannot prove execution readiness. |
 | `404` on a thing you reference | **whichever registry owns it** | skill -> Ornn; connector/service -> NyxID; team/member/scope -> Aevatar |
 | `502` / timeout on an external call | **proxy chain** | which hop? Aevatar tool layer vs NyxID proxy vs the target itself |
 | workflow won't validate / run stalls / binding never `succeeded` | **Aevatar** (engine/runtime) | draft-run error body; run timeline / observatory; binding-run status |
@@ -156,6 +156,7 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 | **schedule fires (`fireCount` climbs) but the real-world effect never happens** | **Aevatar** (the fired call's path / credential) | dispatch success ≠ effect — check the external side-effect out-of-band; the proxy can hand back `{"error":true}` inside a `200` |
 | **scheduled run starts fine, then late steps hit `token_expired`** | **depends entirely on `credentialSourceKind` — read it before you theorize** | see *Scheduled-run credentials are not one thing* below. `nyxid_binding_exchange` ⇒ the fire-time broker token (`BROKER_ACCESS_TTL_SECS = 300`, NyxID `backend/src/services/oauth_broker_service.rs`) is the right hypothesis. `scheduled_invocation_agent_key` ⇒ it is **not** the 300 s broker TTL and a ~5-6 min correlation is coincidence, not evidence |
 | **inbound bot doesn't reply** (Lark/Telegram) | **cross-layer — walk it** | did NyxID relay webhook fire? is the bot connector connected? did the Aevatar channel run start (observatory)? credential = the *sender's* NyxID, present and live? |
+| Lark Base returns `91403` while `bitable:app:readonly` is enabled | **Lark document ACL / usage configuration** | The API scope and Base document sharing are separate. In the Base `...`/More menu choose **Add Applications** and add the exact Bot application used by the selected NyxID UserService; view access is enough for read-only calls. |
 | **`/whoami` says "bound" but tool calls get `credential_denied`** | **NyxID** (grant revoked — false green) | live token-exchange returns `invalid_grant` while the local readmodel still reads "bound"; whoami checks only the local mirror, not the live grant |
 | approval prompt stuck | **NyxID approvals + Aevatar suspension** | NyxID approval request id; Aevatar workflow wait/suspend state |
 | skill search/pull/upload/generate fails | **Ornn** | which `/api/v1/skill...` route? validator violations? version format? |
@@ -163,6 +164,26 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 
 **Do not stop at the first match.** Gather the disambiguating evidence and *eliminate* — a plausible
 first guess that you haven't excluded the alternatives for is not an attribution.
+
+### Workflow execution triage
+
+Preview/readiness and runtime execution are separate proofs. A successful explicit-request preview
+proves the call sites can be admitted for the current workflow/revision; it does not prove that a
+caller credential will propagate into the run or that the downstream service will authorize it.
+
+For one failed run, do not invoke again. Read, in order:
+
+1. the stream terminal frame, if available;
+2. run detail (`completionStatus`, `lastSuccess`, last error, final output);
+3. run audit and its first failed step/tool call;
+4. the binding's exact workflow/revision identity and committed capability admission plan.
+
+For a first NyxID HTTP auth failure, test four hypotheses separately: inbound caller credential
+never entered the run; it entered the run but not the external-capability executor; the executor
+selected the wrong exact UserService/route/credential; or the selected downstream UserService is
+expired/unauthorized. Use distinct `memberId`, `workflowId`, and `publishedServiceId` shapes when
+reproducing identity propagation. Preserve the exact error privately; report only a bounded,
+sanitized classification. A failed mutation or run is never blindly retried.
 
 **Scheduled-run credentials are not one thing.** "It was a scheduled run" tells you nothing about
 its credential. Read `credentialSourceKind` off the run/automation record **first**, then pick the

--- a/skills/aevatar-workflow-authoring/SKILL.md
+++ b/skills/aevatar-workflow-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-workflow-authoring
-description: Author, validate, and persist an executable aevatar workflow from a natural-language request — use it when the user wants to create, build, set up, or automate a multi-step task as a runnable aevatar workflow (make a workflow that…, automate…, build a pipeline…, set up a recurring…). It generates workflow YAML, dispatch-validates it, then saves it as a reusable workflow that can be re-run and watched in the observatory. Not for running an existing workflow — search for that and start it instead.
-version: "2.1"
+description: Author, preview, validate, and persist an executable aevatar workflow from a natural-language request. Use it when the user wants to create, build, set up, or automate a multi-step task as a runnable Aevatar workflow. It covers exact NyxID operation and authored-request admission, bounded YAML, file inputs, terminal run verification, and reusable publication. Not for blindly rerunning an existing failed workflow.
+version: "2.2"
 metadata:
   category: tool-based
   tool-list:
@@ -33,14 +33,15 @@ Everything you need is in this document — the DSL, the engine rules, the tools
 
 1. **Confirm the intent is authoring.** The user wants a *new* runnable workflow. If they want to run something that already exists, stop and search for it instead.
 2. **Clarify just enough.** Pin down: the trigger/input, the ordered steps, the desired output, and which external services (if any) are involved. Ask only what you cannot reasonably infer; do not over-interrogate.
-3. **Discover the exact external operation (only if external calls are needed).** Call `list_external_workflow_capabilities` with `{}` (or `max_results`) and copy one descriptor's exact `selector`. Then call `inspect_external_workflow_capability_readiness` with that `selector` plus `execution_mode: "interactive"` for a current user run or `"durable"` for a scheduled/background run. If readiness is blocked, report its typed blocker; never reconstruct a selector from a display slug or author a route that was not listed.
+3. **Select the exact external capability (only if external calls are needed).** Prefer a published operation: call `list_external_workflow_capabilities`, copy its exact selector, then inspect readiness for `interactive` or `durable`. Use typed `capability.nyxid_request` only when no published operation represents a required HTTP request; it needs an exact UserService selected from authoritative `/api/v1/keys`, a typed method/path/body contract, and bind-time authenticated confirmation/grant. `/api/v1/user-services` is only a routing projection and is never execution authority.
 4. **Author the YAML.** Apply the DSL below and obey every rule in **Engine rules (must obey)**. Prefer the reliable-core primitives; use advanced primitives only when the task truly needs them.
-5. **Validate by dispatching one test run — fire-and-observe, do NOT wait for completion.** Call `aevatar_start_workflow` **once** with the draft inline (`workflow_yamls`). It returns in a second or two with a `run_id` and a status like `accepted`/`streaming` — **that return is your structural pass** (the YAML parsed and dispatched). If instead it returns a parse/validation/4xx error, fix the YAML and retry (cap **2**). **Never poll or wait for `run_finished`, and never re-invoke `aevatar_start_workflow` to "check status"** — the run continues asynchronously and is watchable in the observatory; looping on it stalls the turn.
-6. **Persist as a reusable workflow.** Once the draft dispatches without a parse error, call `ornn_publish_skill` with the final workflow in `workflow_yamls` (see **Persisting**). This creates a private skill in the user's account containing the workflow.
-7. **Report.** Tell the user what was created, the test `run_id` and that they can watch it in the observatory, and how to re-run it ("next time just ask to run *\<name\>*"). Be explicit: you verified it **structurally** (it parsed and dispatched) and reviewed the logic on a best-effort basis — you did **not** wait for the run to finish, so point them to the observatory for the result. Do not claim a guarantee you cannot make.
-8. **Iterate on request.** To change an existing workflow: load it with `use_skill`, edit the YAML, re-validate (step 5), and re-publish as a new version.
+5. **Preview before execution.** Use the explicit-request preview or draft-run readiness surface. Confirm unique call sites, read/write classification, approval requirements, exact workflow/revision identity, and every blocker. Preview/readiness proves admission readiness only; it does not prove runtime credential propagation or downstream authorization.
+6. **Run once when authorized, then observe the same run.** Never use another mutation as a status check. For a real acceptance run, require terminal completion, `lastSuccess=true`, non-empty required step outputs, and non-empty final output. On failure, read run detail and audit, find the first failed step, and diagnose before any rerun. Do not blindly retry a mutation or a failed workflow.
+7. **Persist as a reusable workflow.** After structural validation and any required execution proof, call `ornn_publish_skill` with the final workflow in `workflow_yamls` (see **Persisting**). This creates a private skill in the user's account containing the workflow.
+8. **Report evidence honestly.** Separate preview-ready, accepted, completed, business-verified, blocked by policy, and failed. Do not call `accepted` or an opened SSE stream a successful run.
+9. **Iterate on request.** To change an existing workflow: load it with `use_skill`, edit the YAML, repeat preview and validation, and publish a new version.
 
-> **Turn budget (important).** Your whole turn has a ~60s gateway limit, and tool rounds emit no visible text. So: lead with a one-line text preamble (e.g. "Authoring your workflow…") so output starts streaming immediately; keep tool rounds minimal (skip step 3 when the workflow needs no external service); author in one pass; and **never loop waiting on a run** (step 5 is fire-and-observe). A turn that spends ~60s in silent tool rounds is cut off with no output at all.
+> Keep tool rounds bounded, but do not trade away terminal evidence. Start one authorized run, record its identity privately, and observe that same run through the run/read-model surfaces.
 
 ---
 
@@ -49,6 +50,7 @@ Everything you need is in this document — the DSL, the engine rules, the tools
 These are the failure modes that break generated workflows. Check every one before validating.
 
 - **Single terminal step.** A run ends at the step that has no `next` **and is last in document order**. Make the final step the last line of the document.
+- **Bounded YAML.** Each YAML document is limited to 1 MiB UTF-8, 10,000 parsed nodes, and collection nesting depth 64. Aliases do not bypass these limits. Treat a resource-limit rejection as a document defect; reduce the document instead of retrying it.
 - **Fall-through is by document order, not id order.** A step with no `next` falls through to the *next step written in the file*. So every branch must reach the terminal step via an explicit `next`, and nothing should sit after the terminal step. Getting this wrong silently overwrites your output.
 - **No clock.** The engine has no time source. If the workflow needs "today", a date, or a window, the caller must inject it via the run input (e.g. an early `assign`). Never assume the engine knows the date.
 - **Role is not model.** `target_role` selects the actor, not a model — never put a model name in `target_role`. A role *may* carry `provider`/`model`, but set them only when the user explicitly wants a specific model; otherwise omit and let the session default apply.
@@ -292,7 +294,7 @@ Advanced notes: `human_approval`/`wait_signal` suspend the run until a resume/si
 
 ## Accessing external services
 
-There are three NyxID invocation modes plus a separate host-connector subsystem. Do not mix their fields.
+There is a raw current-turn proxy surface, two compiled workflow capability shapes, and a separate host-connector subsystem. Do not mix their fields.
 
 - **Raw current-turn `nyxid_proxy`.** First select an exact UserService instance. The call requires `service_id + slug + path`; method defaults to GET. Optional fields are `body`, non-sensitive `headers`, and `response_mode`:
   ```json
@@ -305,8 +307,8 @@ There are three NyxID invocation modes plus a separate host-connector subsystem.
   }
   ```
   This is a direct current-turn tool call, not workflow YAML.
-- **Interactive connected-service operation.** Use the request-local `nyxid_service_operation__*` tool name emitted in the current tool catalog. Supply the enumerated `user_service_id` plus only fields present in that operation's dynamic schema. Never derive the tool name from a slug or reuse a tool name from another request.
-- **Compiled workflow operation.** Call `list_external_workflow_capabilities`, copy the exact descriptor `selector`, inspect it for the required execution mode, and persist it beside the step as `capability.nyxid_operation`:
+- **No dynamic current-turn operation tools.** `nyxid_service_operation__*` and `nyxid_service_request` are retired. Never invent or cache one of those tool names. Current-turn management uses the typed connected-service tools; raw one-off HTTP uses `nyxid_proxy` only where that surface is explicitly available.
+- **Compiled published operation.** Call `list_external_workflow_capabilities`, copy the exact descriptor `selector`, inspect it for the required execution mode, and persist it beside the step as `capability.nyxid_operation`:
   ```json
   {
     "selector": {
@@ -331,6 +333,7 @@ There are three NyxID invocation modes plus a separate host-connector subsystem.
       arguments: '{"path_params":{"message_id":"m-42"}}'
   ```
   The compiler's admission proof owns UserService identity, slug, operation ID, method, path template, digest, schemas, and response policy. Runtime `arguments` may contain only admitted `path_params`, `query`, `headers`, `body`, and `response_mode`. Do not send `service_id`, `user_service_id`, `slug`, `path`, `method`, `operation_id`, or a contract digest in `arguments`.
+- **Compiled authored HTTP request.** Use `capability.nyxid_request` only for an exact request contract that cannot be selected as a published operation. Author the typed method, relative path template, allowed request fields, and response policy; select one exact UserService from `/api/v1/keys`. Binding must preview the current request-contract digest and risk, then obtain the authenticated binder's explicit confirmation/grant. Saving a draft, preview success, or `/api/v1/user-services` cannot grant execution. Authored requests never rediscover inventory or OpenAPI at runtime; they execute only the committed proof and matching grant.
 - **Registered workflow connectors.** If the capability is a connector registered in the workflow connector registry, call it with `connector_call` and authorize it on the role:
   ```yaml
   roles:
@@ -349,7 +352,7 @@ There are three NyxID invocation modes plus a separate host-connector subsystem.
 
 ---
 
-## Validating (fire-and-observe — do not wait)
+## Validating and proving a run
 
 Dispatch **one** test run with `aevatar_start_workflow`, passing the draft inline:
 
@@ -357,13 +360,14 @@ Dispatch **one** test run with `aevatar_start_workflow`, passing the draft inlin
 { "workflow_id": "<name>", "workflow_yamls": ["<full yaml>"], "inputs": { "prompt": "<test input>" } }
 ```
 
-`workflow_id` is required; `inputs` is an object (typically `{ "prompt": "..." }`, optionally `input_parts` / `headers`). `aevatar_start_workflow` is **fire-and-return**: it replies in a second or two with a `run_id` and a status like `accepted`/`streaming`, then the run executes **asynchronously**.
+`workflow_id` is required; `inputs` is an object (typically `{ "prompt": "..." }`, optionally `input_parts` / `headers`). File-bearing calls may carry normalized `inlineFile` or `fileRef` parts; member stream invocation and draft-run share the same ingress normalization, so preserve the typed file part instead of flattening it into prompt text.
 
-Judge the *immediate return only*:
-- A `run_id` + `accepted`/`streaming` → the YAML **parsed and dispatched**. That is your structural pass — move on to publish.
-- A parse/validation/4xx error in the return → structural failure (bad YAML, unbound role, bad reference). Fix and retry (cap **2**).
-
-**Do not wait for or poll `run_finished`, and do not re-invoke `aevatar_start_workflow` to "check status."** The run finishes asynchronously; the user watches it in the observatory via the `run_id`. (Waiting or looping is exactly what blows the ~60s turn budget and gets the whole turn cut off.) This confirms the workflow is **structurally** sound (it parsed and dispatched) — not that its business logic is correct. Say so when you report.
+Interpret evidence in order:
+- `accepted`/`streaming` means only that dispatch started.
+- A typed parse, admission, identity, or resource-limit error is a structural failure; fix the document before another run.
+- For the same run, inspect terminal completion, run detail, and audit. Success requires completed terminal state, `lastSuccess=true`, expected non-empty step output, and non-empty final output.
+- On failure, locate the first failed audit step and classify it before retrying. For NyxID HTTP auth failures, distinguish missing caller credential propagation, missing executor propagation, wrong exact route/credential selection, and downstream UserService authorization.
+- Never start another run merely to check whether the previous run finished.
 
 ---
 
@@ -402,20 +406,17 @@ source.)
 # auto-refreshes your token. A raw curl with ~/.nyxid/access_token resolves NO scope
 # (scopeResolved:false) and the stored token expires — it is not a usable path.
 # Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-# NyxID treats `-d` as raw bytes, so declare JSON explicitly; Aevatar rejects writes without it.
-aev() { nyxid proxy request aevatar "$@" -H 'Content-Type: application/json'; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
-NYX=$(tr -d '\n' < ~/.nyxid/base_url)               # e.g. https://nyx.chrono-ai.fun
+aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
 scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 ```
 No `jq`? Any JSON reader works, e.g.
 `... | python3 -c 'import sys,json;print(json.load(sys.stdin)["scopeId"])'`.
-(WAF can 403 Python's `urllib` — drive these calls with the `curl` binary, not a Python HTTP client.)
 
 ### Connectors
-The `nyxid_services` inventory tool is server-side. As a client you must know any external
-connector **slugs** out-of-band (nyxid CLI / console); the dry-run path below assumes a
-workflow with **no** external connectors (pure `llm_call`/`transform`), which is the most
-reliable thing to validate. Never invent a slug.
+The `nyxid_services` inventory tool is server-side. As a client, discover exact connected-service
+instances through the NyxID CLI or the authenticated Aevatar preview surface. `/api/v1/keys` is the
+authoritative instance/readiness inventory; `/api/v1/user-services` is not. Never invent a slug,
+UserService identity, endpoint, method, or path.
 
 ### Dry-run (the client replacement for `aevatar_start_workflow`) — `draft-run`
 `aevatar_start_workflow` is a **server-side agent tool dispatched through the engine, not a REST
@@ -428,7 +429,7 @@ aev "api/scopes/$scopeId/workflow/draft-run" -m POST --stream \
 Body (JSON, **camelCase**): `prompt` (string) + `workflowYamls` (array of YAML strings,
 **required** — omitting it returns 400). The response is an **SSE stream** and the run executes
 synchronously through the connection. Judge it like the server-side validate step:
-- **HTTP 200 + the stream opens with lifecycle/observation frames, no parse/4xx error → structural pass.** You can stop reading there; you do not need to wait for the end.
+- **HTTP 200 + lifecycle frames** proves only dispatch. For execution acceptance, continue to the terminal frame and read the resulting run detail/audit.
 - A parse/validation/4xx error → fix the YAML and retry (cap **2**).
 
 **Reading the SSE frames** (so a naive parser doesn't see "nothing"): each `data:` line is JSON,
@@ -477,16 +478,15 @@ metadata:
 Then **validate first** (the format oracle — read every `violations[].rule`/`message` and fix),
 then **upload** (re-uploading the **same `name`** later creates a **new version**):
 ```bash
-TOK=$(tr -d '\n' < ~/.nyxid/access_token)                     # raw NyxID bearer for the ornn-api proxy
 cd <parent>; zip -r demo-skill.zip demo-skill                 # root folder MUST be included
 # 1) validate → {"data":{"valid":bool,"violations":[{"rule","message"}]}}
-curl -s -X POST -H "Authorization: Bearer $TOK" -H "Content-Type: application/zip" \
-  --data-binary @demo-skill.zip "$NYX/api/v1/proxy/s/ornn-api/api/v1/skill-format/validate"
+nyxid proxy request ornn-api /api/v1/skill-format/validate -m POST \
+  -H 'Content-Type:application/zip' -d @demo-skill.zip
 # 2) publish (private by default; promote to public separately)
-curl -s -X POST -H "Authorization: Bearer $TOK" -H "Content-Type: application/zip" \
-  --data-binary @demo-skill.zip "$NYX/api/v1/proxy/s/ornn-api/api/v1/skills"
+nyxid proxy request ornn-api /api/v1/skills -m POST \
+  -H 'Content-Type:application/zip' -d @demo-skill.zip
 # verify
-curl -s -H "Authorization: Bearer $TOK" "$NYX/api/v1/proxy/s/ornn-api/api/v1/skills/demo-skill"
+nyxid proxy request ornn-api /api/v1/skills/demo-skill
 ```
 The server normalizes the kebab frontmatter into its stored model
 (`runtimes:[{runtime,dependencies,envs}]`, `tools:[{tool,type:mcp}]`, `outputType`).

--- a/skills/nyxid/SKILL.md
+++ b/skills/nyxid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nyxid
-version: "0.5"
+version: "0.6"
 description: Brokers credentials for downstream services so the agent never sees raw API keys or OAuth tokens. Use when the user explicitly mentions NyxID; asks to broker, store, proxy, connect, or manage credentials or a credential-backed service; manages NyxID credential nodes, SSH, MCP, or other NyxID resources; or must call a protected downstream API using an available NyxID-managed credential because no suitable authenticated native path is available. Do not use merely because a service is external, for public or unauthenticated APIs or webhooks, for standard Git operations, or for ordinary GitHub work when local `gh` is authenticated. A GitHub username supplied only to select an account is not a trigger. Operate exclusively through the `nyxid` CLI.
 metadata:
   category: tool-based
@@ -117,7 +117,7 @@ Load the matching `references/<file>.md` when the user asks for one of these top
 
 | Trigger keywords / user request | Load this reference |
 |---|---|
-| "list my services", "what's connected", "discover services", "add a service", "connect OpenAI / GitHub / Lark / etc.", "OAuth scopes", browser-wizard / pairing-code questions, "where do I get the API key" | `references/services.md` |
+| "list my services", "what's connected", "discover services", "add a service", "connect OpenAI / GitHub / Lark / etc.", Lark Base / Bitable `91403`, "OAuth scopes", browser-wizard / pairing-code questions, "where do I get the API key" | `references/services.md` |
 | "call the API", "proxy request", "send a message via Telegram/Discord/Slack" (single call), curl examples, raw HTTP integration, WebSocket auth-frame injection, Home Assistant connection | `references/proxy.md` |
 | "service pool", "pool slug", "load balance services", "several identical backends", "proxy to a pool" | `references/service-pools.md` |
 | "list / rename / delete a service", attaching an OpenAPI spec to a custom endpoint, default headers, "create / rotate / delete an API key", agent key bindings, callback URLs, scope/rate-limit edits | `references/managing.md` |
@@ -137,15 +137,17 @@ Prefer the canonical reference over guessing. If a topic spans two files (e.g. "
 
 ## Working Rules
 
-- Always discover services before assuming a slug exists.
+- Always discover configured service instances with `nyxid service list --output json` before assuming a slug or exact UserService exists. This command reads `GET /api/v1/keys`, the authoritative discovery, readiness, and execution inventory.
+- Treat `/api/v1/user-services` as a routing-configuration projection only. It cannot prove that a credential is discoverable, ready, or authorized for execution.
 - Use `--output json` for machine-readable responses.
-- Prefer slug-based proxy URLs over UUID-based ones.
+- Prefer slug-based proxy URLs, but pin the exact UserService with `--via-service <id>` whenever multiple credentials share a slug or downstream authorization depends on a specific account/Bot. Get that ID only from `nyxid service list --output json`.
 - Use exact downstream API paths. Do not guess undocumented endpoints.
 - Keep request bodies minimal and service-correct.
 - Never try to extract or display the user's stored provider credentials.
 - If multiple AI agents share a machine, each should have its own `NYXID_ACCESS_TOKEN`. Never share a single API key across multiple agents -- it defeats audit isolation and makes revocation impossible without disrupting all agents.
 - Your User-Agent header is forwarded to downstream services by default (passthrough). Some downstreams block SDK-specific User-Agent strings -- see the 403 troubleshooting note in `references/admin.md`.
 - If a downstream requires a static header on every call (scope hint, API version, routing key), configure it once as a service default via `nyxid service update ... --default-header 'name=value'` rather than sending it from every caller.
+- For Lark Base error `91403`, do not ask for `bitable:app:readonly` again when it is already enabled. The application API scope and the individual Base document ACL are separate: in the Base's `...`/More menu choose **Add Applications**, add the exact Bot application used by the selected NyxID UserService, and grant view access for read-only calls.
 
 ## Service pools
 

--- a/skills/nyxid/references/services.md
+++ b/skills/nyxid/references/services.md
@@ -3,6 +3,7 @@
 ## Table of contents
 
 - [Discover Services](#discover-services)
+- [Inventory authority and Lark Base access](#inventory-authority-and-lark-base-access)
 - [Slug rules for `service add`](#slug-rules-for-service-add)
 - [OAuth consent service grants and resource URIs](#oauth-consent-service-grants-and-resource-uris)
 - [Requesting additional OAuth scopes](#requesting-additional-oauth-scopes)
@@ -52,6 +53,29 @@ Official catalog services ship NyxID-hosted curated OpenAPI overlays (served at 
 > For API key services, just run `nyxid service add <slug>` without flags. The CLI securely prompts for the key (input hidden). Never ask the user to paste secrets into chat or set environment variables manually.
 > For automation/scripting only: `--credential-env <VAR>` reads from an environment variable.
 > For multi-field credentials such as AWS access-key JSON: `--credential-file <PATH>` reads the credential bytes from a file. Pass `-` to read from stdin.
+
+## Inventory authority and Lark Base access
+
+`nyxid service list --output json` is backed by `GET /api/v1/keys`. Its response is
+`{"keys":[...]}`; an empty account is `{"keys":[]}`. This is the authoritative view for exact
+UserService discovery, connection/readiness checks, proxy selection, and workflow execution.
+Do not substitute `GET /api/v1/user-services`: that endpoint is a routing-configuration projection
+and cannot prove that a service credential is discoverable, ready, or authorized to execute.
+When more than one configured credential shares a slug, keep the slug route but pass
+`--via-service <user-service-id>` to `nyxid proxy request`, using the exact ID returned by this
+inventory. Never select a Bot or account from a label guess or from `/api/v1/user-services`.
+
+Lark Base access has two independent permission layers:
+
+1. The Bot application needs the relevant Lark API scope, such as `bitable:app:readonly`.
+2. The exact Base document must grant that Bot application access.
+
+Lark error `91403` means the Base document ACL denied the application; it is not evidence that the
+API scope is missing. In the current Base UI, open the Base's `...`/More menu, choose **Add
+Applications**, select the exact Bot application used by the chosen NyxID UserService, and grant
+view access for a read-only probe. A Base is Lark's multi-dimensional table product, not a regular
+spreadsheet file. Re-list services after changing credentials or routes, and retry only a safe,
+idempotent read until access is proven.
 
 ## OAuth consent service grants and resource URIs
 


### PR DESCRIPTION
## Problem

The bundled Aevatar and NyxID skills had drifted from the live Aevatar/NyxID contracts. They still described retired dynamic connected-service tools, treated preview or dispatch admission as sufficient execution evidence, exposed obsolete raw schedule targets, and did not explain the Lark Base document ACL behind error 91403.

## Solution

- Synchronize the seven updated Aevatar skills with the verified Ornn skill family.
- Make GET /api/v1/keys and nyxid service list the authoritative exact UserService inventory; document /api/v1/user-services as a routing projection only.
- Document capability.nyxid_operation and capability.nyxid_request admission, runtime credential-boundary triage, terminal run acceptance, mutation retry safety, file ingress, YAML limits, and member/workflow/published-service identity separation.
- Retire external raw actor/envelope scheduling guidance.
- Explain the current Lark Base Add Applications ACL flow and exact Bot selection with --via-service.
- Align Claude, Codex, Cursor, and Claude marketplace manifests at 0.7.3.

## Impact

Documentation and plugin manifests only. NyxID runtime behavior is unchanged.

Changed paths:
- .claude-plugin
- .codex-plugin
- .cursor-plugin
- skills/aevatar-*
- skills/nyxid/SKILL.md
- skills/nyxid/references/services.md

## Verification

- python3 plugin-creator/scripts/validate_plugin.py .: passed
- claude plugin validate .claude-plugin/plugin.json: passed with the existing root CLAUDE.md packaging warning
- claude plugin validate --strict .claude-plugin/marketplace.json: passed
- Parsed all eight changed SKILL.md frontmatters as the repository versioned skill contract: passed
- Parsed all four JSON manifests and asserted version 0.7.3: passed
- Searched for retired tool, raw schedule, bearer-reading, blind retry, and identity-derivation guidance: no stale matches
- git diff --check: passed

The generic skill-creator quick_validate.py is not directly applicable here because it rejects the version field used by every existing NyxID/Ornn skill. The repository versioned frontmatter was parsed and validated separately.