### PR TITLE
fix: implement projection methods on mock transports

### DIFF
--- a/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
@@ -115,6 +115,19 @@ class StubTransport implements AssistantTransport {
     return structuredClone(history);
   }
 
+  reconcileCalls = 0;
+  releaseCalls = 0;
+
+  async reconcileProjection(conversationId: string) {
+    this.reconcileCalls += 1;
+    return { status: "materialized" as const, conversationId };
+  }
+
+  releaseProjectionWaiter(conversationId: string): void {
+    void conversationId;
+    this.releaseCalls += 1;
+  }
+
   async deleteConversation(conversationId: string): Promise<void> {
     this.deleteCalls += 1;
     await this.deleteImpl(conversationId);
@@ -308,6 +321,37 @@ async function flushAsync(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
 }
+
+describe("ScenarioInterceptTransport projection reconcile", () => {
+  it("delegates projection reconcile for conversations the mock does not own", async () => {
+    const { delegate, transport } = await createTransport();
+
+    const outcome = await transport.reconcileProjection(CONVERSATION_ID);
+    transport.releaseProjectionWaiter(CONVERSATION_ID);
+
+    expect(outcome).toEqual({
+      status: "materialized",
+      conversationId: CONVERSATION_ID,
+    });
+    expect(delegate.reconcileCalls).toBe(1);
+    expect(delegate.releaseCalls).toBe(1);
+  });
+
+  it("resolves locally without touching the delegate while a mock turn owns the conversation", async () => {
+    const { delegate, transport } = await createTransport();
+
+    transport.sendMessage(CONVERSATION_ID, "simulate an error", () => {});
+    const outcome = await transport.reconcileProjection(CONVERSATION_ID);
+    transport.releaseProjectionWaiter(CONVERSATION_ID);
+
+    expect(outcome).toEqual({
+      status: "materialized",
+      conversationId: CONVERSATION_ID,
+    });
+    expect(delegate.reconcileCalls).toBe(0);
+    expect(delegate.releaseCalls).toBe(0);
+  });
+});
 
 describe("ScenarioInterceptTransport ownership", () => {
   it("passes unmatched messages through and tracks delegate completion", async () => {

--- a/frontend/src/lib/assistant/scenario-intercept-transport.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.ts
@@ -23,6 +23,7 @@ import type {
   AssistantTransport,
   Conversation,
   ConversationHistory,
+  ProjectionReconcileOutcome,
   TurnEvent,
   TurnHandle,
   TurnReducerState,
@@ -234,6 +235,34 @@ export class ScenarioInterceptTransport implements AssistantTransport {
     const base = this.baseHistories.get(conversationId);
     if (!base) throw new AssistantConversationNotFoundError();
     return this.projectHistory(conversationId, base);
+  }
+
+  /**
+   * Mock-owned conversations exist only in the wrapper, so there is no
+   * server-side projection to wait on -- they are materialized by
+   * definition. Anything the wrapper does not own is reconciled by the
+   * real transport. Ownership matches `getHistory`'s read-path rule so a
+   * claimed or mock-running conversation never reaches the backend.
+   */
+  async reconcileProjection(
+    conversationId: string,
+  ): Promise<ProjectionReconcileOutcome> {
+    if (!this.mockOwnsProjection(conversationId)) {
+      return this.delegate.reconcileProjection(conversationId);
+    }
+    return { status: "materialized", conversationId };
+  }
+
+  releaseProjectionWaiter(conversationId: string): void {
+    if (!this.mockOwnsProjection(conversationId)) {
+      this.delegate.releaseProjectionWaiter(conversationId);
+    }
+  }
+
+  private mockOwnsProjection(conversationId: string): boolean {
+    if (this.claimedConversations.has(conversationId)) return true;
+    const state = this.ownership.get(conversationId);
+    return state === "mock-running" || state === "verifying";
   }
 
   async deleteConversation(conversationId: string): Promise<void> {

--- a/frontend/src/lib/assistant/transport-shell.test.ts
+++ b/frontend/src/lib/assistant/transport-shell.test.ts
@@ -39,6 +39,16 @@ class RecordingTransport implements AssistantTransport {
     };
   }
 
+  async reconcileProjection(conversationId: string) {
+    this.calls.push("reconcile");
+    return { status: "materialized" as const, conversationId };
+  }
+
+  releaseProjectionWaiter(conversationId: string): void {
+    void conversationId;
+    this.calls.push("release");
+  }
+
   async getHistory(): Promise<ConversationHistory> {
     this.calls.push("history");
     return {

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -18,6 +18,7 @@ import type {
   AssistantTransport,
   Conversation,
   ConversationHistory,
+  ProjectionReconcileOutcome,
   TurnEvent,
   TurnHandle,
 } from "@/types/assistant";
@@ -596,6 +597,16 @@ export class DelegatingAssistantTransport implements AssistantTransport {
 
   getHistory(conversationId: string): Promise<ConversationHistory> {
     return this.transport.getHistory(conversationId);
+  }
+
+  reconcileProjection(
+    conversationId: string,
+  ): Promise<ProjectionReconcileOutcome> {
+    return this.transport.reconcileProjection(conversationId);
+  }
+
+  releaseProjectionWaiter(conversationId: string): void {
+    this.transport.releaseProjectionWaiter(conversationId);
   }
 
   deleteConversation(conversationId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Fixes the `Frontend` CI failure on the rollup PR (#1332), which failed at `npm run build` (type-check) with `TS2420` across four classes.
- **Semantic merge conflict, not a bug in either PR.** The chat-projection work (#1329, already in `main`) added `reconcileProjection` and `releaseProjectionWaiter` to the `AssistantTransport` interface; the mock scenario interception work (#1328) added transports implementing that interface without them. Neither branch conflicted textually, so nothing surfaced until the combined tree was type-checked — which first happens on the rollup, since `ci.yml` gates `main`/`dev` and both feature PRs targeted the rollup branch.

## Changes

| Class | File | Behavior |
|---|---|---|
| `DelegatingAssistantTransport` | `transport.ts` | Pure delegation, mirroring every other method on the wrapper |
| `ScenarioInterceptTransport` | `scenario-intercept-transport.ts` | Ownership-routed (see below) |
| `RecordingTransport` | `transport-shell.test.ts` | Test double + call recording |
| `StubTransport` | `scenario-intercept-transport.test.ts` | Test double + call counters |

**The one non-mechanical decision** is `ScenarioInterceptTransport`. It routes by the same ownership rule `getHistory` already uses: a conversation the mock owns (claimed, `mock-running`, or `verifying`) exists only in the wrapper, so there is no server-side projection to wait on and it resolves locally as `materialized`; anything else delegates to the real transport. Stubbing this unconditionally would have silently broken #1329's new-chat materialization path whenever mock scenarios were enabled — the reconcile would never reach the backend.

Two regression tests lock the split: the delegate **is** called for a conversation the mock does not own, and **is not** called while a mock turn owns one.

## Test Plan

- [x] Existing tests pass (`npm run test`)
- [x] New tests added for new functionality
- [ ] Manually tested the affected flows — not performed; type-level fix with behavioral unit coverage

Full frontend suite on this branch, real exit codes:

```
npm run build  → exit 0 (tsc -b ✓, vite ✓, credential-accept ✓,
                 "Mock scenario footprint assertion passed")
npm run test   → exit 0 — Test Files 208 passed, Tests 2522 passed
npm run lint   → exit 0 — 0 errors (23 pre-existing warnings, untouched files)
```

Backend/CLI untouched; no dependency or lockfile changes.

## Checklist

- [x] Code follows the project's [architecture rules](CONTRIBUTING.md#architecture-rules)
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Documentation updated (if applicable) — n/a, no contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
