### PR TITLE
feat(assistant): gate wire log behind the feature-flag subsystem

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,10 +137,6 @@ ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
 BROKER_REQUIRE_SENDER_CONSTRAINT=false
 BROKER_REQUIRE_ADMIN_CAPABILITY=false
 
-# Sole operator gate for raw assistant wire capture. This is not admin-restricted
-# when enabled; keep it false where browser retention of raw payloads is unsafe.
-AEVATAR_CHAT_WIRE_LOG_ENABLED=false
-
 # ─── Rate Limiting ───
 RATE_LIMIT_PER_SECOND=10
 RATE_LIMIT_BURST=30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,6 @@ JWT_RELAY_ACCESS_TTL_SECS=300       # X-NyxID-User-Token relay access token TTL.
 JWT_ASSISTANT_FORWARD_TTL_SECS=300  # Legacy tombstone for the retired assistant_forward token.
                                     # Live assistant delegation uses the compile-time 300s
                                     # MCP_DELEGATION_TOKEN_TTL_SECS constant; this env has no effect.
-AEVATAR_CHAT_WIRE_LOG_ENABLED=false # Sole operator gate for per-browser assistant wire capture; not admin-restricted when enabled
 SA_TOKEN_TTL_SECS=3600              # Service account tokens
 ENVIRONMENT=development
 RATE_LIMIT_PER_SECOND=10

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -332,10 +332,6 @@ pub struct AppConfig {
     /// platform-only even if legacy catalog records carry resale metadata.
     pub billing_resale_enabled: bool,
 
-    /// Operator kill switch for the assistant Aevatar wire-log diagnostic.
-    /// Defaults to `false`; when disabled, no debug echo work is performed.
-    pub aevatar_chat_wire_log_enabled: bool,
-
     // Registration gate
     /// When `true` (default), new-user registration requires a valid invite
     /// code and first-time social sign-ups are rejected. Set
@@ -598,10 +594,6 @@ impl std::fmt::Debug for AppConfig {
                 &self.oracle_task_retention_days,
             )
             .field("billing_enabled", &self.billing_enabled)
-            .field(
-                "aevatar_chat_wire_log_enabled",
-                &self.aevatar_chat_wire_log_enabled,
-            )
             .field("lago_api_url", &self.lago_api_url)
             .field(
                 "lago_api_key",
@@ -1072,10 +1064,6 @@ impl AppConfig {
             .unwrap_or(0),
             billing_fail_closed: parse_bool_env("BILLING_FAIL_CLOSED", false),
             billing_resale_enabled: parse_bool_env("BILLING_RESALE_ENABLED", false),
-            aevatar_chat_wire_log_enabled: parse_bool_env(
-                "AEVATAR_CHAT_WIRE_LOG_ENABLED",
-                false,
-            ),
 
             invite_code_required: parse_invite_code_required(env::var("INVITE_CODE_REQUIRED").ok()),
             email_auth_enabled: parse_bool_env("EMAIL_AUTH_ENABLED", false),
@@ -1440,7 +1428,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,
@@ -1687,46 +1674,6 @@ mod tests {
     fn parse_bool_env_defaults() {
         assert!(parse_bool_env("NONEXISTENT_VAR_XYZZY_12345", true));
         assert!(!parse_bool_env("NONEXISTENT_VAR_XYZZY_12345", false));
-    }
-
-    #[test]
-    fn aevatar_chat_wire_log_env_name_and_default_are_pinned() {
-        const PROBE_TEST: &str =
-            "config::tests::aevatar_chat_wire_log_env_name_and_default_are_pinned";
-        const EXPECTED_ENV: &str = "NYXID_TEST_EXPECTED_AEVATAR_WIRE_LOG";
-
-        if let Ok(expected) = std::env::var(EXPECTED_ENV) {
-            assert_eq!(
-                AppConfig::from_env().aevatar_chat_wire_log_enabled,
-                expected
-                    .parse::<bool>()
-                    .expect("probe expected value is boolean")
-            );
-            return;
-        }
-
-        let test_binary = std::env::current_exe().expect("resolve current test binary");
-
-        for (configured_value, expected) in [(None, false), (Some("true"), true)] {
-            let mut command = std::process::Command::new(&test_binary);
-            command
-                .arg(PROBE_TEST)
-                .arg("--exact")
-                .env("DATABASE_URL", "mongodb://unused-for-config-test")
-                .env(EXPECTED_ENV, expected.to_string())
-                .env_remove("AEVATAR_CHAT_WIRE_LOG_ENABLED");
-            if let Some(value) = configured_value {
-                command.env("AEVATAR_CHAT_WIRE_LOG_ENABLED", value);
-            }
-
-            let output = command.output().expect("run isolated config probe");
-            assert!(
-                output.status.success(),
-                "isolated config probe failed for {configured_value:?}:\nstdout:\n{}\nstderr:\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
-            );
-        }
     }
 
     #[test]

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -1059,7 +1059,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -235,7 +235,6 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -1217,7 +1217,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -380,7 +380,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -33,7 +33,7 @@ use crate::errors::{AppError, AppResult};
 use crate::handlers::proxy::execute_admin_proxy;
 use crate::models::downstream_service::DownstreamService;
 use crate::mw::auth::{AuthMethod, AuthUser, PROXY_SCOPE, scope_allows_rest_proxy};
-use crate::services::assistant_service;
+use crate::services::{assistant_service, feature_flag_service};
 
 /// Conversation indexes carry titles, timestamps, and counts per row, so the
 /// list route gets its own buffering headroom before any merge/reshape.
@@ -156,18 +156,47 @@ fn truncate_utf8(value: &str, max_bytes: usize) -> (String, bool) {
     (value[..end].to_string(), true)
 }
 
-fn upstream_echo_collector(
+/// Decide whether this request captures a wire-log echo, and start an empty
+/// collector when it does.
+///
+/// **Gate order is load-bearing for latency.** The `X-NyxID-Debug-Upstream: 1`
+/// request header is a free in-memory lookup; the feature flag is resolved
+/// from MongoDB. Normal chat traffic — the overwhelming majority — never sends
+/// the header, so the header is checked first and that traffic performs zero
+/// additional database work. This deliberately inverts the previous
+/// flag-then-header order, which was only correct while the gate was static
+/// process config with no I/O cost.
+///
+/// Fails **closed**: a flag-resolution error suppresses the echo rather than
+/// exposing raw upstream payloads to the browser.
+async fn upstream_echo_collector(
     state: &AppState,
+    auth_user: &AuthUser,
     request_headers: &HeaderMap,
 ) -> Option<Vec<UpstreamEcho>> {
-    if !state.config.aevatar_chat_wire_log_enabled {
-        return None;
-    }
     let requested = request_headers
         .get(DEBUG_UPSTREAM_REQUEST_HEADER)
         .and_then(|value| value.to_str().ok())
         == Some("1");
     if !requested {
+        return None;
+    }
+    let enabled = match feature_flag_service::aevatar_chat_wire_log_enabled(
+        &state.db,
+        &auth_user.user_id.to_string(),
+    )
+    .await
+    {
+        Ok(enabled) => enabled,
+        Err(_) => {
+            // Metadata only — never the request body or any echo content.
+            tracing::warn!(
+                "assistant: wire-log flag resolution failed; suppressing the debug echo"
+            );
+            false
+        }
+    };
+    if !enabled {
         return None;
     }
     Some(Vec::new())
@@ -683,7 +712,7 @@ pub async fn list_conversations(
     request: Request<Body>,
 ) -> AppResult<Response> {
     let authorization = request.headers().get(header::AUTHORIZATION).cloned();
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let user_id = auth_user.user_id.to_string();
     let mut response_parts = None;
     let mut conversations = Vec::new();
@@ -794,7 +823,7 @@ pub async fn get_history(
     Path(conversation_id): Path<String>,
     request: Request<Body>,
 ) -> AppResult<Response> {
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let user_id = auth_user.user_id.to_string();
     let path = match assistant_service::conversation_resource_family(&conversation_id)? {
         assistant_service::ConversationResourceFamily::Typed => {
@@ -824,7 +853,7 @@ pub async fn delete_conversation(
     Path(conversation_id): Path<String>,
     request: Request<Body>,
 ) -> AppResult<Response> {
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let user_id = auth_user.user_id.to_string();
     let family = assistant_service::conversation_resource_family(&conversation_id)?;
     let path = match family {
@@ -877,7 +906,7 @@ pub async fn get_state(
             "Conversation state not found.".to_string(),
         ));
     }
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let path = assistant_service::canonical_state_path(&conversation_id)?;
     let response = forward(
         &state,
@@ -899,7 +928,7 @@ pub async fn get_create_recovery(
     Path(command_id): Path<String>,
     request: Request<Body>,
 ) -> AppResult<Response> {
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let path = assistant_service::history_create_recovery_path(
         &auth_user.user_id.to_string(),
         &command_id,
@@ -922,7 +951,7 @@ pub async fn completions(
     auth_user: AuthUser,
     request: Request<Body>,
 ) -> AppResult<Response> {
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let response = forward(
         &state,
         &auth_user,
@@ -976,7 +1005,7 @@ pub async fn typed_chat(
             prepared.response_kind.accept_header_value().to_string(),
         ),
     ];
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let echoed_body = echoes.as_ref().map(|_| prepared.body.clone());
     let response = forward(
         &state,
@@ -1037,7 +1066,7 @@ pub async fn workflow_chat(
         HeaderValue::from_static("application/json"),
     );
     let request = Request::from_parts(parts, Body::from(payload));
-    let mut echoes = upstream_echo_collector(&state, request.headers());
+    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
     let echoed_body = echoes.as_ref().map(|_| upstream.clone());
     let response = forward(
         &state,
@@ -1183,42 +1212,210 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn disabled_echo_flag_suppresses_an_explicit_capture_request() {
-        let state = crate::test_utils::test_app_state_no_db().await;
+    /// A valid, well-formed capture request. Deliberately *not* an
+    /// invalid-UTF-8 header value: that would trip the header parse gate and
+    /// make a flag assertion vacuous.
+    fn capture_request_headers() -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(DEBUG_UPSTREAM_REQUEST_HEADER, HeaderValue::from_static("1"));
+        headers
+    }
 
-        let echoes = upstream_echo_collector(&state, &headers);
+    /// Register a person account so per-user platform overrides can target it.
+    async fn seed_flag_user(db: &mongodb::Database) -> String {
+        use crate::models::user::{COLLECTION_NAME as USERS, User, UserType};
+        let user_id = uuid::Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_one(crate::test_utils::test_user(&user_id, UserType::Person))
+            .await
+            .expect("insert wire-log flag test user");
+        user_id
+    }
+
+    #[tokio::test]
+    async fn code_default_suppresses_a_valid_capture_request() {
+        let Some(db) = crate::test_utils::connect_test_database("assistant_wire_log_default").await
+        else {
+            eprintln!("skipping assistant wire-log flag test: no local MongoDB available");
+            return;
+        };
+        let user_id = seed_flag_user(&db).await;
+        let state = crate::test_utils::test_app_state(db);
+        let auth_user = crate::test_utils::test_auth_user(&user_id);
+
+        // No override rows at all: the registry default (off) must win even
+        // though the caller asked for a capture with a valid header.
+        let echoes = upstream_echo_collector(&state, &auth_user, &capture_request_headers()).await;
 
         assert!(echoes.is_none());
     }
 
     #[tokio::test]
+    async fn global_override_enables_the_capture_request() {
+        use crate::services::feature_flag_service::{
+            AEVATAR_CHAT_WIRE_LOG_FLAG_KEY, FlagTarget, clear_platform_override,
+            set_platform_override,
+        };
+
+        let Some(db) = crate::test_utils::connect_test_database("assistant_wire_log_global").await
+        else {
+            eprintln!("skipping assistant wire-log flag test: no local MongoDB available");
+            return;
+        };
+        let user_id = seed_flag_user(&db).await;
+        let state = crate::test_utils::test_app_state(db.clone());
+        let auth_user = crate::test_utils::test_auth_user(&user_id);
+
+        set_platform_override(
+            &db,
+            AEVATAR_CHAT_WIRE_LOG_FLAG_KEY,
+            &FlagTarget::Global,
+            true,
+            "admin",
+        )
+        .await
+        .expect("enable the wire-log flag globally");
+
+        let echoes = upstream_echo_collector(&state, &auth_user, &capture_request_headers()).await;
+        assert!(matches!(echoes, Some(ref values) if values.is_empty()));
+
+        // Clearing the override at runtime takes effect on the next request
+        // with no redeploy — the whole point of the DB-backed gate.
+        clear_platform_override(&db, AEVATAR_CHAT_WIRE_LOG_FLAG_KEY, &FlagTarget::Global)
+            .await
+            .expect("clear the global override");
+        assert!(
+            upstream_echo_collector(&state, &auth_user, &capture_request_headers())
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn per_user_override_enables_only_that_user() {
+        use crate::services::feature_flag_service::{
+            AEVATAR_CHAT_WIRE_LOG_FLAG_KEY, FlagTarget, set_platform_override,
+        };
+
+        let Some(db) = crate::test_utils::connect_test_database("assistant_wire_log_user").await
+        else {
+            eprintln!("skipping assistant wire-log flag test: no local MongoDB available");
+            return;
+        };
+        let flagged_id = seed_flag_user(&db).await;
+        let other_id = seed_flag_user(&db).await;
+        let state = crate::test_utils::test_app_state(db.clone());
+
+        set_platform_override(
+            &db,
+            AEVATAR_CHAT_WIRE_LOG_FLAG_KEY,
+            &FlagTarget::User(flagged_id.clone()),
+            true,
+            "admin",
+        )
+        .await
+        .expect("enable the wire-log flag for one user");
+
+        let flagged = crate::test_utils::test_auth_user(&flagged_id);
+        assert!(
+            upstream_echo_collector(&state, &flagged, &capture_request_headers())
+                .await
+                .is_some(),
+            "the targeted user must get the echo"
+        );
+
+        let other = crate::test_utils::test_auth_user(&other_id);
+        assert!(
+            upstream_echo_collector(&state, &other, &capture_request_headers())
+                .await
+                .is_none(),
+            "a per-user override must not leak to another caller"
+        );
+    }
+
+    /// An `AppState` whose MongoDB handle points at a closed loopback port, so
+    /// any database access costs at least the server-selection timeout and
+    /// then fails.
+    async fn unreachable_db_state() -> AppState {
+        let mut options = mongodb::options::ClientOptions::parse(UNREACHABLE_MONGO_URI)
+            .await
+            .expect("parse unreachable mongo uri");
+        options.server_selection_timeout = Some(std::time::Duration::from_millis(
+            UNREACHABLE_MONGO_SELECTION_TIMEOUT_MS,
+        ));
+        options.connect_timeout = Some(std::time::Duration::from_millis(
+            UNREACHABLE_MONGO_SELECTION_TIMEOUT_MS,
+        ));
+        let client =
+            mongodb::Client::with_options(options).expect("build unreachable mongo client");
+        crate::test_utils::test_app_state(client.database("nyxid_unreachable"))
+    }
+
+    // Port 1 has no listener on any sane host, so every connection attempt is
+    // refused immediately and server selection burns the full timeout.
+    const UNREACHABLE_MONGO_URI: &str =
+        "mongodb://127.0.0.1:1/nyxid_unreachable?directConnection=true";
+    const UNREACHABLE_MONGO_SELECTION_TIMEOUT_MS: u64 = 750;
+
+    #[tokio::test]
+    async fn absent_debug_header_performs_no_flag_resolution() {
+        // Latency guarantee: normal chat traffic never sends the debug header
+        // and must therefore never touch the database. With an unreachable
+        // MongoDB, any flag resolution would cost the full 750 ms selection
+        // timeout; the header-first ordering keeps this in the microseconds.
+        let state = unreachable_db_state().await;
+        let auth_user = crate::test_utils::test_auth_user(&uuid::Uuid::new_v4().to_string());
+
+        let started = std::time::Instant::now();
+        let echoes = upstream_echo_collector(&state, &auth_user, &HeaderMap::new()).await;
+        let elapsed = started.elapsed();
+
+        assert!(echoes.is_none());
+        assert!(
+            elapsed < std::time::Duration::from_millis(250),
+            "no-header path did database work ({elapsed:?}); the flag must be resolved \
+             only after the header check"
+        );
+    }
+
+    #[tokio::test]
+    async fn flag_resolution_failure_fails_closed() {
+        let state = unreachable_db_state().await;
+        let auth_user = crate::test_utils::test_auth_user(&uuid::Uuid::new_v4().to_string());
+
+        let started = std::time::Instant::now();
+        let echoes = upstream_echo_collector(&state, &auth_user, &capture_request_headers()).await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            echoes.is_none(),
+            "an unresolvable flag must never open the gate"
+        );
+        // Proves the failure really came from an attempted resolution rather
+        // than from an earlier gate short-circuiting the call.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(UNREACHABLE_MONGO_SELECTION_TIMEOUT_MS / 2),
+            "expected a real resolution attempt against the unreachable database, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn malformed_debug_header_is_not_a_capture_request() {
-        let mut state = crate::test_utils::test_app_state_no_db().await;
-        state.config.aevatar_chat_wire_log_enabled = true;
+        // The header gate rejects this before any flag resolution, so an
+        // unreachable database is also proof that no lookup was attempted.
+        let state = unreachable_db_state().await;
+        let auth_user = crate::test_utils::test_auth_user(&uuid::Uuid::new_v4().to_string());
         let mut headers = HeaderMap::new();
         headers.insert(
             DEBUG_UPSTREAM_REQUEST_HEADER,
             HeaderValue::from_bytes(&[0xff]).expect("opaque invalid UTF-8 header"),
         );
 
-        let echoes = upstream_echo_collector(&state, &headers);
+        let started = std::time::Instant::now();
+        let echoes = upstream_echo_collector(&state, &auth_user, &headers).await;
 
         assert!(echoes.is_none());
-    }
-
-    #[tokio::test]
-    async fn enabled_echo_flag_accepts_an_explicit_capture_request() {
-        let mut state = crate::test_utils::test_app_state_no_db().await;
-        state.config.aevatar_chat_wire_log_enabled = true;
-        let mut headers = HeaderMap::new();
-        headers.insert(DEBUG_UPSTREAM_REQUEST_HEADER, HeaderValue::from_static("1"));
-
-        let echoes = upstream_echo_collector(&state, &headers);
-
-        assert!(matches!(echoes, Some(ref values) if values.is_empty()));
+        assert!(started.elapsed() < std::time::Duration::from_millis(250));
     }
 
     #[test]

--- a/backend/src/handlers/channel_webhooks.rs
+++ b/backend/src/handlers/channel_webhooks.rs
@@ -761,7 +761,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -43,8 +43,6 @@ pub struct PublicConfigResponse {
     pub social_providers: Vec<String>,
     pub invite_code_required: bool,
     pub email_auth_enabled: bool,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    pub aevatar_chat_wire_log_enabled: bool,
     /// Public PostHog ingest key for the frontend. Non-secret by design
     /// (PostHog ingest keys are write-only and project-scoped). Empty
     /// when telemetry is off. See docs/TELEMETRY.md §3.
@@ -125,7 +123,6 @@ pub async fn public_config(State(state): State<AppState>) -> Json<PublicConfigRe
         social_providers,
         invite_code_required: state.config.invite_code_required,
         email_auth_enabled: state.config.email_auth_enabled,
-        aevatar_chat_wire_log_enabled: state.config.aevatar_chat_wire_log_enabled,
         telemetry_dsn,
         telemetry_host,
         telemetry_share_analytics,
@@ -203,7 +200,6 @@ mod tests {
             social_providers: vec!["github".to_string()],
             invite_code_required: true,
             email_auth_enabled: true,
-            aevatar_chat_wire_log_enabled: true,
             telemetry_dsn: None,
             telemetry_host: None,
             telemetry_share_analytics: false,
@@ -215,7 +211,6 @@ mod tests {
         assert_eq!(json["social_providers"], serde_json::json!(["github"]));
         assert_eq!(json["invite_code_required"], true);
         assert_eq!(json["email_auth_enabled"], true);
-        assert_eq!(json["aevatar_chat_wire_log_enabled"], true);
     }
 
     #[test]
@@ -228,7 +223,6 @@ mod tests {
             social_providers: vec![],
             invite_code_required: false,
             email_auth_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             telemetry_dsn: None,
             telemetry_host: None,
             telemetry_share_analytics: false,
@@ -239,8 +233,6 @@ mod tests {
         assert!(json.get("telemetry_host").is_none());
         // telemetry_share_analytics false => skipped (Not::not)
         assert!(json.get("telemetry_share_analytics").is_none());
-        // Disabled diagnostics must not change or advertise the public shape.
-        assert!(json.get("aevatar_chat_wire_log_enabled").is_none());
     }
 
     #[test]
@@ -253,7 +245,6 @@ mod tests {
             social_providers: vec![],
             invite_code_required: false,
             email_auth_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             telemetry_dsn: Some("phc_test123".to_string()),
             telemetry_host: Some("https://us.i.posthog.com".to_string()),
             telemetry_share_analytics: true,

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -6914,6 +6914,32 @@ mod proxy_resolution_integration_tests {
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
 
+    /// Turn the wire-log diagnostic on platform-wide, the way an operator does
+    /// it at runtime through the admin feature-flag API.
+    async fn enable_wire_log_flag(db: &mongodb::Database) {
+        crate::services::feature_flag_service::set_platform_override(
+            db,
+            crate::services::feature_flag_service::AEVATAR_CHAT_WIRE_LOG_FLAG_KEY,
+            &crate::services::feature_flag_service::FlagTarget::Global,
+            true,
+            "test-admin",
+        )
+        .await
+        .expect("enable the wire-log flag globally");
+    }
+
+    /// Runtime kill switch: drop the global override so resolution falls back
+    /// to the registry default (off).
+    async fn disable_wire_log_flag(db: &mongodb::Database) {
+        crate::services::feature_flag_service::clear_platform_override(
+            db,
+            crate::services::feature_flag_service::AEVATAR_CHAT_WIRE_LOG_FLAG_KEY,
+            &crate::services::feature_flag_service::FlagTarget::Global,
+        )
+        .await
+        .expect("clear the wire-log flag override");
+    }
+
     fn assistant_echoes(response: &Response) -> Vec<serde_json::Value> {
         let Some(value) = response.headers().get("x-nyxid-debug-upstream-log") else {
             return Vec::new();
@@ -8127,8 +8153,10 @@ mod proxy_resolution_integration_tests {
         .await
         .unwrap();
 
-        let mut state = test_app_state(db.clone());
-        state.config.aevatar_chat_wire_log_enabled = true;
+        let state = test_app_state(db.clone());
+        // The wire log is gated by a runtime feature flag, not process config:
+        // a platform-global override turns it on for every caller.
+        enable_wire_log_flag(&db).await;
         let auth = access_token_auth(&user_id);
         let billing_policy = crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
             crate::services::billing::BillingIngress::Proxy,
@@ -8674,8 +8702,9 @@ mod proxy_resolution_integration_tests {
                 .is_none()
         );
 
-        let mut flag_off_state = state.clone();
-        flag_off_state.config.aevatar_chat_wire_log_enabled = false;
+        // Turning the runtime flag off must suppress the echo on the very next
+        // request, with no process restart and no other behaviour change.
+        disable_wire_log_flag(&db).await;
         let mut flag_off_request = request(
             Method::POST,
             "/api/v1/assistant/workflow-chat",
@@ -8686,7 +8715,7 @@ mod proxy_resolution_integration_tests {
             HeaderValue::from_static("1"),
         );
         let flag_off_response = crate::handlers::assistant::workflow_chat(
-            axum::extract::State(flag_off_state),
+            axum::extract::State(state.clone()),
             auth.clone(),
             flag_off_request,
         )
@@ -8755,6 +8784,9 @@ mod proxy_resolution_integration_tests {
                 .is_none()
         );
 
+        // Back on: the flag is the sole authorization gate, so a plain
+        // authenticated non-admin caller captures their own exchange too.
+        enable_wire_log_flag(&db).await;
         let non_admin_id = Uuid::new_v4().to_string();
         db.collection::<crate::models::user::User>(USERS)
             .insert_one(test_user(&non_admin_id, UserType::Person))
@@ -8960,8 +8992,8 @@ mod proxy_resolution_integration_tests {
         .await
         .unwrap();
 
-        let mut state = test_app_state(db);
-        state.config.aevatar_chat_wire_log_enabled = true;
+        let state = test_app_state(db.clone());
+        enable_wire_log_flag(&db).await;
         let auth = access_token_auth(&user_id);
         let list_request = || {
             let mut request = Request::builder()

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -1149,7 +1149,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -87,8 +87,20 @@ const BILLING_FLAG_TEST: FeatureFlagDef = FeatureFlagDef {
     default_enabled: true,
 };
 
+/// Operator gate for the Aevatar chat wire-log diagnostic. Off by default and
+/// toggled at runtime (platform-global, org cohort, or per user) so enabling a
+/// browser-side capture of raw assistant payloads never needs a redeploy.
+pub const AEVATAR_CHAT_WIRE_LOG_FLAG_KEY: &str = "experimental:aevatar-chat-wire-log";
+
+const AEVATAR_CHAT_WIRE_LOG_FLAG: FeatureFlagDef = FeatureFlagDef {
+    key: AEVATAR_CHAT_WIRE_LOG_FLAG_KEY,
+    description: "Exposes the Aevatar chat wire-log diagnostic (per-browser capture).",
+    default_enabled: false,
+};
+
 #[cfg(not(test))]
-pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[AI_ASSISTANT_FLAG, BILLING_FLAG];
+pub const FEATURE_FLAGS: &[FeatureFlagDef] =
+    &[AI_ASSISTANT_FLAG, BILLING_FLAG, AEVATAR_CHAT_WIRE_LOG_FLAG];
 
 /// Test builds carry a placeholder flag so the resolution / override pipeline
 /// can exercise multiple definitions alongside the production registry entry.
@@ -96,6 +108,7 @@ pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[AI_ASSISTANT_FLAG, BILLING_FLAG];
 pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
     AI_ASSISTANT_FLAG,
     BILLING_FLAG_TEST,
+    AEVATAR_CHAT_WIRE_LOG_FLAG,
     FeatureFlagDef {
         key: "example_ui",
         description: "Test-only placeholder flag.",
@@ -382,6 +395,26 @@ pub async fn billing_rollout_enabled(
         resolve_from_overrides(&global, &org, actor_user_id, OrgRole::Member)
     };
     Ok(enabled.iter().any(|key| key == BILLING_FLAG_KEY))
+}
+
+/// Whether the Aevatar chat wire-log diagnostic is enabled for the acting user.
+///
+/// Assistant chat is a **personal** surface, so this resolves through the same
+/// grant-union chain as `/users/me`: a platform-global rollout, a grant from
+/// any org the user belongs to, or a personal per-user override all light it
+/// up, and a personal per-user override is the final allow/deny.
+///
+/// Callers gate a diagnostic that exposes raw upstream payloads to the
+/// browser, so a resolution error must be treated as disabled — never as
+/// enabled.
+pub async fn aevatar_chat_wire_log_enabled(
+    db: &mongodb::Database,
+    user_id: &str,
+) -> AppResult<bool> {
+    Ok(resolve_personal_features(db, user_id)
+        .await?
+        .iter()
+        .any(|key| key == AEVATAR_CHAT_WIRE_LOG_FLAG_KEY))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1080,6 +1113,38 @@ mod tests {
         assert!(find_flag("does-not-exist").is_none());
         assert!(find_flag("experimental:ai-assistant").is_some());
         assert!(find_flag("example_ui").is_some());
+    }
+
+    /// Registry keys are a wire contract with `frontend/src/lib/feature-flags.ts`
+    /// (`FEATURE_FLAG`). A key that drifts on one side silently disables the
+    /// surface it gates instead of failing, so the literals are pinned on both
+    /// sides and a rename must be a deliberate two-sided edit.
+    #[test]
+    fn shipped_registry_key_literals_are_pinned() {
+        let shipped: Vec<&str> = FEATURE_FLAGS
+            .iter()
+            .map(|def| def.key)
+            // Test-only placeholder; it has no frontend counterpart.
+            .filter(|key| *key != "example_ui")
+            .collect();
+        assert_eq!(
+            shipped,
+            vec![
+                "experimental:ai-assistant",
+                "experimental:billing",
+                "experimental:aevatar-chat-wire-log",
+            ]
+        );
+        assert_eq!(
+            AEVATAR_CHAT_WIRE_LOG_FLAG_KEY,
+            "experimental:aevatar-chat-wire-log"
+        );
+        assert!(
+            !find_flag(AEVATAR_CHAT_WIRE_LOG_FLAG_KEY)
+                .expect("wire-log flag is registered")
+                .default_enabled,
+            "the wire-log diagnostic must default to off"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -877,7 +877,6 @@ mod tests {
             billing_default_overdraft_cap_credits: 0,
             billing_fail_closed: false,
             billing_resale_enabled: false,
-            aevatar_chat_wire_log_enabled: false,
             invite_code_required: true,
             email_auth_enabled: false,
             auto_verify_email: false,

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -400,7 +400,6 @@ pub(crate) fn test_app_config() -> AppConfig {
         billing_default_overdraft_cap_credits: 0,
         billing_fail_closed: false,
         billing_resale_enabled: false,
-        aevatar_chat_wire_log_enabled: false,
         invite_code_required: false,
         email_auth_enabled: false,
         auto_verify_email: false,

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -55,9 +55,11 @@ See [KMS_MIGRATION_GUIDE.md](KMS_MIGRATION_GUIDE.md) and [KMS_OPERATIONS_GUIDE.m
 
 ## Assistant Diagnostics
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AEVATAR_CHAT_WIRE_LOG_ENABLED` | `false` | Sole operator gate for the Aevatar assistant chat wire-log diagnostic. When enabled, any authenticated assistant caller can opt in from that browser and capture only their own exchanges; the capability is not restricted to admins. Keep disabled where retaining raw, renderer-unredacted assistant payloads in the browser is unacceptable. |
+The Aevatar assistant chat wire-log diagnostic has no environment variable. It
+is gated by the `experimental:aevatar-chat-wire-log` runtime feature flag
+(default off), toggled platform-wide, per org cohort, or per user through the
+platform-admin feature-flag API with no redeploy. See
+`docs/assistant-wire-log.md`.
 
 The standalone remote credential accept routes are backend-served. In split
 frontend/backend deployments, reverse proxies must route

--- a/docs/assistant-wire-log.md
+++ b/docs/assistant-wire-log.md
@@ -1,10 +1,10 @@
 # Assistant Aevatar Wire Log
 
-The assistant chat exposes an operator-gated diagnostic panel for inspecting
-the HTTP exchanges NyxID makes through the managed Aevatar service. The
-fleet-wide feature is disabled by default; when enabled, each authenticated
-assistant caller can opt into capturing their own exchanges with the panel's
-**Capture** switch.
+The assistant chat exposes a flag-gated diagnostic panel for inspecting the
+HTTP exchanges NyxID makes through the managed Aevatar service. It is gated by
+the `experimental:aevatar-chat-wire-log` runtime feature flag, which defaults
+to off; where it is enabled, each authenticated assistant caller can opt into
+capturing their own exchanges with the panel's **Capture** switch.
 
 The wire log is diagnostic data, not an audit log. Backend echoes may persist
 in browser storage, while delivered response bodies and SSE captures remain in
@@ -50,18 +50,38 @@ literal upstream-octet capture.
 
 ## Gates And Header Protocol
 
-Both gates must pass, in this precedence order:
+Both gates must pass:
 
-1. The operator must set `AEVATAR_CHAT_WIRE_LOG_ENABLED=true`. It defaults to
-   `false` and is evaluated before request-header inspection or any database
-   lookup.
+1. The `experimental:aevatar-chat-wire-log` feature flag must be enabled for
+   the calling user. It defaults to **off** in the code registry and is
+   toggled at runtime — platform-wide, for a staff-selected org cohort, or per
+   user — through the platform-admin feature-flag API
+   (`PUT /api/v1/admin/feature-flags/{flag_key}`). No redeploy or restart is
+   involved: the next request resolves the new value. Assistant chat is a
+   personal surface, so resolution uses the same grant-union chain as
+   `/users/me` (`personal user override ?? (global ?? default) || any org
+   grant`).
 2. The authenticated caller must enable the per-browser **Capture** switch,
    which causes the frontend to send `X-NyxID-Debug-Upstream: 1`.
 
+The backend evaluates these in the **opposite** order to the list above, and
+that ordering is deliberate. The request-header check is a free in-memory
+lookup; resolving the flag costs a MongoDB read. Normal chat traffic never
+sends the header, so the header is checked first and that traffic performs
+zero additional database work. A flag-resolution failure fails **closed**: no
+echo is emitted.
+
 The feature flag is the sole authorization gate for the diagnostic and does
-not require a platform-admin role. The backend echo is constructed only from
-the assistant request currently being handled, so a caller can capture their
-own exchange but can never observe another caller's traffic.
+not require a platform-admin role — a platform admin decides *who* gets it,
+but an enabled non-admin caller uses it exactly like anyone else. The backend
+echo is constructed only from the assistant request currently being handled,
+so a caller can capture their own exchange but can never observe another
+caller's traffic.
+
+Raw captures and replay placeholder JSON bypass the chat renderer's credential
+redaction and may contain sensitive upstream payloads verbatim. Leave the flag
+off for any user or environment where browser retention of unredacted raw
+payloads is unacceptable.
 
 On handler paths that return a final `Response` through the assistant echo
 attachment path, NyxID sends a Base64-encoded UTF-8 JSON value in
@@ -85,10 +105,12 @@ an attempted request whose proxy call subsequently failed.
 
 Compatibility is one-directional by design:
 
-- **New frontend + backend without the public feature-flag field** — the field
-  is treated as disabled and the panel stays hidden. This is fail-closed and
-  self-heals once the browser reaches a backend that advertises the enabled
-  flag in `/public/config`.
+- **New frontend + backend that does not know the flag key** — the key is
+  absent from `capabilities.enabled_features` on `/users/me`, so the panel
+  treats it as disabled and stays hidden. This is fail-closed and self-heals
+  once the browser reaches a backend whose registry carries the flag. The
+  frontend re-reads `/users/me` on its existing one-minute interval, so a
+  runtime toggle reaches the panel without a hard reload.
 - **New frontend + flag-aware backend with the old echo payload** — supported.
   The decoder accepts the legacy bare array and normalises it, leaving
   `upstreamOutcome` and `response` absent.
@@ -233,13 +255,13 @@ is explicitly marked "Not replayed." No live controls, queries, navigation, or
 assistant-store writes are mounted by replay.
 
 Raw captures and placeholder JSON may contain sensitive upstream payloads
-verbatim. They bypass the chat renderer's credential redaction. When the
-operator flag is enabled, any authenticated assistant caller can capture their
-own exchanges; no caller can observe another user's traffic. Raw captures are
-session-only, excluded from persistence, telemetry, audit logs, and crash
-reports, and leave the browser only through an explicit copy action. Keep the
-operator flag off in environments where browser retention of unredacted raw
-payloads is unacceptable.
+verbatim. They bypass the chat renderer's credential redaction. Where the
+feature flag is enabled, any authenticated assistant caller — admin or not —
+can capture their own exchanges; no caller can observe another user's traffic.
+Raw captures are session-only, excluded from persistence, telemetry, audit
+logs, and crash reports, and leave the browser only through an explicit copy
+action. Leave the flag off for any user or environment where browser retention
+of unredacted raw payloads is unacceptable.
 
 ## Deliberate Non-Goals
 

--- a/frontend/src/components/assistant/assistant-wire-log-panel.test.tsx
+++ b/frontend/src/components/assistant/assistant-wire-log-panel.test.tsx
@@ -6,26 +6,12 @@ import { useAssistantContextStore } from "@/stores/assistant-context-store";
 import { useAssistantDraftStore } from "@/stores/assistant-draft-store";
 import { useAssistantWireLogStore } from "@/stores/assistant-wire-log-store";
 import { useAuthStore } from "@/stores/auth-store";
+import { FEATURE_FLAG } from "@/lib/feature-flags";
 import type { User } from "@/types/api";
 import {
   AssistantWireLogAction,
   AssistantWireLogPanel,
 } from "./assistant-wire-log-panel";
-
-const publicConfigState = vi.hoisted(() => ({
-  wireLogEnabled: undefined as boolean | undefined,
-}));
-
-vi.mock("@/hooks/use-public-config", () => ({
-  usePublicConfig: () => ({
-    data:
-      publicConfigState.wireLogEnabled === undefined
-        ? {}
-        : {
-            aevatar_chat_wire_log_enabled: publicConfigState.wireLogEnabled,
-          },
-  }),
-}));
 
 const admin: User = {
   id: "admin-1",
@@ -40,8 +26,30 @@ const admin: User = {
   created_at: "2026-07-31T00:00:00.000Z",
 };
 
+/**
+ * The wire-log gate is the `experimental:aevatar-chat-wire-log` runtime
+ * feature flag, resolved server-side and delivered on `/users/me` as
+ * `capabilities.enabled_features`. `undefined` models an older backend that
+ * omits the field entirely.
+ */
+function signIn(enabledFeatures?: readonly string[]) {
+  useAuthStore.setState({
+    user:
+      enabledFeatures === undefined
+        ? admin
+        : { ...admin, capabilities: { enabled_features: enabledFeatures } },
+  });
+}
+
 function renderWithTooltips(node: React.ReactNode) {
-  return render(<TooltipProvider>{node}</TooltipProvider>);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{node}</TooltipProvider>
+    </QueryClientProvider>,
+  );
 }
 
 function responseEnvelope() {
@@ -81,7 +89,7 @@ function sseLines(frames: readonly Record<string, unknown>[]) {
 describe("AssistantWireLogPanel", () => {
   beforeEach(() => {
     localStorage.clear();
-    publicConfigState.wireLogEnabled = false;
+    signIn([]);
     useAssistantWireLogStore.setState({
       featureEnabled: true,
       captureEnabled: true,
@@ -138,7 +146,7 @@ describe("AssistantWireLogPanel", () => {
   });
 
   it("hides the action for everyone while the operator flag is off", async () => {
-    useAuthStore.setState({ user: admin });
+    signIn([]);
     renderWithTooltips(<AssistantWireLogAction />);
 
     expect(
@@ -149,8 +157,31 @@ describe("AssistantWireLogPanel", () => {
     });
   });
 
-  it("treats an omitted operator flag as disabled", async () => {
-    publicConfigState.wireLogEnabled = undefined;
+  it("closes the transport gate when a stale persisted capture meets a disabled flag", async () => {
+    // A browser that captured before the flag was turned off keeps
+    // `captureEnabled` in localStorage — it is persisted, `featureEnabled` is
+    // not. Mounting the action must re-derive the feature gate from the
+    // server-resolved flag, leaving the composed transport gate
+    // (`featureEnabled && captureEnabled`) closed.
+    signIn([]);
+    useAssistantWireLogStore.setState({
+      featureEnabled: true,
+      captureEnabled: true,
+    });
+
+    renderWithTooltips(<AssistantWireLogAction />);
+
+    await waitFor(() => {
+      expect(useAssistantWireLogStore.getState().featureEnabled).toBe(false);
+    });
+    const { featureEnabled, captureEnabled } =
+      useAssistantWireLogStore.getState();
+    expect(captureEnabled).toBe(true);
+    expect(featureEnabled && captureEnabled).toBe(false);
+  });
+
+  it("treats an omitted capability set as disabled", async () => {
+    signIn(undefined);
     useAssistantWireLogStore.setState({ featureEnabled: true });
 
     renderWithTooltips(<AssistantWireLogAction />);
@@ -164,8 +195,7 @@ describe("AssistantWireLogPanel", () => {
   });
 
   it("shows the action for authenticated users regardless of role when the flag is on", async () => {
-    publicConfigState.wireLogEnabled = true;
-    useAuthStore.setState({ user: admin });
+    signIn([FEATURE_FLAG.AEVATAR_CHAT_WIRE_LOG]);
     const { unmount } = renderWithTooltips(<AssistantWireLogAction />);
 
     expect(
@@ -177,7 +207,14 @@ describe("AssistantWireLogPanel", () => {
 
     unmount();
     useAuthStore.setState({
-      user: { ...admin, is_admin: false, role: "user" },
+      user: {
+        ...admin,
+        is_admin: false,
+        role: "user",
+        capabilities: {
+          enabled_features: [FEATURE_FLAG.AEVATAR_CHAT_WIRE_LOG],
+        },
+      },
     });
     renderWithTooltips(<AssistantWireLogAction />);
 

--- a/frontend/src/components/assistant/assistant-wire-log-panel.tsx
+++ b/frontend/src/components/assistant/assistant-wire-log-panel.tsx
@@ -21,7 +21,8 @@ import type {
   AssistantUpstreamEnvelope,
   AssistantWireLogExchange,
 } from "@/schemas/assistant-wire-log";
-import { usePublicConfig } from "@/hooks/use-public-config";
+import { useFeature } from "@/hooks/use-feature-flag";
+import { FEATURE_FLAG } from "@/lib/feature-flags";
 import { useAssistantWireLogStore } from "@/stores/assistant-wire-log-store";
 import { cn } from "@/lib/utils";
 
@@ -548,9 +549,10 @@ export function AssistantWireLogPanel() {
 }
 
 export function AssistantWireLogAction() {
-  const { data: publicConfig } = usePublicConfig();
-  const featureEnabled =
-    publicConfig?.aevatar_chat_wire_log_enabled === true;
+  // Runtime feature flag (`experimental:aevatar-chat-wire-log`), resolved
+  // server-side for this user on the personal surface. Fail-closed: unknown,
+  // loading, or an older backend that omits the key all read as off.
+  const featureEnabled = useFeature(FEATURE_FLAG.AEVATAR_CHAT_WIRE_LOG);
   const setFeatureEnabled = useAssistantWireLogStore(
     (state) => state.setFeatureEnabled,
   );

--- a/frontend/src/hooks/use-feature-flag.test.tsx
+++ b/frontend/src/hooks/use-feature-flag.test.tsx
@@ -103,3 +103,17 @@ describe("useFeature (personal / non-org context)", () => {
     expect(result.current).toBe(false);
   });
 });
+
+describe("feature flag catalog", () => {
+  // The catalog keys are a wire contract with
+  // `backend/src/services/feature_flag_service.rs::FEATURE_FLAGS`; a key that
+  // drifts on one side silently disables the surface it gates instead of
+  // failing. Pinning the literals makes a rename a deliberate two-sided edit.
+  it("pins the backend registry key literals", () => {
+    expect(FEATURE_FLAG).toEqual({
+      AI_ASSISTANT: "experimental:ai-assistant",
+      BILLING: "experimental:billing",
+      AEVATAR_CHAT_WIRE_LOG: "experimental:aevatar-chat-wire-log",
+    });
+  });
+});

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -18,6 +18,7 @@
 export const FEATURE_FLAG = {
   AI_ASSISTANT: "experimental:ai-assistant",
   BILLING: "experimental:billing",
+  AEVATAR_CHAT_WIRE_LOG: "experimental:aevatar-chat-wire-log",
 } as const;
 
 type FeatureFlagKey = (typeof FEATURE_FLAG)[keyof typeof FEATURE_FLAG];

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -979,7 +979,6 @@ const MOCK_PUBLIC_CONFIG = {
   social_providers: ["github"],
   invite_code_required: false,
   email_auth_enabled: true,
-  aevatar_chat_wire_log_enabled: true,
 };
 
 // ── MCP config ──

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -564,7 +564,6 @@ export interface PublicConfig {
   readonly social_providers: readonly string[];
   readonly invite_code_required: boolean;
   readonly email_auth_enabled: boolean;
-  readonly aevatar_chat_wire_log_enabled?: boolean;
   readonly telemetry_dsn?: string;
   readonly telemetry_host?: string;
   readonly telemetry_share_analytics?: boolean;


### PR DESCRIPTION
## What

Replaces the `AEVATAR_CHAT_WIRE_LOG_ENABLED` env var (shipped in #1306) with NyxID's **runtime feature-flag subsystem**, so the Aevatar chat wire-log diagnostic can be toggled without a redeploy.

Follow-up to #1306 (already merged). Targets `main`.

## Why

The env var was static config: changing it required a redeploy, and it was all-or-nothing for the whole deployment. The repo already has a feature-flag subsystem (`feature_flag_service.rs` + `feature_flag_overrides` + the admin API at `/feature-flags`), which is the right mechanism.

## Changes

- Register `experimental:aevatar-chat-wire-log` in `FEATURE_FLAGS` with `default_enabled: false`; mirror the key in `frontend/src/lib/feature-flags.ts`.
- Add a backend resolver for the acting user on the personal surface, mirroring `billing_rollout_enabled`.
- `upstream_echo_collector` now resolves the flag at runtime instead of reading a config field.
- Frontend gates the panel with `useFeature(FEATURE_FLAG.AEVATAR_CHAT_WIRE_LOG)` instead of `usePublicConfig`.
- **Delete** the env var, its `AppConfig` field, and its `PublicConfigResponse` field rather than leaving a dual gate (CLAUDE.md FI-007).

## Latency

The gate ordering is deliberately **inverted** versus #1306. The flag is now a database read, so the cheap `X-NyxID-Debug-Upstream` header check runs **first** and the flag is resolved only for requests that actually ask for capture. Normal chat traffic — which never sends the header — does no database work and pays nothing.

## Toggling

No deploy needed. Via the existing admin API:

```
PUT    /api/v1/admin/feature-flags/experimental:aevatar-chat-wire-log
DELETE /api/v1/admin/feature-flags/experimental:aevatar-chat-wire-log
```

Resolution honours the subsystem's `user → role → org → global → code default` precedence, so it can be enabled for a single user rather than fleet-wide.

## Gates (unchanged otherwise)

1. Feature flag — default off, runtime-toggleable
2. Per-browser **Capture** switch — default off

Not admin-restricted when enabled (per the decision in #1306); raw captures still bypass the chat renderer's credential redaction, as documented.

## Status — CI-first push

Raised early so CI can run while review continues. Verified locally so far:

- `cargo check --workspace --all-targets` clean
- `npm --prefix frontend run build` (tsc -b + vite) clean

**Still outstanding** — will follow on this branch:
- Full `cargo test` / `npm test` runs against a live MongoDB (DB-backed tests skip silently without one)
- Test coverage for the new gate (flag off/on, per-user override, no-DB-work-without-header, fail-closed on resolution error), mutation-verified
- Doc updates in `docs/assistant-wire-log.md` and removal of remaining env-var references
- Adversarial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
