### PR TITLE
feat(billing): tamper-evident hash-chained billing ledger with head anchoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Strict separation: `handlers/` -> `services/` -> `models/`
 - All key material in `Zeroizing` wrappers; all Debug impls redact secrets and key identifiers; `MAX_WRAPPED_DEK_SIZE = 1024` enforced on encrypt and decrypt paths
 - Middleware: rate limiting (`mw/rate_limit.rs`), security headers (`mw/security_headers.rs`), JWT auth (`mw/auth.rs`)
 - Audit logs are tamper-evident for new rows via HMAC-SHA256 hash chaining (`services/audit_chain_service.rs`): new `AuditLog` rows must set `seq`, `prev_hash`, `entry_hash` through the audit service append path; legacy rows without `seq` count as pre-chain, not backfilled. `AUDIT_CHAIN_HMAC_KEY` is an optional 64-hex override; otherwise the key is domain-derived from `ENCRYPTION_KEY` or the JWT private key. v1 does not detect tail truncation without external head anchoring.
+- Billing transactions are tamper-evident via the append-only `billing_ledger` collection (`services/billing/ledger.rs`): charged usage settlements (first-apply only, including the wallet-lock crash bridge), provider-confirmed top-up checkouts, and paid wallet credits (deduped by Lago invoice id) append hash-chained entries with the same `seq`/`prev_hash`/`entry_hash` construction, keyed by `BILLING_LEDGER_HMAC_KEY` or the `billing-ledger` domain derivation. Appends are best-effort (never fail billing); verify via `GET /api/v1/admin/billing-ledger/verify`. Tail truncation is detected: the reconcile sweep anchors the ledger head into the audit chain (`billing_ledger_head_anchored`) and the server log, and verify cross-checks the newest anchor (`tail_truncated` break); entries newer than the last anchor (<= one reconcile interval) are the remaining window.
 - Anonymous catalog endpoints may be enabled only when the service has `identity_propagation_mode = "none"`, `forward_access_token = false`, and `inject_delegation_token = false` (disabled draft rules may be stored on any service); violating admin writes return `AppError::AnonymousIncompatibleService` (400, code 11100). Public execution still force-strips identity propagation, access-token forwarding, delegation-token injection, and downstream auth defaults as defense in depth.
 - Delegated management parity requires the exact `account:read` scope, `GET`, a non-WebSocket request, and a route outside the deny classes in `mw/auth.rs`; the verified `AuthUser` extractor is authoritative. New secret-delivering, execution-shaped, streaming, upgrade, or authentication/provisioning protocol GET routes MUST be added to `delegated_read_denied_path` before mounting.
 
@@ -319,6 +320,7 @@ CLI_PAIRING_HMAC_KEY=               # Optional 64 hex; keys CliPairing.code_hash
                                     # brute force. Unset = derived from ENCRYPTION_KEY or the JWT key
                                     # (stable per-worker, multi-instance safe).
 AUDIT_CHAIN_HMAC_KEY=               # Optional 64 hex; keys audit-log HMAC chaining; same derivation fallback
+BILLING_LEDGER_HMAC_KEY=            # Optional 64 hex; keys billing-ledger HMAC chaining; same derivation fallback
 
 CHANNEL_RELAY_CALLBACK_TIMEOUT_SECS=30
 CHANNEL_RELAY_MAX_BOTS_PER_USER=5

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -135,6 +135,11 @@ pub struct AppConfig {
     /// `ENCRYPTION_KEY` if configured, otherwise from the JWT private key PEM.
     pub audit_chain_hmac_key: Option<String>,
 
+    /// Explicit HMAC key (64 hex chars = 32 bytes) used for billing-ledger
+    /// hash chaining. Same derivation fallback as the audit chain, with a
+    /// distinct `billing-ledger` domain label.
+    pub billing_ledger_hmac_key: Option<String>,
+
     /// Service account token TTL in seconds (default: 3600 = 1 hour)
     pub sa_token_ttl_secs: i64,
 
@@ -443,6 +448,14 @@ impl std::fmt::Debug for AppConfig {
             .field(
                 "audit_chain_hmac_key",
                 if self.audit_chain_hmac_key.is_some() {
+                    &"Some([REDACTED])"
+                } else {
+                    &"None"
+                },
+            )
+            .field(
+                "billing_ledger_hmac_key",
+                if self.billing_ledger_hmac_key.is_some() {
                     &"Some([REDACTED])"
                 } else {
                     &"None"
@@ -821,6 +834,9 @@ impl AppConfig {
                 .ok()
                 .filter(|s| !s.trim().is_empty()),
             audit_chain_hmac_key: env::var("AUDIT_CHAIN_HMAC_KEY")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
+            billing_ledger_hmac_key: env::var("BILLING_LEDGER_HMAC_KEY")
                 .ok()
                 .filter(|s| !s.trim().is_empty()),
 
@@ -1368,6 +1384,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/crypto/aes.rs
+++ b/backend/src/crypto/aes.rs
@@ -987,6 +987,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/crypto/apple_client_secret.rs
+++ b/backend/src/crypto/apple_client_secret.rs
@@ -163,6 +163,7 @@ ci0O2dgc19c2/sLtanU7P2KAzhEo8O0tIc0Dwe/nMqKfue82eGVL3DqM\n\
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/crypto/jwt.rs
+++ b/backend/src/crypto/jwt.rs
@@ -1145,6 +1145,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/crypto/local_key_provider.rs
+++ b/backend/src/crypto/local_key_provider.rs
@@ -308,6 +308,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -2037,6 +2037,31 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
         )
         .await?;
 
+    // ── billing_ledger ──
+    // The unique seq index is what turns concurrent chain appends into a
+    // detectable retry (duplicate key) instead of a fork.
+    let billing_ledger = db.collection::<Document>(crate::models::billing_ledger::COLLECTION_NAME);
+    billing_ledger
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "seq": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("billing_ledger_seq_unique".to_string())
+                        .unique(true)
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    billing_ledger
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "owner_id": 1, "created_at": -1 })
+                .build(),
+        )
+        .await?;
+
     // ── billing_rate_cache ──
     let billing_rate_cache =
         db.collection::<Document>(crate::models::billing_rate_cache::COLLECTION_NAME);

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -18,6 +18,7 @@ use crate::models::downstream_service::{
 };
 use crate::models::user::{COLLECTION_NAME as USERS, PlatformRole, User};
 use crate::mw::auth::AuthUser;
+use crate::services::billing::ledger as billing_ledger;
 use crate::services::{
     admin_audit_service, admin_user_service, audit_chain_service, audit_service, consent_service,
     oauth_client_service, platform_settings_service, role_service,
@@ -192,6 +193,23 @@ pub struct AuditLogVerifyResponse {
     pub head_hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub break_info: Option<audit_chain_service::AuditChainBreak>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_from_seq: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BillingLedgerVerifyResponse {
+    pub status: billing_ledger::BillingLedgerStatus,
+    pub checked_count: u64,
+    pub head_seq: Option<i64>,
+    pub head_hash: Option<String>,
+    /// Ledger seq recorded by the newest audit-chain head anchor.
+    pub anchor_seq: Option<i64>,
+    /// False when the newest anchor event fails audit-chain validation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_valid: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub break_info: Option<billing_ledger::BillingLedgerBreak>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_from_seq: Option<i64>,
 }
@@ -1229,6 +1247,56 @@ pub async fn verify_audit_log(
         head_seq: report.head_seq,
         head_hash: report.head_hash,
         break_info: report.break_info,
+        next_from_seq: report.next_from_seq,
+    }))
+}
+
+/// GET /api/v1/admin/billing-ledger/verify
+///
+/// Verify tamper-evident billing-ledger hash-chain integrity over a
+/// bounded range. Same shape and semantics as the audit-log verify.
+///
+/// The tail-truncation check validates the newest anchor event's own
+/// hash, but the anchor's linkage into an unbroken audit chain is the
+/// audit verifier's job -- run `/admin/audit-log/verify` alongside this
+/// endpoint for the full guarantee.
+pub async fn verify_billing_ledger(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Query(query): Query<AuditLogVerifyQuery>,
+) -> AppResult<Json<BillingLedgerVerifyResponse>> {
+    require_admin_or_operator(&state, &auth_user, "admin.billing_ledger.verify").await?;
+
+    let report = billing_ledger::verify_chain(
+        &state.db,
+        state.billing_ledger_hmac_key.as_slice(),
+        query.from_seq,
+        query.to_seq,
+        query.limit,
+    )
+    .await?;
+
+    // The chain walk cannot see tail truncation (a shortened chain stays
+    // valid), so always cross-check the head against the newest anchor
+    // recorded in the audit chain.
+    let anchor =
+        billing_ledger::check_head_anchor(&state.db, state.audit_chain_hmac_key.as_slice()).await?;
+    let (status, break_info) = match (report.status, report.break_info, anchor.break_info) {
+        (billing_ledger::BillingLedgerStatus::Ok, None, Some(anchor_break)) => (
+            billing_ledger::BillingLedgerStatus::Broken,
+            Some(anchor_break),
+        ),
+        (status, break_info, _) => (status, break_info),
+    };
+
+    Ok(Json(BillingLedgerVerifyResponse {
+        status,
+        checked_count: report.checked_count,
+        head_seq: report.head_seq,
+        head_hash: report.head_hash,
+        anchor_seq: anchor.anchor_seq,
+        anchor_valid: anchor.anchor_valid,
+        break_info,
         next_from_seq: report.next_from_seq,
     }))
 }

