### PR TITLE
fix: keep new chats usable through Aevatar history projection lag

### DIFF
--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -321,12 +321,18 @@ been confirmed by a wire transcript. A positive `stateVersion` is a
 materialization criterion, not either fact; a create context with version zero
 therefore remains pending instead of being mistaken for a settled conversation.
 
-While either fact is pending, public history reads return the local mirror with
-`awaitingProjection: true` and make no transcript request. A single-flight
-background reconciler performs the wire reads. Materialization requires a
+While either fact is pending on a terminal local mirror, public history reads
+return that mirror with `awaitingProjection: true` and make no transcript
+request. Live turns omit the projection flag and cannot be rewritten by a
+background transcript observation. A cold canonical record synthesized only
+from a receipt attempts the transcript once before falling back to an empty
+syncing mirror on `404`. A single-flight background reconciler performs later
+wire reads. Materialization requires a
 wrapped positive fence at least as high as the stored fence and, when known,
-the latest local assistant turn. Legacy arrays can materialize only when they
-contain the required turn. Reconciliation uses full jitter with a 250 ms floor,
+the latest local assistant turn. When streamed assistant messages carry no
+turn id, the stored `requiredTurnId` supplies that keep-max predicate. Legacy
+arrays can materialize only when they contain the required turn.
+Reconciliation uses full jitter with a 250 ms floor,
 a 30-second per-delay cap, and a 90-second deadline. Cold create recovery uses
 an 8-second cap and a 60-second deadline. The existing foreground continuation
 preflight schedule remains `0`, `300`, `900`, and `1800` milliseconds.

--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -1,6 +1,6 @@
 # Assistant Chat Wire Contract
 
-Last verified against `f608b33c` (2026-08-01).
+Last verified against `fix-new-chat-timing` (2026-08-04).
 
 This document specifies the browser-to-NyxID contract and the Aevatar request NyxID produces. It is the canonical API reference for the assistant chat surface.
 
@@ -306,6 +306,57 @@ The wrapped form supplies the workflow continuation fence. The legacy array does
 
 Aevatar Chat History currently materializes text messages, not every browser-local structured block. While a workflow transcript is catching up, `frontend/src/lib/assistant/aevatar-transport.ts:applyHistoryResponse` merges server text with locally retained structured action and approval messages rather than discarding those cards.
 
+### Browser projection lifecycle
+
+A Studio stream and the browser's local mirror are authoritative through a
+turn terminal. A terminal does not synchronously read transcript detail:
+Aevatar's CQRS read model returns `404` until the first terminal has projected,
+and that response cannot distinguish a pending projection from a deleted or
+unknown conversation.
+
+The transport stores two independent facts. `identityPending` means a create
+command was dispatched but no `chatc-...` identity has been adopted.
+`projectionPending` means a workflow turn reached a local terminal that has not
+been confirmed by a wire transcript. A positive `stateVersion` is a
+materialization criterion, not either fact; a create context with version zero
+therefore remains pending instead of being mistaken for a settled conversation.
+
+While either fact is pending, public history reads return the local mirror with
+`awaitingProjection: true` and make no transcript request. A single-flight
+background reconciler performs the wire reads. Materialization requires a
+wrapped positive fence at least as high as the stored fence and, when known,
+the latest local assistant turn. Legacy arrays can materialize only when they
+contain the required turn. Reconciliation uses full jitter with a 250 ms floor,
+a 30-second per-delay cap, and a 90-second deadline. Cold create recovery uses
+an 8-second cap and a 60-second deadline. The existing foreground continuation
+preflight schedule remains `0`, `300`, `900`, and `1800` milliseconds.
+
+A deadline with raw index membership present or unavailable produces the
+non-error `projectionStalled` state and an explicit browser retry. Transcript
+`404` plus two raw-index-absent observations at least ten seconds apart, or a
+raw absence at the deadline, tombstones the conversation. Raw membership is
+read from the upstream response before local list rows are merged; the merged
+sidebar list is never existence evidence.
+
+### Persisted create evidence
+
+The browser stores account-scoped create receipts containing only the command
+ID, placeholder ID, optional canonical ID, positive fence, and timestamps. It
+never stores prompts, messages, tokens, or card content. Receipt persistence is
+best effort: disabled storage and quota failures fall back to memory without
+failing a send. Receipts expire after 24 hours and are capped at 20 per user.
+Browser storage events share evidence between tabs, but reconciliation remains
+single-flight per tab and independently jittered.
+
+Deletion intents use a separate per-user namespace, 24-hour expiry, and cap of
+10. They survive account changes without becoming active under the next
+account. Returning to the original account resumes cleanup. A user who deletes
+an unaliased `workflow-pending-...` draft gets immediate local removal and no
+placeholder DELETE. The intent recovers the canonical ID by `commandId`, sends
+DELETE for that `chatc-...` ID, tombstones both addresses, and is removed only
+after DELETE succeeds. A known canonical intent is excluded from index merges
+while cleanup is outstanding.
+
 ## Delete
 
 `DELETE /conversations/{id}` reserves deletion in the browser transport so a concurrent send, action report, approval, or late recovery cannot resurrect the conversation.
@@ -315,7 +366,7 @@ Aevatar Chat History currently materializes text messages, not every browser-loc
 | `nyxid-chat-...` | `DELETE /api/chat/conversations/{id}` | preserve upstream response, including `202` JSON acceptance |
 | `chatc-...` | `DELETE /api/scopes/{verifiedUserId}/chat-history/conversations/{id}` | normalize every upstream success to `204` with an empty body |
 
-Non-success responses are preserved. Workflow normalization removes `Content-Length` and `Content-Type`. The frontend uses a 15-second request deadline, tombstones the identity during deletion, aborts or waits on active work as required, and invalidates list/detail caches after success. A failed delete restores the visible conversation.
+Non-success responses are preserved. Workflow normalization removes `Content-Length` and `Content-Type`. The frontend uses a 15-second request deadline for known durable identities, tombstones the identity during deletion, aborts or waits on active work as required, and invalidates list/detail caches after success. A failed known-ID delete restores the visible conversation. An unaliased local placeholder uses the durable deletion-intent flow above and is never sent on the wire.
 
 Implementation: `backend/src/handlers/assistant.rs:delete_conversation` and `frontend/src/lib/assistant/aevatar-transport.ts:deleteConversation`.
 

--- a/docs/chat/07-testing-and-gaps.md
+++ b/docs/chat/07-testing-and-gaps.md
@@ -135,7 +135,9 @@ This suite uses the real Aevatar transport with controlled history/stream respon
 - no Studio continuation replay after accepted stream truncation;
 - create recovery entry points, poll validation, history reconciliation, scope guard, alias adoption, terminal-kind preservation, and fail-closed exhaustion;
 - workflow client-only cancellation and workflow delete;
-- account-scope reset, receipt-backed cold reads, raw-index evidence, pending mirror suppression, projection materialization, and pre-alias deletion intents; and
+- account-scope reset and abandoned-retry settlement, receipt-backed cold reads, raw-index evidence, active/pending mirror suppression, projection materialization, and pre-alias deletion intents;
+- new-chat keep-max convergence and retention at current, missing-turn, below-fence, legacy, and live-turn boundaries;
+- receiptless placeholder-alias DELETE, delete-before-context canonical cleanup, and persisted-intent reload sweeping; and
 - refusal to send typed actor approval/wake controls to a `chatc-...` identity.
 
 Captured fixtures in `frontend/src/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse` and `aevatar-chat-history.json` are replayed through awkward byte chunks to exercise incremental parsing and history mapping.
@@ -150,7 +152,7 @@ Supporting unit suites isolate the components:
 - `transport.test.ts` and `mock-data.test.ts`: transport selection and deterministic mock behavior;
 - component tests for thread, composer, sidebar, text, run, approval, connect, action, and artifact rendering;
 - draft, context, and wire-log store tests;
-- `assistant-receipts.test.ts` and `assistant-receipt-store.test.ts`: corrupt entry rejection, positive fences, timestamp skew, per-account namespaces, independent caps, storage fallback, and cross-tab rehydration;
+- `assistant-receipts.test.ts` and `assistant-receipt-store.test.ts`: corrupt entry rejection, positive fences, timestamp skew, per-account namespaces, independent caps, storage fallback, cross-tab rehydration, and materialization-timer deduplication;
 - `backoff.test.ts`: nonzero jitter floor and capped deadline-spanning delays; and
 - `frontend/src/pages/assistant.test.tsx`: page-level selection, send, and state composition.
 

--- a/docs/chat/07-testing-and-gaps.md
+++ b/docs/chat/07-testing-and-gaps.md
@@ -1,6 +1,6 @@
 # Assistant Chat Testing and Gaps
 
-Last verified against `f608b33c` (2026-08-01).
+Last verified against `fix-new-chat-timing` (2026-08-04).
 
 The assistant surface is covered at four levels: browser flow tests against a deterministic transport, React hook and component probes, transport/protocol unit tests, and Rust handler/service tests against reconstructed upstream calls. Live deployment capture remains a separate operational requirement.
 
@@ -85,6 +85,7 @@ This suite covers:
 - cancellation and prevention of late writes;
 - error copy for downstream auth, active turn, history, and generic failures;
 - typed not-found no-retry behavior; and
+- projection reconciliation, canonical-key invalidation, and waiter release;
 - continued streaming when history is missing or fails.
 
 ### `use-assistant.audit.test.tsx`
@@ -133,7 +134,8 @@ This suite uses the real Aevatar transport with controlled history/stream respon
 - reservation-specific 503 refresh and retry;
 - no Studio continuation replay after accepted stream truncation;
 - create recovery entry points, poll validation, history reconciliation, scope guard, alias adoption, terminal-kind preservation, and fail-closed exhaustion;
-- workflow client-only cancellation and workflow delete; and
+- workflow client-only cancellation and workflow delete;
+- account-scope reset, receipt-backed cold reads, raw-index evidence, pending mirror suppression, projection materialization, and pre-alias deletion intents; and
 - refusal to send typed actor approval/wake controls to a `chatc-...` identity.
 
 Captured fixtures in `frontend/src/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse` and `aevatar-chat-history.json` are replayed through awkward byte chunks to exercise incremental parsing and history mapping.
@@ -147,7 +149,9 @@ Supporting unit suites isolate the components:
 - `canonical-command-guard.test.ts`: canonical typed command route/body use;
 - `transport.test.ts` and `mock-data.test.ts`: transport selection and deterministic mock behavior;
 - component tests for thread, composer, sidebar, text, run, approval, connect, action, and artifact rendering;
-- draft, context, and wire-log store tests; and
+- draft, context, and wire-log store tests;
+- `assistant-receipts.test.ts` and `assistant-receipt-store.test.ts`: corrupt entry rejection, positive fences, timestamp skew, per-account namespaces, independent caps, storage fallback, and cross-tab rehydration;
+- `backoff.test.ts`: nonzero jitter floor and capped deadline-spanning delays; and
 - `frontend/src/pages/assistant.test.tsx`: page-level selection, send, and state composition.
 
 ## Rust service tests

--- a/docs/plans/new-chat-projection-race.md
+++ b/docs/plans/new-chat-projection-race.md
@@ -766,7 +766,7 @@ directly (the pattern `aevatar-transport.test.ts` already uses).
 
 Honesty note (review P2.5): tests marked **[guard]** below pass on `main` and
 are kept deliberately as labeled regression guards paired with a falsifiable
-sibling; every unmarked test fails on `main`.
+sibling; every unmarked original-plan test fails on `main`.
 
 ### New files
 
@@ -862,7 +862,7 @@ W5 (evidence):
 W8 (keep-max):
 
 - `a fence-current shorter server transcript containing the latest local turn replaces a longer local mirror after the grace window`
-- `a fence-current shorter read MISSING the latest local turn keeps the local mirror`
+- **[branch-regression]** `a fence-current shorter read MISSING the latest local turn keeps the local mirror`
   (review P2.2's completed predicate)
 - **[guard]** `a below-fence or legacy-array shorter read never replaces a longer local mirror`
   (passes on `main` where keep-max is unconditional; kept as the explicit
@@ -932,6 +932,12 @@ Several design bullets are covered by pre-existing tests rather than counted
 as new coverage: `stateVersion: 0`, context-free terminal recovery, and local
 pending-mirror/no-request behavior. PR #1304's card/order suite remains the
 structured-message guard and its assertions are unchanged.
+
+Follow-up tests marked `[branch-regression]` pass on `main` because `main` has
+the older unconditional keep-max/direct-read/direct-alias behavior, but fail
+against the pre-review implementation (`58ab3594`). They are required guards
+for regressions introduced by this branch's new relaxation and receipt paths,
+not claimed as new `main` coverage.
 
 Deferred from this PR's test diff:
 

--- a/docs/plans/new-chat-projection-race.md
+++ b/docs/plans/new-chat-projection-race.md
@@ -245,11 +245,7 @@ New `StoredConversation` fields (`aevatar-transport.ts:571`):
 - `identityPending?: boolean`, `projectionPending?: boolean` (§2.1);
 - `requiredTurnId?: string | null` — the chat-history turn id of the last local
   workflow terminal (from the context frame / recovery), the turn-presence
-  criterion for materialization; null when unknown (criteria degrade to
-  fence-only);
-- `materializedStateVersion?: number` — highest `stateVersion` confirmed by a
-  **wire** transcript read (`applyHistoryResponse` gains a wire-origin flag;
-  mirror serves never set it);
+  criterion for materialization; null when unknown;
 - `projectionStalledAt?: number` — set on reconciler timeout, cleared on
   explicit retry or any later materialization.
 
@@ -259,8 +255,7 @@ a wire read whose `historyStateVersion` is a positive integer
 `requiredTurnId` is set — `historyIncludesAssistantTurn(entries, requiredTurnId)`.
 This is the same double condition create recovery already uses
 (`:2736-2741`). A legacy-array read (no `stateVersion`) that contains
-`requiredTurnId` also materializes (sets `materializedStateVersion` to the
-stored fence, or marks confirmed when the fence is absent). A `stateVersion: 0`
+`requiredTurnId` also materializes. A `stateVersion: 0`
 context therefore parks in PROJECTION_PENDING until a *positive* fence read
 containing the turn arrives — exactly the sequence the existing regression
 locks in.
@@ -400,14 +395,18 @@ invalidate the right cache keys.
   ≥ 10s apart with transcript still 404 → tombstone (`deletedConversationIds`)
   → `absent`. Before every attempt: check `deletedConversationIds` /
   `deletingConversations` (local delete → `absent`) and the owner scope
-  (§2.7 — scope changed → abort without settling; the scope reset clears the
-  entry).
+  (§2.7 — scope change aborts the request and settles the abandoned entry as
+  `timed_out` before clearing it, so a mounted retry mutation cannot remain
+  pending forever).
 - **Loop body (recovery mode, identityPending):** poll
   `create-recovery/{commandId}` (existing `pollCreateRecovery` request logic,
   driven by the recovery policy schedule) with the same adoption guards
   `recoverWorkflowCreate` uses; on adoption, clear `identityPending`, set
   `projectionPending` + `requiredTurnId`, and continue in projection mode under
-  the remaining deadline.
+  the remaining deadline. An active turn never enters this wire loop: public
+  history omits `awaitingProjection` while the turn is live, and the transport
+  defensively reschedules any already-created entry without a network request
+  or consuming its post-terminal deadline.
 - **Deadline transition (review P1.3 — no `gave_up` limbo):** at the deadline,
   run one final raw-index membership check.
   - Membership **absent** → tombstone → `absent` (the hook invalidates; the
@@ -587,8 +586,10 @@ substrate; W3 (provenance) precedes W4–W7.
   (`MockAssistantTransport` no-op impls).
 - **Change:** fields and transitions per §2.1–2.3. In `getHistory`:
   - the wire-read branch (`:1426`) serves the mirror with
-    `awaitingProjection: true` and NO network call while
-    `identityPending || projectionPending`;
+    `awaitingProjection: true` and NO network call while a local pending mirror
+    has content or terminal provenance. A cold canonical record synthesized
+    only from a receipt attempts one transcript read first, then falls back to
+    the syncing mirror on 404;
   - the **locally-held placeholder branch (`:1414-1425`) stamps
     `awaitingProjection: true` when `identityPending`** — the same-tab
     context-free-terminal case the review flagged; the mounted hook then
@@ -707,10 +708,14 @@ substrate; W3 (provenance) precedes W4–W7.
      keep local: mixed deployment);
   2. `freshStateVersion >= preMergeFence`;
   3. NOT `withinMaterializationGrace`;
-  4. the latest local assistant turn, when one exists
-     (`latestAssistantTurnId(stored)`), is present in the server entries
+  4. the latest known local assistant turn
+     (`latestAssistantTurnId(stored)`, falling back to `requiredTurnId` for
+     streamed new-chat messages that carry no per-message turn id), is present
+     in the server entries
      (`historyIncludesAssistantTurn`) — a fence-current read missing the just
      streamed turn must NOT wipe its text (review P2.2's completed predicate).
+  An active turn is an unconditional keep: `applyHistoryResponse` returns its
+  existing mirror before applying any fence or transcript observation.
   Otherwise keep `existing`. Structured-message preservation
   (`preserveLocalStructuredMessages`, `:537-568`) applies after that decision,
   unchanged — the review found no evidence this recreates PR #1304's card
@@ -906,6 +911,45 @@ a signal to re-examine W3/W8, not the test.
 ### Docs (no tests, but part of done)
 
 `docs/chat/02-wire-contract.md` and `docs/chat/07-testing-and-gaps.md` per W9.
+
+### Implementation coverage reconciliation (post-Opus review)
+
+The lists above describe the design-time target, not an assertion that every
+bullet became a new test. The implementation and follow-up contain the
+load-bearing regressions for this change:
+
+- all three W8 predicates against a real new-chat mirror whose streamed
+  assistant messages have no turn ids, plus a live-turn transcript barrier;
+- the W2 delete-before-context resurrection window, persisted-intent reload
+  sweep, and receiptless placeholder-alias DELETE;
+- cold receipt-first transcript loading, active-first-turn recovery
+  suppression, and account-reset settlement of an outstanding retry;
+- W4 single-flight, nonzero-floor timing, deadline-to-stalled behavior, raw
+  membership evidence, and cold absence; W5 and W7 rendered outcomes; and the
+  receipt-store timer deduplication.
+
+Several design bullets are covered by pre-existing tests rather than counted
+as new coverage: `stateVersion: 0`, context-free terminal recovery, and local
+pending-mirror/no-request behavior. PR #1304's card/order suite remains the
+structured-message guard and its assertions are unchanged.
+
+Deferred from this PR's test diff:
+
+- a request-count-specific W0 abort assertion. Account isolation, controller
+  aborts, and post-await scope guards are covered by the existing account
+  switch test plus the new outstanding-promise settlement case; the Opus
+  reproduction independently inspected the abort path. A deterministic fetch
+  abort spy would duplicate those mechanics rather than close a remaining
+  behavior defect;
+- dedicated W4 pause/resume, late-wake, remote-delete-mid-loop, and
+  recovery-adoption timing cases. The single-flight/deadline/evidence tests
+  exercise their shared state machine and Opus independently verified these
+  mechanics. These remain useful hardening work, but are not represented as
+  shipped coverage here;
+- the W6 `projectTransportState` placeholder/canonical dual-slot copy case.
+  The hook suite covers canonical invalidation, while a pump-level cache-copy
+  test needs a separate transport-event harness. It is deferred and is not
+  claimed as current coverage.
 
 ---
 

--- a/docs/plans/new-chat-projection-race.md
+++ b/docs/plans/new-chat-projection-race.md
@@ -1,0 +1,1021 @@
+# Plan: New-chat projection race — client-side projection lifecycle (rev 2)
+
+Branch `fix-new-chat-timing`, base `origin/rollup-chat-2026-08-04` (== `main` @ `fde6041f`).
+Frontend-only. No backend changes, no new dependencies, no lockfile changes.
+Rev 2 incorporates the GPT-Sol adversarial review
+(`docs/plans/new-chat-projection-race.review-gpt.md`); §7 maps every finding to
+its resolution.
+
+Architecture (decided, not re-litigated): the SSE stream + the transport's local
+mirror are authoritative through a conversation's first turn; the transcript GET
+is background reconciliation, never a prerequisite. Aevatar's CQRS read model
+404s every brand-new `chatc-…` conversation until first-terminal + async
+projection, and "pending", "never existed", and "deleted" are indistinguishable
+at the wire — so the client must carry provenance, evidence, and a reconciler of
+its own. Backend `get_history` (`backend/src/handlers/assistant.rs:828`) stays
+an opaque proxy.
+
+---
+
+## 1. Verification of the seven claimed defects
+
+All file:line references are against `fde6041f` (current worktree HEAD).
+
+### D1 — placeholder id on the wire: PARTIALLY WRONG as described (reviewer-confirmed)
+
+- The described leak — `projectTransportState()` (`frontend/src/hooks/use-assistant.ts:121`,
+  called at `:630` pre-send and `:647` post-send) driving `getHistory` with a
+  `workflow-pending-…` id onto the wire — **no longer exists at HEAD**.
+  `getHistory` has TWO placeholder guards: no-local-record → throw
+  (`frontend/src/lib/assistant/aevatar-transport.ts:1394-1400`) and
+  locally-held → serve the local mirror with no round trip
+  (`aevatar-transport.ts:1414-1425`). The second guard was added in
+  `d418c74a` (PR #1321, "no doomed placeholder reads") and has a regression
+  test at `aevatar-transport.test.ts:6945`.
+- The reviewer independently re-audited every outbound family (history GET,
+  workflow create/continuation `:2557-2575`, approval `:1626-1638`, stop
+  `:4846-4874`, create-recovery `:2685-2705`, no browser `/state`) and
+  confirmed: **`deleteConversation` (`:1302-1354`) is the only live placeholder
+  leak.** Deleting a draft whose alias never arrived sends
+  `DELETE /api/v1/assistant/conversations/workflow-pending-…`, which
+  `conversation_resource_family` (`backend/src/services/assistant_service.rs:98-109`)
+  rejects with 404 — the delete fails, the row stays, the user gets an error
+  toast for a conversation that exists only in their tab.
+
+**P1 therefore narrows to: fix the placeholder delete (with the pre-alias
+deletion-intent design in W2 — see review P1.2) + an invariant test.**
+
+### D2 — transcript GET forced on `turn.completed`: CONFIRMED (with nuance)
+
+`use-assistant.ts:577` — `scheduleProjection(event.event === "turn.completed")`
+projects immediately; `project()` (`:481-496`) calls `projectTransportState` →
+`assistantTransport.getHistory`. At the terminal the turn is no longer active
+(`getHistory`'s live-mirror branch `:1403` no longer applies) and, once the
+context frame aliased the id, the id is canonical `chatc-…` — so `loadHistory`
+(`:2346-2353`) fires a wire GET that is guaranteed to 404 on every new chat's
+first turn. Nuance: the 404 lands in the `noServerTranscriptYet` fallback
+(`:1458-1467`) and the local mirror is served, so the UI usually survives — the
+defect is a *guaranteed doomed read at the single worst moment*, which pollutes
+the wire log, burns the reconciliation opportunity, and (via the same fallback)
+is the mechanism behind D3/D7 ambiguity. Agreed.
+
+### D3 — stuck state on cold load during the projection window: CONFIRMED
+
+`frontend/src/pages/assistant.tsx:189-199` — `explicitConversationIsConfirmedStale`
+requires (id absent from index) AND (history 404). During the projection window
+the index row exists but the transcript 404s, so the redirect never fires.
+What the user gets depends on a race between the two queries:
+
+- history query wins (transport has no record yet): `getHistory` throws
+  `AssistantConversationNotFoundError` (`aevatar-transport.ts:1443-1445`);
+  `useConversation` disables retry on 404/not-found
+  (`use-assistant.ts:305-310`); nothing ever invalidates the query →
+  **permanently stuck error banner** until manual reload.
+- index query wins (`mergeIndexEntry` `aevatar-transport.ts:2304-2344` created a
+  record with `EMPTY_TURN_STATE`): the 404 falls into `:1458-1467` and returns
+  the empty mirror as **success** → silent empty chat that never fills in.
+
+Both shapes confirmed. One wording correction from review (accepted): "the
+index row exists" via the *public* `listConversations()` result is not server
+evidence — the merged list includes the transport's own local records
+(`:1259-1269`). Any membership check used as evidence must read the **raw
+upstream response before `mergeIndexEntry`** (see W5).
+
+### D4 — create-recovery not reload-safe: CONFIRMED (precedent claim corrected)
+
+`conversationAliases` (`aevatar-transport.ts:1229`), `StoredConversation.createRequest`
+(`:600-601`, holds `commandId`), and `stateVersion` (`:589`) are all in-memory
+only. `sendMessage` mints/retains the `commandId` at `:1557-1567`;
+`applyWorkflowChatContext` adopts the alias at `:3864-3872`;
+`recoverWorkflowCreate` (`:2708-2773`) needs `run.clientRequestId`. Nothing is
+persisted. A reload before context-frame adoption loses the only key that can
+recover the server allocation, and a reload at any point loses the continuation
+fence.
+
+Correction accepted from review: `assistant-context-store` is **not** a
+read-time self-heal precedent — it scopes only `recordScreen()` writes
+(`assistant-context-store.ts:41-51`) and is cleared explicitly by the auth store
+on logout (`auth-store.ts:14-17`), and its `clear()` assumes localStorage
+exists. The receipt store defines its own policy in §2.4 (auth-transition
+subscription owned by the receipt module, best-effort storage) rather than
+citing parity.
+
+### D5 — 3s unjittered reconciliation ladder: CONFIRMED
+
+`HISTORY_RECONCILIATION_DELAYS_MS = [0, 300, 900, 1_800]`
+(`aevatar-transport.ts:289`) — 4 attempts, 3.0s total, no jitter, shared by
+`reconcileWorkflowHistory` (`:2633`), `pollCreateRecovery` (`:2691`), and the
+continuation preflight (`:2810`). Real projection lag exceeds this envelope,
+and identical schedules across tabs poll in lockstep. Scope note (per review):
+this PR gives the **new** background reconciler and **new** cold create
+recovery their own deadline-aware schedules (W4); the existing foreground
+preflight/in-run-recovery ladder is deliberately NOT migrated here (see W9).
+
+### D6 — misleading 15s grace comment vs unbounded keep-max: CONFIRMED (comment AND code both need work)
+
+The constant's comment (`aevatar-transport.ts:216-219`) describes only the
+"equal-length stale read" case — and indeed the grace bound
+(`withinMaterializationGrace`, `:2393-2404`) applies only to the
+equal-length + structured case. The longer-local keep-max at `:2390-2392`
+(`comparableLocalMessageCount > messages.length → return existing`) has **no
+time bound and no fence check**. The *code* is the defect for fence-current
+reads (W8, with the exact predicate including turn presence per review P2.2);
+the comment additionally needs to say what each branch is bounded by.
+
+### D7 — index-backed empty mirror resurrects deletions: CONFIRMED, IN SCOPE
+
+Mechanism verified: a stale index row (index TTL 5s,
+`CONVERSATION_LIST_TTL_MS` `:214`) creates an `EMPTY_TURN_STATE` record via
+`mergeIndexEntry`; the transcript 404 then returns success-empty via
+`:1458-1467`. A genuine delete renders as an empty chat instead of not-found.
+Review correction accepted: a one-time index confirmation alone does NOT close
+this — evidence is historical, and the reconciler needs a remote-delete
+transition. D7's closure is now W5 + W4's raw-membership rechecks and the
+absent/timed-out deadline transitions (§2.5), not a single confirmation read.
+
+---
+
+## 2. Design
+
+### 2.1 Conversation readability lifecycle
+
+One lifecycle per conversation, owned by the transport
+(`AevatarAssistantTransport`); the hook layer renders it and triggers the
+reconciler. The pending states are **two independent stored facts** (review
+P1.1) — a positive fence is a reconciliation *criterion*, never the state
+discriminator, because a context frame with `stateVersion: 0` is a valid,
+regression-locked create sequence (`aevatar-transport.ts:3874-3885`,
+`aevatar-transport.test.ts:6806-6849`):
+
+- **`identityPending`** — a workflow create command was dispatched (it may have
+  been admitted upstream) and no canonical `chatc-…` id is known yet.
+  Set: `sendMessage` create dispatch. Cleared: context-frame adoption
+  (`applyWorkflowChatContext`), create-recovery adoption
+  (`recoverWorkflowCreate`), or a **provable pre-admission rejection** (the
+  create POST answered with a definitive non-retryable HTTP error — 400, 401,
+  403, 422 — before any stream: the create demonstrably never happened).
+- **`projectionPending`** — a workflow turn on this conversation reached a
+  local terminal, and no wire transcript read satisfying the reconciliation
+  criteria has been observed since. Set: `finishTurn` for workflow turns
+  (also set at adoption time if the terminal preceded adoption). Cleared:
+  materialization (below).
+
+```
+        createConversation()                    context frame adopts chatc-…
+ (none) ───────────────► DRAFT ────────────────────────────────────────────┐
+                          │ id workflow-pending-…, local only              │
+                          │ sendMessage() → identityPending=true           │
+                          ▼                                                ▼
+                      STREAMING ──── terminal, id still pending ──► IDENTITY_PENDING
+                          │            (context-free failure,        (same tab OR
+                          │             cancel-after-dispatch,        cold reload w/
+                          │             truncated stream)             command receipt)
+                          │ terminal, id known                             │ recovery
+                          ▼                                                │ adopts
+                  PROJECTION_PENDING ◄─────────────────────────────────────┘
+                          │  projectionPending=true; mirror authoritative;
+                          │  transcript GET suppressed; reconciler running
+                          │  criteria met: wire read at positive fence
+                          │  ≥ max(1, storedFence) containing requiredTurnId
+                          ▼
+                     MATERIALIZED ── next turn terminal ──► PROJECTION_PENDING
+                          │
+   DELETE accepted / raw-index-absent transition / definitive rejection
+                          ▼
+                        ABSENT  (deletedConversationIds → NotFound)
+
+   reconciler deadline with membership still present/unavailable
+                          ▼
+                       STALLED  (projectionStalled provenance; explicit retry)
+```
+
+`awaitingProjection` provenance served to callers =
+`identityPending || projectionPending`.
+
+Cold entry points (reload, second tab, direct URL) join at:
+
+- `?c=chatc-…` + receipt or raw-index evidence → PROJECTION_PENDING;
+- `?c=chatc-…` + no evidence after one raw-index confirmation → ABSENT;
+- `?c=workflow-pending-…` + receipt with adopted id → alias repair → canonical path;
+- `?c=workflow-pending-…` + command-only receipt → IDENTITY_PENDING (recovery mode);
+- `?c=workflow-pending-…` + no receipt → ABSENT (today's behavior, unchanged).
+
+### 2.2 Transition ownership
+
+| Transition | Owner |
+| --- | --- |
+| none → DRAFT | `createConversation` (`aevatar-transport.ts:1278`) |
+| DRAFT → STREAMING (+ identityPending) | `sendMessage` (`:1528`, create branch `:1557-1567`) |
+| identityPending cleared by adoption | `applyWorkflowChatContext` (`:3805`) / `recoverWorkflowCreate` (`:2708`) |
+| identityPending cleared by rejection | `streamWorkflowTurn` http_error branch (`:2874`) for definitive 4xx on a create |
+| STREAMING → PROJECTION_PENDING | `finishTurn` (workflow terminals) |
+| PROJECTION_PENDING → MATERIALIZED | `reconcileProjection` via `applyHistoryResponse` (wire-flagged) |
+| → ABSENT | `deleteConversation` tombstone; reconciler raw-index-absent transition; `getHistory` no-evidence confirmation |
+| → STALLED | reconciler deadline with membership present/unavailable |
+| cold → PROJECTION/IDENTITY_PENDING | `getHistory` evidence check (receipts + raw index) |
+| any → scope reset | transport owner-scope boundary (§2.7) |
+
+### 2.3 Provenance representation
+
+`ConversationHistory` (`frontend/src/types/assistant.ts:170`) gains two
+optional fields (a separate status, never encoded as an `ApiError` — review P3):
+
+```ts
+export interface ConversationHistory {
+  readonly conversation: Conversation;
+  readonly messages: AssistantMessage[];
+  readonly has_more: boolean;
+  /**
+   * The answer is the local mirror: identity or projection is still pending
+   * server-side. Absent/false = authoritative server read.
+   */
+  readonly awaitingProjection?: boolean;
+  /**
+   * Reconciliation exhausted its deadline while the conversation still
+   * appears to exist. Rendered as a quiet notice with an explicit retry.
+   */
+  readonly projectionStalled?: boolean;
+}
+```
+
+Optional, so `MockAssistantTransport` and existing fixtures compile unchanged.
+
+New `StoredConversation` fields (`aevatar-transport.ts:571`):
+
+- `identityPending?: boolean`, `projectionPending?: boolean` (§2.1);
+- `requiredTurnId?: string | null` — the chat-history turn id of the last local
+  workflow terminal (from the context frame / recovery), the turn-presence
+  criterion for materialization; null when unknown (criteria degrade to
+  fence-only);
+- `materializedStateVersion?: number` — highest `stateVersion` confirmed by a
+  **wire** transcript read (`applyHistoryResponse` gains a wire-origin flag;
+  mirror serves never set it);
+- `projectionStalledAt?: number` — set on reconciler timeout, cleared on
+  explicit retry or any later materialization.
+
+Materialization criteria (one private method used by the reconciler):
+a wire read whose `historyStateVersion` is a positive integer
+`≥ max(1, positiveStateVersion(stored.stateVersion) ?? 1)` AND — when
+`requiredTurnId` is set — `historyIncludesAssistantTurn(entries, requiredTurnId)`.
+This is the same double condition create recovery already uses
+(`:2736-2741`). A legacy-array read (no `stateVersion`) that contains
+`requiredTurnId` also materializes (sets `materializedStateVersion` to the
+stored fence, or marks confirmed when the fence is absent). A `stateVersion: 0`
+context therefore parks in PROJECTION_PENDING until a *positive* fence read
+containing the turn arrives — exactly the sequence the existing regression
+locks in.
+
+### 2.4 Persisted create receipts and deletion intents (P5 + review P1.2)
+
+New module `frontend/src/stores/assistant-receipt-store.ts` with a Zod schema
+in `frontend/src/schemas/assistant-receipts.ts` (Critical Rule 4). Persisted
+shape:
+
+```ts
+{
+  version: 1,
+  ownerUserId: string | null,
+  receipts: {
+    [commandId: string]: {
+      placeholderId: string,          // workflow-pending-…
+      conversationId?: string,        // chatc-… once adopted
+      stateVersion?: number,          // last observed positive fence (never decreased)
+      createdAt: number,              // epoch ms
+      updatedAt: number,
+    }
+  },
+  deletionIntents: {
+    [commandId: string]: {
+      placeholderId: string,
+      conversationId?: string,        // filled in once recovery names it
+      createdAt: number,
+    }
+  }
+}
+```
+
+- **Never persisted:** prompt text, tokens, message content.
+- **Receipts:** TTL 24h, cap 20, oldest-`updatedAt` evicted first. Deleted on:
+  conversation delete (canonical known), definitive pre-admission rejection
+  (§2.1 — a 400/401/403/422 create must not leave 24h of false existence
+  evidence), and on materialization once older than a 60s floor. Retained for:
+  ambiguous delivery (network error/truncation), cancel-after-dispatch,
+  context-free terminal, adopted identity.
+- **Deletion intents:** separate keyspace, cap 10, expiry 24h. **Receipt
+  eviction never touches intents** (separate cap/scan). An intent means "the
+  user deleted this draft; the canonical resource may exist upstream and must
+  be deleted when identified." Removed only after the canonical DELETE
+  succeeds (or on expiry). See W2 for the flow.
+- **Storage is best-effort** (review P2.3): all storage access
+  (feature-detect, get, set, remove, rehydrate) is wrapped in try/catch with an
+  in-memory fallback map; a receipt write can never throw out of
+  `sendMessage()` after the request identity was chosen. Timestamps are
+  validated on read: non-finite/negative entries dropped; timestamps more than
+  5 minutes in the future are clamped to now (clock-rollback cannot evade TTL
+  indefinitely).
+- **Scope:** the receipt module owns a **one-way subscription** to
+  `useAuthStore` (receipt-store imports auth-store; auth-store never imports
+  receipt-store): on user-id transition (login, logout, account switch) the
+  store clears (logout) or re-keys (switch) immediately — not on next access.
+  Same-user token refresh (user id unchanged) preserves everything. Reads and
+  writes additionally verify `ownerUserId` as defense in depth.
+  **CI note (review P2.3):** `auth-store.ts` and the three existing assistant
+  stores are in the wizard bundle manifest
+  (`cli/src/wizard/bundle-meta/index.manifest:83-86`). The one-way import
+  direction keeps the new receipt store OUT of the wizard's module closure —
+  the closure grows only via imports *from* graph members. W10 verifies the
+  manifest is unchanged; if it is not, stop and re-examine the import graph
+  rather than rebuilding the bundle.
+- **Cross-tab (honest statement, review P2.4):** persistence gives other tabs
+  *evidence* (aliases, fences, intents) via a `storage`-event rehydrate; it
+  does NOT coordinate reconciliation. Reconciliation is per-tab single-flight
+  with independent jittered loops; a storage event carries no materialization
+  outcome. When storage or storage events are unavailable, each tab reconciles
+  independently — bounded per tab by the deadline (≤ ~12 requests over 90s).
+  No lease, no BroadcastChannel.
+- **Fence rules honored** (docs/chat/02 "State-version fences"): only positive
+  safe integers stored; updates take `Math.max`; a persisted fence is a
+  previously observed value for this user+conversation, so seeding
+  `stored.stateVersion` from it on reload is exactly as strict as the tab that
+  observed it. The fence field is **fence-only data**: W5 does not accept a
+  bare fence as existence evidence (review P1.3) — evidence is the receipt's
+  existence within TTL, and even that is only permission to reconcile, never
+  proof of current existence.
+
+Transport touchpoints (the transport already imports `useAuthStore`,
+`aevatar-transport.ts:2713`, so importing plain functions from the receipt
+module follows precedent): write on create dispatch (`:1557-1567`); update on
+adoption (`:3864-3886`, `:2749-2760`); update `stateVersion` where the stored
+fence advances; delete per the lifecycle above.
+
+### 2.5 Single-flight background reconciler (P3 → W4)
+
+```ts
+reconcileProjection(conversationId: string): Promise<{
+  readonly status: "materialized" | "absent" | "timed_out";
+  readonly conversationId: string;   // canonical id the outcome applies to
+}>
+releaseProjectionWaiter(conversationId: string): void
+```
+
+Both methods **canonicalize their argument through `conversationAliases`
+first** (review P3): placeholder and canonical addresses resolve to the same
+entry, and the resolved canonical id is returned in the outcome so callers can
+invalidate the right cache keys.
+
+- **Single-flight per canonical id within the current owner scope.** The entry
+  map lives on the transport and is cleared wholesale on scope reset (§2.7),
+  which is what keys entries by `(scope, canonicalId)` without a composite key.
+  Concurrent callers share one entry promise.
+- **Entry structure & pause semantics (review P3):**
+  `ReconcileEntry = { promise, settle, attempt, startedAt, deadlineAt, timer?,
+  controller?, waiters }`. The shared `promise` is settled ONLY by a terminal
+  outcome (`materialized` / `absent` / `timed_out`) — never rejected. Pausing
+  (waiters hit 0): clear the timer, abort the in-flight fetch controller; the
+  loop function catches its own abort and returns WITHOUT settling; the entry
+  (attempt index, deadlineAt, promise) stays in the map. Resuming (a waiter
+  registers again): spawn a new loop continuation from the stored attempt/
+  deadline that settles the same promise. The hook attaches `.catch` anyway as
+  a defensive guard against unhandled rejections.
+- **Schedule (review P2.1):** deadline-driven, not array-driven. Policy
+  objects, one per mode:
+  - background projection: `{ floorMs: 250, baseMs: 500, capMs: 30_000, deadlineMs: 90_000 }`
+  - ambiguous create recovery (cold, receipt-only): `{ floorMs: 250, baseMs: 500, capMs: 8_000, deadlineMs: 60_000 }`
+
+  Delay for attempt *n*: `floor + random() * (min(cap, base * 2^n) - floor)` —
+  full jitter with a **nonzero floor**, so `random() = 0` yields 250ms spacing
+  (bounded request rate, no burst) and `random() → 1` yields capped
+  exponential. The loop generates delays until `now() >= deadlineAt`; the
+  deadline is checked before *scheduling*, but a timer that fires after the
+  deadline (background-tab throttling, resume from sleep) still performs **one
+  final observation** before the deadline transition. Randomness is injectable:
+  `AevatarAssistantTransport` constructor gains a second optional parameter
+  `random: () => number = Math.random` (mirrors injectable `now`, `:1235`).
+- **Loop body (projection mode):** transcript GET; on a wire body, apply via
+  `applyHistoryResponse` (wire-flagged) and test the materialization criteria
+  (§2.3) → `materialized`. On 404, continue. **Every second 404 attempt (and
+  always at the deadline) recheck raw index membership** (§ W5's
+  `fetchRawIndexMembership`, which inspects the raw upstream rows BEFORE
+  `mergeIndexEntry` — review P1.3). Two membership-absent observations spaced
+  ≥ 10s apart with transcript still 404 → tombstone (`deletedConversationIds`)
+  → `absent`. Before every attempt: check `deletedConversationIds` /
+  `deletingConversations` (local delete → `absent`) and the owner scope
+  (§2.7 — scope changed → abort without settling; the scope reset clears the
+  entry).
+- **Loop body (recovery mode, identityPending):** poll
+  `create-recovery/{commandId}` (existing `pollCreateRecovery` request logic,
+  driven by the recovery policy schedule) with the same adoption guards
+  `recoverWorkflowCreate` uses; on adoption, clear `identityPending`, set
+  `projectionPending` + `requiredTurnId`, and continue in projection mode under
+  the remaining deadline.
+- **Deadline transition (review P1.3 — no `gave_up` limbo):** at the deadline,
+  run one final raw-index membership check.
+  - Membership **absent** → tombstone → `absent` (the hook invalidates; the
+    refetch throws `AssistantConversationNotFoundError`; the existing
+    confirmed-stale repair in `assistant.tsx` navigates away).
+  - Membership **present or unavailable** → set `projectionStalledAt`, resolve
+    `timed_out`. `getHistory` then serves the mirror with
+    `awaitingProjection: false, projectionStalled: true`; the UI drops the
+    syncing pill and renders the stalled notice with an explicit Retry (W7).
+    Retry clears `projectionStalledAt` and calls `reconcileProjection` fresh.
+- **Hook-side contract:** the `useConversation` effect invalidates the mounted
+  key AND `assistantKeys.history(outcome.conversationId)` (when different)
+  plus `assistantKeys.conversations` on **every** terminal outcome — including
+  `timed_out`, so the cached `awaitingProjection: true` snapshot is always
+  replaced by the stalled (or absent, or materialized) truth. Cleanup calls
+  `releaseProjectionWaiter(conversationId)`.
+
+Sketch (final signature; interface members are REQUIRED — see §2.6):
+
+```ts
+useEffect(() => {
+  if (!conversationId || query.data?.awaitingProjection !== true) return;
+  let released = false;
+  assistantTransport
+    .reconcileProjection(conversationId)
+    .then((outcome) => {
+      if (released) return;
+      void queryClient.invalidateQueries({ queryKey: assistantKeys.history(conversationId) });
+      if (outcome.conversationId !== conversationId) {
+        void queryClient.invalidateQueries({ queryKey: assistantKeys.history(outcome.conversationId) });
+      }
+      void queryClient.invalidateQueries({ queryKey: assistantKeys.conversations });
+    })
+    .catch(() => undefined);
+  return () => {
+    released = true;
+    assistantTransport.releaseProjectionWaiter(conversationId);
+  };
+}, [conversationId, query.data?.awaitingProjection, queryClient]);
+```
+
+### 2.6 Transport interface changes
+
+`reconcileProjection` and `releaseProjectionWaiter` are added to
+`AssistantTransport` (`frontend/src/types/assistant.ts:273`) as **required**
+members (review P2.5 — optional members would force optional-call gymnastics
+under strict TS and make hook tests brittle). `MockAssistantTransport`
+implements them as no-ops: `reconcileProjection` resolves
+`{ status: "materialized", conversationId }` immediately;
+`releaseProjectionWaiter` is a no-op. Mock e2e behavior is unchanged (it never
+serves `awaitingProjection`, so the effect never fires there).
+
+### 2.7 Transport owner-scope boundary (review P1.4)
+
+The production transport is a module singleton
+(`frontend/src/lib/assistant/transport.ts:555-567`); logout clears TanStack
+Query (`frontend/src/hooks/use-auth.ts:66-77`) but has never reset the
+transport, so a logout→login without a reload leaks user A's mirror, list rows,
+and transcripts to user B via the merged list (`:1259-1269`) and the
+existing-record 404 fallback (`:1448-1467`).
+
+- `AevatarAssistantTransport` gains `private ownerScopeId: string | null`
+  (initialized lazily from `useAuthStore.getState().user?.id ?? null`) and a
+  constructor-installed `useAuthStore.subscribe` listener. On any user-id
+  transition (A→null, null→B, A→B) it runs `resetScope(next)`:
+  abort every in-flight controller and timer (running turns, pending stops,
+  reconcile entries, recovery loops), then clear `conversations`,
+  `conversationAliases`, `deletedConversationIds`, `deletingConversations`,
+  `pendingActionBatches`, `actionDrainBlocked`, the reconcile map, and reset
+  `listFetchedAt = 0` and `activeConversationId = null`. **Same-user token
+  refresh (id unchanged) does not reset.** The subscription (not
+  check-on-entry alone) is required so a background reconciler timer cannot
+  fire a request for A's conversation id under B's freshly-established session.
+- Defense in depth: every public entry point calls `ensureScope()`
+  (cheap id compare, resets if the subscription somehow missed a transition),
+  and every await inside reconciliation/recovery/history application re-checks
+  the scope before applying a response (extends the existing pattern at
+  `:2713-2721`).
+- The receipt store clears/re-keys on the same transition via its own
+  subscription (§2.4). Deletion intents for the outgoing user stay persisted
+  under that user's scope and resume when that user returns (they are keyed by
+  `ownerUserId`; an intent must not fire DELETEs under another account's
+  session).
+- The wizard-manifest constraint holds: the subscription lives in
+  `aevatar-transport.ts` / the receipt module, which import `auth-store` —
+  never the reverse.
+
+### 2.8 Decisions the prompt asked for explicitly (revised)
+
+1. **Continuation fence reads:** split per the review's scope call.
+   *(a) In this PR:* receipts persist the fence and reload-adopted
+   conversations seed `stored.stateVersion` from them, so the common
+   reload-then-send case skips the preflight entirely.
+   *(b) Deferred:* migrating the foreground preflight
+   (`streamWorkflowTurn` `:2809-2826`) and in-run create recovery off
+   `HISTORY_RECONCILIATION_DELAYS_MS` is a separate foreground admission
+   contract with its own latency/UX budget; it moves only with its own
+   falsifiable case. The `workflowTurnBody` throw (`:2559-2563`) stays as the
+   last-resort invariant (never post an unfenced continuation).
+2. **`HISTORY_RECONCILIATION_DELAYS_MS`:** NOT deleted. It remains the
+   documented schedule for the foreground preflight and in-run recovery. The
+   new reconciler/cold-recovery policies (§2.5) are new code paths with their
+   own separate policy objects — no shared helper config across the three
+   modes (review scope call).
+3. **D6:** code fix + comment rewrite, with the complete predicate (W8).
+4. **D7:** in scope, closed by W5 + W4's raw-membership transitions (§2.5).
+
+---
+
+## 3. Ordered work items
+
+Order matters: W1 (receipts/intents) and W0 (scope boundary) are the
+substrate; W3 (provenance) precedes W4–W7.
+
+### W0 — Transport owner-scope boundary (NEW, review P1.4)
+
+- **Files:** `aevatar-transport.ts` (fields, `resetScope`, `ensureScope`,
+  subscription, post-await guards), `frontend/src/lib/assistant/transport.ts`
+  (no change to reset helper needed — the subscription is constructor-owned).
+- **Change:** §2.7.
+- **Failure mode closed:** logout→login without reload serves user A's local
+  transcript/list rows to user B; a cross-account reconcile timer fires A's
+  conversation id under B's session.
+
+### W1 — Persisted create receipts + deletion intents (P5)
+
+- **Files:** new `frontend/src/schemas/assistant-receipts.ts` (+ test), new
+  `frontend/src/stores/assistant-receipt-store.ts` (+ test);
+  `aevatar-transport.ts` (touchpoints in §2.4).
+- **Change:** store + schema + best-effort storage + auth subscription per
+  §2.4. Exports plain functions (`recordCreateReceipt`, `adoptReceiptIdentity`,
+  `advanceReceiptFence`, `deleteReceipt`, `findReceiptByPlaceholder`,
+  `findReceiptByConversation`, `recordDeletionIntent`, `resolveDeletionIntent`,
+  `listDeletionIntents`) so the transport never calls hooks.
+- **Failure mode closed:** D4 — reload/second tab destroys the recovery key
+  and the continuation fence; plus (new) definitive create rejections leaving
+  24h of false evidence.
+
+### W2 — Placeholder delete without resurrection (P1 residual, review P1.2)
+
+- **Files:** `aevatar-transport.ts` (`deleteConversation` `:1302`,
+  `mergeIndexEntry` `:2304`, a startup/first-list intent sweep).
+- **Change:** when the canonical id still has a pending prefix:
+  1. Cancel the run (existing logic) — note the existing
+     cancel-after-dispatch path already starts background recovery
+     (`:4748-4755`); the deletion path must NOT let that recovery *adopt* into
+     a tombstoned record (guard already exists at `:2717-2721`) — instead the
+     intent below owns identification.
+  2. Tombstone the placeholder, resolve the foreground delete (sidebar row
+     gone immediately; user intent honored without blocking on recovery).
+  3. Move the receipt to a **deletion intent** keyed by `commandId` (never
+     erase the recovery key — review P1.2).
+  4. Background cleanup task (also run for persisted intents at transport
+     startup / first `listConversations` per scope): poll
+     `create-recovery/{commandId}` under the recovery policy; when it names
+     `chatc-A`, record it on the intent, issue the real
+     `DELETE /conversations/chatc-A`, tombstone BOTH addresses, remove the
+     intent. On DELETE failure or recovery exhaustion the intent persists for
+     retry at the next sweep until its 24h expiry (best-effort, stated).
+  5. `mergeIndexEntry` skips ids matching any intent's known `conversationId`
+     (no resurrection flash after identification; before identification a
+     brief flash is possible and bounded — stated limitation).
+  - When a receipt already maps the placeholder to a canonical id, skip
+    recovery: DELETE the canonical id directly, tombstone both, clean up.
+- **Failure mode closed:** the doomed 404 DELETE; and the review's
+  resurrection window — create accepted, delete-before-context, upstream
+  finishes, next list re-materializes `chatc-A` with no tombstone and no
+  DELETE ever sent.
+
+### W3 — Two-fact provenance + no doomed read at the terminal (P2, review P1.1)
+
+- **Files:** `frontend/src/types/assistant.ts` (`ConversationHistory`,
+  required interface members §2.6), `aevatar-transport.ts`
+  (`StoredConversation` fields, `finishTurn`, `applyWorkflowChatContext`,
+  `streamWorkflowTurn` rejection branch, `applyHistoryResponse` wire-flag,
+  `getHistory`), `frontend/src/lib/assistant/transport.ts`
+  (`MockAssistantTransport` no-op impls).
+- **Change:** fields and transitions per §2.1–2.3. In `getHistory`:
+  - the wire-read branch (`:1426`) serves the mirror with
+    `awaitingProjection: true` and NO network call while
+    `identityPending || projectionPending`;
+  - the **locally-held placeholder branch (`:1414-1425`) stamps
+    `awaitingProjection: true` when `identityPending`** — the same-tab
+    context-free-terminal case the review flagged; the mounted hook then
+    starts recovery-mode reconciliation without a reload;
+  - the 404 fallback (`:1458-1467`) stamps provenance per the same facts;
+  - a `projectionStalledAt` mark serves `projectionStalled: true` instead of
+    `awaitingProjection`.
+  - A definitive create rejection (400/401/403/422 pre-stream) clears
+    `identityPending` and deletes the receipt (the turn already fails with the
+    stream-start error today; no new UI needed).
+  `useSendMessage`/pump code is untouched — the pump's terminal projection
+  resolves against the mirror instantly and 404-free.
+- **Failure modes closed:** D2 (the guaranteed 404 GET at `turn.completed` —
+  including the `stateVersion: 0` create the fence-keyed predicate would have
+  missed); the same-tab identity-pending gap; pending provenance being
+  unrepresentable.
+
+### W4 — Deadline-driven jittered single-flight reconciler (P3)
+
+- **Files:** `aevatar-transport.ts` (`reconcileProjection`,
+  `releaseProjectionWaiter`, `fetchRawIndexMembership`, constructor `random`
+  param), new `frontend/src/lib/assistant/backoff.ts` (pure
+  `nextBackoffDelay(policy, attempt, random)` helper + test),
+  `frontend/src/hooks/use-assistant.ts` (`useConversation` effect §2.5).
+- **Change:** §2.5 in full — alias canonicalization, scope-keyed single-flight,
+  wakeable pause without rejecting the shared promise, floored full-jitter
+  deadline loop with a guaranteed final observation on late wake, raw-index
+  membership rechecks, the absent and timed_out deadline transitions, and
+  invalidation on every terminal outcome.
+- **Failure modes closed:** nothing converges the mirror to server truth after
+  the terminal; D5's synchronized ladder for the post-terminal/cold paths;
+  remote deletes invisible to the loop; `gave_up` limbo; multi-tab lockstep
+  (probabilistically, via independent jitter — stated honestly in §2.4).
+
+### W5 — Evidence-gated cold-load 404 handling (P4 + D3 + D7, review P1.3)
+
+- **Files:** `aevatar-transport.ts` (`getHistory` branches `:1394-1400`,
+  `:1442-1467`; new private `fetchRawIndexMembership(conversationId, signal)`).
+- **Change:**
+  - `fetchRawIndexMembership` performs the index GET and answers membership
+    from the **raw upstream rows before `mergeIndexEntry`** (it may still merge
+    afterwards); it can also return `"unavailable"` on failure. The public
+    merged `listConversations()` is never used as evidence (review P1.3 — the
+    merged list contains the very local record under test).
+  1. `chatc-…` 404 with **no local record** (`:1443`): evidence check —
+     (a) a current-user receipt whose `conversationId` matches, or (b) raw
+     index membership (one forced call, TTL-exempt). Evidence → stored record
+     synthesized, `projectionPending` set, return
+     `awaitingProjection: true` empty mirror; the mounted hook starts the
+     reconciler, whose raw-membership rechecks own the remote-delete
+     transition. No evidence → `AssistantConversationNotFoundError` after that
+     single confirmation — zero retries on dead ids.
+  2. `chatc-…` 404 with an **index-born empty record** (`:1458-1467`,
+     `messages.length === 0`, no local terminal facts): same raw membership
+     confirmation. Present → `projectionPending` + syncing mirror (D3's
+     silent-empty becomes visibly syncing and self-healing). Absent →
+     tombstone + `AssistantConversationNotFoundError` (D7's resurrection
+     closed at first read; the reconciler covers later remote deletes).
+  3. `workflow-pending-…` with no record (`:1394-1400`): consult receipts by
+     `placeholderId`. Adopted id → install alias, seed fence, take the
+     canonical path. Command-only → synthesize an `identityPending` record and
+     return a syncing mirror bound to recovery mode. No receipt → throw as
+     today.
+- **Failure modes closed:** D3 (both faces), D7 (with W4), the
+  reload/second-tab/direct-URL cold paths, and evidence-as-permanent-existence
+  (evidence only ever grants reconciliation permission; existence is decided
+  by raw membership + transcript observations).
+
+### W6 — TanStack cache key migration (P6)
+
+- **Files:** `frontend/src/hooks/use-assistant.ts` (`projectTransportState`
+  `:121-149`).
+- **Change:** after the history read resolves, when
+  `history.value.conversation.id !== conversationId` (canonical known), also
+  `setQueryData` the history under `assistantKeys.history(canonicalId)`, and
+  copy `episode`/`turn` slots to the canonical keys when empty. The existing
+  pre-navigation copy in `assistant.tsx:243-254` stays; this covers the gap it
+  cannot: a sidebar click on the canonical id **during** the stream (the
+  sidebar lists the canonical id as soon as the context frame adopts it,
+  `:1263-1269`) currently opens a cold query with no episode/turn state.
+- **Failure mode closed:** navigating to the canonical key opens a separate
+  cold query while the placeholder key holds the live episode.
+
+### W7 — Syncing + stalled affordances, never a stuck error (P7)
+
+- **Files:** `frontend/src/pages/assistant.tsx` (and
+  `chat-thread.tsx` only if the affordance must live inside the thread —
+  prefer the page-level strip; check DESIGN.md + live-app styling first).
+- **Change:** two quiet, non-destructive `role="status"` states above the
+  thread, visually distinct from the destructive error strip (`:507-515`):
+  - `history.data?.awaitingProjection` → "Syncing conversation history…";
+  - `history.data?.projectionStalled` → "History is taking longer than
+    expected." with a Retry button that calls
+    `assistantTransport.reconcileProjection(selectedId)` (through a small
+    hook-layer mutation so the page stays transport-agnostic) and invalidates
+    on settle.
+  No change to `explicitConversationIsConfirmedStale` semantics: after W5 the
+  projection-window combination arrives as success-with-provenance, so the
+  stuck error is unreachable; the genuine-404 path still redirects (existing
+  coverage at `assistant.test.tsx:508-551` remains the guard — no duplicate
+  test). `describeHistoryError`'s 404 copy (`use-assistant.ts:271-281`) stays
+  for residual transient reads.
+- **Failure mode closed:** projection-window cold load rendered as a permanent
+  error or silent empty chat; timeout leaving a forever-"syncing" UI.
+
+### W8 — Bound the longer-local keep-max; fix the comment (D6, review P2.2)
+
+- **Files:** `aevatar-transport.ts` (`applyHistoryResponse` `:2355-2445`,
+  constant comment `:216-219`);
+  `frontend/src/hooks/use-assistant.aevatar.test.tsx` (harness adaptation —
+  see test plan).
+- **Change:** capture the pre-merge fence before `:2373` maxes it. The exact
+  replacement predicate — a shorter server transcript replaces a longer local
+  mirror ONLY when ALL hold:
+  1. `freshStateVersion !== undefined` (wrapped shape — legacy arrays always
+     keep local: mixed deployment);
+  2. `freshStateVersion >= preMergeFence`;
+  3. NOT `withinMaterializationGrace`;
+  4. the latest local assistant turn, when one exists
+     (`latestAssistantTurnId(stored)`), is present in the server entries
+     (`historyIncludesAssistantTurn`) — a fence-current read missing the just
+     streamed turn must NOT wipe its text (review P2.2's completed predicate).
+  Otherwise keep `existing`. Structured-message preservation
+  (`preserveLocalStructuredMessages`, `:537-568`) applies after that decision,
+  unchanged — the review found no evidence this recreates PR #1304's card
+  wipeout, and the #1304 assertions are preserved verbatim (test plan).
+  Rewrite the `:216-219` comment to state all bounds: grace for equal-length
+  structured keeps; fence-currency + turn-presence for longer-local
+  replacement; legacy arrays exempt.
+- **Failure mode closed:** a permanently-longer local mirror pins the view
+  forever and blocks convergence after materialization; and the comment stops
+  promising a bound the code doesn't have.
+
+### W9 — Docs update (scope-reduced; NO ladder migration)
+
+- **Files:** `docs/chat/02-wire-contract.md`, `docs/chat/07-testing-and-gaps.md`.
+- **Change:** `HISTORY_RECONCILIATION_DELAYS_MS` and
+  `RESERVATION_RETRY_DELAYS_MS` are **untouched** (review scope call — the
+  foreground preflight is a separate admission contract; migrating it needs
+  its own falsifiable case, filed as follow-up). Docs additions: the receipts/
+  intents store, the two-fact provenance and reconciler policies, the raw-
+  membership evidence rule, the delete-intent flow, and the new suites in 07's
+  inventory. Bump "Last verified against".
+- **Failure mode closed:** doc drift for the new behavior. (D5's fix for the
+  *new* paths ships in W4's policies; the old ladder consciously remains on
+  the foreground paths.)
+
+### W10 — Gates
+
+`npm run lint`, `npm run test` (vitest), `npm run build` (tsc -b with
+`noUncheckedIndexedAccess` — the CI gate; `tsc --noEmit` is NOT sufficient)
+from `frontend/`. Then verify `git diff --name-only` ∩
+`cli/src/wizard/bundle-meta/index.manifest` = ∅ and that the manifest itself is
+unmodified — the import-direction rule in §2.4 is what keeps it so; if the
+manifest would change, stop and re-examine the import graph (do not rebuild the
+wizard bundle for this PR). No `package.json`/lockfile changes anywhere.
+
+---
+
+## 4. Test plan
+
+Conventions observed and matched: `use-assistant.test.tsx` uses
+`vi.useFakeTimers()` + `resetAssistantTransport(() => TEST_NOW)`
+(`use-assistant.test.tsx:46-54`) — note `resetAssistantTransport` resets only
+the **mock** transport (`transport.ts:569-573`), so hook tests exercise the new
+reconciler contract through a transport double/spy, while reconciler/backoff
+behavior tests instantiate `new AevatarAssistantTransport(now, random)`
+directly (the pattern `aevatar-transport.test.ts` already uses).
+`assistant.test.tsx` mocks the hooks module with `vi.hoisted` state.
+
+Honesty note (review P2.5): tests marked **[guard]** below pass on `main` and
+are kept deliberately as labeled regression guards paired with a falsifiable
+sibling; every unmarked test fails on `main`.
+
+### New files
+
+- `frontend/src/schemas/assistant-receipts.test.ts`
+  - `parses a persisted blob and drops malformed entries`
+  - `rejects nonpositive or unsafe stateVersion values`
+  - `drops non-finite timestamps and clamps future timestamps to now`
+    (clock-rollback TTL evasion, review P2.3)
+- `frontend/src/stores/assistant-receipt-store.test.ts`
+  - `records, adopts, and advances a receipt without decreasing the fence`
+  - `deletes a receipt on definitive create rejection and keeps it on ambiguous failure`
+  - `clears on logout and re-keys on account switch via the auth subscription; same-user token refresh preserves`
+  - `evicts receipts beyond the cap and past the TTL without touching deletion intents`
+  - `keeps functioning in-memory when localStorage getters or setItem throw`
+    (quota/disabled storage, review P2.3 — no throw escapes the write API)
+  - `rehydrates from a storage event from another tab`
+- `frontend/src/lib/assistant/backoff.test.ts`
+  - `delays are floored above zero even when random() returns 0` (review P2.1)
+  - `delays are capped and the sequence spans the policy deadline when random() returns ~1`
+  - `deadline check happens before scheduling, not before observing`
+
+### Additions to `frontend/src/lib/assistant/aevatar-transport.test.ts`
+
+W0 (scope):
+
+- `an account switch clears every local record, alias, and tombstone and aborts live reconciliation`
+  (user A record + running reconcile loop; swap auth user → fetch spy shows no
+  further A-id requests; user B's `listConversations` contains no A rows;
+  `getHistory(A-id)` under B throws rather than serving A's mirror)
+- `a same-user token refresh preserves transport state`
+
+W1/W3 (receipts + provenance):
+
+- `sending a create turn records a receipt and context adoption completes it`
+- `a definitive 4xx create rejection clears identityPending and deletes the receipt`
+- `a context frame with stateVersion 0 still yields projectionPending and no terminal transcript GET`
+  (the review's P1.1 killer case; pairs with the existing version-0 regression
+  at `:6806-6849`, which must stay green)
+- `a context-free failed create leaves identityPending provenance on the same-tab mirror`
+  (stream dies pre-context; `getHistory(placeholder)` returns
+  `awaitingProjection: true` via the locally-held branch)
+- `a pre-context cancel keeps the receipt for background recovery`
+- `serves the mirror without a transcript request while projection is pending`
+  (fetch spy: no GET on post-terminal `getHistory`)
+- `clears projectionPending only on a positive-fence wire read containing the required turn`
+
+W2 (delete):
+
+- `deletes an unaliased pending draft locally, persists a deletion intent, and sends no wire request in the foreground`
+- `background cleanup recovers the canonical id, DELETEs it, tombstones both addresses, and the next list does not resurrect it`
+  (the review's exact P1.2 window: accepted create → delete before context →
+  recovery names `chatc-A` → wire DELETE observed → merged list omits it)
+- `a persisted deletion intent completes after a simulated reload`
+  (fresh transport instance + seeded intent → startup sweep DELETEs)
+- `deletes the receipt's canonical conversation directly when the alias was already adopted`
+
+W4 (reconciler):
+
+- `reconcileProjection single-flights concurrent callers and canonicalizes placeholder addresses to the same entry`
+  (placeholder + canonical args → one loop, same settled outcome; review P3)
+- `retries on floored jittered delays until a fence read containing the turn lands`
+  (deterministic `random`; fake timers; 404, 404, wrapped-at-fence →
+  `materialized`)
+- `random() = 0 does not burst: requests are spaced by the floor and the loop still spans the deadline`
+- `a timer that fires after the deadline still performs one final observation`
+  (advance clock past `deadlineMs` before the timer runs — tab-resume case)
+- `rechecks raw index membership and returns absent when the id disappears remotely`
+  (two spaced membership-absent observations mid-loop → tombstone →
+  `absent`; the review's device-B-deletes case)
+- `at the deadline with membership present it resolves timed_out and marks the record stalled`
+  (subsequent `getHistory` serves `projectionStalled: true`,
+  `awaitingProjection: false` — no limbo)
+- `pausing on last-waiter release aborts the in-flight attempt without settling and resumes from the stored attempt`
+- `aborts on local delete and on account change without settling into the new scope`
+- `recovery mode adopts an identity via create-recovery under the recovery policy and continues into projection mode`
+
+W5 (evidence):
+
+- `a cold chatc- 404 with a matching receipt returns a syncing mirror instead of not-found`
+- `raw index membership is answered from the upstream response, not the merged local list`
+  (seed a local pending record; upstream index response WITHOUT the id →
+  membership false even though `listConversations()` would list it — review
+  P1.3's self-evidence hole)
+- `a cold chatc- 404 with no evidence throws not-found after exactly one raw index confirmation`
+  (fetch count: 1 transcript GET + 1 index GET, nothing else — no retry storm)
+- `an index-born empty record is tombstoned when the raw confirmation no longer lists the id` (D7)
+- `a reloaded placeholder with a receipt alias resolves to its canonical conversation`
+- `a reloaded placeholder with only a commandId gets identityPending provenance and recovers`
+- `a reload-adopted conversation seeds its continuation fence from the receipt`
+  (continuation body carries `minimumStateVersion` with no preflight read;
+  fetch spy)
+
+W8 (keep-max):
+
+- `a fence-current shorter server transcript containing the latest local turn replaces a longer local mirror after the grace window`
+- `a fence-current shorter read MISSING the latest local turn keeps the local mirror`
+  (review P2.2's completed predicate)
+- **[guard]** `a below-fence or legacy-array shorter read never replaces a longer local mirror`
+  (passes on `main` where keep-max is unconditional; kept as the explicit
+  regression pair for the two falsifiable cases above)
+
+### Changes to `frontend/src/hooks/use-assistant.aevatar.test.tsx` (review P2.2/P2.5)
+
+After W3, public `getHistory()` intentionally cannot materialize a pending
+conversation, so the suite's `switchRead()` helper (`:358-367`) and the S2
+immediate-server-id expectations (`:452-498`) must be adapted: the harness
+drives materialization explicitly (call `reconcileProjection` on the real
+transport with the scripted responses, or mount `useConversation` and flush the
+effect) at each point the old flow relied on a direct read. **Every PR #1304
+card-content/order assertion is preserved verbatim** — this is a harness
+adaptation, not an assertion change; any assertion that would need weakening is
+a signal to re-examine W3/W8, not the test.
+
+### Additions to `frontend/src/hooks/use-assistant.test.tsx`
+
+(Transport double implementing the required `reconcileProjection`/
+`releaseProjectionWaiter` members.)
+
+- `useConversation triggers reconciliation for a syncing transcript and invalidates on materialization`
+- `a timed_out outcome invalidates and the refetched stalled state replaces the syncing snapshot`
+  (closes the review's `gave_up`-limbo contradiction at the hook layer)
+- `an absent outcome refetches into not-found`
+- `releases the projection waiter on conversation switch and ignores late outcomes`
+- `invalidates the canonical key when the outcome names a different id than the mounted key`
+  (review P3 alias/invalidation note)
+- `a rejected reconciliation promise is swallowed, not an unhandled rejection`
+  (defensive `.catch` — assert via `process.on("unhandledRejection")` guard or
+  vitest's unhandled-rejection failure mode)
+- W6: `projects the transcript under both the placeholder and canonical keys`
+
+### Additions to `frontend/src/pages/assistant.test.tsx`
+
+- `renders a syncing notice, not an error, for an awaiting-projection transcript`
+  (hoisted state gains `historyAwaitingProjection`; assert the status strip,
+  absence of the destructive strip, no redirect)
+- `renders the stalled notice with a retry action after reconciliation times out`
+  (retry invokes the retry mutation; syncing pill absent)
+- The confirmed-stale redirect for a genuine not-found is already covered at
+  `assistant.test.tsx:508-551` and its inputs do not change — **no duplicate
+  test is added** (review P2.5).
+
+### Docs (no tests, but part of done)
+
+`docs/chat/02-wire-contract.md` and `docs/chat/07-testing-and-gaps.md` per W9.
+
+---
+
+## 5. Risks and rejected alternatives
+
+- **Backend 200-empty synthesis — rejected (restated).** The NyxID proxy has no
+  row of its own for `chatc-` ids; synthesizing 200-empty for upstream 404s
+  would render dead links and deleted conversations as legitimate empty chats
+  for *every* client, and would violate the deliberate opacity of
+  `get_history` (`backend/src/handlers/assistant.rs:819-827`). The client is
+  the only place holding evidence (receipts, mirrors, fences) to disambiguate.
+- **This PR does NOT fix the upstream contract.** Aevatar still cannot
+  distinguish pending/absent/deleted at the wire; that fix is filed
+  separately. Everything here is client-side compensation that remains correct
+  after it lands (§6).
+- **Risk: keep-max relaxation (W8) regresses card preservation.** Mitigated:
+  replacement still routes through `preserveLocalStructuredMessages`; the
+  reviewer independently found no wipeout path; the #1304 assertions are
+  preserved verbatim under an adapted harness (any needed weakening is a stop
+  signal).
+- **Risk: receipts/intents leak across accounts or persist sensitive data.**
+  Mitigated: no prompt/content persisted; auth-subscription clearing at the
+  transition (not next-access); `ownerUserId` checks as defense in depth;
+  TTL + separate caps; intents never fire requests under another account's
+  session.
+- **Risk: pre-identification resurrection flash (W2).** Between the delete and
+  recovery naming `chatc-A`, a list refresh can briefly show the row. Bounded
+  by the recovery policy deadline; the intent guarantees eventual DELETE +
+  tombstone. Accepted and stated.
+- **Risk: raw-membership checks add index GETs.** Bounded: one per cold-404
+  evidence decision; at most every-second-attempt inside a single-flight loop
+  that exists only while a conversation is pending. No steady-state cost.
+- **Risk: reconciler + TanStack interplay causes refetch loops.** Mitigated:
+  invalidation only on terminal outcomes; `timed_out` flips the served
+  provenance to `projectionStalled`, so the effect's
+  `awaitingProjection === true` guard cannot re-arm off the refetched stalled
+  snapshot; single-flight + waiter refcount prevent stacking.
+- **Risk: scope-reset aborts a live turn on account switch.** Intended: no
+  request may continue across an identity boundary; the turn fails locally in
+  the old scope and nothing is applied to the new one.
+- **Rejected: navigating the URL to the canonical id from the transport or
+  pump.** Navigation stays owned by `assistant.tsx`'s repair effect
+  (`:209-271`); lower layers only make caches coherent (W6).
+- **Rejected: a persisted full local transcript.** Storage/privacy surface far
+  larger than the race requires.
+- **Rejected: storage-backed cross-tab reconciliation lease.** Honest per-tab
+  single-flight + independent jitter is bounded and simpler; a lease adds
+  ownership/expiry failure modes for marginal savings (§2.4 states the real
+  guarantee and the storage-unavailable fallback).
+- **Rejected (deferred): migrating the foreground preflight off the 3s
+  ladder.** Separate admission contract; needs its own falsifiable case
+  (review scope call). Receipts' fence seeding already removes its most common
+  trigger.
+
+## 6. Rollout note — safe under today's 404, correct under tomorrow's 200-empty
+
+Per work item, behavior under (A) current Aevatar (404 until projection) and
+(B) future Aevatar (200 `{messages: [], stateVersion, projectionStatus}`):
+
+- **W0 scope boundary / W1 receipts+intents:** status-code independent.
+  Under (B) receipts still serve fence seeding, create recovery after reload,
+  and deletion intents; nothing keys off 404s.
+- **W2 delete intents:** identical under both — recovery is keyed by
+  `commandId`, DELETE by canonical id.
+- **W3 provenance:** facts are set by local events (dispatch, terminal,
+  adoption), not by status codes. Under (B) a 200-empty below-criteria read is
+  simply a confirmed-but-behind read: `projectionPending` stays true, the
+  mirror still serves. If `projectionStatus` ships, reading it is a one-line
+  additive signal (extra JSON fields are already ignored by
+  `readHistoryEntries`).
+- **W4 reconciler:** loops over 404s under (A), over 200-below-criteria bodies
+  under (B) — the materialization criteria (positive fence ≥ required,
+  turn present) are status-code independent, so it terminates identically and
+  stops producing 404s at all. The absent transition still works under (B):
+  a genuine 404 there *means* absent, which the raw-membership check simply
+  confirms sooner.
+- **W5 evidence gating:** load-bearing under (A). Under (B) the
+  404-with-evidence branches stop being reached (pending returns 200);
+  genuine 404 = genuinely absent, so not-found semantics become *more* correct
+  automatically. Retire the branch when the compatibility window closes (same
+  policy as the legacy-array form, `aevatar-transport.ts:499-500`).
+- **W6 cache migration / W7 affordances:** UI-layer; independent of status
+  codes. The syncing strip shows strictly less often under (B).
+- **W8 keep-max bound:** more exercised under (B) (200s arrive earlier) —
+  which is exactly why the fence-current + turn-present gate, not a bare
+  timer, decides replacement.
+- **W9:** doc-only.
+
+Mixed deployment is handled per-response, not per-build: every decision point
+keys off the response *shape* (status, `stateVersion` presence, turn
+presence), matching the repo's deploy-independence posture for the legacy
+transcript array.
+
+---
+
+## 7. Review response (GPT-Sol REWORK → this revision)
+
+| Finding | Resolution in this revision |
+| --- | --- |
+| **P1.1** fence-only state machine | Accepted in full. Two independent stored facts `identityPending`/`projectionPending` (§2.1–2.3); fence + `requiredTurnId` demoted to materialization *criteria*; `stateVersion: 0` context handled explicitly (parks in PROJECTION_PENDING until a positive-fence read with the turn); the locally-held placeholder branch (`:1414-1425`) now stamps identity-pending provenance so the same-tab context-free case starts recovery (W3); receipt terminal policy added — definitive 400/401/403/422 pre-admission rejection deletes the receipt (§2.4, W1/W3 tests). All four demanded tests named in §4. |
+| **P1.2** pre-alias delete resurrection | Accepted in full. W2 rewritten: the receipt is *moved* to a persisted deletion intent keyed by `commandId` (separate keyspace, cap 10, 24h expiry, immune to receipt eviction); bounded recovery under the intent → canonical DELETE → tombstone both → remove intent; startup/first-list sweep completes intents across reloads/tabs; `mergeIndexEntry` skips identified intent ids. The exact resurrection-window test is named. Brief pre-identification flash acknowledged as a bounded, stated limitation (§5). |
+| **P1.3** evidence permanence / no remote-delete transition / `gave_up` limbo | Accepted in full. New `fetchRawIndexMembership` answers from raw upstream rows before `mergeIndexEntry` (the merged public list is never evidence — §W5, D3 correction adopted in §1); evidence is defined as permission to reconcile only (§2.4); the reconciler rechecks raw membership every second 404 attempt and at the deadline, with a two-observation ≥10s absent transition → tombstone → `absent` (§2.5); `gave_up` is replaced by a real deadline transition: final raw-membership check → `absent`, else `timed_out` + `projectionStalledAt` + `projectionStalled` provenance + explicit Retry (W7); the hook invalidates on **every** terminal outcome. All three demanded tests named. |
+| **P1.4** no account scope boundary | Accepted in full. New W0: transport owner scope with a constructor-owned auth-store subscription (prompt abort of timers/controllers, full state clear on user-id transition, same-user refresh preserved), `ensureScope()` on public entry points, post-await scope re-checks, single-flight map cleared per scope (§2.7); receipt store clears on the same transition via its own subscription; account-switch and same-user-refresh tests named. |
+| **P2.1** jitter collapse / wrong window | Accepted. Deadline-driven loop with a 250ms floor and per-attempt exponential cap replaces the finite array; `random()=0` yields floor-spaced requests over the full window; deadline checked before scheduling with one guaranteed final observation after a late wake (§2.5); `random=0`, `random≈1`, and late-wake tests named. |
+| **P2.2** incomplete W8 predicate / false "untouched suite" claim | Accepted. The four-clause predicate now includes latest-local-turn presence (W8); the shorter-current-but-turn-missing keep-local test is named; the `use-assistant.aevatar.test.tsx` claim is retracted — §4 specifies the harness adaptation (drive `reconcileProjection` / mounted hook) with every #1304 assertion preserved verbatim. |
+| **P2.3** storage semantics / wrong precedent / wizard-graph hazard | Accepted. Best-effort storage wrapper with in-memory fallback (no throw out of `sendMessage`), timestamp validation + future-skew clamping, clearing on the auth transition via a one-way receipt-module→auth-store subscription; the `assistant-context-store` parity citation is removed from §1 D4 and §2.4; the import-direction rule that keeps the receipt store out of the wizard closure is stated explicitly and gated in W10. |
+| **P2.4** cross-tab overstated | Accepted. §2.4 now states the real guarantee: per-tab single-flight + independent jitter; storage events share evidence only, carry no materialization outcome; storage-unavailable fallback is independent bounded reconciliation. The "skip straight to a single confirming read" claim is removed; the lease alternative is explicitly rejected in §5. |
+| **P2.5** padding / harness contract / optional-member TS | Accepted. The two passing-on-main tests: the keep-max guard is retained but labeled **[guard]** and paired with its falsifiable siblings; the confirmed-stale-redirect duplicate is dropped (existing coverage at `assistant.test.tsx:508-551` cited instead). The "every test fails on main" claim is replaced with an explicit guard-labeling rule. `resetAssistantTransport` limitation acknowledged: hook tests use a transport double; backoff/reconciler tests instantiate `AevatarAssistantTransport(now, random)` directly. Interface members are **required** with mock no-op implementations (§2.6) — no optional-call strict-TS hazard. |
+| **P3** alias resolution / wakeable pause / status-not-ApiError | Accepted. `reconcileProjection`/`releaseProjectionWaiter` canonicalize through `conversationAliases` and return the canonical id for invalidation (§2.5, alias test named); pause is specified as abort-without-settling with attempt/deadline carried into a resumed loop on the same never-rejecting entry promise, plus a defensive hook `.catch` (§2.5, tests named); syncing/stalled are optional success-data fields, never `ApiError`s (§2.3, W7). |
+| **Scope call** (split the ladder migration; separate policies) | Adopted. `HISTORY_RECONCILIATION_DELAYS_MS` stays for the foreground preflight/in-run recovery (§2.8, W9); the new reconciler and cold create recovery get separate named policy objects (§2.5); the preflight migration is explicitly deferred behind its own falsifiable case (§5). §2.8's fence-seeding half of the continuation decision remains in this PR. |
+| **D-section corrections** | Adopted: D3's merged-list-is-not-evidence wording, D4's precedent retraction, D7 reclassified as closed only by W5+W4 jointly. D1's narrowed conclusion stands (reviewer-confirmed). |
+
+No findings rejected.

--- a/docs/plans/new-chat-projection-race.review-gpt.md
+++ b/docs/plans/new-chat-projection-race.review-gpt.md
@@ -1,0 +1,189 @@
+VERDICT: REWORK
+
+# P1 findings
+
+## P1.1 - The fence-only state machine cannot represent two live first-turn states
+
+**Plan section:** §2.1-2.3, W1, W3, W5.
+
+**Evidence:** The proposed `awaitingProjection()` returns false unless `positiveStateVersion(stored.stateVersion)` exists (`docs/plans/new-chat-projection-race.md:219-224`). That is not true for every valid workflow create. The transport deliberately accepts a context-frame `stateVersion` of zero at `frontend/src/lib/assistant/aevatar-transport.ts:3874-3885`, and the existing regression at `frontend/src/lib/assistant/aevatar-transport.test.ts:6806-6849` proves the supported sequence: first context has version 0, then the next continuation obtains a positive fence through history. A context-free terminal is the other hole: an existing `workflow-pending-*` record is returned by the unconditional local-placeholder branch at `frontend/src/lib/assistant/aevatar-transport.ts:1414-1424`; W5 changes only the `!existing` placeholder branch, so a command-only receipt in the same tab never produces `awaitingProjection` and never starts W4.
+
+**Concrete failure:**
+
+1. First turn receives `aevatar.chat.context { conversationId: "chatc-*", stateVersion: "0" }`, then completes.
+2. W3 evaluates the proposed predicate as false.
+3. The terminal projection still executes the transcript GET, receives the exact 404 this work is meant to remove, and no background reconciler is started.
+
+A second failure is `POST accepted -> stream closes before context -> create recovery misses its short budget -> failed terminal`. The local placeholder and receipt still exist, but `getHistory()` returns an ordinary mirror with no pending provenance. Reloading happens to take a different W5 branch and starts recovery; staying in the original tab does not.
+
+There is also no receipt terminal policy. W1 records before dispatch, but a known 400/401/403 rejection is not an ambiguous create and must not remain 24-hour existence evidence. As written, a reload turns a definitively never-created conversation into a syncing one.
+
+**Specific correction:** Model at least two independent facts rather than deriving all pending state from a positive fence:
+
+- `identityPending`: a create command may have been admitted but no canonical id is known yet.
+- `projectionPending`: a canonical first turn reached a local terminal but its transcript has not been observed.
+- Keep `requiredTurnId` and optional positive `fence` as reconciliation criteria, not as the sole state discriminator.
+- A valid context with version 0 must set canonical identity plus `projectionPending`; reconciliation must wait for a positive history fence containing the required turn.
+- The existing-placeholder branch must surface identity-pending provenance when an ambiguous command receipt exists.
+- Delete a receipt on a provable pre-admission rejection; retain it only for ambiguous delivery, cancellation after dispatch, context-free terminal, or an adopted canonical identity.
+
+Add falsifiable tests for context version 0, same-tab context-free failure, pre-context cancel, and a definitive HTTP rejection that leaves no evidence.
+
+## P1.2 - W2 loses deletion intent before the canonical id exists and can resurrect the chat
+
+**Plan section:** §2.2, §2.4, W2.
+
+**Evidence:** W2 says to cancel, tombstone the placeholder, and delete its receipt immediately when no alias is known (`docs/plans/new-chat-projection-race.md:396-405`). A workflow cancel after dispatch starts create recovery at `frontend/src/lib/assistant/aevatar-transport.ts:4748-4755`, but recovery refuses adoption once the placeholder is tombstoned at `frontend/src/lib/assistant/aevatar-transport.ts:2717-2721`. The list later merges every previously unknown canonical id returned upstream (`frontend/src/lib/assistant/aevatar-transport.ts:1251-1257`) and rejects resurrection only when that same canonical id is in `deletedConversationIds` (`frontend/src/lib/assistant/aevatar-transport.ts:2304-2306`). The client cannot tombstone an id it discarded the only recovery key for.
+
+**Concrete failure:** The create POST is accepted and allocates `chatc-A`; before the context frame reaches the browser, the user deletes the draft. W2 cancels locally, tombstones only `workflow-pending-P`, and erases the `commandId` receipt. Aevatar finishes and lists `chatc-A`. The next list refresh has no tombstone for `chatc-A`, so the supposedly deleted chat reappears in the sidebar. No DELETE was ever sent for the real resource.
+
+**Specific correction:** A pre-alias delete must persist a deletion intent keyed by `commandId`, not erase the receipt. Run bounded create recovery under that intent; when it returns the canonical id, issue the real DELETE, tombstone both addresses, then remove the receipt. If the foreground delete cannot wait for recovery, retain a background cleanup intent across reload/tabs until recovery plus DELETE succeeds or the receipt reaches an explicit cleanup expiry. Scope and cap deletion intents separately so normal receipt eviction cannot discard them. Add the exact `accepted create -> delete before context -> later recovery -> canonical DELETE -> no list resurrection` test; the plan's two W2 tests do not cover this window.
+
+## P1.3 - Evidence is treated as permanent existence, while the reconciler has no remote-delete transition
+
+**Plan section:** §2.4-2.5, W4, W5, W7.
+
+**Evidence:** The plan permits `receipt OR index membership` to turn a 404 into a successful pending mirror (`docs/plans/new-chat-projection-race.md:445-459`). A receipt proves that a create was once attempted or adopted; it does not prove that the conversation still exists. The W4 loop checks only local `deletedConversationIds` / `deletingConversations` (`docs/plans/new-chat-projection-race.md:313-323`); it specifies no authoritative index recheck that can discover deletion in another tab/device. The claimed correction at `docs/plans/new-chat-projection-race.md:676-680` therefore has no implementing transition.
+
+The proposed hook also contradicts the prose. On `"gave_up"` it returns without invalidating or changing cached data (`docs/plans/new-chat-projection-race.md:335-345`), so the cached `awaitingProjection: true` remains visible indefinitely in that mount. It does not "drop the syncing affordance" as claimed at `docs/plans/new-chat-projection-race.md:324-331`.
+
+Finally, a forced call cannot test membership through the public list result. `listConversations()` merges the response into the transport and then returns every local record at `frontend/src/lib/assistant/aevatar-transport.ts:1259-1269`. If W5 calls a force-refresh variant and searches that merged result, the local pending/empty record supplies its own evidence even when the authoritative response omitted the id.
+
+**Concrete failure:** Device B deletes `chatc-A`. Device A has a still-valid receipt and a stale index row, opens `?c=chatc-A`, and receives transcript 404. W5 serves an empty pending mirror. The index later drops the row, but W4 never rechecks it; after 90 seconds W4 returns `gave_up`, the hook leaves `awaitingProjection` untouched, and the deleted chat continues to look alive and syncing. A remount repeats the receipt-backed path until TTL, and clock skew can extend it further.
+
+**Specific correction:**
+
+- Make the forced index helper return membership from the raw response before `mergeIndexEntry`, never from the public merged list.
+- Treat evidence as permission to reconcile, not as timeless proof of current existence.
+- Recheck raw index membership during the loop and at the deadline. When transcript 404 persists and authoritative membership disappears, tombstone and return `absent` even if a historical receipt exists.
+- Retire projection/create evidence immediately on materialization. If a persisted continuation fence must remain for legacy-array deployments, store it as fence-only data that W5 does not accept as existence evidence.
+- Define a real deadline transition. Either expire the evidence and invalidate into not-found after a final raw-index confirmation, or return a separate non-error `projectionTimedOut` state with an explicit retry. Do not leave `awaitingProjection: true` in cache after `gave_up`.
+- Test `initially stale index -> remote deletion becomes absent`, `gave_up changes rendered state`, and `local merged record cannot satisfy raw membership`.
+
+## P1.4 - The singleton transport and single-flight key are not account-scoped
+
+**Plan section:** §2.2-2.5, W1, W4.
+
+**Evidence:** The production transport is a module singleton at `frontend/src/lib/assistant/transport.ts:555-567`. Its conversations, aliases, tombstones, list TTL, and proposed reconcile map live for the singleton's lifetime; `listConversations()` returns all local records at `frontend/src/lib/assistant/aevatar-transport.ts:1259-1269`. Logout clears TanStack Query at `frontend/src/hooks/use-auth.ts:66-77`, but it does not reset the Aevatar transport. The plan captures a `scopeId` only inside a reconciliation task. That prevents one eventual adoption in some paths; it neither clears the mirror nor namespaces `Map<string, ReconcileEntry>`.
+
+**Concrete failure:** User A completes a local first turn, logs out without reloading the SPA, and User B logs in. The query cache is empty, but the transport still contains A's canonical record and prompt. B's list call fetches B's index, then also returns A's local record. Selecting it causes B's wire GET to 404; the existing-record fallback at `frontend/src/lib/assistant/aevatar-transport.ts:1448-1467` can return A's local transcript. A proposed reconciliation promise keyed only by canonical id can likewise be found or completed in the wrong account after a switch.
+
+**Specific correction:** Give the transport an owner scope and enforce a hard scope boundary on every public entry point: on user-id change, abort active reconciliation/recovery controllers and timers, clear conversations/aliases/tombstones/deletion reservations/list TTL, and start a new scope. Key every single-flight entry by `(scopeId, canonicalId)` and recheck scope after every awaited fetch before applying a response. The receipt store must clear or switch scope at the same boundary. Add an account-switch test that asserts no A mirror/list row/result/timer is observable by B. A token refresh with the same user id should preserve the scope and continue normally.
+
+# P2 findings
+
+## P2.1 - The full-jitter schedule does not actually provide the stated 90-second or 15-second window
+
+**Plan section:** §2.5, §2.6, W4, W9.
+
+**Evidence:** The proposed finite bases are multiplied by `random()` (`docs/plans/new-chat-projection-race.md:294-300`). With the explicitly supported injected `random = () => 0`, all eight delays are zero: every request fires back-to-back at t=0 and the loop gives up immediately. That directly contradicts "No attempt at t=0" and the 90-second deadline. Even under uniform randomness the expected sum of the finite schedule is about 45 seconds, not 90. The same defect can collapse the claimed 15-second send-path recovery to an immediate burst.
+
+**Concrete failure:** A deterministic test or a legitimate very-low random sample performs eight 404 GETs immediately after terminal and gives up before projection has any chance to land. A background-throttled tab can suffer the inverse: it wakes after the wall-clock deadline and gives up without one final observation.
+
+**Specific correction:** Use a nonzero floor and continue generating capped delays until the deadline rather than exhausting one finite array. Check the deadline before scheduling but always allow one final observation on wake/resume. Tests must cover `random=0`, `random=1-epsilon`, background clock advancement, request spacing, and maximum deadline.
+
+## P2.2 - The W8 protection is directionally sound, but its stated predicate is incomplete
+
+**Plan section:** W8, §5 risk note.
+
+**Evidence:** The current unconditional longer-local return is at `frontend/src/lib/assistant/aevatar-transport.ts:2387-2392`. Structured activity/card messages are separate synthetic messages (`frontend/src/lib/assistant/aevatar-transport.ts:3996-4029`), and `preserveLocalStructuredMessages()` reinserts them after their turn anchor at `frontend/src/lib/assistant/aevatar-transport.ts:531-568`. Therefore I do not find evidence that the intended current-fence-and-turn-present replacement itself recreates PR #1304's card wipeout.
+
+However, W8 first defines the keep condition as only `legacy OR below-fence OR grace` (`docs/plans/new-chat-projection-race.md:509-516`), then mentions turn presence in prose. The actual boolean must also keep local when the latest local assistant turn is absent. Otherwise a response with `stateVersion >= preMergeFence`, outside grace, but containing only a prior/user row can replace a longer local transcript. `preserveLocalStructuredMessages` saves the card, but the latest streamed text/user message is lost.
+
+**Specific correction:** State and test the exact predicate: a shorter server transcript may win only when it has a usable current fence, is outside any required grace, **and** contains the required latest local turn; otherwise retain local. Preserve structured messages after that decision. Include the exact shorter-current-but-turn-missing case.
+
+The claim that `use-assistant.aevatar.test.tsx` stays green "untouched" is false. Its `switchRead()` calls public `getHistory()` directly at `frontend/src/hooks/use-assistant.aevatar.test.tsx:358-367`; after W3 that call intentionally serves the awaiting mirror and cannot materialize it. S2 expects immediate server ids at `frontend/src/hooks/use-assistant.aevatar.test.tsx:452-498`. Adapt the harness to run the new reconciler (or mount `useConversation`) while preserving every card/order assertion. That is a necessary behavioral update, not permission to weaken the PR #1304 assertions.
+
+## P2.3 - Persistence failure handling and logout semantics are underspecified
+
+**Plan section:** §2.4, W1.
+
+**Evidence:** The cited `assistant-context-store` does not perform a read-time owner self-heal. It scopes `recordScreen()` writes at `frontend/src/stores/assistant-context-store.ts:41-51`, while logout explicitly clears it through `frontend/src/stores/auth-store.ts:14-17`. Its `clear()` directly calls `localStorage.removeItem` at `frontend/src/stores/assistant-context-store.ts:53-57`, so it is not a robustness model for storage-disabled environments.
+
+**Concrete failure:** If localStorage is disabled or quota-exhausted, recording a receipt must not throw out of `sendMessage()` after the request identity was chosen. It should continue with an in-memory receipt and report no false send failure. A receipt with a far-future `updatedAt` can evade `now - updatedAt > TTL` for an arbitrarily long time after clock rollback. Logout currently leaves the new persisted blob on disk until some later accessor happens to self-heal it.
+
+**Specific correction:** Wrap storage acquisition/read/write/remove/rehydrate as best-effort, retain an in-memory fallback, validate finite safe timestamps, and expire or clamp timestamps beyond a small future-skew allowance. Clear on the auth scope transition, not merely the next receipt access. Test storage getter failure, `setItem` quota failure, malformed/future timestamps, logout, and same-user token refresh.
+
+Be aware of CI scope: `frontend/src/stores/auth-store.ts` and all three existing assistant stores are already in `cli/src/wizard/bundle-meta/index.manifest:83-86`. Importing the new receipt store from `auth-store.ts` changes the wizard module closure and requires `npm --prefix frontend run build:wizard` plus committed bundle metadata/assets. A one-way auth subscription owned by the receipt module can avoid adding it to the wizard graph, but it still needs an explicit test.
+
+## P2.4 - Cross-tab coordination is overstated
+
+**Plan section:** §2.4-2.5, §5.
+
+**Evidence:** The receipt shape has no materialized/lease field, and the normal materialization path does not write a state another tab can interpret. A `storage` rehydrate event can share alias/fence evidence, but it cannot make a neighboring tab "skip straight to a single confirming read" as claimed at `docs/plans/new-chat-projection-race.md:320-323`. Each tab still owns an independent map and retry loop; jitter reduces synchronization probabilistically but is not cross-tab single-flight.
+
+**Specific correction:** Either describe the guarantee honestly as per-tab single-flight plus independent jitter, with storage-event-unavailable fallback to independent reconciliation, or add a storage-backed lease/materialized marker with expiry and ownership rules. Do not require `BroadcastChannel`; the plan correctly avoids assuming it, but it must state what happens when neither storage events nor persistent storage work.
+
+## P2.5 - Several named tests are padding or use the wrong harness contract
+
+**Plan section:** §4, W10.
+
+**Evidence and correction:**
+
+- `a below-fence or legacy-array shorter read never replaces a longer local mirror` (`docs/plans/new-chat-projection-race.md:618-619`) passes on main because the existing branch unconditionally keeps every longer local mirror at `frontend/src/lib/assistant/aevatar-transport.ts:2390-2392`. Keep it only as a clearly labeled regression guard paired with the falsifiable current-fence case; do not claim every listed test fails on main.
+- `keeps the confirmed-stale redirect for a genuine not-found` (`docs/plans/new-chat-projection-race.md:643-646`) is already covered by the not-found repair block in `frontend/src/pages/assistant.test.tsx:508-551` and passes on main. Extend the existing test only if the implementation changes its inputs; otherwise it is padding under the owner's rule.
+- The untouched PR #1304 suite cannot converge through public `getHistory()` after W3, as described in P2.2. It needs explicit reconciliation in the harness.
+- `use-assistant.test.tsx` globally uses fake timers and resets the mock transport at `frontend/src/hooks/use-assistant.test.tsx:46-54`. `resetAssistantTransport()` currently resets only `MockAssistantTransport` at `frontend/src/lib/assistant/transport.ts:569-573`; it cannot "forward" Aevatar randomness. Hook tests should spy the optional capability or install a transport double, while Aevatar backoff tests instantiate `AevatarAssistantTransport(now, random)` directly.
+- The §2.5 snippet invokes optional interface methods unconditionally. If the methods remain optional so the mock omits them, narrow both functions or use optional calls before invoking them; otherwise `npm run build` under strict TypeScript will reject the code. Prefer implementing no-op methods on the mock and keeping the interface required, which also makes the hook tests less brittle.
+
+# P3 / notes
+
+- W6's cache migration is coupled to this race and should remain, but test aliasing for `reconcileProjection()` and `releaseProjectionWaiter()` explicitly: both placeholder and canonical arguments must resolve to the same scoped entry, and invalidation must update the key the mounted observer is actually using.
+- A refcounted promise can be paused and resumed, but aborting an `abortableDelay()` normally rejects the shared promise. §2.5 must specify a wakeable paused state or settle/remove the old entry and carry only attempt/deadline metadata into a new promise. Add rejection handling in the hook so an abort or unexpected protocol error cannot become an unhandled promise rejection.
+- W7's quiet status treatment is appropriate. The page already keeps history failures non-blocking at `frontend/src/pages/assistant.tsx:500-535`; the new state should be a separate status, not encoded as an `ApiError`.
+- W10 is correct that no dependency or lockfile edit is needed. Any `frontend/**` edit runs the wizard freshness job (`.github/workflows/ci.yml:129-133`), but the source hash changes only for files in the manifest or its extras (`cli/tests/wizard_bundle_freshness.rs:19-25,62-76`). Recheck the generated module graph if the auth-store import graph changes as described above.
+
+# Corrections to the plan's verification section
+
+## D1
+
+The planner's narrowed conclusion is correct. Commit `d418c74a` exists and added the locally-held placeholder mirror guard now at `frontend/src/lib/assistant/aevatar-transport.ts:1410-1425`, with the regression at `frontend/src/lib/assistant/aevatar-transport.test.ts:6945-7001`. I re-audited the outbound families:
+
+- History GET: both absent and locally-held placeholder branches stop the request at `aevatar-transport.ts:1394-1400,1414-1425`.
+- Workflow create: `workflowTurnBody()` sends `commandId` and no `conversationId` at `aevatar-transport.ts:2571-2575`; continuations send only an adopted `chatc-*` id at `:2557-2569`.
+- Approval: workflow ids, including pending workflow ids, are rejected before `startChatStream()` at `aevatar-transport.ts:1626-1638`.
+- Stop: `requestServerStop()` returns before the request for every workflow run at `aevatar-transport.ts:4846-4854`; the typed body uses the canonical actor id at `:4865-4874`.
+- Create recovery is keyed by encoded `commandId`, not conversation id, at `aevatar-transport.ts:2685-2705`.
+- There is no browser `/state` request in this transport.
+- DELETE remains the live leak: it interpolates the unguarded canonicalized argument at `aevatar-transport.ts:1302-1354`.
+
+So D1 is not a P1 verification error. W2's proposed execution is still unsafe for the pre-alias delete window described in P1.2.
+
+## D2-D3
+
+D2's terminal GET and D3's stuck-error/success-empty split are correctly located. One wording correction: "the index row exists" is not necessarily server evidence. The transport's public list includes its own newly aliased local record even if the fetched upstream index did not contain it (`aevatar-transport.ts:1259-1269`). W5 must keep raw response membership distinct from the merged sidebar list.
+
+## D4
+
+The in-memory-only diagnosis is correct, but the claimed precedent is not. `assistant-context-store` does not self-heal on every read/write; only `recordScreen` scopes writes, and auth explicitly clears the store. The receipt design needs its own owner-check and auth-transition behavior rather than citing parity that is not present.
+
+## D5-D6
+
+D5 is correct: the four delays are exactly `[0, 300, 900, 1800]` at `aevatar-transport.ts:289`, used by the history and create-recovery paths at `:2633` and `:2691`. D6 is also correct that the longer-local return is currently unbounded. The W8 correction remains necessary for eventual convergence, subject to the explicit turn-presence predicate in P2.2.
+
+## D7
+
+The deletion-resurrection bug is real, but D7's proposed closure is not. A one-time index confirmation can itself be stale, a receipt is historical rather than current evidence, and W4 has no later raw-index absence transition. D7 must remain open until P1.3 is incorporated.
+
+# What the plan misses entirely
+
+- Valid `stateVersion: 0` first-turn contexts, already locked in by an existing regression test.
+- Same-tab identity-pending recovery after a context-free failed/truncated/cancelled stream; W5 only repairs the fresh-transport `!existing` path.
+- A lifecycle for receipts after definitive pre-admission failure versus ambiguous delivery.
+- A durable deletion intent when DELETE occurs before alias adoption.
+- Raw index membership versus the transport's merged local sidebar list.
+- A cache/state transition for reconciliation deadline exhaustion.
+- Full transport cleanup and post-await response guards on logout/account switch.
+- Storage-disabled/quota-exhausted operation and future-clock skew.
+- Browser background timer throttling and a required final attempt when a tab resumes after the nominal deadline.
+- The fact that per-tab jitter is not cross-tab single-flight and that a storage event carries no materialization outcome in the proposed schema.
+
+# Scope call
+
+**Keep:** W1-W8's core architecture, including the visible non-error syncing state, cache-key migration, and the fence/turn-gated keep-max relaxation. W8 is coupled to reconciliation because declaring materialization while unconditional keep-max pins a stale local transcript would not actually converge.
+
+**Add before implementation:** explicit identity-pending/projection-pending provenance; receipt outcome/expiry semantics; persisted pre-alias deletion intent; raw-index revalidation plus a real deadline transition; and an account-scope reset/abort boundary. These are not optional hardening. They close concrete resurrection, never-created, and cross-account failure paths created or exposed by the plan.
+
+**Cut or split:** Do not automatically replace all three existing `HISTORY_RECONCILIATION_DELAYS_MS` consumers in the same change. The post-terminal reconciler and cold create recovery need the new deadline-aware schedule. The continuation preflight/reservation behavior is a separate user-facing admission contract and should move only with a dedicated falsifiable case showing the old 3-second budget causes this bug. At minimum, use separate policies rather than one helper configuration for background projection, ambiguous create recovery, and a foreground continuation send.
+
+**CI scope:** Preserve the no-dependency/no-lockfile constraint. If account/logout correction changes the wizard's import closure, rebuild the committed wizard bundle rather than relying on the current manifest assumption.

--- a/docs/plans/new-chat-projection-race.review-opus.md
+++ b/docs/plans/new-chat-projection-race.review-opus.md
@@ -557,3 +557,193 @@ W8 — has been filled, and filled with the right assertions.
   network round trip, and that the reconciler has a GET in flight on a 250 ms–30 s ladder for up
   to 90 s. I did not instrument a live session to estimate how often those overlap.
 - Multi-tab behaviour remains unexercised, unchanged from round 1.
+
+---
+
+# Re-review (round 3 — final)
+
+Reviewer: Opus 5. Head `eb77b3bc`, 2 commits on top of `73b7bb94`. Rounds 1 and 2 left
+intact as the record.
+
+VERDICT: APPROVE
+
+P1-1 is closed on the reachable path, verified by a reproduction I built specifically to
+drive the real reconciler rather than the private method — and confirmed by running that
+same reproduction against the pre-fix source, where it fails. Convergence is not swallowed.
+The double-schedule and livelock hazards I was asked to check are both absent. The rewritten
+test is a genuine behaviour test, not an implementation mirror. All gates reproduce and
+nothing in the round-2 verified-fixed list regressed. This is safe to merge against
+`rollup-chat-2026-08-04`.
+
+## Gate results (round 3)
+
+```
+$ npm run lint
+✖ 23 problems (0 errors, 23 warnings)
+
+$ npm run test
+ Test Files  199 passed (199)
+      Tests  2446 passed (2446)
+   Duration  17.22s
+
+$ npm run build
+dist/credential-accept/assets/credential-accept-Bk5hKdwf.js  154.03 kB │ gzip: 50.35 kB
+✓ built in 47ms
+
+$ cargo test -p nyxid-cli wizard_bundle_is_fresh
+test result: ok. 1 passed; 0 failed
+```
+
+Diff hygiene re-checked across the **full** range `origin/rollup-chat-2026-08-04...HEAD`:
+`*package.json`, `*package-lock.json`, `cli/src/wizard/**`, `backend/**` all empty. Round-3
+source delta is 19 lines in `aevatar-transport.ts` and nothing else, as stated. Worktree clean
+after every experiment.
+
+## P1-1 — CLOSED
+
+### My round-2 reproduction no longer measures anything
+
+Stated plainly because it matters for the record: my round-2 repro called
+`internals.applyHistoryResponse(...)` **directly**. The fix went in at the call site, by my own
+recommendation, so that repro still shows the message being dropped — and now proves nothing,
+because nothing reaches `applyHistoryResponse` that way except the three in-run callers that
+must apply. Running it verbatim would have produced a false REWORK. I rebuilt it.
+
+### Real-path reproduction
+
+New scratch test (appended to the suite, run, reverted; `git status` verified clean) that drives
+the actual sequence: create → turn 1 to terminal → clock +20 s → `reconcileProjection` issues its
+transcript GET against a **gated** fetch → real `sendMessage` for turn 2 whose stream hangs so the
+run stays in `this.running` → the gated transcript response is then released.
+
+HEAD (`eb77b3bc`):
+
+```
+"activeTurnAtSend": "completed",          ← still the same window; isTurnActive alone misses it
+"runningKeys":      ["chatc-8bd999…"],    ← run keyed canonically → arm 1 fires
+"midMirror":        ["user#-","assistant#-","assistant#-","user#-"],
+"afterMirror":      ["user#-","assistant#-","assistant#-","user#-"],
+"keptOptimistic":   true                  ← user's message SURVIVES
+```
+
+Same test, `73b7bb94` source (pre-fix):
+
+```
+"activeTurnAtSend": "completed",
+"afterMirror":      ["user#T1","assistant#T1","assistant#-"],
+"keptOptimistic":   false                 ← user's message wiped
+```
+
+The reproduction still enters the identical window — `activeTurnAtSend` is `"completed"`, so the
+`isTurnActive` arm alone would not have caught it — and the fix catches it there. The window did
+not move; it was closed.
+
+### Convergence is not swallowed
+
+Counter-check through the real reconciler, same harness with turn 2 never sent:
+
+```
+"outcome":     { "status": "materialized", "conversationId": "chatc-8bd999…" },
+"beforeMirror":["user#-","assistant#-","assistant#-"],
+"afterMirror": ["user#T1","assistant#T1","assistant#-"]
+```
+
+A legitimate fence-current read containing the required turn still wins and clears pending. The
+early return costs nothing when no turn is in flight.
+
+### Double-schedule: absent, by construction
+
+`rescheduleAfterTurn = true` is assigned on the single line immediately preceding `return`
+(`:2094-2095`), inside `try`. JS semantics: the `return` runs `finally` — which fires
+`scheduleReconcileEntry` once (`:2167`) — and then exits the function, so the unconditional
+`scheduleReconcileEntry` after the try/finally (`:2170`) is unreachable on that path. There is no
+other assignment to the flag, so the two can never co-execute. No second timer, no doubled request
+rate, no leak. The shipped test corroborates it from the outside by asserting `entry.attempt`
+stays `0` — the guard returns before `entry.attempt += 1`, so the guard path does not consume
+budget either.
+
+### Deadline refresh is not a livelock
+
+Each refresh requires a turn to be in flight, and while a turn is in flight the hook has already
+flipped `awaitingProjection` off (`historyFromStored:1823`), so the effect's cleanup calls
+`releaseProjectionWaiter` → `waiters === 0` → `scheduleReconcileEntry` returns early at `:2176`
+without arming a timer. The entry parks, keeps its refreshed deadline, and resumes when the turn
+ends. Extending the budget across a streaming turn is the correct semantic — streaming time should
+not be charged against the projection deadline — and every extension is bounded by a turn that
+itself sets a fresh `projectionPending`. When sends stop, the deadline expires normally into
+`timed_out` and the stalled UI. Not a livelock.
+
+### The placeholder arm is correct and sufficient
+
+`this.running` is keyed by `canonicalConversationId(sendAddress)` evaluated at send time.
+
+- Continuation on an aliased conversation → keyed canonical → covered by
+  `this.running.has(entry.conversationId)`. My repro confirms it: `runningKeys: ["chatc-…"]`.
+- Create whose run predates aliasing → keyed by the placeholder while `adoptRecoveredReceipt`
+  re-keys `entry.conversationId` to canonical → covered by the new
+  `this.running.has(entry.placeholderId)` arm. `entry.placeholderId` is reliably populated on
+  exactly that path (`reconcileProjection` sets it from `requestedId` when the request came in on
+  a placeholder, which is the only way an entry becomes `identityPending`).
+- Any run that has already announced its turn is caught by the third arm, `isTurnActive`,
+  regardless of keying.
+
+I looked for a run keyed under an address covered by none of the three and could not construct
+one: an entry on a canonical id with `placeholderId === undefined` only arises from a cold load
+with raw-index evidence, where this tab has no local create run to key under a placeholder. The
+arm is a correct addition, not a hole.
+
+### The rewritten test is a real behaviour test
+
+`aevatar-transport.test.ts:7822`. It gates the transcript fetch behind a manually-resolved
+promise, starts reconciliation, waits for the GET to be observed, then issues a **real**
+`sendMessage` whose second stream hangs, and asserts at `:7926`:
+
+```ts
+expect(activeTurnAtSend).toBe("completed");
+```
+
+That is precisely the assertion round 2 found missing — it pins that the test is exercising the
+window where `isTurnActive` is false, so the test cannot pass by accident on the old predicate.
+It then asserts the follow-up survives, the deadline was refreshed, `attempt` stayed `0`, and
+finally that an account reset settles the outcome as `timed_out` (which also exercises the
+round-2 `resetScope` settle P3). Verified it fails against `73b7bb94`:
+
+```
+ × [branch-regression] keeps a new-chat mirror untouched while a follow-up turn is active
+      Tests  1 failed | 3 passed | 179 skipped (183)
+```
+
+(The other three `[branch-regression]` tests pass at `73b7bb94` — correctly, since they are
+regressions of the round-2 fixes, already verified against `58ab3594` in round 2.)
+
+## Round-2 verified-fixed list — no regressions
+
+- **P2-1** re-measured at round-3 head, unchanged: `duringFirstTurn: undefined`,
+  `createRecoveryCallsDuringHealthyTurn: 0`, `awaitingAfterTerminal: true`.
+- **P2-2 / P2-3 / all four P3s** — untouched by round 3 (source delta is confined to
+  `runReconcileObservation`), and their tests are green in the 2446-test run.
+- **Account scope, intent durability, `stateVersion: 0` provenance (`:6806-6849`), backoff
+  floor** — all green in the full run; none of their code paths were modified.
+- **#1304 assertions** — `use-assistant.aevatar.test.tsx` was not touched in round 2 or round 3
+  (confirmed from both diffstats); still 6 tests, assertions unchanged since round 1.
+
+## Residual notes (non-blocking, no action required to merge)
+
+- `scheduleReconcileEntry` would overwrite `entry.timer` if it were ever called twice on a live
+  entry, leaking the first handle. Unreachable today for the reasons above; a defensive
+  `if (entry.timer !== undefined) return;` would make it structurally safe against future edits.
+- The W4 timing probes (pause/resume, late wake, remote-delete-mid-loop, recovery-adoption) remain
+  the least-exercised paths in the change, as recorded in round 2. Still a legitimate deferral —
+  I re-derived them and found no defect — but the first place to look at a future bug report.
+- Multi-tab behaviour remains unexercised across all three rounds.
+
+## Sign-off
+
+I am treating this as a merge sign-off, not a "looks fine". What convinced me: the one defect I
+could reproduce is now closed on the path that actually reaches it, demonstrated by a
+reproduction I wrote myself that fails against the immediately preceding commit and passes here;
+the fix does not trade content loss for stalled convergence, which I checked separately through
+the same real path; the two hazards I was asked to look for in the new control flow (double
+schedule, unbounded deadline extension) are provably absent rather than merely untriggered; and
+the accompanying test asserts the discriminating condition rather than restating the
+implementation. Ship it.

--- a/docs/plans/new-chat-projection-race.review-opus.md
+++ b/docs/plans/new-chat-projection-race.review-opus.md
@@ -1,0 +1,331 @@
+# Adversarial review — new-chat projection race (`fix-new-chat-timing`)
+
+Reviewer: Opus 5. Base `origin/rollup-chat-2026-08-04` (== `main` @ `fde6041f`), 4 commits,
+3270 insertions / 19 files. Frontend-only.
+
+VERDICT: REWORK
+
+One reproduced P1: the W8 keep-max relaxation, combined with the new always-on reconciler,
+deletes the user's in-flight message from the transcript. This is the same class of
+user-visible content loss PR #1304 fixed, reintroduced through a new path, and W8 shipped
+with **zero** new tests. Everything else in the change is in good shape — the scope
+boundary, the receipt/intent store, the evidence gating and the single-flight loop all hold
+up under inspection, and the gates reproduce exactly.
+
+---
+
+## Gate results
+
+All run from `frontend/` on a clean worktree at HEAD. Every implementer number reproduced.
+
+**`npm run lint`** — reproduced (0 errors, 23 warnings):
+
+```
+/…/src/pages/ai-setup.tsx
+  243:9  warning  The 'clients' logical expression could make the dependencies of useMemo Hook (at line 249) change on every render…
+
+✖ 23 problems (0 errors, 23 warnings)
+```
+
+**`npm run test`** — reproduced (199 files, 2436 tests):
+
+```
+ Test Files  199 passed (199)
+      Tests  2436 passed (2436)
+   Start at  02:50:55
+   Duration  21.83s
+```
+
+(The happy-dom `AbortError` / `catalog 401` lines in the log are pre-existing teardown noise,
+not failures.)
+
+**`npm run build`** — reproduced, green:
+
+```
+dist/assets/ssh-terminal-m7gQIClx.js   472.22 kB │ gzip: 123.58 kB
+✓ built in 595ms
+…
+✓ built in 49ms
+```
+
+**Wizard bundle freshness** — verified independently:
+
+```
+$ cargo test -p nyxid-cli wizard_bundle_is_fresh
+test wizard_bundle_is_fresh ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+**Diff hygiene** — verified: `git diff --stat origin/rollup-chat-2026-08-04...HEAD` restricted
+to `*package.json`, `*package-lock.json`, `cli/src/wizard/**`, `backend/**` returns empty.
+No backend change; the proxy stays opaque. Layering claim holds.
+
+**No coverage padding (spot check)** — reverted `aevatar-transport.ts` to base, kept the new
+modules and tests, ran the transport suite:
+
+```
+ Test Files  1 failed (1)
+      Tests  7 failed | 166 passed (173)
+ FAIL … > clears local mirrors on account switch but preserves same-user refreshes
+ FAIL … > uses raw index membership as cold 404 evidence and then materializes
+ FAIL … > single-flights concurrent projection waiters
+ FAIL … > turns a deadline with continuing index membership into stalled provenance
+ FAIL … > rejects a cold 404 after one raw absent confirmation
+ FAIL … > deletes a dispatched unaliased create locally without a placeholder DELETE
+ FAIL … > reads a pending placeholder from the local mirror without a doomed request
+```
+
+All 6 new transport tests fail on base source. No padding among the tests that exist. The
+problem is the tests that **don't** exist — see P2-4. Worktree restored clean after each
+experiment (`git status --porcelain` empty).
+
+---
+
+## P1 findings (block the PR)
+
+### P1-1 — A fence-current shorter transcript deletes the user's in-flight message
+
+`frontend/src/lib/assistant/aevatar-transport.ts:3112-3123` (predicate),
+`:3363-3375` (`latestAssistantTurnId`), `:822-831` (`historyIncludesAssistantTurn`),
+`:3068` (`applyHistoryResponse` — no active-turn guard).
+
+**The defect.** W8's fourth clause — the one the GPT review demanded, "the latest local
+assistant turn must be present in the server entries" — is **vacuous for exactly the
+conversations this PR is about**. `latestAssistantTurnId` scans the local mirror for an
+assistant message carrying a turn id (`:3363-3375`); messages produced by the live stream
+carry none. It therefore returns `null`, and `historyIncludesAssistantTurn(entries, null)`
+returns `true` unconditionally (`:826`). Clauses 1–3 (wrapped shape, fence-current, past the
+15s grace) are all satisfiable during a normal projection lag, so a shorter server transcript
+replaces a longer local mirror.
+
+Separately, `applyHistoryResponse` has **no active-turn guard**, unlike its sibling
+`mergeIndexEntry` (`:3015`, `if (existing && isTurnActive(…)) return;`). Before this PR that
+did not matter, because nothing called `applyHistoryResponse` mid-stream. It matters now:
+`getHistory`'s active-turn branch (`:1686`) returns `historyFromStored` (`:1805`), which
+stamps `awaitingProjection: true` whenever `projectionPending` is set — and nothing clears
+`projectionPending` when a *new* turn starts. So the `useConversation` effect
+(`frontend/src/hooks/use-assistant.ts:337-359`) keeps a reconciler running straight through
+the next turn, and its loop body calls `applyHistoryResponse` (`:2043`) with no interlock.
+
+**Failure scenario.** New chat. Turn 1 completes → `projectionPending = true`,
+`stateVersion = 3`, mirror `[user, assistant, assistant]` — no assistant carries a turn id.
+Upstream projection lags past the 15s grace (the exact condition this PR exists to handle).
+The user sends a follow-up; the optimistic user message is appended. A reconcile observation
+lands in the window between that append and the assistant's first delivered block, carrying a
+fence-current (`stateVersion: 4 ≥ 3`) transcript that only holds turn 1. Clause 4 passes
+vacuously → replacement → **the message the user just sent disappears from the transcript
+while the assistant answers it.**
+
+**How I verified it.** Scratch test appended to the real suite (then reverted; worktree
+verified clean), driving the real transport through `createConversation` → a full workflow
+turn → a 20s clock advance → `sendMessage` → one `applyHistoryResponse` call with a
+fence-current two-entry body:
+
+```
+"beforeMirror": ["user#-", "assistant#-", "assistant#-"],   ← no assistant turn id
+"fenceBefore": 3,  "pendingBefore": true,
+"midMirror":   ["user#-", "assistant#-", "assistant#-", "user#-"],   ← optimistic send
+"afterMirror": ["user#T1", "assistant#T1", "assistant#-"]            ← user message GONE
+```
+
+On `main` the same input keeps the mirror: keep-max there is unconditional
+(`comparableLocalMessageCount > messages.length → return existing`). This is a regression, not
+a pre-existing hazard.
+
+A control run on a *seeded* conversation (whose mirror does contain an assistant with a turn
+id) kept the local mirror intact — confirming clause 4 does work when it is not vacuous, and
+that the vacuity is the whole defect.
+
+**Fix.** Both halves:
+
+1. `applyHistoryResponse` (`:3068`) must return `existing` untouched when
+   `isTurnActive(existing.turnState.activeTurn?.status)`, matching the guard `mergeIndexEntry`
+   already carries at `:3015`. A background reconciliation read must never rewrite a mirror
+   that a live turn is writing into.
+2. `latestAssistantTurnId` (`:3363`) must fall back to `stored.requiredTurnId` when no local
+   assistant message carries a turn id, so clause 4 is never vacuous for a conversation with a
+   known local terminal. (Alternatively require `latestTurnId !== null` for replacement — but
+   the `requiredTurnId` fallback preserves the intended convergence.)
+
+Then add the three W8 tests the plan named in §4 and the diff omits — in particular
+"a fence-current shorter read MISSING the latest local turn keeps the local mirror" written
+against a *new-chat* mirror, not a seeded one, since the seeded shape hides the bug.
+
+---
+
+## P2 findings (should fix before merge)
+
+### P2-1 — The reconciler runs during the whole first turn, polling create-recovery on every new chat
+
+`aevatar-transport.ts:1686` + `:1805` (active-turn branch now stamps provenance),
+`use-assistant.ts:337`, `aevatar-transport.ts:2133` (`adoptRecoveredReceipt`).
+
+`sendMessage`'s create branch sets `identityPending = true` (`:2247`), so from the first token
+of a new chat `getHistory` answers `awaitingProjection: true`, the page shows the
+"Syncing conversation history…" strip (`pages/assistant.tsx:520`), and the hook effect fires
+`reconcileProjection`. With `identityPending` set, the loop takes the recovery branch and polls
+`create-recovery/{commandId}` on the backoff schedule **for the duration of a perfectly healthy
+first turn**. On `main` create-recovery was only polled behind `workflowCreateNeedsRecovery`
+(`:3560-3567`); there is no such guard here. This is a new doomed-poll loop on every new chat —
+the wire-log pollution D2 set out to remove, reintroduced at a different address.
+
+If one of those polls returns 200 mid-stream, `adoptRecoveredReceipt` (`:2133`) adopts identity
+concurrently with the context frame, and unlike `recoverWorkflowCreate` (`:3543`) it does **not**
+update `this.activeConversationId` — leaving the active pointer on the placeholder.
+
+Fix: gate the recovery-mode loop behind the existing `workflowCreateNeedsRecovery` predicate (or
+simply skip reconciliation while a turn is active on the conversation), and mirror the
+`activeConversationId` update from `:3543` into `adoptRecoveredReceipt`.
+
+### P2-2 — A cold load with a live receipt renders an empty chat and never reads the transcript
+
+`aevatar-transport.ts:1666-1676` (synthesize on `findReceiptByConversation`) and `:1691-1696`
+(pending short-circuit, no network).
+
+On reload, `this.conversations` is empty. `getHistory(chatc-A)` finds a receipt, synthesizes a
+`projectionPending` record with `EMPTY_TURN_STATE`, and the pending short-circuit at `:1691`
+returns that empty mirror **without ever attempting the transcript GET**. Any conversation whose
+receipt is still within its 24h TTL — i.e. every chat created in the last day, since
+`retireReceiptAfterMaterialization` only fires in a tab that stayed open — cold-loads as an empty
+chat with a syncing banner until the reconciler's first observation lands, and stays empty for
+the whole backoff ladder if that read fails transiently. Before this PR the same load did one
+direct read and rendered.
+
+Fix: only short-circuit on `projectionPending` when the record has local content or a local
+terminal fact; a synthesized-from-receipt record should attempt the wire read first and fall back
+to the syncing mirror on 404 (which the `:1725` branch already does correctly).
+
+### P2-3 — `deleteConversation` silently drops the wire DELETE when the receipt is missing
+
+`aevatar-transport.ts:1424-1447`.
+
+The new early-return branch triggers on `isPlaceholder && !pendingReceipt?.conversationId`. It
+consults **only the receipt store** — never `conversationAliases`. If a placeholder has already
+been aliased to `chatc-A` but its receipt is gone (cap-20 eviction, 24h TTL, storage disabled, or
+`activeOwnerUserId === null` making every receipt call a no-op), the branch tombstones locally and
+returns with no request. `main` would have canonicalized through the alias and issued a real
+DELETE. The server row survives, permanently.
+
+Reachable when the URL still carries the placeholder id at delete time (the repair effect in
+`assistant.tsx:209-271` has not yet swapped the id, or a live turn is blocking the swap).
+
+Fix: take the local-only branch only when the placeholder has neither a receipt-known canonical id
+**nor** an entry in `conversationAliases`; otherwise fall through to the canonical DELETE path.
+
+### P2-4 — The shipped test set is well short of the plan, and the gap is exactly where the P1 lives
+
+Counted per file, base vs HEAD: `aevatar-transport.test.ts` 150→156, `use-assistant.test.tsx`
+22→24, `assistant.test.tsx` 20→22, plus 3 backoff + 2 schema + 7 receipt-store = **22 new tests**
+against roughly 35 named in the plan's §4.
+
+Not implemented, all named in the plan:
+
+- **W8 keep-max — zero new tests.** The plan named three (two falsifiable + one `[guard]`). This
+  is the highest-risk edit in the change and the one that is broken.
+- **W2** — the P1.2 resurrection-window test (recovery names `chatc-A` → wire DELETE observed →
+  merged list omits it) and the reload-sweep test.
+- **W3** — the `stateVersion: 0` context test, the context-free failed create, and
+  "serves the mirror without a transcript request while projection is pending".
+- **W4** — pause/resume, late-wake final observation, remote-delete `absent` transition,
+  recovery-mode adoption.
+- **W6** — the dual-key projection test.
+
+The account-switch test that does exist asserts list emptiness and a `getHistory` throw, but not
+the plan's "fetch spy shows no further A-id requests" — the abort half of W0 is untested.
+
+This is not padding (what shipped is real), but the plan is part of the diff and claims this
+coverage. Either write the missing tests or amend §4 to state what was deferred and why.
+
+---
+
+## P3 / notes
+
+- `materializedStateVersion` (`:616`, written at `:3201`) is write-only — never read by any
+  decision. Either use it in the materialization criteria or drop the field.
+- `retireReceiptAfterMaterialization` (`assistant-receipt-store.ts:185`) schedules an untracked
+  `setTimeout` on **every** materializing history read until the receipt is actually deleted, so a
+  chat read repeatedly inside its 60s floor accumulates redundant timers. Idempotent, but it
+  should be guarded or the handle stored.
+- `resetScope` (`:1309`) clears `reconcileEntries` without settling their promises. A pending
+  `useRetryConversationProjection` mutation would then stay `isPending` forever (Retry button
+  permanently disabled). Settle abandoned entries as `timed_out` on scope reset.
+- `mergeIndexEntry` (`:3007`) calls `listDeletionIntents()` once per index row, and each call runs
+  a full `pruneState` sort of receipts and intents. O(n) prune passes per list fetch. Hoist the
+  intent set out of the loop.
+- `use-assistant.aevatar.test.tsx` changes `serverHistory`'s fixture from `stateVersion: 4` to
+  `100`. I checked: this is a harness change only, it moves the fence *up* (making replacement
+  more likely, i.e. stricter), and no #1304 card-content or ordering assertion was modified or
+  removed (test count unchanged at 6). The "assertions preserved verbatim" claim holds.
+
+---
+
+## Verified-sound (do not re-litigate)
+
+- **Gates.** Lint, test, build, wizard freshness all reproduce the implementer's numbers exactly.
+  No `package.json` / lockfile / `cli/src/wizard/**` / backend changes. Frontend-only holds.
+- **CLAUDE.md Rule 4.** Zod schema in `schemas/assistant-receipts.ts`, store in
+  `stores/assistant-receipt-store.ts`, hooks in `hooks/use-assistant.ts`. No `console.log` and no
+  raw `useForm` introduced (both greps clean).
+- **W0 account scope, cross-user leakage.** I could not construct a path where B observes or acts
+  on A's data. `resetScope` (`:1309`) aborts running turns, scope controllers and reconcile
+  timers, and clears every map before flipping `ownerScopeId`. Post-await scope re-checks are
+  present at the load-bearing points (`:1381`, `:1741`, `:1791`, `:2005`, `:2027`,
+  `fetchRawIndexMembership:1874`). Receipts are namespaced per user in localStorage with an
+  `ownerUserId` equality check on read (`assistant-receipt-store.ts:28`), so B's session cannot
+  read A's blob; A's unresolved intents survive under A's key and resume on return, as designed.
+  `cleanupDeletionIntent` re-checks `scopeId !== this.ownerScopeId` after every await
+  (`:1315`, `:1331`, `:1344`, `:1362`) so an intent cannot fire a DELETE under another account.
+  Same-user token refresh does not reset (the subscription compares ids, not tokens) — asserted by
+  the shipped test.
+- **W2 intent durability.** Intents live in a separate keyspace with their own cap (10) and are
+  pruned by a separate scan (`pruneState`, `:44-49`), so receipt eviction genuinely cannot touch
+  them. The intent is recorded *before* the receipt is deleted (`:1440-1447`). `mergeIndexEntry`
+  skips ids named by an intent (`:3007`). The single-flight `deletionCleanup` map prevents
+  duplicate sweeps within a tab.
+- **W3 provenance / `stateVersion: 0`.** `applyMaterializationObservation` (`:3181`) requires
+  `freshStateVersion >= max(1, positiveStateVersion(stored.stateVersion) ?? 1)`, so a `0` fence
+  cannot satisfy it and the conversation parks in `projectionPending` until a positive-fence read
+  containing the turn arrives — exactly what the existing regression at
+  `aevatar-transport.test.ts:6806-6849` locks in, and that test is still green in the full run.
+  Provenance is carried as optional success fields, never an `ApiError`.
+- **W4 mechanics.** Single-flight keys on the canonicalized id and aliases are installed from the
+  receipt before canonicalization (`:1907-1916`), so placeholder and canonical addresses reach the
+  same entry. The shared promise is created with `resolve` only and is never rejected; pause aborts
+  the controller and returns from inside `try` so `scheduleReconcileEntry` after the `finally` is
+  skipped — no settle, attempt/deadline preserved. `fetchRawIndexMembership` rethrows only on
+  explicit abort, which lands in `resumeReconcileEntry`'s `.catch` and is filtered by the
+  waiters/scope check. The hook attaches a defensive `.catch` (`use-assistant.ts:355`).
+  `nextBackoffDelay` (`backoff.ts:25`) is correctly floored: `random() === 0` yields exactly
+  `floorMs`, so there is no zero-delay burst.
+- **W5 raw-membership evidence.** `fetchRawIndexMembership` (`:1868`) computes `present` from the
+  raw `response.conversations` array **before** calling `mergeIndexEntry` (`:1879-1882`). The
+  merged local list can never be its own evidence. The cold-404-with-no-evidence path throws
+  `AssistantConversationNotFoundError` after exactly one confirmation — no retry storm — and the
+  shipped test asserts the fetch count.
+- **`timed_out` is a recoverable state, not a spinner.** `settleReconcileEntry` sets
+  `projectionStalledAt` (`:2173`); `historyFromStored` (`:1805`) then serves
+  `projectionStalled: true` and drops `awaitingProjection`, so the hook effect's
+  `awaitingProjection === true` guard cannot re-arm off the refetched snapshot. The page renders
+  the stalled strip with a working Retry (`pages/assistant.tsx:504-518`), and
+  `reconcileProjection` clears `projectionStalledAt` and restores `projectionPending` on retry
+  (`:1919-1922`). No limbo.
+
+---
+
+## Unverified
+
+- **Multi-tab behavior.** I did not exercise two tabs sharing one localStorage namespace. The
+  `storage`-event rehydrate (`assistant-receipt-store.ts:260`) only invalidates the memory cache;
+  the plan is honest that reconciliation is not coordinated. I found no correctness hazard by
+  inspection, but I did not reproduce a two-tab race.
+- **Real upstream fence behavior.** P1-1's clause-2 bypass depends on a lagging server transcript
+  ever reporting `stateVersion >= ` the locally observed fence. I demonstrated the content loss
+  with a fence of 4 against a stored fence of 3, which is what a *materialized-but-behind-the-live-
+  turn* read looks like. I did not confirm against a live Aevatar instance how often the server's
+  transcript fence sits at or above the last context-frame fence while the transcript is still
+  short. The `applyHistoryResponse` active-turn guard (fix 1) closes the finding regardless of that
+  frequency.
+- **`activeOwnerUserId === null` in production.** P2-3's worst trigger is receipts no-oping because
+  the auth store's `user` is null. I confirmed the module reads `useAuthStore.getState().user?.id`
+  at import and updates via subscription, but did not trace every app-boot ordering to prove the
+  transport can never dispatch a create before `user` is populated.

--- a/docs/plans/new-chat-projection-race.review-opus.md
+++ b/docs/plans/new-chat-projection-race.review-opus.md
@@ -329,3 +329,231 @@ coverage. Either write the missing tests or amend §4 to state what was deferred
   the auth store's `user` is null. I confirmed the module reads `useAuthStore.getState().user?.id`
   at import and updates via subscription, but did not trace every app-boot ordering to prove the
   transport can never dispatch a create before `user` is populated.
+
+---
+
+# Re-review (round 2)
+
+Reviewer: Opus 5. Head now `73b7bb94`, 5 new commits on top of `58ab3594`
+(the round-1 head). Round-1 findings above are left intact as the record.
+
+VERDICT: REWORK
+
+P1-1 is **not** closed. The guard landed in two of the three places it was needed and the
+one place it is missing is exactly the window the implementer claims to have closed. My
+round-1 reproduction still deletes the user's message, unchanged. The four other findings
+(P2-1, P2-2, P2-3, all P3s) are genuinely fixed and I verified each; the coverage label is
+honest. This is one call-site away from APPROVE.
+
+## Gate results (round 2)
+
+All re-run from a clean worktree at `73b7bb94`. Every reported number reproduced.
+
+```
+$ npm run lint
+✖ 23 problems (0 errors, 23 warnings)
+
+$ npm run test
+ Test Files  199 passed (199)
+      Tests  2446 passed (2446)
+   Duration  46.62s
+
+$ npm run build
+dist/credential-accept/assets/credential-accept-Bk5hKdwf.js  154.03 kB │ gzip: 50.35 kB
+✓ built in 47ms
+
+$ cargo test -p nyxid-cli wizard_bundle_is_fresh
+test wizard_bundle_is_fresh ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+2446 confirmed (up 10 from 2436), 199 files. Diff hygiene re-checked at the full range
+`origin/rollup-chat-2026-08-04...HEAD`: no `package.json`, no lockfile, no `cli/src/wizard/**`,
+no `backend/**`. Round-2 source touches only `aevatar-transport.ts` and
+`assistant-receipt-store.ts`. Worktree clean after every experiment.
+
+## Coverage accounting — the `[branch-regression]` label is honest
+
+Verified directly, as asked. Checked out `58ab3594`'s `aevatar-transport.ts` +
+`assistant-receipt-store.ts` under the round-2 test file and ran the four labelled tests:
+
+```
+ × [branch-regression] keeps a new-chat mirror untouched while a follow-up turn is active
+ × [branch-regression] keeps a longer new-chat mirror when the current fence omits its required turn
+ × [branch-regression] deletes an aliased placeholder through the wire when its receipt is gone
+ × [branch-regression] reads a cold canonical receipt from the transcript before serving pending
+      Tests  4 failed | 179 skipped (183)
+```
+
+All four fail against the pre-review implementation. They are branch regressions, not padding,
+and the label is correctly applied. Plan §4's shipped-vs-deferred accounting is likewise
+accurate against what I counted.
+
+I also confirmed the claim that the W8 tests exercise the `requiredTurnId` fallback rather than
+the seeded shape that hid the round-1 bug — `aevatar-transport.test.ts:7907-7912` asserts every
+local assistant message has `turnId === undefined` and that `stored.requiredTurnId` is the
+fallback source. That claim is true and it is the right assertion.
+
+---
+
+## P1 findings (block the PR)
+
+### P1-1 (SURVIVES) — the active-turn guard misses the window it was added for
+
+`aevatar-transport.ts:3124` (the guard), `:2079-2080` (the unguarded apply),
+`:2032-2045` (the pre-check that does it correctly).
+
+**What landed.** Three interlocks were added. Two are correct and consult the transport's
+running-turn map: `getHistory` (`:1693`, `this.running.has(...) || isTurnActive(...)`) and the
+reconciler's **pre-flight** check (`:2032`, same disjunction). The third —
+`applyHistoryResponse` itself (`:3124`) — checks **only** `isTurnActive(existing.turnState
+.activeTurn?.status)`. It does not consult `this.running`.
+
+**Why that is the wrong predicate.** I measured the reducer's state immediately after a real
+`sendMessage`:
+
+```
+"activeTurnAtSend": "completed"
+```
+
+Between `sendMessage()` and the first delivered frame, `activeTurn` still carries the *previous*
+turn's terminal status. `isTurnActive` is false for the entire duration of the create/continuation
+POST plus SSE header round trip — hundreds of milliseconds on every send. That is precisely the
+"between `sendMessage()` and `RUN_STARTED`" window the implementer says it closed; it is closed in
+`getHistory` and in the reconciler pre-check, and left open at the point where the mirror is
+actually overwritten.
+
+**Reachability.** The reconciler pre-check at `:2032` runs *before* the transcript GET is issued.
+After the `await` at `:2075` the only re-check is scope (`:2079`); `applyHistoryResponse` is then
+called at `:2080`. So: reconciler passes the pre-check (no turn in flight) → issues the GET → the
+user sends a follow-up → the response lands → the guard at `:3124` sees `status: "completed"` →
+replacement proceeds. The reconciler polls on a 250 ms–30 s ladder for up to 90 s while the user
+reads and types, so there is an in-flight window on every poll.
+
+**Reproduced, unchanged from round 1.** Same scratch test against the real transport at
+`73b7bb94` (appended to the suite, run, reverted; `git status` verified clean):
+
+```
+"beforeMirror":     ["user#-", "assistant#-", "assistant#-"]
+"midMirror":        ["user#-", "assistant#-", "assistant#-", "user#-"]   ← optimistic send
+"activeTurnAtSend": "completed"                                          ← guard does not fire
+"afterMidTurnRead": ["user#T1", "assistant#T1", "assistant#-"]           ← user message GONE
+```
+
+**Why the new test does not catch it.** `aevatar-transport.test.ts:7815`
+("[branch-regression] keeps a new-chat mirror untouched while a follow-up turn is active")
+hand-assigns `activeTurn: { turnId: null, status: "running", error: null }` at `:7857` before
+calling `applyHistoryResponse`. That is the one state in which the guard fires, and it is not the
+state a real `sendMessage` produces. The test validates the guard as written rather than the
+behaviour it was written for. It does fail at `58ab3594`, so the label is honest — but it is
+false assurance.
+
+**Fix — at the call site, not in `applyHistoryResponse`.** Do **not** add a blanket
+`this.running` check inside `applyHistoryResponse`: three legitimate in-run callers
+(`:3589`, `:3649` create-recovery, `:3726` reservation-retry fence refresh) must still apply while
+their own run is in `this.running`, and a blanket check would silently break the continuation
+fence refresh. The correct change is at `:2079-2080` — re-evaluate the same `turnInFlight`
+disjunction already computed at `:2032` after the await, and on a hit skip the apply, refresh
+`entry.deadlineAt`, and reschedule, exactly as `:2038-2044` does. Then rewrite the test at
+`:7815` to reach `applyHistoryResponse` through `reconcileProjection` with a real `sendMessage`
+in the in-flight window, rather than hand-setting `activeTurn`.
+
+**Severity note, stated honestly.** This is narrower than round 1: it needs a reconcile GET
+already in flight when the user sends, and it self-heals at the next materialization (the server
+transcript will contain the user message once the turn commits). It is still the silent
+disappearance of the user's own message from the transcript while the assistant answers it — the
+#1304 class — and the fix is a few lines at one call site.
+
+---
+
+## Verified fixed (I re-derived each; do not re-litigate)
+
+- **P2-1 — healthy first turns are clean.** Confirmed by direct measurement, not by reading the
+  summary. During a normal new-chat first turn: `awaitingProjection` is `undefined` and
+  create-recovery request count is **0**. After the terminal, `awaitingProjection` becomes `true`
+  as intended.
+
+  ```
+  "duringFirstTurn": undefined,
+  "createRecoveryCallsDuringHealthyTurn": 0,
+  "awaitingAfterTerminal": true,
+  ```
+
+  Mechanism checks out: `historyFromStored` (`:1823`) suppresses `awaitingProjection` when
+  `turnInFlight || isTurnActive`, so the hook effect never arms during the turn and the syncing
+  strip does not render. `runReconcileObservation` (`:2032-2045`) reschedules locally with a fresh
+  post-terminal deadline and no network when a turn is in flight.
+  `adoptRecoveredReceipt:2199-2201` now updates `activeConversationId` when the placeholder is the
+  active address, matching `recoverWorkflowCreate:3543`.
+
+- **Convergence is not frozen.** The specific risk I flagged — that a guard could trade content
+  loss for a permanently stale mirror. It does not. With no turn in flight, past the grace, a
+  fence-current read containing the required turn wins:
+
+  ```
+  "pendingBefore": true,  "requiredTurnId": "turn-d619…",
+  "beforeMirror":  ["user#-", "assistant#-", "assistant#-"],
+  "afterMirror":   ["user#T1", "assistant#T1", "assistant#-"],
+  "pendingAfter":  false,  "awaitingAfter": undefined,
+  ```
+
+  The `latestAssistantTurnId` fallback to `safeTurnId(stored.requiredTurnId)` (`:3415`) closes the
+  round-1 vacuity: clause 4 is now a real condition for new-chat mirrors. The unlabelled sibling
+  test at `:7882` asserts the same convergence and is genuine net-new coverage.
+
+- **P2-2 — cold receipt-backed load reads the wire first.** The pending short-circuit at
+  `:1707-1715` now additionally requires `messages.length > 0 || requiredTurnId != null ||
+  lastLocalTurnCompletedAt !== undefined`. A record synthesized purely from a receipt has none of
+  those, so it falls through to the transcript GET and renders on success; on 404 it lands in the
+  `existing` branch and serves the syncing mirror. `identityPending` still short-circuits, which is
+  correct — a placeholder has no server address to read.
+
+- **P2-3 — receiptless alias deletion.** `:1436` captures `conversationAliases.get(conversationId)`
+  and `:1438-1441` requires both `!pendingReceipt?.conversationId` **and** `!aliasedConversationId`
+  before taking the local-only branch. An evicted receipt can no longer suppress the canonical
+  wire DELETE.
+
+- **All four P3s landed as described.** `materializedStateVersion` removed from the interface and
+  both spread sites; retirement timers keyed `owner\0commandId`, deduplicated at
+  `retireReceiptAfterMaterialization:208-209`, cancelled in both `deleteReceipt:186-192` and
+  `deleteReceiptForOwner:99-102`, and cleared in the test reset; `resetScope:1313-1320` settles
+  abandoned entries as `timed_out` (over a copied array, so the later `clear()` is safe);
+  deletion-intent ids computed once per index response and passed into `mergeIndexEntry`
+  (`:1374-1381`, `:1879-1886`, `:3053-3059`).
+
+- **Nothing regressed in the round-1 verified-sound areas.** Re-checked: the account-scope reset
+  and post-await scope guards are intact (and now also settle waiters); intent durability still
+  rests on separate keyspace/cap/prune; the `stateVersion: 0` criterion at
+  `applyMaterializationObservation` is unchanged and the `:6806-6849` regression is green in the
+  full 2446-test run; `nextBackoffDelay`'s floor is untouched; the #1304 assertions in
+  `use-assistant.aevatar.test.tsx` are unchanged (file untouched in round 2, still 6 tests).
+
+## The three deferrals — my honest assessment
+
+- **W0 abort-spy test** (assert no further A-id requests after an account switch) —
+  **legitimate hardening deferral.** The abort code exists and I traced it (`resetScope` aborts
+  run controllers, scope controllers, and reconcile timers before clearing state); the shipped
+  test covers the observable outcome (empty list, `getHistory` throws). A spy would be stronger
+  but its absence hides no known defect.
+- **W4 pause/resume, late-wake, remote-delete-mid-loop, recovery-adoption timing** —
+  **legitimate deferral, with residual risk.** I re-derived all four by inspection in round 1 and
+  again here and found them correct: pause aborts and returns from inside `try` so the post-`finally`
+  reschedule is skipped and the entry keeps its attempt/deadline; `finalObservationDue` guarantees
+  one observation after a late wake; the two-observation ≥10 s absent transition is coherent. These
+  are the least-exercised paths in the change and the first place I would look at a future bug
+  report, but nothing here is load-bearing for a defect I can name.
+- **W6 pump-level dual-slot copy test** — **legitimate deferral.** The code
+  (`use-assistant.ts:136-159`) is straightforward `setQueryData` mirroring guarded by
+  `getQueryData(...) === undefined`, and the pre-existing pre-navigation copy in
+  `assistant.tsx:243-254` remains the primary path. Low risk.
+
+None of the three is load-bearing for correctness. The coverage gap that *was* load-bearing —
+W8 — has been filled, and filled with the right assertions.
+
+## Unverified (round 2)
+
+- I did not measure the wall-clock probability of the P1-1 window in production. I established
+  the window exists (`activeTurnAtSend: "completed"`), that the send-to-first-frame gap is a
+  network round trip, and that the reconciler has a GET in flight on a 250 ms–30 s ladder for up
+  to 90 s. I did not instrument a live session to estimate how often those overlap.
+- Multi-tab behaviour remains unexercised, unchanged from round 1.

--- a/frontend/src/hooks/use-assistant.aevatar.test.tsx
+++ b/frontend/src/hooks/use-assistant.aevatar.test.tsx
@@ -71,7 +71,7 @@ function serverTurnMessages(
 function serverHistory(messages: readonly ServerHistoryMessage[]) {
   return {
     messages,
-    stateVersion: 4,
+    stateVersion: 100,
   };
 }
 
@@ -226,6 +226,9 @@ interface ProbeSession {
     messages: readonly ServerHistoryMessage[],
   ) => void;
   readonly setServerAssistantText: (text: string) => void;
+  readonly historyIsMaterialized: () => boolean;
+  readonly projectionCanMaterialize: () => boolean;
+  readonly materializeProjection: () => Promise<ConversationHistory>;
   readonly unmount: () => void;
 }
 
@@ -299,6 +302,29 @@ async function startProbe(): Promise<ProbeSession> {
     );
   };
 
+  const materializeProjection = async (): Promise<ConversationHistory> => {
+    const reconciliation = transport.reconcileProjection(conversation.id);
+    const requiredTurnId = observedEvents
+      .filter((event) => event.event === "turn.completed")
+      .at(-1)?.turn_id;
+    const canMaterialize = serverMessages.some(
+      (message) =>
+        message.role === "assistant" && message.turnId === requiredTurnId,
+    );
+    if (canMaterialize) {
+      await reconciliation;
+    } else {
+      await vi.waitFor(async () => {
+        const observed = await transport.getHistory(conversation.id);
+        expect(observed.messages[0]?.id).toBe(serverMessages[0]?.id);
+      });
+      transport.releaseProjectionWaiter(conversation.id);
+    }
+    const history = await transport.getHistory(conversation.id);
+    queryClient.setQueryData(assistantKeys.history(conversation.id), history);
+    return history;
+  };
+
   await send("Connect GitHub");
 
   return {
@@ -325,6 +351,17 @@ async function startProbe(): Promise<ProbeSession> {
           : message,
       );
     },
+    historyIsMaterialized: () => historyMode === "materialized",
+    projectionCanMaterialize: () => {
+      const requiredTurnId = observedEvents
+        .filter((event) => event.event === "turn.completed")
+        .at(-1)?.turn_id;
+      return serverMessages.some(
+        (message) =>
+          message.role === "assistant" && message.turnId === requiredTurnId,
+      );
+    },
+    materializeProjection,
     unmount: () => {
       unsubscribe();
       hook.unmount();
@@ -353,13 +390,21 @@ async function finishAndWait(
     );
     expect(episode?.projecting).toBe(false);
   });
+  if (
+    session.historyIsMaterialized() &&
+    session.projectionCanMaterialize()
+  ) {
+    await session.materializeProjection();
+  }
 }
 
 async function switchRead(session: ProbeSession): Promise<ConversationHistory> {
   session.queryClient.removeQueries({
     queryKey: assistantKeys.history(session.placeholderId),
   });
-  const history = await session.transport.getHistory(session.placeholderId);
+  const history = session.historyIsMaterialized()
+    ? await session.materializeProjection()
+    : await session.transport.getHistory(session.placeholderId);
   session.queryClient.setQueryData(
     assistantKeys.history(session.placeholderId),
     history,

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -677,22 +677,103 @@ describe("conversation not-found resolution", () => {
     const historySpy = vi
       .spyOn(assistantTransport, "getHistory")
       .mockRejectedValue(new AssistantConversationNotFoundError());
-    const { result, unmount } = renderHook(
+    const { unmount } = renderHook(
       () => useConversation("nyxid-pending-lost-after-reload"),
       { wrapper: Wrapper },
     );
 
+    await vi.waitFor(() => expect(historySpy).toHaveBeenCalledTimes(1));
+
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
+      await Promise.resolve();
     });
 
-    expect(result.current.error).toBeInstanceOf(
-      AssistantConversationNotFoundError,
-    );
+    await vi.waitFor(() => {
+      expect(
+        queryClient.getQueryState(
+          assistantKeys.history("nyxid-pending-lost-after-reload"),
+        )?.error,
+      ).toBeInstanceOf(
+        AssistantConversationNotFoundError,
+      );
+    });
     expect(historySpy).toHaveBeenCalledTimes(1);
 
     historySpy.mockRestore();
     unmount();
+    queryClient.clear();
+  });
+});
+
+describe("conversation projection reconciliation", () => {
+  const conversationId = "workflow-pending-reconcile";
+  const canonicalId = "chatc-reconciled";
+  const syncingHistory: ConversationHistory = {
+    conversation: {
+      id: conversationId,
+      title: "Syncing",
+      created_at: new Date(TEST_NOW).toISOString(),
+      last_message_at: new Date(TEST_NOW).toISOString(),
+    },
+    messages: [],
+    has_more: false,
+    awaitingProjection: true,
+  };
+
+  it("starts reconciliation and invalidates mounted and canonical keys", async () => {
+    const { queryClient, Wrapper } = createHarness();
+    const historySpy = vi
+      .spyOn(assistantTransport, "getHistory")
+      .mockResolvedValue(syncingHistory);
+    const reconcileSpy = vi
+      .spyOn(assistantTransport, "reconcileProjection")
+      .mockResolvedValue({ status: "materialized", conversationId: canonicalId });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { unmount } = renderHook(() => useConversation(conversationId), {
+      wrapper: Wrapper,
+    });
+
+    await vi.waitFor(() => expect(reconcileSpy).toHaveBeenCalledOnce());
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: assistantKeys.history(canonicalId),
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: assistantKeys.conversations,
+      });
+    });
+
+    historySpy.mockRestore();
+    reconcileSpy.mockRestore();
+    invalidateSpy.mockRestore();
+    unmount();
+    queryClient.clear();
+  });
+
+  it("releases the waiter when the mounted conversation unmounts", async () => {
+    const { queryClient, Wrapper } = createHarness();
+    const historySpy = vi
+      .spyOn(assistantTransport, "getHistory")
+      .mockResolvedValue(syncingHistory);
+    const reconcileSpy = vi
+      .spyOn(assistantTransport, "reconcileProjection")
+      .mockReturnValue(new Promise(() => undefined));
+    const releaseSpy = vi.spyOn(
+      assistantTransport,
+      "releaseProjectionWaiter",
+    );
+    const { unmount } = renderHook(() => useConversation(conversationId), {
+      wrapper: Wrapper,
+    });
+    await vi.waitFor(() => expect(reconcileSpy).toHaveBeenCalledOnce());
+
+    unmount();
+    expect(releaseSpy).toHaveBeenCalledWith(conversationId);
+
+    historySpy.mockRestore();
+    reconcileSpy.mockRestore();
+    releaseSpy.mockRestore();
     queryClient.clear();
   });
 });

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -133,6 +133,31 @@ async function projectTransportState(
           assistantKeys.history(conversationId),
           () => history.value,
         );
+        const canonicalId = history.value.conversation.id;
+        if (canonicalId !== conversationId) {
+          queryClient.setQueryData<ConversationHistory>(
+            assistantKeys.history(canonicalId),
+            () => history.value,
+          );
+          if (
+            queryClient.getQueryData(assistantKeys.episode(canonicalId)) ===
+            undefined
+          ) {
+            queryClient.setQueryData(
+              assistantKeys.episode(canonicalId),
+              queryClient.getQueryData(assistantKeys.episode(conversationId)),
+            );
+          }
+          if (
+            queryClient.getQueryData(assistantKeys.turn(canonicalId)) ===
+            undefined
+          ) {
+            queryClient.setQueryData(
+              assistantKeys.turn(canonicalId),
+              queryClient.getQueryData(assistantKeys.turn(conversationId)),
+            );
+          }
+        }
       }
       if (conversations.status === "fulfilled") {
         queryClient.setQueryData<Conversation[]>(
@@ -298,7 +323,8 @@ export function useConversations() {
 }
 
 export function useConversation(conversationId: string | undefined) {
-  return useQuery({
+  const queryClient = useQueryClient();
+  const query = useQuery({
     queryKey: assistantKeys.history(conversationId ?? ""),
     queryFn: () => assistantTransport.getHistory(conversationId ?? ""),
     enabled: Boolean(conversationId),
@@ -306,6 +332,60 @@ export function useConversation(conversationId: string | undefined) {
       if (error instanceof AssistantConversationNotFoundError) return false;
       if (error instanceof ApiError && error.status === 404) return false;
       return failureCount < 3;
+    },
+  });
+  useEffect(() => {
+    if (!conversationId || query.data?.awaitingProjection !== true) return;
+    let released = false;
+    assistantTransport
+      .reconcileProjection(conversationId)
+      .then((outcome) => {
+        if (released) return;
+        void queryClient.invalidateQueries({
+          queryKey: assistantKeys.history(conversationId),
+        });
+        if (outcome.conversationId !== conversationId) {
+          void queryClient.invalidateQueries({
+            queryKey: assistantKeys.history(outcome.conversationId),
+          });
+        }
+        void queryClient.invalidateQueries({
+          queryKey: assistantKeys.conversations,
+        });
+      })
+      .catch(() => undefined);
+    return () => {
+      released = true;
+      assistantTransport.releaseProjectionWaiter(conversationId);
+    };
+  }, [conversationId, query.data?.awaitingProjection, queryClient]);
+  return query;
+}
+
+export function useRetryConversationProjection(
+  conversationId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      return assistantTransport.reconcileProjection(conversationId);
+    },
+    onSuccess: async (outcome) => {
+      if (!conversationId) return;
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: assistantKeys.history(conversationId),
+        }),
+        outcome.conversationId === conversationId
+          ? Promise.resolve()
+          : queryClient.invalidateQueries({
+              queryKey: assistantKeys.history(outcome.conversationId),
+            }),
+        queryClient.invalidateQueries({
+          queryKey: assistantKeys.conversations,
+        }),
+      ]);
     },
   });
 }

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -21,7 +21,12 @@ import capturedHistory from "@/lib/assistant/__fixtures__/aevatar-chat-history.j
 import capturedStream from "@/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse?raw";
 import { useAuthStore } from "@/stores/auth-store";
 import {
+  adoptReceiptIdentity,
+  deleteReceipt,
+  findReceiptByPlaceholder,
   listDeletionIntents,
+  recordCreateReceipt,
+  recordDeletionIntent,
   resetAssistantReceiptStoreForTests,
 } from "@/stores/assistant-receipt-store";
 import type { User } from "@/types/api";
@@ -31,6 +36,7 @@ import type {
   ContentBlock,
   Conversation,
   TurnEvent,
+  TurnReducerState,
 } from "@/types/assistant";
 
 const USER_ID = "add69059-bece-4f0e-9559-99cfd10b47eb";
@@ -5749,6 +5755,25 @@ describe("studio new chats and typed actor compatibility", () => {
     };
   }
 
+  function workflowInternals(transport: AevatarAssistantTransport) {
+    return transport as unknown as {
+      activeConversationId: string | null;
+      conversations: Map<
+        string,
+        {
+          turnState: TurnReducerState;
+          requiredTurnId?: string | null;
+          stateVersion?: number;
+          lastLocalTurnCompletedAt?: number;
+        }
+      >;
+      applyHistoryResponse(
+        conversationId: string,
+        body: unknown,
+      ): { turnState: TurnReducerState };
+    };
+  }
+
   function reservationUnavailable(): ChatStreamHeadersResult {
     return {
       kind: "http_error",
@@ -7734,6 +7759,273 @@ describe("studio new chats and typed actor compatibility", () => {
     ).toBe(false);
   });
 
+  it("does not expose syncing or poll create recovery during an active first turn", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(chatStreamClient, "start").mockImplementation(
+        (request): ChatStreamRequestHandle => {
+          const headers = Promise.resolve({
+            kind: "response" as const,
+            status: 200,
+            contentType: "text/event-stream",
+          });
+          const completion = headers.then(() => {
+            request.onFrames([
+              { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+            ]);
+            return new Promise<ChatStreamCompletionResult>(() => undefined);
+          });
+          return { headers, completion, cancel: vi.fn() };
+        },
+      );
+      const mock = stubFetch();
+      const transport = new AevatarAssistantTransport();
+      const placeholder = await transport.createConversation();
+      transport.sendMessage(placeholder.id, "healthy create", () => undefined);
+      expect(
+        (await transport.getHistory(placeholder.id)).awaitingProjection,
+      ).toBeUndefined();
+      const internals = workflowInternals(transport);
+      await vi.waitFor(() =>
+        expect(
+          internals.conversations.get(placeholder.id)?.turnState.activeTurn
+            ?.status,
+        ).toBe("running"),
+      );
+
+      const activeHistory = await transport.getHistory(placeholder.id);
+      expect(activeHistory.awaitingProjection).toBeUndefined();
+      const pendingOutcome = transport.reconcileProjection(placeholder.id);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(
+        mock.mock.calls.some(([input]) =>
+          String(input).includes("/conversations/create-recovery/"),
+        ),
+      ).toBe(false);
+
+      useAuthStore.getState().setUser(null);
+      await expect(pendingOutcome).resolves.toMatchObject({
+        status: "timed_out",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a new-chat mirror untouched while a follow-up turn is active", async () => {
+    let now = 0;
+    mockChatStreams((request) =>
+      request.url === WORKFLOW_URL
+        ? {
+            frames: [
+              ...WORKFLOW_PREAMBLE,
+              { textMessageStart: { messageId: "live-first" } },
+              { textMessageContent: { delta: "Local first reply" } },
+              { textMessageEnd: {} },
+              ...WORKFLOW_TAIL,
+            ],
+          }
+        : undefined,
+    );
+    stubFetch();
+    const transport = new AevatarAssistantTransport(() => now);
+    const placeholder = await transport.createConversation();
+    await collectWorkflowTurn(transport, placeholder.id, "first prompt");
+    now = 20_000;
+
+    const history = await transport.getHistory(placeholder.id);
+    const internals = workflowInternals(transport);
+    const stored = internals.conversations.get(history.conversation.id)!;
+    stored.turnState = {
+      ...stored.turnState,
+      messages: [
+        ...stored.turnState.messages,
+        {
+          id: "optimistic-follow-up",
+          role: "user",
+          schema_version: 1,
+          blocks: [
+            {
+              type: "text",
+              block_id: "optimistic-follow-up-text",
+              text: "follow-up prompt",
+            },
+          ],
+          created_at: new Date(now).toISOString(),
+        },
+      ],
+      activeTurn: { turnId: null, status: "running", error: null },
+    };
+    const before = stored.turnState.messages;
+
+    const observed = internals.applyHistoryResponse(history.conversation.id, {
+      messages: [
+        {
+          id: "server-first-assistant",
+          role: "assistant",
+          content: "Local first reply",
+          timestamp: 1,
+          turnId: WORKFLOW_TURN,
+        },
+      ],
+      stateVersion: 4,
+    });
+
+    expect(observed.turnState.messages).toBe(before);
+    expect(
+      observed.turnState.messages.some(
+        (message) => message.id === "optimistic-follow-up",
+      ),
+    ).toBe(true);
+  });
+
+  it("replaces a longer new-chat mirror once the current fence contains its required turn", async () => {
+    let now = 0;
+    mockChatStreams((request) =>
+      request.url === WORKFLOW_URL
+        ? {
+            frames: [
+              ...WORKFLOW_PREAMBLE,
+              { textMessageStart: { messageId: "replace-first" } },
+              { textMessageContent: { delta: "Local first reply" } },
+              { textMessageEnd: {} },
+              ...WORKFLOW_TAIL,
+            ],
+          }
+        : undefined,
+    );
+    stubFetch();
+    const transport = new AevatarAssistantTransport(() => now);
+    const placeholder = await transport.createConversation();
+    await collectWorkflowTurn(transport, placeholder.id, "first prompt");
+    now = 20_000;
+
+    const history = await transport.getHistory(placeholder.id);
+    const internals = workflowInternals(transport);
+    const stored = internals.conversations.get(history.conversation.id)!;
+    const before = stored.turnState.messages;
+    expect(
+      before
+        .filter((message) => message.role === "assistant")
+        .every((message) => message.turnId === undefined),
+    ).toBe(true);
+    expect(stored.requiredTurnId).toBe(WORKFLOW_TURN);
+
+    const observed = internals.applyHistoryResponse(history.conversation.id, {
+      messages: [
+        {
+          id: "server-first-assistant",
+          role: "assistant",
+          content: "Persisted first reply",
+          timestamp: 1,
+          turnId: WORKFLOW_TURN,
+        },
+      ],
+      stateVersion: 4,
+    });
+
+    expect(observed.turnState.messages).not.toBe(before);
+    expect(observed.turnState.messages.length).toBeLessThan(before.length);
+    expect(observed.turnState.messages[0]?.id).toBe("server-first-assistant");
+    expect(
+      observed.turnState.messages.some((message) =>
+        message.id.startsWith("assistant-activity-"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a longer new-chat mirror when the current fence omits its required turn", async () => {
+    let now = 0;
+    mockChatStreams((request) =>
+      request.url === WORKFLOW_URL
+        ? {
+            frames: [
+              ...WORKFLOW_PREAMBLE,
+              { textMessageStart: { messageId: "missing-first" } },
+              { textMessageContent: { delta: "Local first reply" } },
+              { textMessageEnd: {} },
+              ...WORKFLOW_TAIL,
+            ],
+          }
+        : undefined,
+    );
+    stubFetch();
+    const transport = new AevatarAssistantTransport(() => now);
+    const placeholder = await transport.createConversation();
+    await collectWorkflowTurn(transport, placeholder.id, "first prompt");
+    now = 20_000;
+
+    const history = await transport.getHistory(placeholder.id);
+    const internals = workflowInternals(transport);
+    const stored = internals.conversations.get(history.conversation.id)!;
+    const before = stored.turnState.messages;
+    expect(
+      before
+        .filter((message) => message.role === "assistant")
+        .every((message) => message.turnId === undefined),
+    ).toBe(true);
+
+    const observed = internals.applyHistoryResponse(history.conversation.id, {
+      messages: [
+        {
+          id: "older-assistant",
+          role: "assistant",
+          content: "Older reply",
+          timestamp: 1,
+          turnId: "turn-before-the-new-chat",
+        },
+      ],
+      stateVersion: 4,
+    });
+
+    expect(observed.turnState.messages).toBe(before);
+  });
+
+  it("[guard] keeps below-fence and legacy shorter reads from replacing local", async () => {
+    let now = 0;
+    mockChatStreams((request) =>
+      request.url === WORKFLOW_URL
+        ? {
+            frames: [
+              ...WORKFLOW_PREAMBLE,
+              { textMessageStart: { messageId: "guard-first" } },
+              { textMessageContent: { delta: "Local first reply" } },
+              { textMessageEnd: {} },
+              ...WORKFLOW_TAIL,
+            ],
+          }
+        : undefined,
+    );
+    stubFetch();
+    const transport = new AevatarAssistantTransport(() => now);
+    const placeholder = await transport.createConversation();
+    await collectWorkflowTurn(transport, placeholder.id, "first prompt");
+    now = 20_000;
+
+    const history = await transport.getHistory(placeholder.id);
+    const internals = workflowInternals(transport);
+    const stored = internals.conversations.get(history.conversation.id)!;
+    const before = stored.turnState.messages;
+    const entry = {
+      id: "server-first-assistant",
+      role: "assistant",
+      content: "Persisted first reply",
+      timestamp: 1,
+      turnId: WORKFLOW_TURN,
+    };
+
+    expect(
+      internals.applyHistoryResponse(history.conversation.id, {
+        messages: [entry],
+        stateVersion: 2,
+      }).turnState.messages,
+    ).toBe(before);
+    expect(
+      internals.applyHistoryResponse(history.conversation.id, [entry]).turnState
+        .messages,
+    ).toBe(before);
+  });
+
   it("deletes a legacy workflow conversation through its server id", async () => {
     const mock = stubFetch(
       routeWorkflow([
@@ -7766,6 +8058,85 @@ describe("studio new chats and typed actor compatibility", () => {
     await expect(
       transport.getHistory(WORKFLOW_CONVERSATION),
     ).rejects.toBeInstanceOf(AssistantConversationNotFoundError);
+  });
+
+  it("deletes an aliased placeholder through the wire when its receipt is gone", async () => {
+    mockChatStreams((request) =>
+      request.url === WORKFLOW_URL
+        ? { frames: [...WORKFLOW_PREAMBLE, ...WORKFLOW_TAIL] }
+        : undefined,
+    );
+    const mock = stubFetch((_url, init) =>
+      init?.method === "DELETE" ? jsonResponse({}) : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    const placeholder = await transport.createConversation();
+    await collectWorkflowTurn(transport, placeholder.id, "create");
+    const receipt = findReceiptByPlaceholder(placeholder.id);
+    expect(receipt?.conversationId).toBe(WORKFLOW_CONVERSATION);
+    deleteReceipt(receipt!.commandId);
+
+    await transport.deleteConversation(placeholder.id);
+
+    expect(
+      mock.mock.calls.some(
+        ([input, init]) =>
+          String(input) ===
+            `${ASSISTANT_BASE}/conversations/${WORKFLOW_CONVERSATION}` &&
+          init?.method === "DELETE",
+      ),
+    ).toBe(true);
+  });
+
+  it("recovers and deletes a create removed before its context can arrive", async () => {
+    const headers = new Promise<ChatStreamHeadersResult>(() => undefined);
+    const completion = new Promise<ChatStreamCompletionResult>(() => undefined);
+    vi.spyOn(chatStreamClient, "start").mockReturnValue({
+      headers,
+      completion,
+      cancel: vi.fn(),
+    });
+    const mock = stubFetch((url, init) => {
+      if (url.includes("/conversations/create-recovery/")) {
+        return jsonResponse({
+          status: "append_committed",
+          conversationId: WORKFLOW_CONVERSATION,
+          stateVersion: 3,
+          turnId: WORKFLOW_TURN,
+        });
+      }
+      if (
+        url === `${ASSISTANT_BASE}/conversations/${WORKFLOW_CONVERSATION}` &&
+        init?.method === "DELETE"
+      ) {
+        return jsonResponse({});
+      }
+      if (url === `${ASSISTANT_BASE}/conversations`) {
+        return jsonResponse({
+          conversations: [{ id: WORKFLOW_CONVERSATION, title: "Stale row" }],
+        });
+      }
+      return undefined;
+    });
+    const transport = new AevatarAssistantTransport();
+    const placeholder = await transport.createConversation();
+    transport.sendMessage(placeholder.id, "create then delete", () => undefined);
+    await vi.waitFor(() => expect(chatStreamClient.start).toHaveBeenCalledOnce());
+
+    await transport.deleteConversation(placeholder.id);
+    await vi.waitFor(() =>
+      expect(
+        mock.mock.calls.some(
+          ([input, init]) =>
+            String(input) ===
+              `${ASSISTANT_BASE}/conversations/${WORKFLOW_CONVERSATION}` &&
+            init?.method === "DELETE",
+        ),
+      ).toBe(true),
+    );
+
+    expect(await transport.listConversations()).toEqual([]);
+    expect(listDeletionIntents()).toEqual([]);
   });
 
   it("posts a workflow action continuation to the actor named by its frame", async () => {
@@ -7895,6 +8266,98 @@ describe("projection lifecycle boundaries", () => {
     await expect(transport.getHistory(conversation.id)).rejects.toBeInstanceOf(
       AssistantConversationNotFoundError,
     );
+  });
+
+  it("settles an abandoned reconciliation when the account scope changes", async () => {
+    stubFetch((url) =>
+      url === `${ASSISTANT_BASE}/conversations`
+        ? jsonResponse({ conversations: [{ id: CHAT_ID }] })
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await transport.getHistory(CHAT_ID);
+    const outcome = transport.reconcileProjection(CHAT_ID);
+
+    useAuthStore.getState().setUser({ id: "another-user" } as User);
+
+    await expect(outcome).resolves.toEqual({
+      status: "timed_out",
+      conversationId: CHAT_ID,
+    });
+  });
+
+  it("reads a cold canonical receipt from the transcript before serving pending", async () => {
+    recordCreateReceipt("cold-command", "workflow-pending-cold");
+    adoptReceiptIdentity("cold-command", CHAT_ID, 3);
+    const mock = stubFetch((url, init) =>
+      url === `${ASSISTANT_BASE}/conversations/${CHAT_ID}` &&
+      (init?.method ?? "GET") === "GET"
+        ? jsonResponse({
+            messages: [
+              {
+                id: "cold-assistant",
+                role: "assistant",
+                content: "Already materialized",
+                timestamp: 1,
+                turnId: "cold-turn",
+              },
+            ],
+            stateVersion: 3,
+          })
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+
+    const history = await transport.getHistory(CHAT_ID);
+
+    expect(history.messages[0]?.id).toBe("cold-assistant");
+    expect(history.awaitingProjection).toBeUndefined();
+    expect(
+      mock.mock.calls.filter(
+        ([input]) =>
+          String(input) === `${ASSISTANT_BASE}/conversations/${CHAT_ID}`,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("sweeps a persisted deletion intent after a transport reload", async () => {
+    recordDeletionIntent(
+      "reload-delete-command",
+      "workflow-pending-reload-delete",
+    );
+    const mock = stubFetch((url, init) => {
+      if (url.includes("/conversations/create-recovery/")) {
+        return jsonResponse({
+          status: "append_committed",
+          conversationId: CHAT_ID,
+          stateVersion: 3,
+          turnId: "reload-delete-turn",
+        });
+      }
+      if (
+        url === `${ASSISTANT_BASE}/conversations/${CHAT_ID}` &&
+        init?.method === "DELETE"
+      ) {
+        return jsonResponse({});
+      }
+      if (url === `${ASSISTANT_BASE}/conversations`) {
+        return jsonResponse({ conversations: [{ id: CHAT_ID }] });
+      }
+      return undefined;
+    });
+    const reloadedTransport = new AevatarAssistantTransport();
+
+    await reloadedTransport.listConversations();
+    await vi.waitFor(() => expect(listDeletionIntents()).toEqual([]));
+
+    expect(
+      mock.mock.calls.some(
+        ([input, init]) =>
+          String(input) === `${ASSISTANT_BASE}/conversations/${CHAT_ID}` &&
+          init?.method === "DELETE",
+      ),
+    ).toBe(true);
+    expect(await reloadedTransport.listConversations()).toEqual([]);
   });
 
   it("uses raw index membership as cold 404 evidence and then materializes", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -20,6 +20,10 @@ import { selectAssistantTransportKind } from "@/lib/assistant/transport";
 import capturedHistory from "@/lib/assistant/__fixtures__/aevatar-chat-history.json";
 import capturedStream from "@/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse?raw";
 import { useAuthStore } from "@/stores/auth-store";
+import {
+  listDeletionIntents,
+  resetAssistantReceiptStoreForTests,
+} from "@/stores/assistant-receipt-store";
 import type { User } from "@/types/api";
 import type {
   ActionCardContentBlock,
@@ -413,6 +417,8 @@ function perTurnStub(
 }
 
 beforeEach(() => {
+  localStorage.clear();
+  resetAssistantReceiptStoreForTests();
   useAuthStore.getState().setUser({ id: USER_ID } as User);
 });
 
@@ -6998,6 +7004,7 @@ describe("studio new chats and typed actor compatibility", () => {
       expect(history.messages.length).toBeGreaterThan(0);
       expect(history.messages).toBe(mirror?.turnState.messages);
       expect(history.has_more).toBe(false);
+      expect(history.awaitingProjection).toBe(true);
       expect(mock).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
@@ -7863,6 +7870,172 @@ describe("studio new chats and typed actor compatibility", () => {
             "Reported — awaiting assistant verification.",
       ),
     ).toBe(true);
+  });
+});
+
+describe("projection lifecycle boundaries", () => {
+  const CHAT_ID = "chatc-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  it("clears local mirrors on account switch but preserves same-user refreshes", async () => {
+    stubFetch((url) =>
+      url === `${ASSISTANT_BASE}/conversations`
+        ? jsonResponse({ conversations: [] })
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+
+    useAuthStore.getState().setUser({ id: USER_ID } as User);
+    expect((await transport.listConversations()).map(({ id }) => id)).toContain(
+      conversation.id,
+    );
+
+    useAuthStore.getState().setUser({ id: "another-user" } as User);
+    expect(await transport.listConversations()).toEqual([]);
+    await expect(transport.getHistory(conversation.id)).rejects.toBeInstanceOf(
+      AssistantConversationNotFoundError,
+    );
+  });
+
+  it("uses raw index membership as cold 404 evidence and then materializes", async () => {
+    let projected = false;
+    const mock = stubFetch((url, init) => {
+      if (url === `${ASSISTANT_BASE}/conversations`) {
+        return jsonResponse({ conversations: [{ id: CHAT_ID, title: "New" }] });
+      }
+      if (
+        url === `${ASSISTANT_BASE}/conversations/${CHAT_ID}` &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        return projected
+          ? jsonResponse({
+              messages: [
+                {
+                  id: "assistant-turn-a",
+                  role: "assistant",
+                  content: "Ready",
+                  timestamp: 1,
+                  turnId: "turn-a",
+                },
+              ],
+              stateVersion: 1,
+            })
+          : jsonResponse({ message: "not ready" }, 404);
+      }
+      return undefined;
+    });
+    const transport = new AevatarAssistantTransport();
+
+    const pending = await transport.getHistory(CHAT_ID);
+    expect(pending.awaitingProjection).toBe(true);
+    projected = true;
+    await expect(transport.reconcileProjection(CHAT_ID)).resolves.toEqual({
+      status: "materialized",
+      conversationId: CHAT_ID,
+    });
+    expect((await transport.getHistory(CHAT_ID)).messages[0]?.id).toBe(
+      "assistant-turn-a",
+    );
+    expect(
+      mock.mock.calls.filter(
+        ([input]) => String(input) === `${ASSISTANT_BASE}/conversations`,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("single-flights concurrent projection waiters", async () => {
+    let projected = false;
+    stubFetch((url) => {
+      if (url === `${ASSISTANT_BASE}/conversations`) {
+        return jsonResponse({ conversations: [{ id: CHAT_ID }] });
+      }
+      if (url === `${ASSISTANT_BASE}/conversations/${CHAT_ID}`) {
+        return projected
+          ? jsonResponse({ messages: [], stateVersion: 1 })
+          : jsonResponse({ message: "not ready" }, 404);
+      }
+      return undefined;
+    });
+    const transport = new AevatarAssistantTransport();
+    await transport.getHistory(CHAT_ID);
+    projected = true;
+
+    const first = transport.reconcileProjection(CHAT_ID);
+    const second = transport.reconcileProjection(CHAT_ID);
+
+    expect(second).toBe(first);
+    await expect(first).resolves.toMatchObject({ status: "materialized" });
+  });
+
+  it("turns a deadline with continuing index membership into stalled provenance", async () => {
+    vi.useFakeTimers();
+    let now = 0;
+    try {
+      stubFetch((url) =>
+        url === `${ASSISTANT_BASE}/conversations`
+          ? jsonResponse({ conversations: [{ id: CHAT_ID }] })
+          : undefined,
+      );
+      const transport = new AevatarAssistantTransport(() => now, () => 0);
+      const pending = await transport.getHistory(CHAT_ID);
+      expect(pending.awaitingProjection).toBe(true);
+
+      const outcome = transport.reconcileProjection(CHAT_ID);
+      await vi.advanceTimersByTimeAsync(0);
+      now = 90_000;
+      await vi.advanceTimersByTimeAsync(250);
+
+      await expect(outcome).resolves.toMatchObject({ status: "timed_out" });
+      expect((await transport.getHistory(CHAT_ID)).projectionStalled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a cold 404 after one raw absent confirmation", async () => {
+    const mock = stubFetch((url) =>
+      url === `${ASSISTANT_BASE}/conversations`
+        ? jsonResponse({ conversations: [] })
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+
+    await expect(transport.getHistory(CHAT_ID)).rejects.toBeInstanceOf(
+      AssistantConversationNotFoundError,
+    );
+    expect(mock).toHaveBeenCalledTimes(2);
+  });
+
+  it("deletes a dispatched unaliased create locally without a placeholder DELETE", async () => {
+    const headers = new Promise<ChatStreamHeadersResult>(() => undefined);
+    const completion = new Promise<ChatStreamCompletionResult>(() => undefined);
+    const start = vi.spyOn(chatStreamClient, "start").mockReturnValue({
+      headers,
+      completion,
+      cancel: vi.fn(),
+    });
+    const mock = stubFetch((url) =>
+      url.includes("/conversations/create-recovery/")
+        ? jsonResponse({ message: "not ready" }, 404)
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    const conversation = await transport.createConversation();
+    transport.sendMessage(conversation.id, "Create then delete", () => undefined);
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+
+    await transport.deleteConversation(conversation.id);
+
+    expect(listDeletionIntents()).toHaveLength(1);
+    expect(
+      mock.mock.calls.some(
+        ([input, init]) =>
+          String(input).includes(conversation.id) && init?.method === "DELETE",
+      ),
+    ).toBe(false);
+    await expect(
+      transport.getHistory(conversation.id),
+    ).rejects.toBeInstanceOf(AssistantConversationNotFoundError);
   });
 });
 

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -5767,6 +5767,13 @@ describe("studio new chats and typed actor compatibility", () => {
           lastLocalTurnCompletedAt?: number;
         }
       >;
+      reconcileEntries: Map<
+        string,
+        {
+          attempt: number;
+          deadlineAt: number;
+        }
+      >;
       applyHistoryResponse(
         conversationId: string,
         body: unknown,
@@ -7814,69 +7821,143 @@ describe("studio new chats and typed actor compatibility", () => {
 
   it("[branch-regression] keeps a new-chat mirror untouched while a follow-up turn is active", async () => {
     let now = 0;
-    mockChatStreams((request) =>
-      request.url === WORKFLOW_URL
-        ? {
-            frames: [
-              ...WORKFLOW_PREAMBLE,
-              { textMessageStart: { messageId: "live-first" } },
-              { textMessageContent: { delta: "Local first reply" } },
-              { textMessageEnd: {} },
-              ...WORKFLOW_TAIL,
-            ],
-          }
-        : undefined,
+    let streamCount = 0;
+    let cancelFollowUp: (() => void) | undefined;
+    vi.spyOn(chatStreamClient, "start").mockImplementation(
+      (request): ChatStreamRequestHandle => {
+        streamCount += 1;
+        if (streamCount === 1) {
+          const headers = Promise.resolve({
+            kind: "response" as const,
+            status: 200,
+            contentType: "text/event-stream",
+          });
+          return {
+            headers,
+            completion: headers.then(() => {
+              request.onFrames([
+                ...WORKFLOW_PREAMBLE,
+                { textMessageStart: { messageId: "live-first" } },
+                { textMessageContent: { delta: "Local first reply" } },
+                { textMessageEnd: {} },
+                ...WORKFLOW_TAIL,
+              ]);
+              return { kind: "complete" as const };
+            }),
+            cancel: vi.fn(),
+          };
+        }
+
+        let resolveHeaders!: (result: ChatStreamHeadersResult) => void;
+        const headers = new Promise<ChatStreamHeadersResult>((resolve) => {
+          resolveHeaders = resolve;
+        });
+        cancelFollowUp = () => resolveHeaders({ kind: "cancelled" });
+        return {
+          headers,
+          completion: headers.then(
+            (result): ChatStreamCompletionResult =>
+              result.kind === "cancelled"
+                ? result
+                : { kind: "complete" as const },
+          ),
+          cancel: () => cancelFollowUp?.(),
+        };
+      },
     );
-    stubFetch();
+    let resolveTranscript!: (response: Response) => void;
+    const transcript = new Promise<Response>((resolve) => {
+      resolveTranscript = resolve;
+    });
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (
+          url === `${ASSISTANT_BASE}/conversations/${WORKFLOW_CONVERSATION}` &&
+          (init?.method ?? "GET") === "GET"
+        ) {
+          return transcript;
+        }
+        return Promise.resolve(
+          jsonResponse(
+            { error: "not_found", error_code: -1, message: "404" },
+            404,
+          ),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
     const transport = new AevatarAssistantTransport(() => now);
     const placeholder = await transport.createConversation();
     await collectWorkflowTurn(transport, placeholder.id, "first prompt");
-    now = 20_000;
-
     const history = await transport.getHistory(placeholder.id);
     const internals = workflowInternals(transport);
-    const stored = internals.conversations.get(history.conversation.id)!;
-    stored.turnState = {
-      ...stored.turnState,
-      messages: [
-        ...stored.turnState.messages,
-        {
-          id: "optimistic-follow-up",
-          role: "user",
-          schema_version: 1,
-          blocks: [
-            {
-              type: "text",
-              block_id: "optimistic-follow-up-text",
-              text: "follow-up prompt",
-            },
-          ],
-          created_at: new Date(now).toISOString(),
-        },
-      ],
-      activeTurn: { turnId: null, status: "running", error: null },
-    };
-    const before = stored.turnState.messages;
-
-    const observed = internals.applyHistoryResponse(history.conversation.id, {
-      messages: [
-        {
-          id: "server-first-assistant",
-          role: "assistant",
-          content: "Local first reply",
-          timestamp: 1,
-          turnId: WORKFLOW_TURN,
-        },
-      ],
-      stateVersion: 4,
-    });
-
-    expect(observed.turnState.messages).toBe(before);
-    expect(
-      observed.turnState.messages.some(
-        (message) => message.id === "optimistic-follow-up",
+    now = 20_000;
+    const outcome = transport.reconcileProjection(history.conversation.id);
+    await vi.waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${ASSISTANT_BASE}/conversations/${history.conversation.id}`,
+        expect.anything(),
       ),
-    ).toBe(true);
+    );
+    const initialDeadline = internals.reconcileEntries.get(
+      history.conversation.id,
+    )!.deadlineAt;
+
+    const followUp = transport.sendMessage(
+      history.conversation.id,
+      "follow-up prompt",
+      () => undefined,
+    );
+    const activeTurnAtSend = internals.conversations.get(
+      history.conversation.id,
+    )!.turnState.activeTurn?.status;
+    const mirrorHasFollowUp = () =>
+      internals.conversations
+        .get(history.conversation.id)!
+        .turnState.messages.some(
+          (message) =>
+            message.role === "user" &&
+            message.blocks.some(
+              (block) =>
+                block.type === "text" && block.text === "follow-up prompt",
+            ),
+        );
+    expect(activeTurnAtSend).toBe("completed");
+    expect(mirrorHasFollowUp()).toBe(true);
+
+    now = 21_000;
+    resolveTranscript(
+      jsonResponse({
+        messages: [
+          {
+            id: "server-first-assistant",
+            role: "assistant",
+            content: "Local first reply",
+            timestamp: 1,
+            turnId: WORKFLOW_TURN,
+          },
+        ],
+        stateVersion: 4,
+      }),
+    );
+    await vi.waitFor(() => {
+      const deadlineWasRefreshed =
+        (internals.reconcileEntries.get(history.conversation.id)?.deadlineAt ??
+          0) > initialDeadline;
+      expect(deadlineWasRefreshed || !mirrorHasFollowUp()).toBe(true);
+    });
+    expect(mirrorHasFollowUp()).toBe(true);
+    expect(
+      internals.reconcileEntries.get(history.conversation.id)?.deadlineAt,
+    ).toBeGreaterThan(initialDeadline);
+    expect(
+      internals.reconcileEntries.get(history.conversation.id)?.attempt,
+    ).toBe(0);
+
+    followUp.cancel();
+    useAuthStore.getState().setUser(null);
+    await expect(outcome).resolves.toMatchObject({ status: "timed_out" });
   });
 
   it("replaces a longer new-chat mirror once the current fence contains its required turn", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -7812,7 +7812,7 @@ describe("studio new chats and typed actor compatibility", () => {
     }
   });
 
-  it("keeps a new-chat mirror untouched while a follow-up turn is active", async () => {
+  it("[branch-regression] keeps a new-chat mirror untouched while a follow-up turn is active", async () => {
     let now = 0;
     mockChatStreams((request) =>
       request.url === WORKFLOW_URL
@@ -7934,7 +7934,7 @@ describe("studio new chats and typed actor compatibility", () => {
     ).toBe(true);
   });
 
-  it("keeps a longer new-chat mirror when the current fence omits its required turn", async () => {
+  it("[branch-regression] keeps a longer new-chat mirror when the current fence omits its required turn", async () => {
     let now = 0;
     mockChatStreams((request) =>
       request.url === WORKFLOW_URL
@@ -8060,7 +8060,7 @@ describe("studio new chats and typed actor compatibility", () => {
     ).rejects.toBeInstanceOf(AssistantConversationNotFoundError);
   });
 
-  it("deletes an aliased placeholder through the wire when its receipt is gone", async () => {
+  it("[branch-regression] deletes an aliased placeholder through the wire when its receipt is gone", async () => {
     mockChatStreams((request) =>
       request.url === WORKFLOW_URL
         ? { frames: [...WORKFLOW_PREAMBLE, ...WORKFLOW_TAIL] }
@@ -8286,7 +8286,7 @@ describe("projection lifecycle boundaries", () => {
     });
   });
 
-  it("reads a cold canonical receipt from the transcript before serving pending", async () => {
+  it("[branch-regression] reads a cold canonical receipt from the transcript before serving pending", async () => {
     recordCreateReceipt("cold-command", "workflow-pending-cold");
     adoptReceiptIdentity("cold-command", CHAT_ID, 3);
     const mock = stubFetch((url, init) =>

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -612,8 +612,6 @@ interface StoredConversation {
   projectionPending?: boolean;
   /** Latest local workflow turn that must appear before materialization. */
   requiredTurnId?: string | null;
-  /** Highest transcript fence confirmed by a wire response. */
-  materializedStateVersion?: number;
   /** Reconciliation deadline, after which the mirror is explicitly stalled. */
   projectionStalledAt?: number;
   /**
@@ -1312,9 +1310,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
       this.clearWatchdog(run);
     }
     for (const controller of this.scopeControllers) controller.abort();
-    for (const entry of this.reconcileEntries.values()) {
+    for (const entry of [...this.reconcileEntries.values()]) {
       if (entry.timer !== undefined) clearTimeout(entry.timer);
       entry.controller?.abort();
+      entry.settle({
+        status: "timed_out",
+        conversationId: entry.conversationId,
+      });
     }
     this.conversations.clear();
     this.running.clear();
@@ -1369,9 +1371,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
         `${ASSISTANT_PREFIX}/conversations`,
       );
       if (scopeId !== this.ensureScope()) return [];
+      const deletionIntentIds = new Set(
+        listDeletionIntents().flatMap((intent) =>
+          intent.conversationId ? [intent.conversationId] : [],
+        ),
+      );
       for (const entry of response.conversations ?? []) {
         const id = entry?.id?.trim();
-        if (id) this.mergeIndexEntry(id, entry);
+        if (id) this.mergeIndexEntry(id, entry, deletionIntentIds);
       }
     }
     // An aliased conversation is stored under both its placeholder key and
@@ -1426,9 +1433,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
     )
       ? findReceiptByPlaceholder(conversationId)
       : undefined;
+    const aliasedConversationId = this.conversationAliases.get(conversationId);
     if (
       conversationId.startsWith(PENDING_WORKFLOW_CONVERSATION_PREFIX) &&
-      !pendingReceipt?.conversationId
+      !pendingReceipt?.conversationId &&
+      !aliasedConversationId
     ) {
       const run = this.running.get(conversationId);
       if (run) this.cancelTurn(conversationId, run);
@@ -1681,16 +1690,25 @@ export class AevatarAssistantTransport implements AssistantTransport {
     ) {
       throw new AssistantConversationNotFoundError();
     }
+    const turnInFlight =
+      this.running.has(requestedId) || this.running.has(conversationId);
     // During a streaming turn the local mirror is ahead of the server;
     // serving it keeps per-event re-projection off the network entirely.
-    if (existing && isTurnActive(existing.turnState.activeTurn?.status)) {
+    if (
+      existing &&
+      (turnInFlight || isTurnActive(existing.turnState.activeTurn?.status))
+    ) {
       this.activateConversation(conversationId, existing);
-      return this.historyFromStored(existing);
+      return this.historyFromStored(existing, true);
     }
     if (
       existing &&
-      (existing.identityPending || existing.projectionPending ||
-        existing.projectionStalledAt !== undefined)
+      (existing.identityPending ||
+        ((existing.projectionPending ||
+          existing.projectionStalledAt !== undefined) &&
+          (existing.turnState.messages.length > 0 ||
+            existing.requiredTurnId != null ||
+            existing.lastLocalTurnCompletedAt !== undefined)))
     ) {
       this.activateConversation(conversationId, existing);
       return this.historyFromStored(existing);
@@ -1802,15 +1820,20 @@ export class AevatarAssistantTransport implements AssistantTransport {
     this.activeConversationId = conversationId;
   }
 
-  private historyFromStored(stored: StoredConversation): ConversationHistory {
+  private historyFromStored(
+    stored: StoredConversation,
+    turnInFlight = false,
+  ): ConversationHistory {
     const stalled = stored.projectionStalledAt !== undefined;
+    const turnActive =
+      turnInFlight || isTurnActive(stored.turnState.activeTurn?.status);
     return {
       conversation: stored.conversation,
       messages: stored.turnState.messages,
       has_more: false,
       ...(stalled
         ? { projectionStalled: true }
-        : stored.identityPending || stored.projectionPending
+        : !turnActive && (stored.identityPending || stored.projectionPending)
           ? { awaitingProjection: true }
           : {}),
     };
@@ -1853,9 +1876,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
       const present = entries.some(
         (entry) => entry?.id?.trim() === conversationId,
       );
+      const deletionIntentIds = new Set(
+        listDeletionIntents().flatMap((intent) =>
+          intent.conversationId ? [intent.conversationId] : [],
+        ),
+      );
       for (const entry of entries) {
         const id = entry?.id?.trim();
-        if (id) this.mergeIndexEntry(id, entry);
+        if (id) this.mergeIndexEntry(id, entry, deletionIntentIds);
       }
       this.listFetchedAt = this.now();
       return present;
@@ -1998,6 +2026,23 @@ export class AevatarAssistantTransport implements AssistantTransport {
       this.deletingConversations.has(entry.conversationId)
     ) {
       this.settleReconcileEntry(entry, "absent");
+      return;
+    }
+    const activeStored = this.conversations.get(entry.conversationId);
+    const turnInFlight =
+      this.running.has(entry.conversationId) ||
+      (entry.placeholderId !== undefined &&
+        this.running.has(entry.placeholderId));
+    if (
+      activeStored &&
+      (turnInFlight || isTurnActive(activeStored.turnState.activeTurn?.status))
+    ) {
+      const policy = activeStored.identityPending
+        ? CREATE_RECOVERY_BACKOFF_POLICY
+        : PROJECTION_BACKOFF_POLICY;
+      entry.deadlineAt = this.now() + policy.deadlineMs;
+      entry.running = false;
+      this.scheduleReconcileEntry(entry);
       return;
     }
 
@@ -2151,6 +2196,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
     this.conversations.set(recovery.conversationId, stored);
     this.conversations.set(placeholderId, stored);
     this.conversationAliases.set(placeholderId, recovery.conversationId);
+    if (this.activeConversationId === placeholderId) {
+      this.activeConversationId = recovery.conversationId;
+    }
     adoptReceiptIdentity(
       entry.commandId ?? "",
       recovery.conversationId,
@@ -3002,15 +3050,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * clobber a streaming transcript); everything else adopts the server's
    * title, timestamps, and counts without a per-conversation detail fetch.
    */
-  private mergeIndexEntry(id: string, entry: AevatarHistoryIndexEntry): void {
+  private mergeIndexEntry(
+    id: string,
+    entry: AevatarHistoryIndexEntry,
+    deletionIntentIds: ReadonlySet<string>,
+  ): void {
     if (this.deletedConversationIds.has(id)) return;
-    if (
-      listDeletionIntents().some(
-        (intent) => intent.conversationId === id,
-      )
-    ) {
-      return;
-    }
+    if (deletionIntentIds.has(id)) return;
     const existing = this.conversations.get(id);
     if (existing && isTurnActive(existing.turnState.activeTurn?.status)) {
       return;
@@ -3049,7 +3095,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
       identityPending: existing?.identityPending,
       projectionPending: existing?.projectionPending,
       requiredTurnId: existing?.requiredTurnId,
-      materializedStateVersion: existing?.materializedStateVersion,
       projectionStalledAt: existing?.projectionStalledAt,
       sessionId: existing?.sessionId,
       createRequest: existing?.createRequest,
@@ -3075,8 +3120,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (this.deletedConversationIds.has(conversationId)) {
       throw new AssistantConversationNotFoundError();
     }
-    const entries = readHistoryEntries(body);
     const existing = this.conversations.get(conversationId);
+    if (existing && isTurnActive(existing.turnState.activeTurn?.status)) {
+      return existing;
+    }
+    const entries = readHistoryEntries(body);
     const messages = entries
       .map((entry, index) => historyEntryToMessage(entry, index))
       .filter((message): message is AssistantMessage => message !== null);
@@ -3168,7 +3216,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
       identityPending: existing?.identityPending,
       projectionPending: existing?.projectionPending,
       requiredTurnId: existing?.requiredTurnId,
-      materializedStateVersion: existing?.materializedStateVersion,
       projectionStalledAt: existing?.projectionStalledAt,
       sessionId: existing?.sessionId,
       createRequest: existing?.createRequest,
@@ -3197,12 +3244,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
     stored.identityPending = false;
     stored.projectionPending = false;
     stored.projectionStalledAt = undefined;
-    if (freshStateVersion !== undefined) {
-      stored.materializedStateVersion = Math.max(
-        stored.materializedStateVersion ?? 0,
-        freshStateVersion,
-      );
-    }
     const receipt = findReceiptByConversation(stored.conversation.id);
     if (receipt) retireReceiptAfterMaterialization(receipt.commandId, this.now());
   }
@@ -3371,7 +3412,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       const turnId = safeTurnId(message.turnId);
       if (turnId) return turnId;
     }
-    return null;
+    return safeTurnId(stored.requiredTurnId);
   }
 
   private async readWorkflowHistory(

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -12,6 +12,11 @@ import {
 } from "@/lib/assistant/errors";
 import { resolveAssistantAction } from "@/lib/assistant/action-registry";
 import {
+  CREATE_RECOVERY_BACKOFF_POLICY,
+  PROJECTION_BACKOFF_POLICY,
+  nextBackoffDelay,
+} from "@/lib/assistant/backoff";
+import {
   chatStreamClient,
   type ChatStreamCompletionResult,
   type ChatStreamRequestHandle,
@@ -53,6 +58,7 @@ import type {
   TurnHandle,
   TurnReducerState,
   TurnStatus,
+  ProjectionReconcileOutcome,
 } from "@/types/assistant";
 import { isTurnActive } from "@/types/assistant";
 import {
@@ -60,6 +66,18 @@ import {
   useAssistantWireLogStore,
 } from "@/stores/assistant-wire-log-store";
 import { useAuthStore } from "@/stores/auth-store";
+import {
+  adoptReceiptIdentity,
+  advanceReceiptFence,
+  deleteReceipt,
+  findReceiptByConversation,
+  findReceiptByPlaceholder,
+  listDeletionIntents,
+  recordCreateReceipt,
+  recordDeletionIntent,
+  retireReceiptAfterMaterialization,
+  resolveDeletionIntent,
+} from "@/stores/assistant-receipt-store";
 
 // NyxID's own assistant pass-through (PRD decision 4). NyxID resolves the
 // admin-managed aevatar service and derives the aevatar scope from the
@@ -213,9 +231,10 @@ const assistantApi = {
 // network round-trip per streamed token.
 const CONVERSATION_LIST_TTL_MS = 5_000;
 
-// Chat History materializes after the stream terminal. Keep the exact live
-// transcript briefly so an equal-length stale read cannot replace optimistic
-// identities before the authoritative turn is visible.
+// Chat History materializes after the stream terminal. Equal-length structured
+// mirrors keep their exact identities during this grace. Longer local mirrors
+// converge only on wrapped, fence-current responses containing the latest
+// assistant turn; legacy arrays retain the conservative keep-max behavior.
 const HISTORY_MATERIALIZATION_GRACE_MS = 15_000;
 
 // New chats run on Aevatar's Workflow Studio chat engine: the turn body
@@ -587,6 +606,16 @@ interface StoredConversation {
    * turn's `aevatar.chat.context` frame.
    */
   stateVersion?: number;
+  /** A create command was dispatched but no canonical conversation is known. */
+  identityPending?: boolean;
+  /** A locally terminal workflow turn is not yet confirmed in wire history. */
+  projectionPending?: boolean;
+  /** Latest local workflow turn that must appear before materialization. */
+  requiredTurnId?: string | null;
+  /** Highest transcript fence confirmed by a wire response. */
+  materializedStateVersion?: number;
+  /** Reconciliation deadline, after which the mirror is explicitly stalled. */
+  projectionStalledAt?: number;
   /**
    * Client session correlation handle sent on every workflow turn of this
    * conversation. Minted once and reused so the whole conversation shares
@@ -707,6 +736,24 @@ interface RunningTurn {
   actionContinuation: ActionContinuationState | null;
   optimisticMessageAppended: boolean;
   createRecoveryStarted: boolean;
+}
+
+interface ReconcileEntry {
+  readonly promise: Promise<ProjectionReconcileOutcome>;
+  readonly settle: (outcome: ProjectionReconcileOutcome) => void;
+  readonly scopeId: string | null;
+  readonly placeholderId?: string;
+  conversationId: string;
+  commandId?: string;
+  attempt: number;
+  startedAt: number;
+  deadlineAt: number;
+  waiters: number;
+  timer?: ReturnType<typeof setTimeout>;
+  controller?: AbortController;
+  running: boolean;
+  finalObservationDue: boolean;
+  firstAbsentAt?: number;
 }
 
 type StreamConsumptionResult =
@@ -1230,10 +1277,75 @@ export class AevatarAssistantTransport implements AssistantTransport {
   /** Conversation currently materialized in the chat view. */
   private activeConversationId: string | null = null;
   private readonly now: () => number;
+  private readonly random: () => number;
+  private ownerScopeId: string | null;
+  private readonly scopeControllers = new Set<AbortController>();
+  private readonly reconcileEntries = new Map<string, ReconcileEntry>();
+  private readonly deletionCleanup = new Map<string, Promise<void>>();
+  private deletionSweepStarted = false;
   private listFetchedAt = 0;
 
-  constructor(now: () => number = Date.now) {
+  constructor(
+    now: () => number = Date.now,
+    random: () => number = Math.random,
+  ) {
     this.now = now;
+    this.random = random;
+    this.ownerScopeId = useAuthStore.getState().user?.id ?? null;
+    useAuthStore.subscribe((state, previousState) => {
+      const nextScope = state.user?.id ?? null;
+      if (nextScope !== (previousState.user?.id ?? null)) {
+        this.resetScope(nextScope);
+      }
+    });
+  }
+
+  private ensureScope(): string | null {
+    const nextScope = useAuthStore.getState().user?.id ?? null;
+    if (nextScope !== this.ownerScopeId) this.resetScope(nextScope);
+    return this.ownerScopeId;
+  }
+
+  private resetScope(nextScope: string | null): void {
+    for (const run of this.running.values()) {
+      run.controller.abort();
+      this.clearWatchdog(run);
+    }
+    for (const controller of this.scopeControllers) controller.abort();
+    for (const entry of this.reconcileEntries.values()) {
+      if (entry.timer !== undefined) clearTimeout(entry.timer);
+      entry.controller?.abort();
+    }
+    this.conversations.clear();
+    this.running.clear();
+    this.pendingStops.clear();
+    this.pendingActionBatches.clear();
+    this.actionDrainBlocked.clear();
+    this.deletedConversationIds.clear();
+    this.deletingConversations.clear();
+    this.conversationAliases.clear();
+    this.scopeControllers.clear();
+    this.reconcileEntries.clear();
+    this.deletionCleanup.clear();
+    this.activeConversationId = null;
+    this.listFetchedAt = 0;
+    this.deletionSweepStarted = false;
+    this.ownerScopeId = nextScope;
+  }
+
+  private scopeController(): AbortController {
+    const controller = new AbortController();
+    this.scopeControllers.add(controller);
+    controller.signal.addEventListener(
+      "abort",
+      () => this.scopeControllers.delete(controller),
+      { once: true },
+    );
+    return controller;
+  }
+
+  private releaseScopeController(controller: AbortController): void {
+    this.scopeControllers.delete(controller);
   }
 
   /** Follow a placeholder alias to the server conversation id, if any. */
@@ -1242,6 +1354,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   async listConversations(): Promise<Conversation[]> {
+    const scopeId = this.ensureScope();
+    if (!this.deletionSweepStarted) {
+      this.deletionSweepStarted = true;
+      void this.sweepDeletionIntents(scopeId);
+    }
     const now = Date.now();
     if (
       this.running.size === 0 &&
@@ -1251,6 +1368,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       const response = await assistantApi.get<AevatarConversationListResponse>(
         `${ASSISTANT_PREFIX}/conversations`,
       );
+      if (scopeId !== this.ensureScope()) return [];
       for (const entry of response.conversations ?? []) {
         const id = entry?.id?.trim();
         if (id) this.mergeIndexEntry(id, entry);
@@ -1276,6 +1394,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   async createConversation(): Promise<Conversation> {
+    this.ensureScope();
     // New chats run on the workflow (studio) surface, where the conversation
     // is created server-side by the FIRST turn's chat-history reservation
     // (`conversation.conversationId: null` in the turn body) — there is no
@@ -1300,7 +1419,40 @@ export class AevatarAssistantTransport implements AssistantTransport {
   }
 
   async deleteConversation(conversationId: string): Promise<void> {
+    this.ensureScope();
     const requestedId = conversationId;
+    const pendingReceipt = conversationId.startsWith(
+      PENDING_WORKFLOW_CONVERSATION_PREFIX,
+    )
+      ? findReceiptByPlaceholder(conversationId)
+      : undefined;
+    if (
+      conversationId.startsWith(PENDING_WORKFLOW_CONVERSATION_PREFIX) &&
+      !pendingReceipt?.conversationId
+    ) {
+      const run = this.running.get(conversationId);
+      if (run) this.cancelTurn(conversationId, run);
+      if (pendingReceipt) {
+        recordDeletionIntent(
+          pendingReceipt.commandId,
+          pendingReceipt.placeholderId,
+          undefined,
+          this.now(),
+        );
+        deleteReceipt(pendingReceipt.commandId);
+      }
+      this.tombstoneConversation(conversationId);
+      if (pendingReceipt) {
+        void this.startDeletionIntentCleanup(
+          pendingReceipt.commandId,
+          this.ownerScopeId,
+        );
+      }
+      return;
+    }
+    if (pendingReceipt?.conversationId) {
+      this.conversationAliases.set(conversationId, pendingReceipt.conversationId);
+    }
     conversationId = this.canonicalConversationId(conversationId);
     // A turn still streaming into the conversation must not keep painting
     // a transcript that is about to disappear: cancel first, matching the
@@ -1337,7 +1489,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       await this.awaitPendingStop(conversationId);
       // Own deadline: the reservation rejects sends while it holds, so an
       // accepted-but-never-answered DELETE must not lock the conversation.
-      const deadline = new AbortController();
+      const deadline = this.scopeController();
       const deadlineTimer = setTimeout(
         () => deadline.abort(),
         DELETE_REQUEST_DEADLINE_MS,
@@ -1354,6 +1506,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
         );
       } finally {
         clearTimeout(deadlineTimer);
+        this.releaseScopeController(deadline);
       }
       // Local removal only after the server accepted: a failed delete keeps
       // the conversation listed and retryable. A placeholder that aliased
@@ -1363,6 +1516,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
       this.deletedConversationIds.add(conversationId);
       this.pendingActionBatches.delete(conversationId);
       this.actionDrainBlocked.delete(conversationId);
+      const receipt = findReceiptByConversation(conversationId);
+      if (receipt) deleteReceipt(receipt.commandId);
       for (const [placeholder, target] of this.conversationAliases) {
         if (target === conversationId) {
           this.conversations.delete(placeholder);
@@ -1385,12 +1540,140 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
   }
 
+  private async sweepDeletionIntents(scopeId: string | null): Promise<void> {
+    await Promise.allSettled(
+      listDeletionIntents().map((intent) =>
+        this.startDeletionIntentCleanup(intent.commandId, scopeId),
+      ),
+    );
+  }
+
+  private startDeletionIntentCleanup(
+    commandId: string,
+    scopeId: string | null,
+  ): Promise<void> {
+    const existing = this.deletionCleanup.get(commandId);
+    if (existing) return existing;
+    const operation = this.cleanupDeletionIntent(commandId, scopeId).finally(
+      () => {
+        if (this.deletionCleanup.get(commandId) === operation) {
+          this.deletionCleanup.delete(commandId);
+        }
+      },
+    );
+    this.deletionCleanup.set(commandId, operation);
+    return operation;
+  }
+
+  private async cleanupDeletionIntent(
+    commandId: string,
+    scopeId: string | null,
+  ): Promise<void> {
+    if (!scopeId || scopeId !== this.ownerScopeId) return;
+    let intent = listDeletionIntents().find(
+      (candidate) => candidate.commandId === commandId,
+    );
+    if (!intent) return;
+    const controller = this.scopeController();
+    const deadlineAt = this.now() + CREATE_RECOVERY_BACKOFF_POLICY.deadlineMs;
+    try {
+      let conversationId = intent.conversationId;
+      for (let attempt = 0; !conversationId; attempt += 1) {
+        if (controller.signal.aborted || scopeId !== this.ownerScopeId) return;
+        try {
+          const response = await assistantApi.get<AevatarCreateRecoveryResponse>(
+            `${ASSISTANT_PREFIX}/conversations/create-recovery/${encodeURIComponent(commandId)}`,
+            controller.signal,
+          );
+          const recovered = this.decodeCreateRecovery(response);
+          conversationId = recovered.conversationId;
+          recordDeletionIntent(
+            commandId,
+            intent.placeholderId,
+            conversationId,
+            intent.createdAt,
+          );
+          intent = { ...intent, conversationId };
+        } catch (error) {
+          if (controller.signal.aborted || scopeId !== this.ownerScopeId) return;
+          if (!(error instanceof ApiError && error.status === 404)) return;
+          if (this.now() >= deadlineAt) return;
+          await abortableDelay(
+            nextBackoffDelay(
+              CREATE_RECOVERY_BACKOFF_POLICY,
+              attempt,
+              this.random,
+            ),
+            controller.signal,
+          );
+        }
+      }
+      if (!conversationId || scopeId !== this.ownerScopeId) return;
+      const deleteTimer = setTimeout(
+        () => controller.abort(),
+        DELETE_REQUEST_DEADLINE_MS,
+      );
+      try {
+        await apiClient<unknown>(
+          `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
+          {
+            method: "DELETE",
+            preserveSessionOn401: true,
+            signal: controller.signal,
+            ...assistantWireLogOptions(),
+          },
+        );
+      } finally {
+        clearTimeout(deleteTimer);
+      }
+      if (scopeId !== this.ownerScopeId) return;
+      this.tombstoneConversation(intent.placeholderId);
+      this.tombstoneConversation(conversationId);
+      resolveDeletionIntent(commandId);
+    } catch {
+      // The persisted intent is retried on the next per-scope sweep.
+    } finally {
+      controller.abort();
+      this.releaseScopeController(controller);
+    }
+  }
+
   async getHistory(conversationId: string): Promise<ConversationHistory> {
+    const scopeId = this.ensureScope();
+    const requestedId = conversationId;
+    if (
+      conversationId.startsWith(PENDING_WORKFLOW_CONVERSATION_PREFIX) &&
+      !this.conversations.has(conversationId)
+    ) {
+      const receipt = findReceiptByPlaceholder(conversationId);
+      if (!receipt) throw new AssistantConversationNotFoundError();
+      if (receipt.conversationId) {
+        this.conversationAliases.set(conversationId, receipt.conversationId);
+        conversationId = receipt.conversationId;
+      } else {
+        const stored = this.syntheticPendingConversation(conversationId, {
+          identityPending: true,
+          stateVersion: receipt.stateVersion,
+        });
+        this.conversations.set(conversationId, stored);
+      }
+    }
     conversationId = this.canonicalConversationId(conversationId);
     if (this.deletedConversationIds.has(conversationId)) {
       throw new AssistantConversationNotFoundError();
     }
-    const existing = this.conversations.get(conversationId);
+    let existing = this.conversations.get(conversationId);
+    const canonicalReceipt = findReceiptByConversation(conversationId);
+    if (!existing && canonicalReceipt) {
+      existing = this.syntheticPendingConversation(conversationId, {
+        projectionPending: true,
+        stateVersion: canonicalReceipt.stateVersion,
+      });
+      this.conversations.set(conversationId, existing);
+      if (requestedId !== conversationId) {
+        this.conversations.set(requestedId, existing);
+      }
+    }
     if (
       !existing &&
       (conversationId.startsWith(LEGACY_PENDING_TYPED_CONVERSATION_PREFIX) ||
@@ -1401,11 +1684,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // During a streaming turn the local mirror is ahead of the server;
     // serving it keeps per-event re-projection off the network entirely.
     if (existing && isTurnActive(existing.turnState.activeTurn?.status)) {
-      return {
-        conversation: existing.conversation,
-        messages: existing.turnState.messages,
-        has_more: false,
-      };
+      this.activateConversation(conversationId, existing);
+      return this.historyFromStored(existing);
+    }
+    if (
+      existing &&
+      (existing.identityPending || existing.projectionPending ||
+        existing.projectionStalledAt !== undefined)
+    ) {
+      this.activateConversation(conversationId, existing);
+      return this.historyFromStored(existing);
     }
     // A pending placeholder exists nowhere server-side — the id never left
     // this client — so the read can only 404 and land in the
@@ -1416,12 +1704,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
       (conversationId.startsWith(LEGACY_PENDING_TYPED_CONVERSATION_PREFIX) ||
         conversationId.startsWith(PENDING_WORKFLOW_CONVERSATION_PREFIX))
     ) {
-      this.activeConversationId = conversationId;
-      return {
-        conversation: existing.conversation,
-        messages: existing.turnState.messages,
-        has_more: false,
-      };
+      this.activateConversation(conversationId, existing);
+      return this.historyFromStored(existing);
     }
     let stored: StoredConversation;
     try {
@@ -1441,37 +1725,74 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // transient and protocol failures retain their original type.
       if (!existing) {
         if (error instanceof ApiError && error.status === 404) {
-          throw new AssistantConversationNotFoundError();
+          if (!conversationId.startsWith(WORKFLOW_CONVERSATION_PREFIX)) {
+            throw new AssistantConversationNotFoundError();
+          }
+          const membership = await this.fetchRawIndexMembership(conversationId);
+          if (scopeId !== this.ensureScope()) {
+            throw new AssistantConversationNotFoundError();
+          }
+          if (membership === "unavailable" && !canonicalReceipt) throw error;
+          if (membership !== true && !canonicalReceipt) {
+            throw new AssistantConversationNotFoundError();
+          }
+          stored =
+            this.conversations.get(conversationId) ??
+            this.syntheticPendingConversation(conversationId, {
+              projectionPending: true,
+              stateVersion: canonicalReceipt?.stateVersion,
+            });
+          stored.projectionPending = true;
+          stored.stateVersion =
+            canonicalReceipt?.stateVersion ?? stored.stateVersion;
+          this.conversations.set(conversationId, stored);
+        } else {
+          throw error;
         }
-        throw error;
+      } else {
+        const noServerTranscriptYet =
+          error instanceof ApiError && error.status === 404;
+        if (
+          noServerTranscriptYet &&
+          conversationId.startsWith(WORKFLOW_CONVERSATION_PREFIX) &&
+          existing.turnState.messages.length === 0 &&
+          !existing.identityPending &&
+          !existing.projectionPending
+        ) {
+          const membership = await this.fetchRawIndexMembership(conversationId);
+          if (scopeId !== this.ensureScope() || membership === false) {
+            this.tombstoneConversation(conversationId);
+            throw new AssistantConversationNotFoundError();
+          }
+          if (membership === true) existing.projectionPending = true;
+          if (membership === "unavailable") throw error;
+        }
+        if (
+          !noServerTranscriptYet &&
+          existing.turnState.messages.length === 0
+        ) {
+          throw error;
+        }
+        stored = existing;
       }
-      // 404 is the EXPECTED answer for a conversation that has not yet
-      // completed a turn. The two upstream halves materialize at different
-      // times: `nyxid-chat` mints the actor at create, while the
-      // `chat-history` row is only written when a turn reaches a terminal.
-      // Aevatar's `HandleGetConversation` maps a missing read-model document
-      // to 404 — NOT to an empty array — so every brand-new conversation
-      // 404s here, as does the window between a turn's terminal frame and
-      // its history materialization. For a conversation we already hold,
-      // that is "no server transcript yet", and the local mirror is the
-      // truthful answer rather than a failure.
-      const noServerTranscriptYet =
-        error instanceof ApiError && error.status === 404;
-      // Transient failures (network, 5xx) may serve the local mirror — but
-      // only when it holds a real transcript. A conversation the index
-      // merged in carries `EMPTY_TURN_STATE`, and answering with that would
-      // dress a failed read as a legitimately empty chat.
-      if (!noServerTranscriptYet && existing.turnState.messages.length === 0) {
-        throw error;
-      }
-      stored = existing;
     }
     // Re-check AFTER the await: a delete completing while the history
     // request was in flight must not be answered with the pre-delete
     // snapshot captured above (the fallback `existing`).
-    if (this.deletedConversationIds.has(conversationId)) {
+    if (
+      scopeId !== this.ensureScope() ||
+      this.deletedConversationIds.has(conversationId)
+    ) {
       throw new AssistantConversationNotFoundError();
     }
+    this.activateConversation(conversationId, stored);
+    return this.historyFromStored(stored);
+  }
+
+  private activateConversation(
+    conversationId: string,
+    stored: StoredConversation,
+  ): void {
     if (
       conversationId.startsWith(WORKFLOW_CONVERSATION_PREFIX) &&
       this.activeConversationId !== conversationId
@@ -1479,11 +1800,381 @@ export class AevatarAssistantTransport implements AssistantTransport {
       stored.sessionId = crypto.randomUUID();
     }
     this.activeConversationId = conversationId;
+  }
+
+  private historyFromStored(stored: StoredConversation): ConversationHistory {
+    const stalled = stored.projectionStalledAt !== undefined;
     return {
       conversation: stored.conversation,
       messages: stored.turnState.messages,
       has_more: false,
+      ...(stalled
+        ? { projectionStalled: true }
+        : stored.identityPending || stored.projectionPending
+          ? { awaitingProjection: true }
+          : {}),
     };
+  }
+
+  private syntheticPendingConversation(
+    conversationId: string,
+    facts: Pick<
+      StoredConversation,
+      "identityPending" | "projectionPending" | "stateVersion"
+    >,
+  ): StoredConversation {
+    const nowIso = new Date(this.now()).toISOString();
+    return {
+      conversation: {
+        id: conversationId,
+        title: "Conversation",
+        created_at: nowIso,
+        last_message_at: nowIso,
+      },
+      turnState: EMPTY_TURN_STATE,
+      actionRequestFingerprints: new Map(),
+      activityMessageTurnIds: new Map(),
+      ...facts,
+    };
+  }
+
+  private async fetchRawIndexMembership(
+    conversationId: string,
+    signal?: AbortSignal,
+  ): Promise<boolean | "unavailable"> {
+    const scopeId = this.ownerScopeId;
+    try {
+      const response = await assistantApi.get<AevatarConversationListResponse>(
+        `${ASSISTANT_PREFIX}/conversations`,
+        signal,
+      );
+      if (scopeId !== this.ownerScopeId) return "unavailable";
+      const entries = response.conversations ?? [];
+      const present = entries.some(
+        (entry) => entry?.id?.trim() === conversationId,
+      );
+      for (const entry of entries) {
+        const id = entry?.id?.trim();
+        if (id) this.mergeIndexEntry(id, entry);
+      }
+      this.listFetchedAt = this.now();
+      return present;
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      return "unavailable";
+    }
+  }
+
+  private tombstoneConversation(conversationId: string): void {
+    const canonicalId = this.canonicalConversationId(conversationId);
+    this.conversations.delete(conversationId);
+    this.conversations.delete(canonicalId);
+    this.deletedConversationIds.add(conversationId);
+    this.deletedConversationIds.add(canonicalId);
+    const entry = this.reconcileEntries.get(canonicalId);
+    if (entry?.timer !== undefined) clearTimeout(entry.timer);
+    entry?.controller?.abort();
+  }
+
+  reconcileProjection(
+    requestedId: string,
+  ): Promise<ProjectionReconcileOutcome> {
+    const scopeId = this.ensureScope();
+    const placeholderReceipt = requestedId.startsWith(
+      PENDING_WORKFLOW_CONVERSATION_PREFIX,
+    )
+      ? findReceiptByPlaceholder(requestedId)
+      : undefined;
+    if (placeholderReceipt?.conversationId) {
+      this.conversationAliases.set(requestedId, placeholderReceipt.conversationId);
+    }
+    let conversationId = this.canonicalConversationId(requestedId);
+    let stored = this.conversations.get(conversationId);
+    if (!stored && placeholderReceipt && !placeholderReceipt.conversationId) {
+      stored = this.syntheticPendingConversation(requestedId, {
+        identityPending: true,
+        stateVersion: placeholderReceipt.stateVersion,
+      });
+      this.conversations.set(requestedId, stored);
+      conversationId = requestedId;
+    }
+    if (!stored) {
+      const receipt = findReceiptByConversation(conversationId);
+      if (receipt) {
+        stored = this.syntheticPendingConversation(conversationId, {
+          projectionPending: true,
+          stateVersion: receipt.stateVersion,
+        });
+        this.conversations.set(conversationId, stored);
+      }
+    }
+
+    const existing = this.reconcileEntries.get(conversationId);
+    if (existing) {
+      existing.waiters += 1;
+      this.resumeReconcileEntry(existing);
+      return existing.promise;
+    }
+
+    if (stored?.projectionStalledAt !== undefined) {
+      stored.projectionStalledAt = undefined;
+      if (!stored.identityPending) stored.projectionPending = true;
+    }
+    const commandId =
+      placeholderReceipt?.commandId ??
+      findReceiptByConversation(conversationId)?.commandId;
+    const policy = stored?.identityPending
+      ? CREATE_RECOVERY_BACKOFF_POLICY
+      : PROJECTION_BACKOFF_POLICY;
+    let settle!: (outcome: ProjectionReconcileOutcome) => void;
+    const promise = new Promise<ProjectionReconcileOutcome>((resolve) => {
+      settle = resolve;
+    });
+    const entry: ReconcileEntry = {
+      promise,
+      settle,
+      scopeId,
+      placeholderId:
+        requestedId.startsWith(PENDING_WORKFLOW_CONVERSATION_PREFIX)
+          ? requestedId
+          : placeholderReceipt?.placeholderId,
+      conversationId,
+      commandId,
+      attempt: 0,
+      startedAt: this.now(),
+      deadlineAt: this.now() + policy.deadlineMs,
+      waiters: 1,
+      running: false,
+      finalObservationDue: false,
+    };
+    this.reconcileEntries.set(conversationId, entry);
+    this.resumeReconcileEntry(entry);
+    return promise;
+  }
+
+  releaseProjectionWaiter(requestedId: string): void {
+    this.ensureScope();
+    const conversationId = this.canonicalConversationId(requestedId);
+    const entry =
+      this.reconcileEntries.get(conversationId) ??
+      this.reconcileEntries.get(requestedId);
+    if (!entry) return;
+    entry.waiters = Math.max(0, entry.waiters - 1);
+    if (entry.waiters > 0) return;
+    if (entry.timer !== undefined) {
+      clearTimeout(entry.timer);
+      entry.timer = undefined;
+    }
+    if (entry.controller) {
+      entry.controller.abort();
+    } else {
+      entry.running = false;
+    }
+  }
+
+  private resumeReconcileEntry(entry: ReconcileEntry): void {
+    if (
+      entry.running ||
+      entry.timer !== undefined ||
+      entry.waiters === 0 ||
+      entry.scopeId !== this.ownerScopeId
+    ) {
+      return;
+    }
+    entry.running = true;
+    void this.runReconcileObservation(entry).catch(() => {
+      if (entry.scopeId !== this.ownerScopeId || entry.waiters === 0) return;
+      this.scheduleReconcileEntry(entry);
+    });
+  }
+
+  private async runReconcileObservation(entry: ReconcileEntry): Promise<void> {
+    if (entry.scopeId !== this.ownerScopeId || entry.waiters === 0) {
+      entry.running = false;
+      return;
+    }
+    if (
+      this.deletedConversationIds.has(entry.conversationId) ||
+      this.deletingConversations.has(entry.conversationId)
+    ) {
+      this.settleReconcileEntry(entry, "absent");
+      return;
+    }
+
+    const controller = this.scopeController();
+    entry.controller = controller;
+    let transcriptWasMissing = false;
+    let observedMembership: boolean | "unavailable" | undefined;
+    try {
+      const stored = this.conversations.get(entry.conversationId);
+      if (stored?.identityPending) {
+        if (!entry.commandId) {
+          this.settleReconcileEntry(entry, "timed_out");
+          return;
+        }
+        try {
+          const response = await assistantApi.get<AevatarCreateRecoveryResponse>(
+            `${ASSISTANT_PREFIX}/conversations/create-recovery/${encodeURIComponent(entry.commandId)}`,
+            controller.signal,
+          );
+          if (entry.scopeId !== this.ownerScopeId) return;
+          const recovered = this.decodeCreateRecovery(response);
+          this.adoptRecoveredReceipt(entry, stored, recovered);
+        } catch (error) {
+          if (controller.signal.aborted) return;
+          if (!(error instanceof ApiError && error.status === 404)) throw error;
+          transcriptWasMissing = true;
+        }
+      } else {
+        try {
+          const body = await assistantApi.get<AevatarHistoryResponse>(
+            `${ASSISTANT_PREFIX}/conversations/${entry.conversationId}`,
+            controller.signal,
+          );
+          if (entry.scopeId !== this.ownerScopeId) return;
+          const projected = this.applyHistoryResponse(entry.conversationId, body);
+          if (!projected.identityPending && !projected.projectionPending) {
+            this.settleReconcileEntry(entry, "materialized");
+            return;
+          }
+        } catch (error) {
+          if (controller.signal.aborted) return;
+          if (!(error instanceof ApiError && error.status === 404)) throw error;
+          transcriptWasMissing = true;
+        }
+      }
+
+      entry.attempt += 1;
+      const deadlineReached =
+        entry.finalObservationDue || this.now() >= entry.deadlineAt;
+      entry.finalObservationDue = false;
+      if (
+        !this.conversations.get(entry.conversationId)?.identityPending &&
+        transcriptWasMissing &&
+        (entry.attempt % 2 === 0 || deadlineReached)
+      ) {
+        const membership = await this.fetchRawIndexMembership(
+          entry.conversationId,
+          controller.signal,
+        );
+        observedMembership = membership;
+        if (entry.scopeId !== this.ownerScopeId) return;
+        if (membership === false) {
+          if (deadlineReached) {
+            this.tombstoneConversation(entry.conversationId);
+            this.settleReconcileEntry(entry, "absent");
+            return;
+          }
+          if (
+            entry.firstAbsentAt !== undefined &&
+            this.now() - entry.firstAbsentAt >= 10_000
+          ) {
+            this.tombstoneConversation(entry.conversationId);
+            this.settleReconcileEntry(entry, "absent");
+            return;
+          }
+          entry.firstAbsentAt ??= this.now();
+        } else if (membership === true) {
+          entry.firstAbsentAt = undefined;
+        }
+      }
+
+      if (deadlineReached) {
+        const identityPending =
+          this.conversations.get(entry.conversationId)?.identityPending === true;
+        const membership = identityPending
+          ? "unavailable"
+          : observedMembership ??
+            (await this.fetchRawIndexMembership(
+              entry.conversationId,
+              controller.signal,
+            ));
+        if (membership === false) {
+          this.tombstoneConversation(entry.conversationId);
+          this.settleReconcileEntry(entry, "absent");
+        } else {
+          this.settleReconcileEntry(entry, "timed_out");
+        }
+        return;
+      }
+    } finally {
+      if (entry.controller === controller) entry.controller = undefined;
+      this.releaseScopeController(controller);
+      entry.running = false;
+    }
+    this.scheduleReconcileEntry(entry);
+  }
+
+  private scheduleReconcileEntry(entry: ReconcileEntry): void {
+    if (
+      entry.scopeId !== this.ownerScopeId ||
+      entry.waiters === 0 ||
+      !this.reconcileEntries.has(entry.conversationId)
+    ) {
+      return;
+    }
+    const identityPending =
+      this.conversations.get(entry.conversationId)?.identityPending === true;
+    const policy = identityPending
+      ? CREATE_RECOVERY_BACKOFF_POLICY
+      : PROJECTION_BACKOFF_POLICY;
+    const delay = nextBackoffDelay(
+      policy,
+      Math.max(0, entry.attempt - 1),
+      this.random,
+    );
+    entry.timer = setTimeout(() => {
+      entry.timer = undefined;
+      entry.finalObservationDue = this.now() >= entry.deadlineAt;
+      this.resumeReconcileEntry(entry);
+    }, delay);
+  }
+
+  private adoptRecoveredReceipt(
+    entry: ReconcileEntry,
+    stored: StoredConversation,
+    recovery: ReturnType<AevatarAssistantTransport["decodeCreateRecovery"]>,
+  ): void {
+    const placeholderId = entry.placeholderId ?? entry.conversationId;
+    stored.conversation = {
+      ...stored.conversation,
+      id: recovery.conversationId,
+    };
+    stored.identityPending = false;
+    stored.projectionPending = true;
+    stored.requiredTurnId = recovery.turnId;
+    stored.stateVersion = Math.max(
+      stored.stateVersion ?? 0,
+      recovery.stateVersion,
+    );
+    stored.createRequest = undefined;
+    this.conversations.set(recovery.conversationId, stored);
+    this.conversations.set(placeholderId, stored);
+    this.conversationAliases.set(placeholderId, recovery.conversationId);
+    adoptReceiptIdentity(
+      entry.commandId ?? "",
+      recovery.conversationId,
+      recovery.stateVersion,
+      this.now(),
+    );
+    this.reconcileEntries.delete(entry.conversationId);
+    entry.conversationId = recovery.conversationId;
+    this.reconcileEntries.set(entry.conversationId, entry);
+  }
+
+  private settleReconcileEntry(
+    entry: ReconcileEntry,
+    status: ProjectionReconcileOutcome["status"],
+  ): void {
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    entry.controller?.abort();
+    const stored = this.conversations.get(entry.conversationId);
+    if (status === "timed_out" && stored) {
+      stored.projectionStalledAt = this.now();
+    }
+    this.reconcileEntries.delete(entry.conversationId);
+    if (entry.placeholderId) this.reconcileEntries.delete(entry.placeholderId);
+    entry.settle({ status, conversationId: entry.conversationId });
   }
 
   private appendOptimisticUserMessage(
@@ -1530,6 +2221,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     content: string,
     onEvent: (event: TurnEvent) => void,
   ): TurnHandle {
+    this.ensureScope();
     const requestedId = conversationId;
     conversationId = this.canonicalConversationId(conversationId);
     const stored = this.conversations.get(conversationId);
@@ -1564,6 +2256,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
           ? stored.createRequest.commandId
           : crypto.randomUUID();
       stored.createRequest = { prompt: normalized, commandId: clientRequestId };
+      stored.identityPending = true;
+      stored.projectionStalledAt = undefined;
+      recordCreateReceipt(clientRequestId, requestedId, this.now());
     }
     const run = this.newRun(onEvent, null, protocol, clientRequestId);
     this.running.set(conversationId, run);
@@ -1592,6 +2287,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
    * Stop needs a transport-level lookup to abort a hung request).
    */
   cancelActiveTurn(conversationId: string): void {
+    this.ensureScope();
     // A create-and-first-turn run is keyed under the placeholder id the send
     // used. Resolve forward and reverse so either the placeholder or the
     // canonical address can stop it, then cancel under the run's own key.
@@ -1623,6 +2319,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     approved: boolean,
     onEvent?: (event: TurnEvent) => void,
   ): Promise<TurnHandle | null> {
+    this.ensureScope();
     conversationId = this.canonicalConversationId(conversationId);
     if (this.deletingConversations.has(conversationId)) {
       throw new Error("This conversation is being deleted.");
@@ -1811,6 +2508,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     inProgress: boolean,
     onEvent: (event: TurnEvent) => void = noopEvent,
   ): void {
+    this.ensureScope();
     if (
       this.deletingConversations.has(
         this.canonicalConversationId(conversationId),
@@ -1847,6 +2545,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     note: string,
     onEvent: (event: TurnEvent) => void = noopEvent,
   ): void {
+    this.ensureScope();
     if (!this.conversations.has(conversationId)) {
       throw new Error("Conversation was not found.");
     }
@@ -1884,6 +2583,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     reports: readonly ActionReport[],
     onEvent: (event: TurnEvent) => void = noopEvent,
   ): TurnHandle | null {
+    this.ensureScope();
     if (!this.conversations.has(conversationId)) {
       throw new AssistantConversationNotFoundError();
     }
@@ -2020,6 +2720,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     originTurnId: string,
     onEvent: (event: TurnEvent) => void = noopEvent,
   ): TurnHandle {
+    this.ensureScope();
     const requestedId = conversationId;
     const actorId = this.canonicalConversationId(conversationId);
     const stored =
@@ -2303,6 +3004,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
    */
   private mergeIndexEntry(id: string, entry: AevatarHistoryIndexEntry): void {
     if (this.deletedConversationIds.has(id)) return;
+    if (
+      listDeletionIntents().some(
+        (intent) => intent.conversationId === id,
+      )
+    ) {
+      return;
+    }
     const existing = this.conversations.get(id);
     if (existing && isTurnActive(existing.turnState.activeTurn?.status)) {
       return;
@@ -2338,6 +3046,11 @@ export class AevatarAssistantTransport implements AssistantTransport {
       activityMessageTurnIds: existing?.activityMessageTurnIds ?? new Map(),
       lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion: existing?.stateVersion,
+      identityPending: existing?.identityPending,
+      projectionPending: existing?.projectionPending,
+      requiredTurnId: existing?.requiredTurnId,
+      materializedStateVersion: existing?.materializedStateVersion,
+      projectionStalledAt: existing?.projectionStalledAt,
       sessionId: existing?.sessionId,
       createRequest: existing?.createRequest,
     });
@@ -2370,11 +3083,16 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // The watermark is fresher than any stored one even when the transcript
     // below keeps the local mirror (keep-max), so capture it first.
     const freshStateVersion = historyStateVersion(body);
+    const preMergeFence = Math.max(
+      1,
+      positiveStateVersion(existing?.stateVersion) ?? 1,
+    );
     if (existing && freshStateVersion !== undefined) {
       existing.stateVersion = Math.max(
         existing.stateVersion ?? 0,
         freshStateVersion,
       );
+      advanceReceiptFence(conversationId, freshStateVersion, this.now());
     }
     const localMessages = existing?.turnState.messages ?? [];
     const localStructuredBlocks = structuredBlockCount(localMessages);
@@ -2387,19 +3105,29 @@ export class AevatarAssistantTransport implements AssistantTransport {
     const comparableLocalMessageCount = serverLacksLocalStructure
       ? localMessages.filter((message) => !hasStructuredBlocks(message)).length
       : localMessages.length;
-    if (existing && comparableLocalMessageCount > messages.length) {
-      return existing;
-    }
     const withinMaterializationGrace =
       existing?.lastLocalTurnCompletedAt !== undefined &&
       this.now() - existing.lastLocalTurnCompletedAt <=
         HISTORY_MATERIALIZATION_GRACE_MS;
+    if (existing && comparableLocalMessageCount > messages.length) {
+      const latestTurnId = this.latestAssistantTurnId(existing);
+      const canReplaceLongerLocal =
+        freshStateVersion !== undefined &&
+        freshStateVersion >= preMergeFence &&
+        !withinMaterializationGrace &&
+        historyIncludesAssistantTurn(entries, latestTurnId);
+      if (!canReplaceLongerLocal) {
+        this.applyMaterializationObservation(existing, body, entries);
+        return existing;
+      }
+    }
     if (
       existing &&
       serverLacksLocalStructure &&
       comparableLocalMessageCount === messages.length &&
       withinMaterializationGrace
     ) {
+      this.applyMaterializationObservation(existing, body, entries);
       return existing;
     }
     const projectedMessages =
@@ -2437,11 +3165,46 @@ export class AevatarAssistantTransport implements AssistantTransport {
         freshStateVersion === undefined
           ? existing?.stateVersion
           : Math.max(existing?.stateVersion ?? 0, freshStateVersion),
+      identityPending: existing?.identityPending,
+      projectionPending: existing?.projectionPending,
+      requiredTurnId: existing?.requiredTurnId,
+      materializedStateVersion: existing?.materializedStateVersion,
+      projectionStalledAt: existing?.projectionStalledAt,
       sessionId: existing?.sessionId,
       createRequest: existing?.createRequest,
     };
+    this.applyMaterializationObservation(stored, body, entries);
     this.conversations.set(conversationId, stored);
     return stored;
+  }
+
+  private applyMaterializationObservation(
+    stored: StoredConversation,
+    body: AevatarHistoryResponse,
+    entries: readonly AevatarHistoryEntry[],
+  ): void {
+    const freshStateVersion = historyStateVersion(body);
+    const containsRequiredTurn = historyIncludesAssistantTurn(
+      entries,
+      stored.requiredTurnId ?? null,
+    );
+    const fenceSatisfied =
+      freshStateVersion === undefined
+        ? Array.isArray(body) && containsRequiredTurn
+        : freshStateVersion >=
+          Math.max(1, positiveStateVersion(stored.stateVersion) ?? 1);
+    if (!fenceSatisfied || !containsRequiredTurn) return;
+    stored.identityPending = false;
+    stored.projectionPending = false;
+    stored.projectionStalledAt = undefined;
+    if (freshStateVersion !== undefined) {
+      stored.materializedStateVersion = Math.max(
+        stored.materializedStateVersion ?? 0,
+        freshStateVersion,
+      );
+    }
+    const receipt = findReceiptByConversation(stored.conversation.id);
+    if (receipt) retireReceiptAfterMaterialization(receipt.commandId, this.now());
   }
 
   private newRun(
@@ -2509,6 +3272,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
         run.streamDispatched
       ) {
         stored.lastLocalTurnCompletedAt = this.now();
+        if (
+          run.protocol === "workflow" &&
+          (stored.identityPending === true ||
+            stored.conversation.id.startsWith(WORKFLOW_CONVERSATION_PREFIX))
+        ) {
+          stored.projectionPending = true;
+          stored.requiredTurnId = run.turnId;
+          stored.projectionStalledAt = undefined;
+        }
       }
       stored.conversation = {
         ...stored.conversation,
@@ -2750,12 +3522,21 @@ export class AevatarAssistantTransport implements AssistantTransport {
       ...stored.conversation,
       id: recovery.conversationId,
     };
+    stored.identityPending = false;
+    stored.projectionPending = true;
+    stored.requiredTurnId = recovery.turnId;
     stored.stateVersion = Math.max(
       stored.stateVersion ?? 0,
       recovery.stateVersion,
       reconciled.stateVersion,
     );
     stored.createRequest = undefined;
+    adoptReceiptIdentity(
+      run.clientRequestId,
+      recovery.conversationId,
+      recovery.stateVersion,
+      this.now(),
+    );
     this.conversations.set(recovery.conversationId, stored);
     this.conversationAliases.set(conversationId, recovery.conversationId);
     if (this.activeConversationId === conversationId) {
@@ -2779,12 +3560,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (run.createRecoveryStarted || run.protocol !== "workflow") return;
     if (!this.workflowCreateNeedsRecovery(conversationId)) return;
     run.createRecoveryStarted = true;
-    const recoveryController = new AbortController();
+    const recoveryController = this.scopeController();
     void this.recoverWorkflowCreate(
       conversationId,
       run,
       recoveryController.signal,
-    ).catch(() => undefined);
+    )
+      .catch(() => undefined)
+      .finally(() => this.releaseScopeController(recoveryController));
   }
 
   private workflowCreateNeedsRecovery(conversationId: string): boolean {
@@ -2848,7 +3631,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
         finalFailure = { code: response.code, message: response.message };
         if (isCreate && this.workflowCreateNeedsRecovery(conversationId)) {
           run.createRecoveryStarted = true;
-          const recoveryController = new AbortController();
+          const recoveryController = this.scopeController();
           try {
             if (
               await this.recoverWorkflowCreate(
@@ -2867,6 +3650,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
                 message: error.message,
               };
             }
+          } finally {
+            this.releaseScopeController(recoveryController);
           }
         }
         break;
@@ -2922,6 +3707,17 @@ export class AevatarAssistantTransport implements AssistantTransport {
           if (refreshed) continue;
           if (refreshFailed) break;
         }
+        if (
+          isCreate &&
+          (response.status === 400 ||
+            response.status === 401 ||
+            response.status === 403 ||
+            response.status === 422)
+        ) {
+          stored.identityPending = false;
+          stored.projectionPending = false;
+          deleteReceipt(run.clientRequestId);
+        }
         finalFailure = error;
         break;
       }
@@ -2935,7 +3731,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
         result.kind === "retryable"
       ) {
         run.createRecoveryStarted = true;
-        const recoveryController = new AbortController();
+        const recoveryController = this.scopeController();
         try {
           if (
             await this.recoverWorkflowCreate(
@@ -2954,6 +3750,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
               message: error.message,
             };
           }
+        } finally {
+          this.releaseScopeController(recoveryController);
         }
       }
       break;
@@ -3862,10 +4660,13 @@ export class AevatarAssistantTransport implements AssistantTransport {
       return;
     }
     if (stored && serverId && stored.conversation.id !== serverId) {
+      const commandId = stored.createRequest?.commandId ?? run.clientRequestId;
       stored.conversation = { ...stored.conversation, id: serverId };
+      stored.identityPending = false;
       stored.createRequest = undefined;
       this.conversations.set(serverId, stored);
       this.conversationAliases.set(conversationId, serverId);
+      adoptReceiptIdentity(commandId, serverId, undefined, this.now());
       if (this.activeConversationId === conversationId) {
         this.activeConversationId = serverId;
       }
@@ -3883,6 +4684,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
     if (stored && stateVersion > 0) {
       stored.stateVersion = Math.max(stored.stateVersion ?? 0, stateVersion);
+      advanceReceiptFence(serverId ?? stored.conversation.id, stateVersion);
     }
 
     if (run.deliveryStarted) return;
@@ -3904,6 +4706,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       };
       return;
     }
+    if (stored) stored.requiredTurnId = turnId;
     run.deliveryStarted = true;
     run.turnId ??= turnId;
     if (!run.turnAnnounced) {
@@ -4751,6 +5554,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
       // a run-actor id; cancellation cannot prove the create was rejected.
       if (run.streamDispatched) {
         this.startCreateRecoveryInBackground(conversationId, run);
+      } else {
+        const stored = this.conversations.get(conversationId);
+        if (stored?.identityPending) {
+          stored.identityPending = false;
+          deleteReceipt(run.clientRequestId);
+        }
       }
       run.controller.abort();
     } else if (run.turnId) {
@@ -4857,7 +5666,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // wait). A manual controller instead of AbortSignal.timeout so this
     // never throws on an environment that lacks the static — the deferred
     // placeholder release depends on this call not throwing.
-    const deadline = new AbortController();
+    const deadline = this.scopeController();
     const deadlineTimer = setTimeout(
       () => deadline.abort(),
       STOP_REQUEST_DEADLINE_MS,
@@ -4876,8 +5685,14 @@ export class AevatarAssistantTransport implements AssistantTransport {
       signal: deadline.signal,
       ...assistantWireLogOptions(),
     }).then(
-      () => clearTimeout(deadlineTimer),
-      () => clearTimeout(deadlineTimer),
+      () => {
+        clearTimeout(deadlineTimer);
+        this.releaseScopeController(deadline);
+      },
+      () => {
+        clearTimeout(deadlineTimer);
+        this.releaseScopeController(deadline);
+      },
     );
     this.trackFence(actorConversationId, pending);
     return pending;

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -2050,6 +2050,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     entry.controller = controller;
     let transcriptWasMissing = false;
     let observedMembership: boolean | "unavailable" | undefined;
+    let rescheduleAfterTurn = false;
     try {
       const stored = this.conversations.get(entry.conversationId);
       if (stored?.identityPending) {
@@ -2077,6 +2078,23 @@ export class AevatarAssistantTransport implements AssistantTransport {
             controller.signal,
           );
           if (entry.scopeId !== this.ownerScopeId) return;
+          const postFetchStored = this.conversations.get(entry.conversationId);
+          const postFetchTurnInFlight =
+            this.running.has(entry.conversationId) ||
+            (entry.placeholderId !== undefined &&
+              this.running.has(entry.placeholderId));
+          if (
+            postFetchStored &&
+            (postFetchTurnInFlight ||
+              isTurnActive(postFetchStored.turnState.activeTurn?.status))
+          ) {
+            const policy = postFetchStored.identityPending
+              ? CREATE_RECOVERY_BACKOFF_POLICY
+              : PROJECTION_BACKOFF_POLICY;
+            entry.deadlineAt = this.now() + policy.deadlineMs;
+            rescheduleAfterTurn = true;
+            return;
+          }
           const projected = this.applyHistoryResponse(entry.conversationId, body);
           if (!projected.identityPending && !projected.projectionPending) {
             this.settleReconcileEntry(entry, "materialized");
@@ -2146,6 +2164,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       if (entry.controller === controller) entry.controller = undefined;
       this.releaseScopeController(controller);
       entry.running = false;
+      if (rescheduleAfterTurn) this.scheduleReconcileEntry(entry);
     }
     this.scheduleReconcileEntry(entry);
   }

--- a/frontend/src/lib/assistant/backoff.test.ts
+++ b/frontend/src/lib/assistant/backoff.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROJECTION_BACKOFF_POLICY,
+  nextBackoffDelay,
+} from "./backoff";
+
+describe("assistant projection backoff", () => {
+  it("floors every delay when random returns zero", () => {
+    expect(
+      Array.from({ length: 12 }, (_, attempt) =>
+        nextBackoffDelay(PROJECTION_BACKOFF_POLICY, attempt, () => 0),
+      ),
+    ).toEqual(Array.from({ length: 12 }, () => 250));
+  });
+
+  it("caps exponential delays and can span the policy deadline", () => {
+    const delays = Array.from({ length: 12 }, (_, attempt) =>
+      nextBackoffDelay(PROJECTION_BACKOFF_POLICY, attempt, () => 0.999999),
+    );
+    expect(Math.max(...delays)).toBeLessThanOrEqual(30_000);
+    expect(delays.reduce((sum, delay) => sum + delay, 0)).toBeGreaterThan(
+      PROJECTION_BACKOFF_POLICY.deadlineMs,
+    );
+  });
+
+  it("does not let an out-of-range random sample escape policy bounds", () => {
+    expect(nextBackoffDelay(PROJECTION_BACKOFF_POLICY, 0, () => -10)).toBe(
+      250,
+    );
+    expect(nextBackoffDelay(PROJECTION_BACKOFF_POLICY, 20, () => 10)).toBe(
+      30_000,
+    );
+  });
+});

--- a/frontend/src/lib/assistant/backoff.ts
+++ b/frontend/src/lib/assistant/backoff.ts
@@ -1,0 +1,33 @@
+export interface BackoffPolicy {
+  readonly floorMs: number;
+  readonly baseMs: number;
+  readonly capMs: number;
+  readonly deadlineMs: number;
+}
+
+export const PROJECTION_BACKOFF_POLICY: BackoffPolicy = {
+  floorMs: 250,
+  baseMs: 500,
+  capMs: 30_000,
+  deadlineMs: 90_000,
+};
+
+export const CREATE_RECOVERY_BACKOFF_POLICY: BackoffPolicy = {
+  floorMs: 250,
+  baseMs: 500,
+  capMs: 8_000,
+  deadlineMs: 60_000,
+};
+
+export function nextBackoffDelay(
+  policy: BackoffPolicy,
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const ceiling = Math.max(
+    policy.floorMs,
+    Math.min(policy.capMs, policy.baseMs * 2 ** Math.max(0, attempt)),
+  );
+  const sample = Math.min(1, Math.max(0, random()));
+  return Math.round(policy.floorMs + sample * (ceiling - policy.floorMs));
+}

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -100,6 +100,14 @@ class MockAssistantTransport implements AssistantTransport {
     return assistantMockStore.getHistory(conversationId);
   }
 
+  async reconcileProjection(conversationId: string) {
+    return { status: "materialized" as const, conversationId };
+  }
+
+  releaseProjectionWaiter(conversationId: string): void {
+    void conversationId;
+  }
+
   async deleteConversation(conversationId: string): Promise<void> {
     for (const address of assistantMockStore.conversationAddresses(
       conversationId,

--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -21,6 +21,7 @@ const {
   mockContinueAction,
   mockDeleteMutateAsync,
   mockSendMutateAsync,
+  mockRetryProjection,
   mockToastError,
   state,
 } = vi.hoisted(() => ({
@@ -31,6 +32,7 @@ const {
   mockContinueAction: vi.fn(),
   mockDeleteMutateAsync: vi.fn(),
   mockSendMutateAsync: vi.fn(),
+  mockRetryProjection: vi.fn(),
   mockToastError: vi.fn(),
   state: {
     pathname: "/assistant",
@@ -39,6 +41,8 @@ const {
     conversationsResolved: true,
     historyError: undefined as unknown,
     historyCanonicalId: undefined as string | undefined,
+    historyAwaitingProjection: false,
+    historyProjectionStalled: false,
     turnStatus: null as
       | "queued"
       | "running"
@@ -138,12 +142,18 @@ vi.mock("@/hooks/use-assistant", () => ({
           },
           messages: state.historyMessages,
           has_more: false,
+          awaitingProjection: state.historyAwaitingProjection,
+          projectionStalled: state.historyProjectionStalled,
         }
       : undefined,
     isLoading: false,
     isFetching: false,
     isError: state.historyError !== undefined,
     error: state.historyError,
+  }),
+  useRetryConversationProjection: () => ({
+    mutate: mockRetryProjection,
+    isPending: false,
   }),
   useAssistantTurn: () => ({
     data:
@@ -269,6 +279,8 @@ beforeEach(() => {
   state.conversationsResolved = true;
   state.historyError = undefined;
   state.historyCanonicalId = undefined;
+  state.historyAwaitingProjection = false;
+  state.historyProjectionStalled = false;
   state.turnStatus = null;
   state.sendPending = undefined;
   state.cancelPending = false;
@@ -286,6 +298,38 @@ beforeEach(() => {
     lastScreen: null,
   });
   useAssistantDraftStore.setState({ ownerUserId: user.id, drafts: {} });
+});
+
+describe("AssistantPage projection status", () => {
+  it("renders a syncing notice instead of a transcript error", () => {
+    state.search = { c: existingConversation.id };
+    state.historyAwaitingProjection = true;
+
+    renderPage();
+
+    expect(
+      screen.getByText("Syncing conversation history..."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/You can keep chatting/)).not.toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("renders a stalled notice whose retry action restarts reconciliation", async () => {
+    const event = userEvent.setup();
+    state.search = { c: existingConversation.id };
+    state.historyProjectionStalled = true;
+
+    renderPage();
+    await event.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      screen.getByText("History is taking longer than expected."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Syncing conversation history..."),
+    ).not.toBeInTheDocument();
+    expect(mockRetryProjection).toHaveBeenCalledOnce();
+  });
 });
 
 describe("AssistantPage new chat", () => {

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { toast } from "sonner";
+import { RefreshCw } from "lucide-react";
 import { AssistantShell } from "@/components/assistant/assistant-shell";
 import { AssistantSidebar } from "@/components/assistant/assistant-sidebar";
 import { ChatComposer } from "@/components/assistant/chat-composer";
@@ -17,6 +18,7 @@ import {
   useActionCardActions,
   useCancelTurn,
   useConversation,
+  useRetryConversationProjection,
   useConversations,
   useDecideApproval,
   useDeleteConversation,
@@ -140,6 +142,7 @@ export function AssistantPage({
   const selectedId =
     !drafting && selectedFromSearch ? selectedFromSearch : undefined;
   const history = useConversation(selectedId);
+  const retryProjection = useRetryConversationProjection(selectedId);
   const turn = useAssistantTurn(selectedId);
   const episode = useTurnEpisode(selectedId);
   const sendMessage = useSendMessage(selectedId);
@@ -498,6 +501,30 @@ export function AssistantPage({
       headerActions={<AssistantWireLogAction />}
     >
       <div className="relative flex h-full min-h-0 flex-col bg-background">
+        {history.data?.projectionStalled ? (
+          <div
+            role="status"
+            className="flex items-center justify-center gap-2 border-b border-border/60 bg-muted/30 px-6 py-2 text-[12px] text-text-secondary"
+          >
+            <span>History is taking longer than expected.</span>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 text-foreground underline-offset-2 hover:underline disabled:opacity-50"
+              disabled={retryProjection.isPending}
+              onClick={() => retryProjection.mutate()}
+            >
+              <RefreshCw className="size-3" aria-hidden="true" />
+              Retry
+            </button>
+          </div>
+        ) : history.data?.awaitingProjection ? (
+          <div
+            role="status"
+            className="border-b border-border/60 bg-muted/30 px-6 py-2 text-center text-[12px] text-text-secondary"
+          >
+            Syncing conversation history...
+          </div>
+        ) : null}
         {/* A failed transcript read is REPORTED, never blocking. It used to
             replace the whole thread, which also took the composer's context
             away and made the chat look dead — even though sending still

--- a/frontend/src/schemas/assistant-receipts.test.ts
+++ b/frontend/src/schemas/assistant-receipts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { parseAssistantReceiptState } from "./assistant-receipts";
+
+const NOW = Date.parse("2026-08-04T00:00:00.000Z");
+
+describe("assistant receipt schema", () => {
+  it("parses a persisted blob and drops malformed child entries", () => {
+    const parsed = parseAssistantReceiptState(
+      {
+        version: 1,
+        ownerUserId: "user-a",
+        receipts: {
+          good: {
+            placeholderId: "workflow-pending-a",
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+          bad: { placeholderId: "" },
+        },
+        deletionIntents: {
+          good: { placeholderId: "workflow-pending-b", createdAt: NOW },
+          bad: { placeholderId: 4, createdAt: NOW },
+        },
+      },
+      NOW,
+    );
+
+    expect(Object.keys(parsed?.receipts ?? {})).toEqual(["good"]);
+    expect(Object.keys(parsed?.deletionIntents ?? {})).toEqual(["good"]);
+  });
+
+  it.each([0, -1, Number.MAX_SAFE_INTEGER + 1, 1.5])(
+    "rejects the unusable stateVersion %s",
+    (stateVersion) => {
+      const parsed = parseAssistantReceiptState(
+        {
+          version: 1,
+          ownerUserId: "user-a",
+          receipts: {
+            bad: {
+              placeholderId: "workflow-pending-a",
+              stateVersion,
+              createdAt: NOW,
+              updatedAt: NOW,
+            },
+          },
+          deletionIntents: {},
+        },
+        NOW,
+      );
+      expect(parsed?.receipts).toEqual({});
+    },
+  );
+
+  it("drops invalid timestamps and clamps timestamps far in the future", () => {
+    const parsed = parseAssistantReceiptState(
+      {
+        version: 1,
+        ownerUserId: "user-a",
+        receipts: {
+          invalid: {
+            placeholderId: "workflow-pending-invalid",
+            createdAt: -1,
+            updatedAt: NOW,
+          },
+          future: {
+            placeholderId: "workflow-pending-future",
+            createdAt: NOW + 10 * 60_000,
+            updatedAt: NOW + 10 * 60_000,
+          },
+        },
+        deletionIntents: {},
+      },
+      NOW,
+    );
+
+    expect(parsed?.receipts.invalid).toBeUndefined();
+    expect(parsed?.receipts.future).toMatchObject({
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  });
+});

--- a/frontend/src/schemas/assistant-receipts.ts
+++ b/frontend/src/schemas/assistant-receipts.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+export const ASSISTANT_RECEIPT_VERSION = 1 as const;
+
+const persistedReceiptSchema = z.object({
+  placeholderId: z.string().min(1),
+  conversationId: z.string().min(1).optional(),
+  stateVersion: z.number().int().positive().safe().optional(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+const persistedDeletionIntentSchema = z.object({
+  placeholderId: z.string().min(1),
+  conversationId: z.string().min(1).optional(),
+  createdAt: z.number(),
+});
+
+const persistedAssistantReceiptsEnvelopeSchema = z.object({
+  version: z.literal(ASSISTANT_RECEIPT_VERSION),
+  ownerUserId: z.string().min(1).nullable(),
+  receipts: z.record(z.string(), z.unknown()),
+  deletionIntents: z.record(z.string(), z.unknown()),
+});
+
+export type AssistantCreateReceipt = z.infer<typeof persistedReceiptSchema>;
+export type AssistantDeletionIntent = z.infer<
+  typeof persistedDeletionIntentSchema
+>;
+
+export interface AssistantReceiptState {
+  readonly version: typeof ASSISTANT_RECEIPT_VERSION;
+  readonly ownerUserId: string | null;
+  readonly receipts: Record<string, AssistantCreateReceipt>;
+  readonly deletionIntents: Record<string, AssistantDeletionIntent>;
+}
+
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
+
+function normalizeTimestamp(value: number, now: number): number | undefined {
+  if (!Number.isFinite(value) || value < 0) return undefined;
+  return value > now + MAX_FUTURE_SKEW_MS ? now : value;
+}
+
+export function emptyAssistantReceiptState(
+  ownerUserId: string | null,
+): AssistantReceiptState {
+  return {
+    version: ASSISTANT_RECEIPT_VERSION,
+    ownerUserId,
+    receipts: {},
+    deletionIntents: {},
+  };
+}
+
+/** Parse the durable envelope while dropping only malformed child entries. */
+export function parseAssistantReceiptState(
+  value: unknown,
+  now: number = Date.now(),
+): AssistantReceiptState | undefined {
+  const envelope = persistedAssistantReceiptsEnvelopeSchema.safeParse(value);
+  if (!envelope.success) return undefined;
+
+  const receipts: Record<string, AssistantCreateReceipt> = {};
+  for (const [commandId, candidate] of Object.entries(envelope.data.receipts)) {
+    const parsed = persistedReceiptSchema.safeParse(candidate);
+    if (!parsed.success) continue;
+    const createdAt = normalizeTimestamp(parsed.data.createdAt, now);
+    const updatedAt = normalizeTimestamp(parsed.data.updatedAt, now);
+    if (createdAt === undefined || updatedAt === undefined) continue;
+    receipts[commandId] = { ...parsed.data, createdAt, updatedAt };
+  }
+
+  const deletionIntents: Record<string, AssistantDeletionIntent> = {};
+  for (const [commandId, candidate] of Object.entries(
+    envelope.data.deletionIntents,
+  )) {
+    const parsed = persistedDeletionIntentSchema.safeParse(candidate);
+    if (!parsed.success) continue;
+    const createdAt = normalizeTimestamp(parsed.data.createdAt, now);
+    if (createdAt === undefined) continue;
+    deletionIntents[commandId] = { ...parsed.data, createdAt };
+  }
+
+  return {
+    version: ASSISTANT_RECEIPT_VERSION,
+    ownerUserId: envelope.data.ownerUserId,
+    receipts,
+    deletionIntents,
+  };
+}

--- a/frontend/src/stores/assistant-receipt-store.test.ts
+++ b/frontend/src/stores/assistant-receipt-store.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { User } from "@/types/api";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  adoptReceiptIdentity,
+  advanceReceiptFence,
+  deleteReceipt,
+  findReceiptByConversation,
+  findReceiptByPlaceholder,
+  listDeletionIntents,
+  recordCreateReceipt,
+  recordDeletionIntent,
+  resetAssistantReceiptStoreForTests,
+  retireReceiptAfterMaterialization,
+} from "./assistant-receipt-store";
+
+const user = (id: string) => ({ id }) as User;
+
+describe("assistant receipt store", () => {
+  beforeEach(() => {
+    useAuthStore.getState().setUser(null);
+    localStorage.clear();
+    resetAssistantReceiptStoreForTests();
+    useAuthStore.getState().setUser(user("user-a"));
+  });
+
+  it("records, adopts, and advances a receipt without decreasing its fence", () => {
+    const now = Date.now();
+    recordCreateReceipt("command-a", "workflow-pending-a", now);
+    adoptReceiptIdentity("command-a", "chatc-a", 3, now + 100);
+    advanceReceiptFence("chatc-a", 2, now + 200);
+
+    expect(findReceiptByPlaceholder("workflow-pending-a")).toMatchObject({
+      commandId: "command-a",
+      conversationId: "chatc-a",
+      stateVersion: 3,
+      createdAt: now,
+      updatedAt: now + 200,
+    });
+    expect(findReceiptByConversation("chatc-a")?.stateVersion).toBe(3);
+  });
+
+  it("deletes a definitive receipt without touching its deletion intent", () => {
+    recordCreateReceipt("command-a", "workflow-pending-a");
+    recordDeletionIntent("delete-a", "workflow-pending-delete");
+    deleteReceipt("command-a");
+
+    expect(findReceiptByPlaceholder("workflow-pending-a")).toBeUndefined();
+    expect(listDeletionIntents()).toHaveLength(1);
+  });
+
+  it("retires a materialized receipt after its retention floor", async () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.now();
+      recordCreateReceipt("command-a", "workflow-pending-a", now);
+      retireReceiptAfterMaterialization("command-a", now);
+
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(findReceiptByPlaceholder("workflow-pending-a")).toBeDefined();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(findReceiptByPlaceholder("workflow-pending-a")).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("separates accounts and preserves outgoing deletion intents", () => {
+    recordCreateReceipt("command-a", "workflow-pending-a");
+    recordDeletionIntent("delete-a", "workflow-pending-delete-a");
+
+    useAuthStore.getState().setUser(user("user-b"));
+    expect(findReceiptByPlaceholder("workflow-pending-a")).toBeUndefined();
+    expect(listDeletionIntents()).toEqual([]);
+    recordCreateReceipt("command-b", "workflow-pending-b");
+
+    useAuthStore.getState().setUser(user("user-a"));
+    expect(findReceiptByPlaceholder("workflow-pending-a")).toBeDefined();
+    expect(findReceiptByPlaceholder("workflow-pending-b")).toBeUndefined();
+    expect(listDeletionIntents()[0]?.commandId).toBe("delete-a");
+  });
+
+  it("evicts expired and over-cap receipts independently from intents", () => {
+    const now = Date.now();
+    recordCreateReceipt("expired", "workflow-pending-expired", now - 86_400_001);
+    for (let index = 0; index < 22; index += 1) {
+      recordCreateReceipt(
+        `command-${String(index)}`,
+        `workflow-pending-${String(index)}`,
+        now + index,
+      );
+    }
+    recordDeletionIntent("delete-a", "workflow-pending-delete", undefined, now);
+
+    expect(findReceiptByPlaceholder("workflow-pending-expired")).toBeUndefined();
+    const persisted = JSON.parse(
+      localStorage.getItem("nyxid.assistant_receipts.v1.user-a") ?? "{}",
+    ) as { receipts?: Record<string, unknown> };
+    expect(Object.keys(persisted.receipts ?? {})).toHaveLength(20);
+    expect(listDeletionIntents()).toHaveLength(1);
+  });
+
+  it("keeps working in memory when browser storage throws", () => {
+    const original = globalThis.localStorage;
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("disabled");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    });
+    resetAssistantReceiptStoreForTests();
+
+    expect(() =>
+      recordCreateReceipt("command-a", "workflow-pending-a"),
+    ).not.toThrow();
+    expect(findReceiptByPlaceholder("workflow-pending-a")).toBeDefined();
+    vi.stubGlobal("localStorage", original);
+  });
+
+  it("rehydrates current-account evidence from a storage event", () => {
+    const key = "nyxid.assistant_receipts.v1.user-a";
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: 1,
+        ownerUserId: "user-a",
+        receipts: {
+          remote: {
+            placeholderId: "workflow-pending-remote",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        },
+        deletionIntents: {},
+      }),
+    );
+    window.dispatchEvent(new StorageEvent("storage", { key }));
+
+    expect(
+      findReceiptByPlaceholder("workflow-pending-remote")?.commandId,
+    ).toBe("remote");
+  });
+});

--- a/frontend/src/stores/assistant-receipt-store.test.ts
+++ b/frontend/src/stores/assistant-receipt-store.test.ts
@@ -55,6 +55,8 @@ describe("assistant receipt store", () => {
       const now = Date.now();
       recordCreateReceipt("command-a", "workflow-pending-a", now);
       retireReceiptAfterMaterialization("command-a", now);
+      retireReceiptAfterMaterialization("command-a", now);
+      expect(vi.getTimerCount()).toBe(1);
 
       await vi.advanceTimersByTimeAsync(59_999);
       expect(findReceiptByPlaceholder("workflow-pending-a")).toBeDefined();

--- a/frontend/src/stores/assistant-receipt-store.ts
+++ b/frontend/src/stores/assistant-receipt-store.ts
@@ -1,0 +1,271 @@
+import {
+  emptyAssistantReceiptState,
+  parseAssistantReceiptState,
+  type AssistantCreateReceipt,
+  type AssistantDeletionIntent,
+  type AssistantReceiptState,
+} from "@/schemas/assistant-receipts";
+import { useAuthStore } from "@/stores/auth-store";
+
+const STORAGE_PREFIX = "nyxid.assistant_receipts.v1.";
+const RECEIPT_TTL_MS = 24 * 60 * 60 * 1_000;
+const RECEIPT_CAP = 20;
+const DELETION_INTENT_CAP = 10;
+
+let activeOwnerUserId = useAuthStore.getState().user?.id ?? null;
+const memoryByOwner = new Map<string, AssistantReceiptState>();
+
+function storageKey(ownerUserId: string): string {
+  return `${STORAGE_PREFIX}${encodeURIComponent(ownerUserId)}`;
+}
+
+function readStorage(ownerUserId: string): AssistantReceiptState | undefined {
+  try {
+    if (typeof localStorage === "undefined") return undefined;
+    const raw = localStorage.getItem(storageKey(ownerUserId));
+    if (!raw) return undefined;
+    const parsed = parseAssistantReceiptState(JSON.parse(raw));
+    return parsed?.ownerUserId === ownerUserId ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pruneState(
+  state: AssistantReceiptState,
+  now: number,
+): AssistantReceiptState {
+  const receipts = Object.fromEntries(
+    Object.entries(state.receipts)
+      .filter(([, receipt]) => now - receipt.updatedAt <= RECEIPT_TTL_MS)
+      .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+      .slice(0, RECEIPT_CAP),
+  );
+  const deletionIntents = Object.fromEntries(
+    Object.entries(state.deletionIntents)
+      .filter(([, intent]) => now - intent.createdAt <= RECEIPT_TTL_MS)
+      .sort(([, left], [, right]) => right.createdAt - left.createdAt)
+      .slice(0, DELETION_INTENT_CAP),
+  );
+  return { ...state, receipts, deletionIntents };
+}
+
+function loadOwner(ownerUserId: string): AssistantReceiptState {
+  const cached = memoryByOwner.get(ownerUserId);
+  const state = pruneState(
+    cached ??
+      readStorage(ownerUserId) ??
+      emptyAssistantReceiptState(ownerUserId),
+    Date.now(),
+  );
+  memoryByOwner.set(ownerUserId, state);
+  return state;
+}
+
+function persist(state: AssistantReceiptState): void {
+  const ownerUserId = state.ownerUserId;
+  if (!ownerUserId) return;
+  const pruned = pruneState(state, Date.now());
+  memoryByOwner.set(ownerUserId, pruned);
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(storageKey(ownerUserId), JSON.stringify(pruned));
+    }
+  } catch {
+    // The in-memory namespace remains authoritative for this tab.
+  }
+}
+
+function activeState(): AssistantReceiptState | undefined {
+  const ownerUserId = activeOwnerUserId;
+  if (!ownerUserId) return undefined;
+  return loadOwner(ownerUserId);
+}
+
+function updateActive(
+  update: (state: AssistantReceiptState) => AssistantReceiptState,
+): void {
+  const current = activeState();
+  if (!current || current.ownerUserId !== activeOwnerUserId) return;
+  persist(update(current));
+}
+
+function deleteReceiptForOwner(ownerUserId: string, commandId: string): void {
+  const state = loadOwner(ownerUserId);
+  if (!(commandId in state.receipts)) return;
+  const receipts = { ...state.receipts };
+  delete receipts[commandId];
+  persist({ ...state, receipts });
+}
+
+export function recordCreateReceipt(
+  commandId: string,
+  placeholderId: string,
+  now: number = Date.now(),
+): void {
+  updateActive((state) => ({
+    ...state,
+    receipts: {
+      ...state.receipts,
+      [commandId]: {
+        placeholderId,
+        createdAt: state.receipts[commandId]?.createdAt ?? now,
+        updatedAt: now,
+      },
+    },
+  }));
+}
+
+export function adoptReceiptIdentity(
+  commandId: string,
+  conversationId: string,
+  stateVersion?: number,
+  now: number = Date.now(),
+): void {
+  updateActive((state) => {
+    const receipt = state.receipts[commandId];
+    if (!receipt) return state;
+    const usableFence =
+      Number.isSafeInteger(stateVersion) && (stateVersion ?? 0) > 0
+        ? stateVersion
+        : undefined;
+    return {
+      ...state,
+      receipts: {
+        ...state.receipts,
+        [commandId]: {
+          ...receipt,
+          conversationId,
+          stateVersion:
+            usableFence === undefined
+              ? receipt.stateVersion
+              : Math.max(receipt.stateVersion ?? 0, usableFence),
+          updatedAt: now,
+        },
+      },
+    };
+  });
+}
+
+export function advanceReceiptFence(
+  conversationId: string,
+  stateVersion: number,
+  now: number = Date.now(),
+): void {
+  if (!Number.isSafeInteger(stateVersion) || stateVersion <= 0) return;
+  updateActive((state) => {
+    const match = Object.entries(state.receipts).find(
+      ([, receipt]) => receipt.conversationId === conversationId,
+    );
+    if (!match) return state;
+    const [commandId, receipt] = match;
+    return {
+      ...state,
+      receipts: {
+        ...state.receipts,
+        [commandId]: {
+          ...receipt,
+          stateVersion: Math.max(receipt.stateVersion ?? 0, stateVersion),
+          updatedAt: now,
+        },
+      },
+    };
+  });
+}
+
+export function deleteReceipt(commandId: string): void {
+  updateActive((state) => {
+    if (!(commandId in state.receipts)) return state;
+    const receipts = { ...state.receipts };
+    delete receipts[commandId];
+    return { ...state, receipts };
+  });
+}
+
+export function retireReceiptAfterMaterialization(
+  commandId: string,
+  now: number = Date.now(),
+): void {
+  const ownerUserId = activeOwnerUserId;
+  const receipt = activeState()?.receipts[commandId];
+  if (!ownerUserId || !receipt) return;
+  const delayMs = Math.max(0, receipt.createdAt + 60_000 - now);
+  setTimeout(() => deleteReceiptForOwner(ownerUserId, commandId), delayMs);
+}
+
+export function findReceiptByPlaceholder(
+  placeholderId: string,
+): (AssistantCreateReceipt & { readonly commandId: string }) | undefined {
+  const match = Object.entries(activeState()?.receipts ?? {}).find(
+    ([, receipt]) => receipt.placeholderId === placeholderId,
+  );
+  return match ? { commandId: match[0], ...match[1] } : undefined;
+}
+
+export function findReceiptByConversation(
+  conversationId: string,
+): (AssistantCreateReceipt & { readonly commandId: string }) | undefined {
+  const match = Object.entries(activeState()?.receipts ?? {}).find(
+    ([, receipt]) => receipt.conversationId === conversationId,
+  );
+  return match ? { commandId: match[0], ...match[1] } : undefined;
+}
+
+export function recordDeletionIntent(
+  commandId: string,
+  placeholderId: string,
+  conversationId?: string,
+  now: number = Date.now(),
+): void {
+  updateActive((state) => ({
+    ...state,
+    deletionIntents: {
+      ...state.deletionIntents,
+      [commandId]: {
+        placeholderId,
+        conversationId:
+          conversationId ?? state.deletionIntents[commandId]?.conversationId,
+        createdAt: state.deletionIntents[commandId]?.createdAt ?? now,
+      },
+    },
+  }));
+}
+
+export function resolveDeletionIntent(commandId: string): void {
+  updateActive((state) => {
+    if (!(commandId in state.deletionIntents)) return state;
+    const deletionIntents = { ...state.deletionIntents };
+    delete deletionIntents[commandId];
+    return { ...state, deletionIntents };
+  });
+}
+
+export function listDeletionIntents(): readonly (AssistantDeletionIntent & {
+  readonly commandId: string;
+})[] {
+  return Object.entries(activeState()?.deletionIntents ?? {}).map(
+    ([commandId, intent]) => ({ commandId, ...intent }),
+  );
+}
+
+useAuthStore.subscribe((state, previousState) => {
+  const nextOwnerUserId = state.user?.id ?? null;
+  const previousOwnerUserId = previousState.user?.id ?? null;
+  if (nextOwnerUserId === previousOwnerUserId) return;
+  activeOwnerUserId = nextOwnerUserId;
+  if (nextOwnerUserId) loadOwner(nextOwnerUserId);
+});
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    const ownerUserId = activeOwnerUserId;
+    if (!ownerUserId || event.key !== storageKey(ownerUserId)) return;
+    memoryByOwner.delete(ownerUserId);
+    loadOwner(ownerUserId);
+  });
+}
+
+export function resetAssistantReceiptStoreForTests(): void {
+  memoryByOwner.clear();
+  activeOwnerUserId = useAuthStore.getState().user?.id ?? null;
+}

--- a/frontend/src/stores/assistant-receipt-store.ts
+++ b/frontend/src/stores/assistant-receipt-store.ts
@@ -14,9 +14,14 @@ const DELETION_INTENT_CAP = 10;
 
 let activeOwnerUserId = useAuthStore.getState().user?.id ?? null;
 const memoryByOwner = new Map<string, AssistantReceiptState>();
+const retirementTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 function storageKey(ownerUserId: string): string {
   return `${STORAGE_PREFIX}${encodeURIComponent(ownerUserId)}`;
+}
+
+function retirementKey(ownerUserId: string, commandId: string): string {
+  return `${ownerUserId}\0${commandId}`;
 }
 
 function readStorage(ownerUserId: string): AssistantReceiptState | undefined {
@@ -91,6 +96,10 @@ function updateActive(
 }
 
 function deleteReceiptForOwner(ownerUserId: string, commandId: string): void {
+  const timerKey = retirementKey(ownerUserId, commandId);
+  const timer = retirementTimers.get(timerKey);
+  if (timer !== undefined) clearTimeout(timer);
+  retirementTimers.delete(timerKey);
   const state = loadOwner(ownerUserId);
   if (!(commandId in state.receipts)) return;
   const receipts = { ...state.receipts };
@@ -174,6 +183,13 @@ export function advanceReceiptFence(
 }
 
 export function deleteReceipt(commandId: string): void {
+  const ownerUserId = activeOwnerUserId;
+  if (ownerUserId) {
+    const timerKey = retirementKey(ownerUserId, commandId);
+    const timer = retirementTimers.get(timerKey);
+    if (timer !== undefined) clearTimeout(timer);
+    retirementTimers.delete(timerKey);
+  }
   updateActive((state) => {
     if (!(commandId in state.receipts)) return state;
     const receipts = { ...state.receipts };
@@ -189,8 +205,14 @@ export function retireReceiptAfterMaterialization(
   const ownerUserId = activeOwnerUserId;
   const receipt = activeState()?.receipts[commandId];
   if (!ownerUserId || !receipt) return;
+  const timerKey = retirementKey(ownerUserId, commandId);
+  if (retirementTimers.has(timerKey)) return;
   const delayMs = Math.max(0, receipt.createdAt + 60_000 - now);
-  setTimeout(() => deleteReceiptForOwner(ownerUserId, commandId), delayMs);
+  const timer = setTimeout(
+    () => deleteReceiptForOwner(ownerUserId, commandId),
+    delayMs,
+  );
+  retirementTimers.set(timerKey, timer);
 }
 
 export function findReceiptByPlaceholder(
@@ -266,6 +288,8 @@ if (typeof window !== "undefined") {
 }
 
 export function resetAssistantReceiptStoreForTests(): void {
+  for (const timer of retirementTimers.values()) clearTimeout(timer);
+  retirementTimers.clear();
   memoryByOwner.clear();
   activeOwnerUserId = useAuthStore.getState().user?.id ?? null;
 }

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -171,6 +171,15 @@ export interface ConversationHistory {
   readonly conversation: Conversation;
   readonly messages: AssistantMessage[];
   readonly has_more: boolean;
+  /** The local stream mirror is authoritative while identity/history catches up. */
+  readonly awaitingProjection?: boolean;
+  /** Background reconciliation reached its deadline without proving absence. */
+  readonly projectionStalled?: boolean;
+}
+
+export interface ProjectionReconcileOutcome {
+  readonly status: "materialized" | "absent" | "timed_out";
+  readonly conversationId: string;
 }
 
 export type TurnStatus =
@@ -274,6 +283,10 @@ export interface AssistantTransport {
   listConversations(): Promise<Conversation[]>;
   createConversation(): Promise<Conversation>;
   getHistory(conversationId: string): Promise<ConversationHistory>;
+  reconcileProjection(
+    conversationId: string,
+  ): Promise<ProjectionReconcileOutcome>;
+  releaseProjectionWaiter(conversationId: string): void;
   deleteConversation(conversationId: string): Promise<void>;
   sendMessage(
     conversationId: string,


### PR DESCRIPTION
## Summary

- **Root cause (upstream, contained here — not fixed here):** Aevatar's chat-history read model is CQRS — a conversation row materializes only when its first turn reaches a terminal state, and `HandleGetConversation` maps a missing read-model doc to HTTP 404, never 200-empty. So "exists but not yet projected", "never existed", and "deleted" are indistinguishable at the wire, and every brand-new `chatc-…` conversation 404s until projection lands. **The upstream contract fix (200-empty + projection status) is out of scope and still owed**; this PR is client-side containment. NyxID's backend proxy stays fully opaque — zero backend changes.
- **What changed:** the SSE stream + local mirror are now authoritative through a conversation's first turn, and the transcript GET is background reconciliation instead of a prerequisite. Concretely, by plan work item (`docs/plans/new-chat-projection-race.md`):
  - **W0** — transport owner-scope boundary: auth-store subscription aborts all timers/controllers and clears every local map on account switch/logout (same-user token refresh preserved), closing a logout→login-without-reload path that could serve user A's mirror to user B.
  - **W1** — persisted create receipts + deletion intents (`stores/assistant-receipt-store.ts`, Zod schema in `schemas/assistant-receipts.ts`): `commandId → chatc-id` + fence survive reload/second tabs; no prompt/message content is ever persisted; best-effort storage with in-memory fallback; definitive create rejections (400/401/403/422) delete the receipt.
  - **W2** — deleting a draft whose canonical id is unknown no longer fires a doomed 404 `DELETE /conversations/workflow-pending-…`; a persisted deletion intent recovers the canonical id in the background, DELETEs it, and tombstones both addresses so the "deleted draft resurrects in the sidebar" window is closed.
  - **W3** — two-fact pending provenance (`identityPending` / `projectionPending`) served as optional `awaitingProjection` / `projectionStalled` success fields (never errors); the guaranteed doomed transcript GET on every new chat's first `turn.completed` is gone; valid `stateVersion: 0` contexts are handled.
  - **W4** — single-flight, deadline-driven reconciler with floored full-jitter backoff (90s projection / 60s create-recovery policies), wakeable pause on last-waiter release, raw-index membership rechecks with a remote-delete → not-found transition, and a `timed_out` → stalled-with-Retry state instead of limbo.
  - **W5** — evidence-gated cold-load 404s: a receipt or **raw upstream index membership** (never the merged local list) turns a projection-window 404 into a quiet syncing state; a no-evidence 404 stays not-found after exactly one confirmation read (no retry storm on dead ids); index-born empty mirrors can no longer resurrect deleted conversations.
  - **W6** — transcript/episode/turn caches are mirrored under the canonical query key once the context frame names it, so navigating to the canonical id mid-stream no longer opens a cold query.
  - **W7** — the projection window renders "Syncing conversation history…" (and a stalled notice with Retry after the deadline) instead of the previous permanently-stuck error banner / silent empty chat.
  - **W8** — the unbounded longer-local keep-max in `applyHistoryResponse` is bounded by a fence-current + required-turn-present predicate so the mirror converges to server truth after materialization, with live-turn interlocks so a reconcile read can never rewrite a mirror a turn is writing into.
  - **W9** — `docs/chat/02-wire-contract.md` and `docs/chat/07-testing-and-gaps.md` updated.

## Adversarial review history (three rounds, recorded in-repo)

Plan → GPT-Sol adversarial plan review (REWORK, 4 P1s) → plan rev 2 → implementation → three Opus review rounds (`docs/plans/new-chat-projection-race.review-opus.md`):

- **Round 1 (REWORK)** reproduced a P1 in W8: the "server entries must contain the latest local assistant turn" clause was **vacuous for new chats** (streamed messages carry no turn id), so a fence-current shorter server transcript could silently delete the user's just-sent message while the assistant answered it — the same content-loss class PR #1304 fixed, reintroduced through a new path.
- **Round 2 (REWORK)** caught that the first fix guarded on `isTurnActive` alone, which is false for the entire send-to-first-frame window (the reducer still holds the previous turn's terminal status — measured as `activeTurnAtSend: "completed"`), and that the accompanying test hand-assigned `status: "running"`, validating the implementation rather than the behavior.
- **Round 3 (APPROVE)** verified the final fix at the reconciler call site (19 lines; `applyHistoryResponse` untouched so its three legitimate in-run callers still apply), with a reproduction driving the real reconciler that fails at the pre-fix commit and passes at HEAD, plus proofs that convergence is not swallowed and that the double-schedule/livelock hazards are absent by construction.

The rework history is stated deliberately: the surviving defect class was found, reproduced, and closed on the reachable path with a behavior-level regression test.

## Explicit deferrals (agreed in review, recorded in the plan)

- **Foreground retry-ladder migration**: the continuation preflight / in-run create recovery keep the existing `[0, 300, 900, 1800]` ms schedule; only the new background reconciler and cold create recovery use the new jittered deadline policies. Migrating the foreground admission path needs its own falsifiable case (follow-up).
- **Cross-tab**: storage-event **evidence sharing** (receipts/aliases/fences/intents) plus independent per-tab jittered reconciliation — this is *not* a browser-wide lease or cross-tab single-flight, and the plan says so honestly. Each tab's loop is bounded by its deadline.
- **Three deferred test probes** (judged non-load-bearing in review): a request-count W0 abort spy, dedicated W4 timing probes (pause/resume, late wake, remote-delete-mid-loop, recovery-adoption), and the W6 pump-level dual-slot copy case. All recorded with reasoning in plan §4.
- **Upstream**: the Aevatar 200-empty/projection-status contract fix remains a separate work item.

## Test Plan

Verified independently at head `df144b01` (source head `eb77b3bc` + review-doc commit):

- `npm run test` — **199 files / 2446 tests passed** (happy-dom teardown `AbortError` noise is pre-existing, not failures)
- `npm run lint` — **0 errors, 23 warnings** (all 23 pre-existing, none in touched files' new code)
- `npm run build` — green (tsc -b with `noUncheckedIndexedAccess` + vite)
- `cargo test -p nyxid-cli --test wizard_bundle_freshness` — **1 passed** (no wizard rebuild needed; no touched file is in the wizard module graph)
- Diff hygiene: 20 files, all `frontend/src/**` + `docs/**`; no `package.json`, no lockfile, no `cli/src/wizard/**`, no `backend/**`
- Mergeability: merge base == `rollup-chat-2026-08-04` head (`fde6041f`), `git merge-tree` clean

- [x] Existing tests pass (`npm run test`; backend untouched — `cargo test` scope limited to the wizard-freshness gate above)
- [x] New tests added for new functionality (24 net-new tests: transport reconciler/evidence/scope/delete-intent, receipt store, receipt schema, backoff, hooks, page; plus 4 `[branch-regression]` guards verified to fail against the pre-review implementation)
- [ ] Manually tested the affected flows (not run against a live Aevatar; behavior was exercised through the real transport in the test harness and three review reproductions — live-stack verification would be a worthwhile pre-deploy check)

## Checklist

- [x] Code follows the project's [architecture rules](CONTRIBUTING.md#architecture-rules) (frontend-only; proxy opacity preserved; Zod in `schemas/`, TanStack hooks in `hooks/`, store in `stores/`)
- [x] No hardcoded secrets or credentials (receipts persist ids/fences/timestamps only — never prompt or message content)
- [x] Error messages do not leak internal details (pending/stalled states are success-data provenance fields, not errors)
- [x] Documentation updated (`docs/chat/02-wire-contract.md`, `docs/chat/07-testing-and-gaps.md`, plan + full three-round review record under `docs/plans/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