--- a/backend/src/handlers/channel_webhooks.rs
+++ b/backend/src/handlers/channel_webhooks.rs
@@ -694,6 +694,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             cookie_domain: None,
             telegram_bot_token: None,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -142,6 +142,9 @@ pub struct AppState {
     /// Server-side HMAC key used for tamper-evident audit-log hash chaining.
     /// Lives in process memory only and is never persisted to MongoDB.
     pub audit_chain_hmac_key: std::sync::Arc<zeroize::Zeroizing<[u8; 32]>>,
+    /// Server-side HMAC key for tamper-evident billing-ledger hash chaining.
+    /// Domain-separated from the audit chain with the `billing-ledger` label.
+    pub billing_ledger_hmac_key: std::sync::Arc<zeroize::Zeroizing<[u8; 32]>>,
     /// Per-channel rate limiter keyed by conversation_id, for the HTTP Event
     /// Gateway (NyxID#221). Distinct from `per_agent_limiter`.
     pub per_channel_event_limiter: mw::rate_limit::SharedPerChannelEventLimiter,
@@ -360,6 +363,13 @@ async fn main() {
     );
     services::audit_service::init_audit_chain_hmac_key(audit_chain_hmac_key.clone());
     let audit_chain_hmac_key = Arc::new(audit_chain_hmac_key);
+    let billing_ledger_hmac_key = services::billing::ledger::derive_billing_ledger_hmac_key(
+        config.billing_ledger_hmac_key.as_deref(),
+        config.encryption_key.as_deref(),
+        Some(&jwt_private_key_pem),
+    );
+    services::billing::ledger::init_billing_ledger_hmac_key(billing_ledger_hmac_key.clone());
+    let billing_ledger_hmac_key = Arc::new(billing_ledger_hmac_key);
     // JWT private key bytes carry no secret beyond what's already in JwtKeys;
     // drop them immediately after derivation.
     drop(jwt_private_key_pem);
@@ -671,6 +681,7 @@ async fn main() {
         cli_pairing_hmac_key,
         auth_device_hmac_key,
         audit_chain_hmac_key,
+        billing_ledger_hmac_key,
         per_channel_event_limiter,
         per_message_edit_limiter,
         event_dedup_cache,

--- a/backend/src/models/billing_ledger.rs
+++ b/backend/src/models/billing_ledger.rs
@@ -1,0 +1,77 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::models::service_billing::BillingMetric;
+use crate::models::usage_meter::BillingLayer;
+
+pub const COLLECTION_NAME: &str = "billing_ledger";
+
+/// The money-moving billing events recorded on the tamper-evident ledger.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BillingLedgerEventType {
+    /// A usage charge was applied to a wallet (settlement first-apply).
+    UsageSettled,
+    /// A top-up checkout session was created for an owner.
+    TopupCreated,
+    /// Lago reported paid credits landing on a wallet.
+    WalletCredited,
+}
+
+/// One append-only, hash-chained billing ledger entry.
+///
+/// Entries are chained like audit logs (`seq`/`prev_hash`/`entry_hash`
+/// HMAC-SHA256): every entry commits to its predecessor, so a mutated,
+/// deleted, or inserted row breaks verification at that seq. Rows are
+/// never updated after insert.
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+pub struct BillingLedgerEntry {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub seq: i64,
+    pub prev_hash: String,
+    pub entry_hash: String,
+    pub event_type: BillingLedgerEventType,
+    pub owner_id: String,
+    /// Usage meter row id, top-up session id, or Lago customer id,
+    /// depending on `event_type`.
+    pub reference_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layer: Option<BillingLayer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<BillingMetric>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quantity: Option<i64>,
+    /// Credits moved by this event: the charge for `usage_settled`, the
+    /// requested amount for `topup_created`. Absent for balance snapshots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount_credits: Option<i64>,
+    /// Post-event wallet balance snapshot (`wallet_credited` only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balance_credits: Option<i64>,
+    /// At-most-once guard for externally delivered events (e.g. the Lago
+    /// invoice id behind a `wallet_credited` webhook, which Lago retries).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wallet_id: Option<String>,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub created_at: DateTime<Utc>,
+}
+
+impl BillingLedgerEventType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UsageSettled => "usage_settled",
+            Self::TopupCreated => "topup_created",
+            Self::WalletCredited => "wallet_credited",
+        }
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod approval_request;
 pub mod audit_log;
 pub mod auth_device_code;
 pub mod authorization_code;
+pub mod billing_ledger;
 pub mod billing_rate_cache;
 pub mod billing_topup_session;
 pub mod billing_wallet;

--- a/backend/src/models/service_billing.rs
+++ b/backend/src/models/service_billing.rs
@@ -10,6 +10,18 @@ pub enum BillingMetric {
     Bytes,
 }
 
+impl BillingMetric {
+    /// Stable serde-matching name; used in ledger canonical encoding, so
+    /// variant renames must not change these strings.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tokens => "tokens",
+            Self::Requests => "requests",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 pub struct ServiceBilling {
     /// Opt-in platform-layer charging. Services default to free (metered

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -752,6 +752,10 @@ pub fn build_router(
         .route("/audit-log", get(handlers::admin::list_audit_log))
         .route("/audit-log/verify", get(handlers::admin::verify_audit_log))
         .route(
+            "/billing-ledger/verify",
+            get(handlers::admin::verify_billing_ledger),
+        )
+        .route(
             "/settings/broker",
             get(handlers::admin::get_broker_settings)
                 .patch(handlers::admin::update_broker_settings),

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -75,6 +75,18 @@ pub fn log_for_user(
     );
 }
 
+/// Awaitable system-attributed audit entry (no acting user). Used where the
+/// caller needs completion ordering, e.g. billing-ledger head anchoring.
+pub async fn log_system_event(
+    db: mongodb::Database,
+    event_type: impl Into<String>,
+    event_data: Option<serde_json::Value>,
+) -> Result<(), mongodb::error::Error> {
+    let event_type = event_type.into();
+    let entry = build_audit_entry(None, event_type.clone(), event_data, None, None, None, None);
+    write_audit_entry(db, entry, event_type).await
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_audit_entry(
     user_id: Option<String>,

--- a/backend/src/services/billing/ledger.rs
+++ b/backend/src/services/billing/ledger.rs
@@ -1,0 +1,1007 @@
+//! Tamper-evident billing ledger.
+//!
+//! Mirrors the audit-log hash chain (`services/audit_chain_service.rs`):
+//! every money-moving billing event appends an immutable entry whose
+//! HMAC-SHA256 `entry_hash` commits to the previous entry, so mutating,
+//! deleting, or inserting history breaks verification at that seq. The
+//! operational billing rows (`usage_meter`, `billing_topup_sessions`)
+//! stay mutable by design; this ledger is the append-only journal of
+//! their money-moving transitions.
+
+use std::sync::OnceLock;
+
+use chrono::{DateTime, TimeZone, Utc};
+use futures::TryStreamExt;
+use hmac::{Hmac, Mac};
+use mongodb::bson::doc;
+use rand::Rng;
+use serde::Serialize;
+use sha2::Sha256;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::errors::{AppError, AppResult};
+use crate::models::audit_log::{AuditLog, COLLECTION_NAME as AUDIT_LOG};
+use crate::models::billing_ledger::{
+    BillingLedgerEntry, BillingLedgerEventType, COLLECTION_NAME as BILLING_LEDGER,
+};
+use crate::models::usage_meter::UsageMeterRow;
+use crate::services::{audit_chain_service, audit_service};
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub const GENESIS_PREV_HASH: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+const RECORD_SEPARATOR: u8 = 0x1e;
+const MAX_APPEND_ATTEMPTS: usize = 8;
+pub const DEFAULT_VERIFY_LIMIT: i64 = 10_000;
+pub const MAX_VERIFY_LIMIT: i64 = 10_000;
+
+static BILLING_LEDGER_HMAC_KEY: OnceLock<Zeroizing<[u8; 32]>> = OnceLock::new();
+
+pub fn init_billing_ledger_hmac_key(key: Zeroizing<[u8; 32]>) {
+    if BILLING_LEDGER_HMAC_KEY.set(key).is_err() {
+        tracing::warn!("billing-ledger HMAC key was already initialized");
+    }
+}
+
+fn billing_ledger_hmac_key() -> Option<&'static [u8]> {
+    BILLING_LEDGER_HMAC_KEY.get().map(|key| key.as_ref())
+}
+
+pub fn derive_billing_ledger_hmac_key(
+    env_override: Option<&str>,
+    encryption_key: Option<&str>,
+    jwt_private_key_pem: Option<&[u8]>,
+) -> Zeroizing<[u8; 32]> {
+    if let Some(raw) = env_override {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            match hex::decode(trimmed) {
+                Ok(bytes) if bytes.len() == 32 => {
+                    let mut out = [0u8; 32];
+                    out.copy_from_slice(&bytes);
+                    tracing::info!("billing-ledger HMAC key loaded from BILLING_LEDGER_HMAC_KEY");
+                    return Zeroizing::new(out);
+                }
+                _ => {
+                    panic!("BILLING_LEDGER_HMAC_KEY must be 64 hex characters (32 bytes)");
+                }
+            }
+        }
+    }
+
+    let jwt_private_key_pem = jwt_private_key_pem.unwrap_or_default();
+    if let Some(master) = decode_hmac_seed(encryption_key) {
+        tracing::info!("billing-ledger HMAC key derived from ENCRYPTION_KEY");
+        return crate::crypto::hmac_keys::derive_hmac_key(
+            "billing-ledger",
+            Some(&master),
+            jwt_private_key_pem,
+        );
+    }
+
+    if !jwt_private_key_pem.is_empty() {
+        tracing::info!("billing-ledger HMAC key derived from JWT private key");
+        return crate::crypto::hmac_keys::derive_hmac_key(
+            "billing-ledger",
+            None,
+            jwt_private_key_pem,
+        );
+    }
+
+    panic!(
+        "billing-ledger HMAC key has no source: BILLING_LEDGER_HMAC_KEY, ENCRYPTION_KEY, \
+         and the JWT private key are all missing."
+    );
+}
+
+fn decode_hmac_seed(encryption_key: Option<&str>) -> Option<Zeroizing<Vec<u8>>> {
+    let hex_key = encryption_key?;
+    let Ok(master) = hex::decode(hex_key.trim()) else {
+        return None;
+    };
+    if master.len() == 32 {
+        Some(Zeroizing::new(master))
+    } else {
+        None
+    }
+}
+
+/// Record a first-apply charged usage settlement on the ledger, off the
+/// settlement path (spawned, like audit logging). Best-effort: an append
+/// failure must never fail or roll back the settlement itself.
+pub fn record_usage_settled_async(db: mongodb::Database, row: UsageMeterRow, credits: i64) {
+    tokio::spawn(async move {
+        let entry = BillingLedgerEntry {
+            id: Uuid::new_v4().to_string(),
+            seq: 0,
+            prev_hash: String::new(),
+            entry_hash: String::new(),
+            event_type: BillingLedgerEventType::UsageSettled,
+            owner_id: row.billing_owner_id.clone(),
+            reference_id: row.id.clone(),
+            transaction_id: Some(row.transaction_id.clone()),
+            layer: Some(row.layer),
+            metric: Some(row.metric),
+            service_slug: row.service_slug.clone(),
+            model: row.model.clone(),
+            quantity: row.quantity,
+            amount_credits: Some(credits),
+            balance_credits: None,
+            dedupe_key: None,
+            wallet_id: row.wallet_id.clone(),
+            created_at: Utc::now(),
+        };
+        append_best_effort(&db, entry).await;
+    });
+}
+
+/// Record a charge whose `released` transition committed through the
+/// wallet-lock crash bridge, where only the row id is at hand.
+pub fn record_usage_settled_by_row_id_async(db: mongodb::Database, row_id: String, credits: i64) {
+    tokio::spawn(async move {
+        match db
+            .collection::<UsageMeterRow>(crate::models::usage_meter::COLLECTION_NAME)
+            .find_one(doc! { "_id": &row_id })
+            .await
+        {
+            Ok(Some(row)) => {
+                record_usage_settled_async(db, row, credits);
+            }
+            Ok(None) => {
+                tracing::warn!(row_id = %row_id, "settled usage row missing for ledger entry");
+            }
+            Err(error) => {
+                tracing::warn!(%error, row_id = %row_id, "failed to load settled usage row for ledger");
+            }
+        }
+    });
+}
+
+/// Record a top-up checkout that was actually created with the provider
+/// (not the local pending stub, which may still fail before any money can
+/// move).
+pub async fn record_topup_created(
+    db: &mongodb::Database,
+    owner_id: &str,
+    session_id: &str,
+    amount_credits: i64,
+    lago_wallet_id: &str,
+) {
+    let entry = BillingLedgerEntry {
+        id: Uuid::new_v4().to_string(),
+        seq: 0,
+        prev_hash: String::new(),
+        entry_hash: String::new(),
+        event_type: BillingLedgerEventType::TopupCreated,
+        owner_id: owner_id.to_string(),
+        reference_id: session_id.to_string(),
+        transaction_id: None,
+        layer: None,
+        metric: None,
+        service_slug: None,
+        model: None,
+        quantity: None,
+        amount_credits: Some(amount_credits),
+        balance_credits: None,
+        dedupe_key: None,
+        wallet_id: Some(lago_wallet_id.to_string()),
+        created_at: Utc::now(),
+    };
+    append_best_effort(db, entry).await;
+}
+
+/// Record paid credits landing on a wallet (Lago `invoice.paid_credit_added`).
+/// `balance_credits` is the post-credit wallet balance snapshot. Lago
+/// retries webhook deliveries, so a `dedupe_key` (the Lago invoice id)
+/// makes the record at-most-once; without one, duplicates are possible.
+pub async fn record_wallet_credited(
+    db: &mongodb::Database,
+    owner_id: &str,
+    customer_id: &str,
+    balance_credits: i64,
+    dedupe_key: Option<String>,
+) {
+    if let Some(key) = dedupe_key.as_deref() {
+        match db
+            .collection::<BillingLedgerEntry>(BILLING_LEDGER)
+            .count_documents(doc! { "event_type": "wallet_credited", "dedupe_key": key })
+            .await
+        {
+            Ok(0) => {}
+            Ok(_) => return,
+            Err(error) => {
+                tracing::warn!(%error, "wallet-credited ledger dedupe check failed");
+                return;
+            }
+        }
+    }
+
+    let entry = BillingLedgerEntry {
+        id: Uuid::new_v4().to_string(),
+        seq: 0,
+        prev_hash: String::new(),
+        entry_hash: String::new(),
+        event_type: BillingLedgerEventType::WalletCredited,
+        owner_id: owner_id.to_string(),
+        reference_id: customer_id.to_string(),
+        transaction_id: None,
+        layer: None,
+        metric: None,
+        service_slug: None,
+        model: None,
+        quantity: None,
+        amount_credits: None,
+        balance_credits: Some(balance_credits),
+        dedupe_key,
+        wallet_id: None,
+        created_at: Utc::now(),
+    };
+    append_best_effort(db, entry).await;
+}
+
+async fn append_best_effort(db: &mongodb::Database, entry: BillingLedgerEntry) {
+    let Some(key) = billing_ledger_hmac_key() else {
+        tracing::warn!(
+            event_type = entry.event_type.as_str(),
+            reference_id = %entry.reference_id,
+            "billing-ledger HMAC key is not initialized; ledger entry skipped"
+        );
+        return;
+    };
+    if let Err(error) = append_chained_entry(db, entry, key).await {
+        tracing::warn!(%error, "failed to append billing ledger entry");
+    }
+}
+
+pub async fn append_chained_entry(
+    db: &mongodb::Database,
+    mut entry: BillingLedgerEntry,
+    key: &[u8],
+) -> Result<BillingLedgerEntry, mongodb::error::Error> {
+    let collection = db.collection::<BillingLedgerEntry>(BILLING_LEDGER);
+    let mut last_error = None;
+
+    for attempt in 1..=MAX_APPEND_ATTEMPTS {
+        let tail = read_tail(db).await?;
+        let (seq, prev_hash) = match tail {
+            Some(tail) => (tail.seq + 1, tail.entry_hash),
+            None => (1, GENESIS_PREV_HASH.to_string()),
+        };
+
+        entry.created_at = truncate_to_bson_millis(entry.created_at);
+        entry.seq = seq;
+        entry.prev_hash = prev_hash;
+        entry.entry_hash = compute_entry_hash(&entry, key);
+
+        match collection.insert_one(&entry).await {
+            Ok(_) => return Ok(entry),
+            Err(error) if is_duplicate_key_error(&error) && attempt < MAX_APPEND_ATTEMPTS => {
+                last_error = Some(error);
+                sleep_before_retry(attempt).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        mongodb::error::Error::custom("billing ledger append exhausted retries")
+    }))
+}
+
+pub fn compute_entry_hash(entry: &BillingLedgerEntry, key: &[u8]) -> String {
+    hmac_sha256_hex(key, &canonical_entry_bytes(entry))
+}
+
+fn canonical_entry_bytes(entry: &BillingLedgerEntry) -> Vec<u8> {
+    let fields = [
+        entry.seq.to_string(),
+        entry.prev_hash.clone(),
+        entry.id.clone(),
+        entry.event_type.as_str().to_string(),
+        entry.owner_id.clone(),
+        entry.reference_id.clone(),
+        entry.transaction_id.clone().unwrap_or_default(),
+        entry
+            .layer
+            .map(|layer| layer.as_transaction_suffix().to_string())
+            .unwrap_or_default(),
+        entry
+            .metric
+            .map(|metric| metric.as_str().to_string())
+            .unwrap_or_default(),
+        entry.service_slug.clone().unwrap_or_default(),
+        entry.model.clone().unwrap_or_default(),
+        entry
+            .quantity
+            .map(|quantity| quantity.to_string())
+            .unwrap_or_default(),
+        entry
+            .amount_credits
+            .map(|credits| credits.to_string())
+            .unwrap_or_default(),
+        entry
+            .balance_credits
+            .map(|credits| credits.to_string())
+            .unwrap_or_default(),
+        entry.dedupe_key.clone().unwrap_or_default(),
+        entry.wallet_id.clone().unwrap_or_default(),
+        entry.created_at.timestamp_millis().to_string(),
+    ];
+    join_record_fields(&fields)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BillingLedgerBreakKind {
+    Gap,
+    LinkMismatch,
+    HashMismatch,
+    /// The newest audit-chain head anchor points past the surviving ledger
+    /// head: entries were deleted from the tail of the chain.
+    TailTruncated,
+    /// The newest anchor event fails audit-chain hash validation: it was
+    /// forged or corrupted, so the truncation check cannot be trusted.
+    AnchorInvalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BillingLedgerBreak {
+    pub break_seq: i64,
+    pub break_kind: BillingLedgerBreakKind,
+    pub expected: String,
+    pub actual: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BillingLedgerStatus {
+    Ok,
+    Broken,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BillingLedgerVerifyReport {
+    pub status: BillingLedgerStatus,
+    pub checked_count: u64,
+    pub head_seq: Option<i64>,
+    pub head_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub break_info: Option<BillingLedgerBreak>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_from_seq: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+struct ChainTail {
+    seq: i64,
+    entry_hash: String,
+}
+
+/// Audit event type carrying billing-ledger head anchors. Anchoring the
+/// head `(seq, entry_hash)` into the tamper-evident audit chain (plus the
+/// server log line below) is what makes tail truncation detectable: a
+/// shortened-but-valid chain no longer matches the newest anchor.
+pub const HEAD_ANCHOR_EVENT_TYPE: &str = "billing_ledger_head_anchored";
+
+/// Result of cross-checking the ledger head against the newest anchor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HeadAnchorCheck {
+    /// Ledger seq recorded by the newest valid anchor, if any exists.
+    pub anchor_seq: Option<i64>,
+    /// False when an anchor event exists but fails audit-chain hash
+    /// validation (a forged or corrupted anchor); absent when no anchor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_valid: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub break_info: Option<BillingLedgerBreak>,
+}
+
+/// Anchor the current ledger head into the audit chain when it advanced
+/// past the newest anchor. Called from the reconcile sweep; also emits the
+/// head to the server log so shipped logs form an external anchor.
+pub async fn anchor_head(db: &mongodb::Database) -> AppResult<Option<i64>> {
+    let Some(head) = read_tail(db).await? else {
+        return Ok(None);
+    };
+    if let Some(anchor) = load_latest_anchor(db).await?
+        && anchor.ledger_seq >= head.seq
+    {
+        return Ok(None);
+    }
+
+    audit_service::log_system_event(
+        db.clone(),
+        HEAD_ANCHOR_EVENT_TYPE,
+        Some(serde_json::json!({
+            "seq": head.seq,
+            "head_hash": head.entry_hash,
+        })),
+    )
+    .await?;
+    tracing::info!(
+        head_seq = head.seq,
+        head_hash = %head.entry_hash,
+        "billing ledger head anchored"
+    );
+    Ok(Some(head.seq))
+}
+
+/// Cross-check the ledger head against the newest audit-chain anchor.
+/// `audit_key` is the audit-chain HMAC key, used to validate that the
+/// anchor event itself was not forged or corrupted.
+pub async fn check_head_anchor(
+    db: &mongodb::Database,
+    audit_key: &[u8],
+) -> AppResult<HeadAnchorCheck> {
+    let Some(anchor) = load_latest_anchor(db).await? else {
+        return Ok(HeadAnchorCheck {
+            anchor_seq: None,
+            anchor_valid: None,
+            break_info: None,
+        });
+    };
+
+    let expected_hash = audit_chain_service::compute_entry_hash(&anchor.entry, audit_key)?;
+    if anchor.entry.entry_hash.as_deref() != Some(expected_hash.as_str()) {
+        // A forged anchor would otherwise silently disable the truncation
+        // check, so it must surface as a chain break, not a side note.
+        return Ok(HeadAnchorCheck {
+            anchor_seq: Some(anchor.ledger_seq),
+            anchor_valid: Some(false),
+            break_info: Some(BillingLedgerBreak {
+                break_seq: anchor.ledger_seq,
+                break_kind: BillingLedgerBreakKind::AnchorInvalid,
+                expected: expected_hash,
+                actual: anchor.entry.entry_hash.unwrap_or_default(),
+            }),
+        });
+    }
+
+    let head = read_tail(db).await?;
+    let truncated = match &head {
+        None => true,
+        Some(head) => head.seq < anchor.ledger_seq,
+    };
+    if truncated {
+        return Ok(HeadAnchorCheck {
+            anchor_seq: Some(anchor.ledger_seq),
+            anchor_valid: Some(true),
+            break_info: Some(BillingLedgerBreak {
+                break_seq: anchor.ledger_seq,
+                break_kind: BillingLedgerBreakKind::TailTruncated,
+                expected: anchor.ledger_seq.to_string(),
+                actual: head
+                    .map(|head| head.seq.to_string())
+                    .unwrap_or_else(|| "missing".to_string()),
+            }),
+        });
+    }
+
+    let break_info = match load_entry_by_seq(db, anchor.ledger_seq).await? {
+        None => Some(BillingLedgerBreak {
+            break_seq: anchor.ledger_seq,
+            break_kind: BillingLedgerBreakKind::Gap,
+            expected: anchor.ledger_seq.to_string(),
+            actual: "missing".to_string(),
+        }),
+        Some(entry) if entry.entry_hash != anchor.head_hash => Some(BillingLedgerBreak {
+            break_seq: anchor.ledger_seq,
+            break_kind: BillingLedgerBreakKind::HashMismatch,
+            expected: anchor.head_hash.clone(),
+            actual: entry.entry_hash,
+        }),
+        Some(_) => None,
+    };
+
+    Ok(HeadAnchorCheck {
+        anchor_seq: Some(anchor.ledger_seq),
+        anchor_valid: Some(true),
+        break_info,
+    })
+}
+
+struct LatestAnchor {
+    entry: AuditLog,
+    ledger_seq: i64,
+    head_hash: String,
+}
+
+/// Newest chained anchor event by audit-chain seq. Unchained events (no
+/// audit seq) are ignored: without a chain position they carry no
+/// integrity and a database-only attacker could insert them freely.
+async fn load_latest_anchor(
+    db: &mongodb::Database,
+) -> Result<Option<LatestAnchor>, mongodb::error::Error> {
+    let entry = db
+        .collection::<AuditLog>(AUDIT_LOG)
+        .find(doc! {
+            "event_type": HEAD_ANCHOR_EVENT_TYPE,
+            "seq": { "$exists": true },
+        })
+        .sort(doc! { "seq": -1 })
+        .limit(1)
+        .await?
+        .try_next()
+        .await?;
+
+    Ok(entry.and_then(|entry| {
+        let data = entry.event_data.clone()?;
+        let ledger_seq = data.get("seq")?.as_i64()?;
+        let head_hash = data.get("head_hash")?.as_str()?.to_string();
+        Some(LatestAnchor {
+            entry,
+            ledger_seq,
+            head_hash,
+        })
+    }))
+}
+
+pub async fn verify_chain(
+    db: &mongodb::Database,
+    key: &[u8],
+    from_seq: Option<i64>,
+    to_seq: Option<i64>,
+    limit: Option<i64>,
+) -> AppResult<BillingLedgerVerifyReport> {
+    let from_seq = from_seq.unwrap_or(1);
+    if from_seq < 1 {
+        return Err(AppError::ValidationError(
+            "from_seq must be greater than or equal to 1".to_string(),
+        ));
+    }
+
+    if let Some(to_seq) = to_seq
+        && to_seq < from_seq
+    {
+        return Err(AppError::ValidationError(
+            "to_seq must be greater than or equal to from_seq".to_string(),
+        ));
+    }
+
+    let limit = limit.unwrap_or(DEFAULT_VERIFY_LIMIT);
+    if !(1..=MAX_VERIFY_LIMIT).contains(&limit) {
+        return Err(AppError::ValidationError(format!(
+            "limit must be between 1 and {MAX_VERIFY_LIMIT}"
+        )));
+    }
+
+    let collection = db.collection::<BillingLedgerEntry>(BILLING_LEDGER);
+    let tail = read_tail(db).await?;
+    let head_seq = tail.as_ref().map(|tail| tail.seq);
+    let head_hash = tail.map(|tail| tail.entry_hash);
+
+    let mut filter = doc! { "seq": { "$gte": from_seq } };
+    if let Some(to_seq) = to_seq {
+        filter.insert("seq", doc! { "$gte": from_seq, "$lte": to_seq });
+    }
+
+    let entries: Vec<BillingLedgerEntry> = collection
+        .find(filter)
+        .sort(doc! { "seq": 1 })
+        .limit(limit)
+        .await?
+        .try_collect()
+        .await?;
+
+    let mut checked_count = 0_u64;
+    let mut expected_seq = from_seq;
+    let mut expected_prev_hash = if from_seq == 1 {
+        GENESIS_PREV_HASH.to_string()
+    } else {
+        match load_entry_by_seq(db, from_seq - 1).await? {
+            Some(previous) => previous.entry_hash,
+            None => {
+                return Ok(broken_report(
+                    checked_count,
+                    head_seq,
+                    head_hash,
+                    BillingLedgerBreak {
+                        break_seq: from_seq,
+                        break_kind: BillingLedgerBreakKind::Gap,
+                        expected: (from_seq - 1).to_string(),
+                        actual: "missing".to_string(),
+                    },
+                ));
+            }
+        }
+    };
+
+    for entry in &entries {
+        if entry.seq != expected_seq {
+            return Ok(broken_report(
+                checked_count,
+                head_seq,
+                head_hash,
+                BillingLedgerBreak {
+                    break_seq: expected_seq,
+                    break_kind: BillingLedgerBreakKind::Gap,
+                    expected: expected_seq.to_string(),
+                    actual: entry.seq.to_string(),
+                },
+            ));
+        }
+
+        if entry.prev_hash != expected_prev_hash {
+            return Ok(broken_report(
+                checked_count,
+                head_seq,
+                head_hash,
+                BillingLedgerBreak {
+                    break_seq: expected_seq,
+                    break_kind: BillingLedgerBreakKind::LinkMismatch,
+                    expected: expected_prev_hash,
+                    actual: entry.prev_hash.clone(),
+                },
+            ));
+        }
+
+        let expected_entry_hash = compute_entry_hash(entry, key);
+        if entry.entry_hash != expected_entry_hash {
+            return Ok(broken_report(
+                checked_count,
+                head_seq,
+                head_hash,
+                BillingLedgerBreak {
+                    break_seq: expected_seq,
+                    break_kind: BillingLedgerBreakKind::HashMismatch,
+                    expected: expected_entry_hash,
+                    actual: entry.entry_hash.clone(),
+                },
+            ));
+        }
+
+        checked_count += 1;
+        expected_seq += 1;
+        expected_prev_hash = entry.entry_hash.clone();
+    }
+
+    let next_from_seq = if entries.len() as i64 == limit
+        && to_seq.is_none_or(|to_seq| expected_seq <= to_seq)
+        && head_seq.is_some_and(|head_seq| expected_seq <= head_seq)
+    {
+        Some(expected_seq)
+    } else {
+        None
+    };
+
+    Ok(BillingLedgerVerifyReport {
+        status: BillingLedgerStatus::Ok,
+        checked_count,
+        head_seq,
+        head_hash,
+        break_info: None,
+        next_from_seq,
+    })
+}
+
+async fn read_tail(db: &mongodb::Database) -> Result<Option<ChainTail>, mongodb::error::Error> {
+    let tail = db
+        .collection::<BillingLedgerEntry>(BILLING_LEDGER)
+        .find(doc! { "seq": { "$exists": true, "$type": "long" } })
+        .sort(doc! { "seq": -1 })
+        .limit(1)
+        .await?
+        .try_next()
+        .await?;
+
+    Ok(tail.map(|entry| ChainTail {
+        seq: entry.seq,
+        entry_hash: entry.entry_hash,
+    }))
+}
+
+async fn load_entry_by_seq(
+    db: &mongodb::Database,
+    seq: i64,
+) -> Result<Option<BillingLedgerEntry>, mongodb::error::Error> {
+    db.collection::<BillingLedgerEntry>(BILLING_LEDGER)
+        .find_one(doc! { "seq": seq })
+        .await
+}
+
+fn broken_report(
+    checked_count: u64,
+    head_seq: Option<i64>,
+    head_hash: Option<String>,
+    break_info: BillingLedgerBreak,
+) -> BillingLedgerVerifyReport {
+    BillingLedgerVerifyReport {
+        status: BillingLedgerStatus::Broken,
+        checked_count,
+        head_seq,
+        head_hash,
+        break_info: Some(break_info),
+        next_from_seq: None,
+    }
+}
+
+/// Length-prefixed join: `<len>:<bytes>` per field, separated by 0x1E.
+/// The prefix makes the encoding injective even when a field value itself
+/// contains the separator, so adjacent user-influenced fields (slug,
+/// model) cannot be re-split into a different tuple with the same bytes.
+fn join_record_fields(fields: &[String]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (index, field) in fields.iter().enumerate() {
+        if index > 0 {
+            out.push(RECORD_SEPARATOR);
+        }
+        out.extend_from_slice(field.len().to_string().as_bytes());
+        out.push(b':');
+        out.extend_from_slice(field.as_bytes());
+    }
+    out
+}
+
+fn hmac_sha256_hex(key: &[u8], input: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts any key length");
+    mac.update(input);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn truncate_to_bson_millis(ts: DateTime<Utc>) -> DateTime<Utc> {
+    Utc.timestamp_millis_opt(ts.timestamp_millis())
+        .single()
+        .expect("timestamp_millis from DateTime<Utc> is valid")
+}
+
+fn is_duplicate_key_error(error: &mongodb::error::Error) -> bool {
+    matches!(
+        error.kind.as_ref(),
+        mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(write_error))
+            if write_error.code == 11000
+    )
+}
+
+async fn sleep_before_retry(attempt: usize) {
+    let base_ms = 5_u64.saturating_mul(1_u64 << attempt.min(5));
+    let jitter_ms = rand::thread_rng().gen_range(0..=10);
+    tokio::time::sleep(std::time::Duration::from_millis(base_ms + jitter_ms)).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::connect_test_database;
+
+    const TEST_KEY: &[u8; 32] = &[7u8; 32];
+
+    fn entry(reference: &str) -> BillingLedgerEntry {
+        BillingLedgerEntry {
+            id: Uuid::new_v4().to_string(),
+            seq: 0,
+            prev_hash: String::new(),
+            entry_hash: String::new(),
+            event_type: BillingLedgerEventType::UsageSettled,
+            owner_id: "owner-1".to_string(),
+            reference_id: reference.to_string(),
+            transaction_id: Some(format!("{reference}-platform")),
+            layer: Some(crate::models::usage_meter::BillingLayer::Platform),
+            metric: Some(crate::models::service_billing::BillingMetric::Tokens),
+            service_slug: Some("chrono-llm".to_string()),
+            model: None,
+            quantity: Some(100),
+            amount_credits: Some(5),
+            balance_credits: None,
+            dedupe_key: None,
+            wallet_id: Some("wallet-1".to_string()),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn canonical_bytes_are_stable_and_field_sensitive() {
+        let mut a = entry("req-1");
+        a.created_at = truncate_to_bson_millis(a.created_at);
+        a.seq = 1;
+        a.prev_hash = GENESIS_PREV_HASH.to_string();
+        let hash = compute_entry_hash(&a, TEST_KEY);
+        assert_eq!(hash, compute_entry_hash(&a, TEST_KEY));
+
+        let mut tampered = a.clone();
+        tampered.amount_credits = Some(6);
+        assert_ne!(hash, compute_entry_hash(&tampered, TEST_KEY));
+
+        let mut tampered = a.clone();
+        tampered.owner_id = "owner-2".to_string();
+        assert_ne!(hash, compute_entry_hash(&tampered, TEST_KEY));
+    }
+
+    #[tokio::test]
+    async fn append_links_entries_and_verify_reports_ok() {
+        let Some(db) = connect_test_database("billing_ledger_append_verify").await else {
+            return;
+        };
+
+        let first = append_chained_entry(&db, entry("req-1"), TEST_KEY)
+            .await
+            .expect("append first");
+        assert_eq!(first.seq, 1);
+        assert_eq!(first.prev_hash, GENESIS_PREV_HASH);
+
+        let second = append_chained_entry(&db, entry("req-2"), TEST_KEY)
+            .await
+            .expect("append second");
+        assert_eq!(second.seq, 2);
+        assert_eq!(second.prev_hash, first.entry_hash);
+
+        let report = verify_chain(&db, TEST_KEY, None, None, None)
+            .await
+            .expect("verify");
+        assert_eq!(report.status, BillingLedgerStatus::Ok);
+        assert_eq!(report.checked_count, 2);
+        assert_eq!(report.head_seq, Some(2));
+    }
+
+    #[tokio::test]
+    async fn verify_detects_mutation_deletion_and_relink() {
+        let Some(db) = connect_test_database("billing_ledger_tamper").await else {
+            return;
+        };
+
+        for reference in ["req-1", "req-2", "req-3"] {
+            append_chained_entry(&db, entry(reference), TEST_KEY)
+                .await
+                .expect("append");
+        }
+        let collection = db.collection::<BillingLedgerEntry>(BILLING_LEDGER);
+
+        // Mutating a stored amount breaks the entry hash at that seq.
+        collection
+            .update_one(
+                doc! { "seq": 2 },
+                doc! { "$set": { "amount_credits": 999 } },
+            )
+            .await
+            .expect("tamper update");
+        let report = verify_chain(&db, TEST_KEY, None, None, None)
+            .await
+            .expect("verify");
+        assert_eq!(report.status, BillingLedgerStatus::Broken);
+        let break_info = report.break_info.expect("break info");
+        assert_eq!(break_info.break_seq, 2);
+        assert_eq!(break_info.break_kind, BillingLedgerBreakKind::HashMismatch);
+
+        // Deleting the tampered entry leaves a detectable gap instead.
+        collection
+            .delete_one(doc! { "seq": 2 })
+            .await
+            .expect("tamper delete");
+        let report = verify_chain(&db, TEST_KEY, None, None, None)
+            .await
+            .expect("verify");
+        assert_eq!(report.status, BillingLedgerStatus::Broken);
+        assert_eq!(
+            report.break_info.expect("break info").break_kind,
+            BillingLedgerBreakKind::Gap
+        );
+
+        // Re-sequencing the tail cannot repair the chain: the link no
+        // longer matches the surviving predecessor.
+        collection
+            .update_one(doc! { "seq": 3 }, doc! { "$set": { "seq": 2 } })
+            .await
+            .expect("tamper reseq");
+        let report = verify_chain(&db, TEST_KEY, None, None, None)
+            .await
+            .expect("verify");
+        assert_eq!(report.status, BillingLedgerStatus::Broken);
+        assert_eq!(
+            report.break_info.expect("break info").break_kind,
+            BillingLedgerBreakKind::LinkMismatch
+        );
+    }
+
+    const AUDIT_TEST_KEY: &[u8; 32] = &[2u8; 32];
+
+    #[tokio::test]
+    async fn anchor_head_detects_tail_truncation() {
+        let Some(db) = connect_test_database("billing_ledger_anchor").await else {
+            return;
+        };
+        crate::services::audit_service::init_audit_chain_hmac_key(Zeroizing::new(*AUDIT_TEST_KEY));
+
+        for reference in ["req-1", "req-2", "req-3"] {
+            append_chained_entry(&db, entry(reference), TEST_KEY)
+                .await
+                .expect("append");
+        }
+
+        assert_eq!(anchor_head(&db).await.expect("anchor"), Some(3));
+        // Re-anchoring an unchanged head is a no-op.
+        assert_eq!(anchor_head(&db).await.expect("re-anchor"), None);
+
+        let check = check_head_anchor(&db, AUDIT_TEST_KEY)
+            .await
+            .expect("check anchored");
+        assert_eq!(check.anchor_seq, Some(3));
+        assert_eq!(check.anchor_valid, Some(true));
+        assert!(check.break_info.is_none());
+
+        // New entries appended after the anchor are fine (anchor lag).
+        append_chained_entry(&db, entry("req-4"), TEST_KEY)
+            .await
+            .expect("append after anchor");
+        let check = check_head_anchor(&db, AUDIT_TEST_KEY)
+            .await
+            .expect("check lag");
+        assert!(check.break_info.is_none());
+
+        // Truncating the tail past the anchor leaves a shorter chain that
+        // still verifies link-by-link, but no longer matches the anchor.
+        db.collection::<BillingLedgerEntry>(BILLING_LEDGER)
+            .delete_many(doc! { "seq": { "$gte": 3 } })
+            .await
+            .expect("truncate tail");
+        let report = verify_chain(&db, TEST_KEY, None, None, None)
+            .await
+            .expect("verify truncated");
+        assert_eq!(
+            report.status,
+            BillingLedgerStatus::Ok,
+            "walk alone is blind"
+        );
+        let check = check_head_anchor(&db, AUDIT_TEST_KEY)
+            .await
+            .expect("check truncated");
+        let break_info = check.break_info.expect("truncation break");
+        assert_eq!(break_info.break_kind, BillingLedgerBreakKind::TailTruncated);
+        assert_eq!(break_info.break_seq, 3);
+    }
+
+    #[tokio::test]
+    async fn forged_anchor_is_flagged_invalid() {
+        let Some(db) = connect_test_database("billing_ledger_forged_anchor").await else {
+            return;
+        };
+
+        append_chained_entry(&db, entry("req-1"), TEST_KEY)
+            .await
+            .expect("append");
+
+        // An attacker with database access chains an anchor under a key of
+        // their choosing; validation against the real audit key rejects it.
+        let forged = AuditLog {
+            id: Uuid::new_v4().to_string(),
+            user_id: None,
+            event_type: HEAD_ANCHOR_EVENT_TYPE.to_string(),
+            event_data: Some(serde_json::json!({ "seq": 1, "head_hash": "bogus" })),
+            ip_address: None,
+            user_agent: None,
+            api_key_id: None,
+            api_key_name: None,
+            seq: None,
+            prev_hash: None,
+            entry_hash: None,
+            created_at: Utc::now(),
+        };
+        audit_chain_service::append_chained_entry(&db, forged, &[9u8; 32])
+            .await
+            .expect("forged append");
+
+        let check = check_head_anchor(&db, AUDIT_TEST_KEY)
+            .await
+            .expect("check forged");
+        assert_eq!(check.anchor_valid, Some(false));
+        assert_eq!(
+            check.break_info.expect("forged anchor break").break_kind,
+            BillingLedgerBreakKind::AnchorInvalid
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_wrong_key() {
+        let Some(db) = connect_test_database("billing_ledger_wrong_key").await else {
+            return;
+        };
+
+        append_chained_entry(&db, entry("req-1"), TEST_KEY)
+            .await
+            .expect("append");
+        let report = verify_chain(&db, &[9u8; 32], None, None, None)
+            .await
+            .expect("verify");
+        assert_eq!(report.status, BillingLedgerStatus::Broken);
+    }
+}

--- a/backend/src/services/billing/meter.rs
+++ b/backend/src/services/billing/meter.rs
@@ -1160,6 +1160,120 @@ mod tests {
         assert_eq!(final_row.status, UsageStatus::Finalized);
     }
 
+    /// A settlement first-apply appends exactly one tamper-evident ledger
+    /// entry; replays append nothing, and the resulting chain verifies.
+    #[tokio::test]
+    async fn settle_first_apply_appends_exactly_one_ledger_entry() {
+        let Some(db) = connect_test_database("billing_ledger_settle_hook").await else {
+            return;
+        };
+        crate::services::billing::ledger::init_billing_ledger_hmac_key(zeroize::Zeroizing::new(
+            [3u8; 32],
+        ));
+        create_usage_transaction_index(&db).await;
+        insert_rate(&db, "platform_requests", 5).await;
+        let owner_id = "owner-ledger-hook";
+        insert_wallet(&db, owner_id, 10, 0).await;
+        crate::services::billing::reservation::try_reserve_prepaid(&db, owner_id, 5)
+            .await
+            .expect("reserve")
+            .expect("reserved");
+
+        let ctx = platform_context("billing-ledger-hook", owner_id);
+        let reservation = BillingReservation {
+            owner_id: owner_id.to_string(),
+            wallet_id: format!("wallet-{owner_id}"),
+            total_reserved_credits: 5,
+            layers: vec![crate::services::billing::reservation::LayerReservation {
+                layer: BillingLayer::Platform,
+                reserved_credits: 5,
+            }],
+        };
+        let metered = open(&db, &ctx, Some(&reservation)).await.expect("open");
+        mark_forwarded(&db, &metered).await.expect("mark forwarded");
+        settle(
+            &db,
+            &metered,
+            crate::models::service_billing::PlatformUsage::single_request(64),
+            None,
+            None,
+        )
+        .await
+        .expect("settle");
+
+        let row = db
+            .collection::<UsageMeterRow>(crate::models::usage_meter::COLLECTION_NAME)
+            .find_one(doc! { "billing_request_id": "billing-ledger-hook" })
+            .await
+            .expect("find row")
+            .expect("row exists");
+        assert!(row.released);
+
+        // A replay of the settlement claim must not append a second entry.
+        crate::services::billing::reservation::claim_released_and_settle(&db, &row)
+            .await
+            .expect("settle replay");
+
+        // The append is spawned off the settlement path; wait for it.
+        let ledger = db.collection::<crate::models::billing_ledger::BillingLedgerEntry>(
+            crate::models::billing_ledger::COLLECTION_NAME,
+        );
+        let mut entries: Vec<crate::models::billing_ledger::BillingLedgerEntry> = Vec::new();
+        for _ in 0..100 {
+            entries = ledger
+                .find(doc! { "owner_id": owner_id })
+                .await
+                .expect("find ledger entries")
+                .try_collect()
+                .await
+                .expect("collect ledger entries");
+            if !entries.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert_eq!(entries.len(), 1, "one charge, one ledger entry");
+        let entry = &entries[0];
+        assert_eq!(
+            entry.event_type,
+            crate::models::billing_ledger::BillingLedgerEventType::UsageSettled
+        );
+        assert_eq!(entry.reference_id, row.id);
+        assert_eq!(entry.quantity, Some(1));
+        assert_eq!(entry.amount_credits, Some(5));
+
+        // Free metered traffic (no wallet) settles without a ledger entry.
+        let free_ctx = platform_context("billing-ledger-free", "owner-ledger-free");
+        let free_metered = open(&db, &free_ctx, None).await.expect("open free");
+        mark_forwarded(&db, &free_metered)
+            .await
+            .expect("mark free forwarded");
+        settle(
+            &db,
+            &free_metered,
+            crate::models::service_billing::PlatformUsage::single_request(64),
+            None,
+            None,
+        )
+        .await
+        .expect("settle free");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let free_entries = ledger
+            .count_documents(doc! { "owner_id": "owner-ledger-free" })
+            .await
+            .expect("count free entries");
+        assert_eq!(free_entries, 0, "free traffic moves no money");
+
+        let report =
+            crate::services::billing::ledger::verify_chain(&db, &[3u8; 32], None, None, None)
+                .await
+                .expect("verify ledger");
+        assert_eq!(
+            report.status,
+            crate::services::billing::ledger::BillingLedgerStatus::Ok
+        );
+    }
+
     #[tokio::test]
     async fn failed_live_settlement_is_durable_and_recovers_without_double_debit() {
         let Some(db) = connect_test_database("billing_settle_outbox_recovery").await else {

--- a/backend/src/services/billing/mod.rs
+++ b/backend/src/services/billing/mod.rs
@@ -1,4 +1,5 @@
 pub mod lago_client;
+pub mod ledger;
 pub mod meter;
 pub mod owner_resolver;
 pub mod provisioning;

--- a/backend/src/services/billing/provisioning.rs
+++ b/backend/src/services/billing/provisioning.rs
@@ -259,6 +259,17 @@ pub async fn create_topup_checkout(
                         "billing top-up checkout session disappeared after update".to_string(),
                     )
                 })?;
+            // Ledger the top-up only once the provider checkout actually
+            // exists; a pending stub that fails before this point cannot
+            // move money and must not leave a phantom entry.
+            super::ledger::record_topup_created(
+                db,
+                owner_id,
+                &session.id,
+                amount_credits,
+                &lago_wallet_id,
+            )
+            .await;
             Ok(TopUpCheckout {
                 session,
                 reused: false,
@@ -552,6 +563,7 @@ mod tests {
         let Some(db) = connect_test_database("billing_topup_checkout").await else {
             return;
         };
+        super::super::ledger::init_billing_ledger_hmac_key(zeroize::Zeroizing::new([3u8; 32]));
         let owner_id = insert_owner(&db, "topup@example.com").await;
         let lago = FakeLago::default();
 
@@ -585,6 +597,17 @@ mod tests {
             .expect("count top-up sessions");
         assert_eq!(session_count, 1);
         assert_eq!(lago.topup_creates.load(Ordering::SeqCst), 1);
+
+        // Exactly one ledger entry: appended when the provider checkout was
+        // created, not duplicated by the idempotent replay.
+        let ledger_count = db
+            .collection::<crate::models::billing_ledger::BillingLedgerEntry>(
+                crate::models::billing_ledger::COLLECTION_NAME,
+            )
+            .count_documents(doc! { "owner_id": &owner_id, "event_type": "topup_created" })
+            .await
+            .expect("count ledger entries");
+        assert_eq!(ledger_count, 1);
     }
 
     #[tokio::test]

--- a/backend/src/services/billing/reconcile.rs
+++ b/backend/src/services/billing/reconcile.rs
@@ -60,6 +60,12 @@ impl BillingReconciler {
     pub async fn run_once(&self) -> AppResult<ReconcileStats> {
         let mut stats = ReconcileStats::default();
         stats.abandoned += self.abandon_unforwarded_reserved().await?;
+        // Anchor the billing-ledger head into the audit chain whenever it
+        // advanced, so tail truncation of the ledger is detectable. Best
+        // effort: an anchor failure must not stall the sweep.
+        if let Err(error) = super::ledger::anchor_head(&self.db).await {
+            tracing::warn!(error = %error, "billing ledger head anchoring failed");
+        }
         if !self.config.billing_enabled {
             return Ok(stats);
         }

--- a/backend/src/services/billing/reservation.rs
+++ b/backend/src/services/billing/reservation.rs
@@ -415,6 +415,13 @@ pub async fn apply_settlement_for_row(
     if let Some(wallet_id) = row.wallet_id.as_deref() {
         clear_wallet_settlement_lock(db, wallet_id, &row.billing_owner_id, &row.id).await?;
     }
+    // This is one of the two places the `released` transition commits (the
+    // other is `complete_wallet_settlement_lock`), so the tamper-evident
+    // ledger hook lives here. Only actual charges are ledgered: free
+    // metered traffic (no wallet) and zero-credit settlements move no money.
+    if update.modified_count > 0 && row.wallet_id.is_some() && actual_credits > 0 {
+        super::ledger::record_usage_settled_async(db.clone(), row.clone(), actual_credits);
+    }
     Ok(update.modified_count > 0)
 }
 
@@ -525,6 +532,17 @@ async fn complete_wallet_settlement_lock(
                 lock.row_id
             )));
         }
+    }
+
+    // Crash-bridge counterpart of the ledger hook in
+    // `apply_settlement_for_row`: this path also commits a `released`
+    // transition for a charge, so it must be ledgered too.
+    if update.matched_count == 1 && lock.actual_credits > 0 {
+        super::ledger::record_usage_settled_by_row_id_async(
+            db.clone(),
+            lock.row_id.clone(),
+            lock.actual_credits,
+        );
     }
 
     clear_wallet_settlement_lock(db, wallet_id, owner_id, &lock.row_id).await

--- a/backend/src/services/billing/webhook.rs
+++ b/backend/src/services/billing/webhook.rs
@@ -57,13 +57,25 @@ pub async fn handle_lago_webhook_event(
         let balance_credits = lago.wallet_balance(&customer_id).await?;
         return Ok(
             match refresh_wallet_balance(db, &customer_id, balance_credits).await? {
-                Some(outcome) => LagoWebhookOutcome {
-                    action: LagoWebhookAction::WalletRefreshed,
-                    owner_id: Some(outcome.owner_id),
-                    customer_id: Some(customer_id),
-                    balance_credits: Some(outcome.balance_credits),
-                    pending_debits_cleared: outcome.pending_debits_cleared,
-                },
+                Some(outcome) => {
+                    if event_type == "invoice.paid_credit_added" {
+                        super::ledger::record_wallet_credited(
+                            db,
+                            &outcome.owner_id,
+                            &customer_id,
+                            outcome.balance_credits,
+                            extract_paid_credit_dedupe_key(payload),
+                        )
+                        .await;
+                    }
+                    LagoWebhookOutcome {
+                        action: LagoWebhookAction::WalletRefreshed,
+                        owner_id: Some(outcome.owner_id),
+                        customer_id: Some(customer_id),
+                        balance_credits: Some(outcome.balance_credits),
+                        pending_debits_cleared: outcome.pending_debits_cleared,
+                    }
+                }
                 None => ignored_for_customer(customer_id),
             },
         );
@@ -225,6 +237,19 @@ async fn invalidate_entitlement_decision(
         .await?;
 
     Ok(updated.map(|wallet| (wallet.owner_id, customer_id)))
+}
+
+/// At-most-once key for `invoice.paid_credit_added` ledger entries: the
+/// Lago invoice id, stable across Lago's webhook delivery retries.
+fn extract_paid_credit_dedupe_key(payload: &Value) -> Option<String> {
+    payload
+        .get("invoice")
+        .and_then(|invoice| invoice.get("lago_id"))
+        .or_else(|| payload.get("lago_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("lago-invoice:{value}"))
 }
 
 fn extract_external_customer_id(value: &Value) -> Option<String> {

--- a/backend/src/services/channel_relay_service.rs
+++ b/backend/src/services/channel_relay_service.rs
@@ -1079,6 +1079,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/services/social_auth_service.rs
+++ b/backend/src/services/social_auth_service.rs
@@ -805,6 +805,7 @@ mod tests {
             broker_require_admin_capability: false,
             cli_pairing_hmac_key: None,
             audit_chain_hmac_key: None,
+            billing_ledger_hmac_key: None,
             sa_token_ttl_secs: 3600,
             telemetry_dsn: None,
             telemetry_host: None,

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -333,6 +333,7 @@ pub(crate) fn test_app_config() -> AppConfig {
         broker_require_admin_capability: false,
         cli_pairing_hmac_key: None,
         audit_chain_hmac_key: None,
+        billing_ledger_hmac_key: None,
         sa_token_ttl_secs: 3600,
         cookie_domain: None,
         telegram_bot_token: None,
@@ -559,6 +560,7 @@ pub(crate) fn test_app_state_with_config(db: mongodb::Database, config: AppConfi
         // service-level tests pass their own explicit HMAC key.
         auth_device_hmac_key: Arc::new(zeroize::Zeroizing::new([1u8; 32])),
         audit_chain_hmac_key: Arc::new(zeroize::Zeroizing::new([2u8; 32])),
+        billing_ledger_hmac_key: Arc::new(zeroize::Zeroizing::new([3u8; 32])),
         per_channel_event_limiter: Arc::new(crate::mw::rate_limit::PerChannelEventLimiter::new(
             config.channel_event_rate_limit_per_second,
             config.channel_event_rate_limit_burst,

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -215,6 +215,18 @@ The backend picks the audit-chain key at startup using the first match:
 
 Legacy rows without `seq` are not backfilled. The verifier reports them as `pre_chain_count` rather than claiming historical integrity. This v1 chain does not detect tail truncation: deleting the newest N rows leaves a valid shorter chain until `(head_seq, head_hash)` is anchored outside MongoDB.
 
+## Billing Ledger Hash Chain (Optional)
+
+Money-moving billing events (charged usage settlements, provider-confirmed top-up checkouts, paid credits landing on a wallet) are journaled to the append-only `billing_ledger` collection with the same hash-chain construction as the audit log. The operational billing rows stay mutable by design; the ledger is what makes their money-moving history tamper-evident. Verify via `GET /api/v1/admin/billing-ledger/verify`.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BILLING_LEDGER_HMAC_KEY` | *(derived from `ENCRYPTION_KEY`, then JWT private key)* | Explicit 32-byte HMAC key (64 hex chars) for billing-ledger hash chaining. Same key-selection rules as `AUDIT_CHAIN_HMAC_KEY`, with the domain-separated `billing-ledger` label, so the two chains never share a key even when both derive from `ENCRYPTION_KEY`. |
+
+Ledger appends are best-effort relative to billing itself: a ledger write failure is logged and never fails or rolls back a settlement or top-up.
+
+Unlike the audit chain, the billing ledger detects tail truncation: the reconcile sweep anchors the ledger head `(seq, head_hash)` into the audit chain (event `billing_ledger_head_anchored`) whenever it advances, and the verify endpoint cross-checks the newest anchor against the surviving head. Deleting ledger tail entries past an anchor reports `tail_truncated`; hiding it would additionally require truncating the audit chain back past the anchor, destroying unrelated audit history. Each anchor is also written to the server log (`billing ledger head anchored`), so shipped logs form an external anchor outside MongoDB. Entries newer than the latest anchor (up to one reconcile interval, `BILLING_RECONCILE_INTERVAL_SECS`) remain inside the undetectable window.
+
 ## Social Login (Optional)
 
 | Variable | Description |


### PR DESCRIPTION
## Summary

- Journal money-moving billing events to an append-only `billing_ledger` collection, hash-chained like the audit log (`seq`/`prev_hash`/`entry_hash`, HMAC-SHA256): editing, deleting, inserting, or re-sequencing history breaks verification at that seq. Operational billing rows stay mutable by design; the ledger is the immutable journal of their money-moving transitions.
- Ledgered events: charged usage settlements (hooked at both `released` commit points including the wallet-lock crash bridge, first-apply only, spawned off the settlement path), provider-confirmed top-up checkouts, and paid wallet credits (deduped by Lago invoice id). Free metered traffic and zero-credit settlements move no money and are not ledgered.
- Detect tail truncation (which the audit chain v1 cannot): the reconcile sweep anchors the ledger head into the audit chain (`billing_ledger_head_anchored`) and the server log whenever it advances; `GET /api/v1/admin/billing-ledger/verify` cross-checks the newest anchor against the surviving head and reports `tail_truncated`. A forged anchor surfaces as `anchor_invalid` (status Broken) rather than silently disabling the check. Entries newer than the latest anchor (at most one reconcile interval) remain in the undetectable window; hiding an anchored truncation additionally requires destroying audit-chain history, and shipped server logs terminate the recursion outside MongoDB.
- Key handling: `BILLING_LEDGER_HMAC_KEY` override or domain-separated `billing-ledger` derivation from `ENCRYPTION_KEY` / the JWT key; process memory only; config Debug redacts it. Canonical encoding is length-prefixed so adjacent user-influenced fields (slug, model) cannot be re-split into a different tuple with identical bytes. Unique index on `seq` turns concurrent appends into retries, never forks.
- Ledger appends are best-effort relative to billing: a write failure is logged and never fails or rolls back a settlement or top-up.

## Test Plan

- [x] Chain unit tests: canonical stability and field sensitivity; append linking; verify Ok
- [x] Tamper detection: mutated amount (hash_mismatch), deleted entry (gap), re-sequenced tail (link_mismatch), wrong key
- [x] Tail truncation: chain walk alone stays Ok, anchor cross-check reports tail_truncated; anchor lag and re-anchor no-op covered; forged anchor flagged anchor_invalid
- [x] Settlement hook: one charge produces exactly one entry across settle + reconcile replay; free (walletless) traffic produces none
- [x] Top-up hook: entry appended on provider checkout creation, not duplicated by idempotent replay
- [x] cargo test -p nyxid: 4940 passed, 0 failed
- [x] cargo fmt + clippy clean (pre-commit hooks)

## Checklist

- [x] Code follows the project's architecture rules
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Documentation updated (docs/ENV.md, CLAUDE.md)