### PR TITLE
feat: refresh Aevatar platform skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "nyxid",
       "description": "Brokers downstream credentials through the nyxid CLI and bundles synchronized Aevatar platform skills for workflows, teams, services, schedules, channels, and managed Codex.",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "source": "./",
       "author": {
         "name": "ChronoAIProject"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nyxid",
   "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "ChronoAIProject"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nyxid",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
   "author": {
     "name": "ChronoAIProject",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "nyxid",
   "displayName": "NyxID",
   "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": {
     "name": "ChronoAIProject",
     "url": "https://github.com/ChronoAIProject"

--- a/skills/aevatar-feasibility-advisor/SKILL.md
+++ b/skills/aevatar-feasibility-advisor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-feasibility-advisor
 description: Use before building when a user asks whether Aevatar can achieve a goal, what prerequisites it has, or why it is unavailable. Triggers include bots and third-party APIs, inbound channels, external HTTP triggers, schedules, service exposure, Agent Profiles and tool ceilings, and bounded managed or private-host codex_exec work. It distinguishes outbound connectors from inbound channels and separates not connected, host-gated, not deployed, and genuinely unsupported outcomes. It chooses managed_sandbox versus private_ssh without promising repository, model, credential, runtime, or deployment capabilities the caller does not control, then routes feasible work to the owning Aevatar skill.
-version: "1.5"
+version: "1.6"
 metadata:
   category: plain
   tag:
@@ -104,11 +104,17 @@ header. Two read-only CLI calls tell you the ground truth:
 nyxid service list --output json
 nyxid catalog list --output json
 ```
-(Inside an Aevatar session, use the typed connected-service inventory/management tool actually
-present.) **The live catalog and authoritative `/api/v1/keys` instance inventory are the source of truth — never assert a connector
-exists or doesn't without checking it.** The examples below are illustrative, not a fixed list.
-`/api/v1/user-services` is only a route projection; it cannot prove discovery, readiness, or
-execution authority.
+(Inside an Aevatar session, use the typed connected-service tools actually present.) For a request
+to connect, add, or authorize a named service, `nyxid_catalog` is discovery only: use it to resolve
+the exact catalog slug when necessary, then **always** call `nyxid_require_service`. Finish from
+that typed readiness result; it is the authority for a missing-service blocker and interactive
+`service.connect` handoff. Never stop at catalog prose.
+
+**The live catalog and authoritative `/api/v1/keys` instance inventory are the source of truth —
+never assert a connector exists or does not without checking them.** `/api/v1/keys` is the exact
+UserService authority for execution. `/api/v1/user-services` is only a routing projection; it
+cannot prove discovery, readiness, or execution authority. The examples below are illustrative,
+not a fixed list.
 
 ### Reading a catalog entry (this is the "what's the prerequisite" answer)
 - `requires_credential: true` → the user must connect it before any call works.
@@ -131,6 +137,8 @@ execution authority.
    connector `api-twitter`) + *(c)* run **daily** (schedule). Decompose into capability
    classes before judging.
 2. **Classify each piece** against the matrix below and collect its prerequisite.
+   In-session connect/add/authorize requests must resolve the catalog slug, then pass it to
+   `nyxid_require_service`; do not substitute prose or `/api/v1/user-services` for typed readiness.
 3. **Find the gating piece** — the answer to the whole request is the *weakest* piece (a
    single host-gated or impossible piece caps the whole thing).
 4. **Report honestly** with the template at the end: possible + prereqs, or host-action-needed,
@@ -182,7 +190,9 @@ State these plainly when they bite:
 
 - **Connect a connector** → "In the NyxID console, connect **`<slug>`**. <`credential_mode:user`:
   it's a one-click OAuth to your own account.> <`admin`: you'll paste a token — `<api_key_instructions>`;
-  get it at `<api_key_url>`.>" Then confirm with `GET /api/v1/services` that the slug appears.
+  get it at `<api_key_url>`.>" In-session, finish through `nyxid_require_service`; for REST/CLI
+  verification, confirm the exact UserService and readiness through `/api/v1/keys`, not merely the
+  `/api/v1/user-services` projection.
 - **Register an inbound channel** (Lark/Telegram) → connect the bot connector, then register the
   channel via the channel-admin tool so NyxID wires the webhook to Aevatar's relay.
 - **External HTTP trigger** (Lark Base / webhook sender / external cron) → do **not** ask for

--- a/skills/aevatar-platform-map/SKILL.md
+++ b/skills/aevatar-platform-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-platform-map
 description: Entry point, panorama, and router for the Aevatar skill family. Use before building, running, publishing, scheduling, externally triggering, or operating Aevatar resources; configuring an Agent Profile; assessing managed/private codex_exec feasibility and setup; running the canonical Codex readiness proof; authoring a workflow with codex_exec; diagnosing a Codex failure; or deciding which companion skill owns a request. It teaches resource and identity boundaries, NyxID-brokered auth, client REST versus in-session tools, deployment gates, and exact handoffs without treating member, workflow, service, profile, schedule, or Codex capabilities as one lifecycle.
-version: "1.11"
+version: "1.12"
 metadata:
   category: plain
   tag:
@@ -191,7 +191,7 @@ target contract through the Codex-specific skills below. Do not invent a REST pa
 Keep these modes separate; they share credentials but not caller-owned fields:
 
 - **Raw one-off HTTP:** call `nyxid_proxy` with exact `service_id + slug + path`; optional fields are `method`, `body`, non-sensitive `headers`, and `response_mode`. Example: `{"service_id":"us-gh-7","slug":"api-github","path":"/user","method":"GET"}`.
-- **Current-turn connected-service tools:** use only the typed tools actually present, such as `nyxid_services`, `nyxid_approvals`, `nyxid_require_service`, and `nyxid_service_inventory`. Retired dynamic `nyxid_service_operation__*` and `nyxid_service_request` tools do not exist; never invent their names.
+- **Current-turn connected-service tools:** use only the typed tools actually present, such as `nyxid_services`, `nyxid_approvals`, `nyxid_require_service`, `nyxid_catalog`, and `nyxid_service_inventory`. `nyxid_catalog` is discovery only. For a connect, add, or authorize request, use it only to resolve the exact catalog slug, then always finish through `nyxid_require_service`; its typed readiness result is the authority for any `service.connect` handoff. Never finish such a request with catalog prose. Retired dynamic `nyxid_service_operation__*` and `nyxid_service_request` tools do not exist; never invent their names.
 - **Compiled published operation:** the YAML step calls `nyxid_proxy` and carries an exact copied `capability.nyxid_operation` selector. Its admission proof owns UserService, slug, operation ID, method, path template, digest, schemas, and response policy. Runtime arguments may contain only admitted `path_params`, `query`, `headers`, `body`, and `response_mode`; never repeat route or proof fields.
 - **Compiled authored request:** `capability.nyxid_request` carries a typed HTTP request contract and exact UserService selection from authoritative `/api/v1/keys`. Binding requires authenticated confirmation/grant for the current request-contract digest and risk. `/api/v1/user-services`, draft save, and preview success are not execution authority.
 - **Studio member:** call `aevatar_invoke_member` with `{"member_id":"m-alpha","payload":{"prompt":"hello"}}`; `endpoint_id` is optional and defaults to `chat`. Never substitute a draft `workflowId` or `publishedServiceId` for `member_id`.
@@ -219,10 +219,11 @@ For managed `codex_exec`, normal execution is credential-read-only. Explicitly `
 | Trigger an existing workflow from an external HTTP sender such as **Lark Base** | `aevatar-feasibility-advisor` first, then `aevatar-service-publisher` | NyxID `/api/v1/proxy/s/aevatar/api/scopes/{scopeId}/members/{memberId}/invoke/...`, host-managed `/api/workflow-webhooks/{routeKey}` if configured |
 | **Invoke**, watch **runs**, observe | (this map + service-publisher's invoke section) | `/invoke/{endpointId}`, `/runs/*`, `/api/workflow/observatory/*` |
 
-If a companion skill is not already loaded, find it with an ornn skill search for the
-capability (e.g. "aevatar team builder", "aevatar service publisher", "aevatar
-scheduler"), then load it. None of them depend on this map at run time — they restate the
-minimal bootstrap above.
+If a companion skill is not already loaded, find it with `ornn_search_skills` for the capability
+(e.g. "aevatar team builder", "aevatar service publisher", "aevatar scheduler"), then load it.
+Search uses the caller-scoped remote skill authority. It must not fall back to a generic platform
+token, and an authorization/token-resolution failure is an error rather than an empty catalog.
+None of the companion skills depend on this map at run time; they restate the minimal bootstrap.
 
 ## The full aevatar skill collection
 
@@ -236,8 +237,8 @@ server-side at publish time.)
 
 **Scope first — feasibility** (`category: plain`, public)
 - `aevatar-feasibility-advisor` — *use before building*: is the goal possible, what are its
-  prerequisites (which NyxID connector to configure, what's host-gated), and what's impossible
-  + the alternative. Teaches the connector-vs-channel split and the prerequisite matrix.
+  prerequisites (which NyxID connector to configure and what's host-gated), and which constraints
+  require a different design. Teaches the connector-vs-channel split and the prerequisite matrix.
 
 **Define the agent — Agent Profile** (`category: plain`, public)
 - `aevatar-agent-profile-management` — the profile resource surface: purpose, instructions,
@@ -322,6 +323,12 @@ lifecycle, and none of its IDs are aliases. Agent Profile work is not part of th
   credential issuance, vault write, projection visibility, publication, cron fire, or success —
   read state back (binding run status, a newer authoritative `stateVersion`, invocation readiness,
   run timeline) instead of trusting a bare 2xx.
+- **Observe the accepted run, not role-local completion.** A workflow stream must emit its first
+  projection-backed business frame within 30 seconds; SSE keepalive does not count. Only root
+  `RUN_FINISHED` and root `RUN_ERROR` are terminal. Role text, reasoning, tool-call, tool-result,
+  and role terminal frames are progress. `RUN_OBSERVATION_TIMEOUT` closes a stalled observation
+  stream but does not by itself prove whole-run failure; query the same `actorId + commandId` and
+  never create another run as a status probe.
 - **Detect deployment-gated capabilities.** Agent Profile management exists in the codebase but
   may not be exposed by the running deployment. Probe the surface (tool list, or the complete
   route family in `GET /api/openapi.json`) before promising it — and report its absence honestly

--- a/skills/aevatar-service-publisher/SKILL.md
+++ b/skills/aevatar-service-publisher/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-service-publisher
 description: Publish an Aevatar member, team, or workflow as an invocable service and (host permitting) register it with NyxID, then verify, invoke, or wire external HTTP triggers such as Lark Base automation — all over the REST API. Use when a user wants to "publish/bind a service", "expose my workflow/team as a service", "register it with NyxID", "make it callable", "get the service slug/URL", "invoke my service", "let Lark Base call my workflow", "trigger this workflow from an external webhook", or "version/deploy/roll out a service". It covers the simple scope binding, reading back a member's published service, the full account-level service lifecycle (revision → publish → deploy → rollout), how to confirm the NyxID registration (slug + status), how to invoke an endpoint, and how to distinguish direct NyxID proxy triggering from host-gated externalExposure. Build the team/member first with the team-builder skill.
-version: "1.6"
+version: "1.7"
 metadata:
   category: plain
   tag:
@@ -123,6 +123,11 @@ Optional staged rollout: `POST …/rollouts` then `:advance` / `:pause` / `:resu
 and access policies: `POST …/bindings`, `POST …/policies`. The service self-describes at
 `GET /api/services/{serviceId}/openapi.json`.
 
+Prepare and publish are idempotent for an existing prepared/published revision. A published
+revision remains published through replay and duplicate prepare/publish commands; do not mint a
+replacement revision or demote it because invocation readiness is temporarily behind. Reconcile
+the existing revision and its projection/catalog state.
+
 ## Verify (always)
 
 ```bash
@@ -146,6 +151,13 @@ The endpoint contract tells you the path, readiness, and a ready-to-run curl exa
 aev "api/scopes/$scopeId/members/$memberId/endpoints/chat/contract" \
   | jq '{invokePath, canInvoke:.invocationReadiness.canInvoke, curlExample}'
 ```
+Invocation readiness is exact, not a generic "deployed" flag. Require the invocation catalog to
+contain the selected revision **and deployment** and to report every selected endpoint ready. The
+contract must show `invocationReadiness.canInvoke:true`, `status:"ready"`, the expected
+`revisionId`, and a non-empty matching deployment identity. `invocation_catalog_not_ready` is a
+materialization lag and means **not invocable yet**; reread the same contract/read model instead of
+republishing, creating another revision, or claiming readiness.
+
 The streaming path (`…/invoke/{endpointId}:stream`, SSE) accepts the `{"prompt":"…"}` shorthand.
 An opened stream or accepted receipt is not success. Follow the same run to terminal completion,
 then read run detail/audit and require completed status, `lastSuccess=true`, expected non-empty
@@ -155,6 +167,14 @@ aev "api/scopes/$scopeId/members/$memberId/invoke/chat:stream" -m POST --stream 
   -d '{"prompt":"smoke test"}'
 # retain the returned run identity privately, then read its detail and audit
 ```
+After acceptance, the stream must emit its first projection-backed business frame within 30
+seconds. SSE `: keepalive` is transport-only and does not extend that deadline. Only root
+`RUN_FINISHED` and root `RUN_ERROR` terminate observation; role text, reasoning, tool-call,
+tool-result, and role terminal frames are progress. Root
+`RUN_ERROR(code=RUN_OBSERVATION_TIMEOUT)` closes the stream because observation stalled and is not
+proof that the whole run failed. Query the same `actorId + commandId`; never invoke again just to
+check status.
+
 The **non-streaming** `…/invoke/{endpointId}` expects the full typed envelope (it rejects a
 bare `{prompt}` with 400 "payloadTypeUrl is required") — prefer `:stream` for a quick check.
 Teams and account-level services invoke the same way:

--- a/skills/aevatar-team-builder/SKILL.md
+++ b/skills/aevatar-team-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-team-builder
 description: Build an Aevatar agent team and its members over the REST API. Use when a user wants to "create a team", "add a member", "make a workflow member / script member / gagent member", "set the team's entry point", or "assemble agents into a team". It creates the team, creates members whose implementation is a workflow (most common), a script, or a hosted gagent, binds each member's concrete implementation (the workflow YAML is attached here), waits for the async binding to succeed, and sets the team entry member. Author the workflow YAML first with the workflow-authoring skill; publish the result as a service with the service-publisher skill.
-version: "1.4"
+version: "1.5"
 metadata:
   category: plain
   tag:
@@ -43,6 +43,10 @@ scopeId=$(aev "api/studio/context" | jq -r .scopeId)
 Member implementation kinds are the lowercase strings **`workflow`**, **`script`**,
 **`gagent`**.
 
+Member routes authorize the authenticated caller against the route `scopeId`. They do not require
+the caller subject, `memberId`, or any other resource ID to be equal. Keep scope authority and
+resource identity separate; never rewrite an ID to make those strings match.
+
 ## Step 1 — Create the team
 
 ```bash
@@ -55,8 +59,7 @@ let the server mint one). Read the returned id back — do not invent it.
 ## Step 2 — Create the member shell
 
 Create the member as a **shell**. Do **not** pass `implementationRef` here — the concrete
-implementation (the workflow + its YAML) is attached in Step 3. Passing a forward
-`workflowId` that does not exist yet returns **HTTP 500**.
+implementation (the workflow + its YAML) is attached in Step 3.
 
 ```bash
 wfId="wf-my-workflow"   # workflow draft identity; it is not the member or published-service id
@@ -70,8 +73,12 @@ memberId=$(aev "api/scopes/$scopeId/members" -m POST -d "{
 `workflow|script|gagent`); `description?`, `memberId?`, `teamId?` (attach now, or add
 later via PATCH). The new member returns at `lifecycleStage:"created"` and is already
 assigned a `publishedServiceId`; its `implementationRef` stays `null` until Step 3 fills
-it in. (Verified: omitting `implementationRef` returns 201; sending it with a not-yet-bound
-`workflowId` returns 500.)
+it in.
+
+If the requested team does not exist, member creation and provisioning return typed HTTP 404:
+`{"code":"STUDIO_TEAM_NOT_FOUND","scopeId":"<scope>","teamId":"<team>"}` (plus a
+message). Treat this as a missing Team resource in the stated scope; do not retry, invent another
+team ID, or reinterpret `teamId` as a member/workflow/service identity.
 
 Keep all three identities distinct: the response `memberId` owns Team authority, `wfId` names the
 workflow draft/definition, and `publishedServiceId` is the callable runtime identity. Only explicit
@@ -120,6 +127,18 @@ aev "api/scopes/$scopeId/members/$memberId" \
 ```
 Do not report success on the 2xx from the PUT alone — that is only `accepted`; wait for the
 run to reach `succeeded`.
+
+Binding success is not yet invocation readiness. Read the selected endpoint contract and require
+the exact bound revision, deployment, and endpoint to be visible in the invocation catalog:
+```bash
+aev "api/scopes/$scopeId/members/$memberId/endpoints/chat/contract" \
+  | jq '{revisionId, deploymentStatus, readiness:.invocationReadiness}'
+```
+Proceed only when `invocationReadiness.canInvoke == true`, `status == "ready"`, and the returned
+`revisionId` matches the binding result. `invocation_catalog_not_ready` means projection/catalog
+materialization has not observed that endpoint revision; the member is **not invocable yet** even
+though the binding run succeeded. Continue reading the same contract until it changes or report
+the lag honestly; do not create a new binding to force readiness.
 
 ## Step 4 — Set the team entry member
 

--- a/skills/aevatar-triage/SKILL.md
+++ b/skills/aevatar-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-triage
 description: Use after an Aevatar workflow, codex_exec call, schedule, channel, connector, skill, Agent Profile, or control-plane request fails or behaves unexpectedly. It applies when the agent must attribute the first broken boundary across Aevatar, NyxID, Ornn, chrono-sandbox/gVisor, the managed runner, or private SSH; distinguish credential sources and deployment gaps; preserve sanitized evidence; determine defect versus usage; or draft an issue for explicit user confirmation. Never use it to guess a root cause from one error string or auto-file.
-version: "1.7"
+version: "1.8"
 metadata:
   category: plain
   tag:
@@ -146,6 +146,7 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 | Symptom | Most likely layer | Disambiguating evidence to gather |
 |---|---|---|
 | `401` / `403` on a connector/tool call | **Aevatar -> NyxID -> provider auth chain** | Did caller credential enter the run, reach the executor, select the exact UserService/route, and remain authorized downstream? Establish the first missing boundary; do not assign the layer from status alone. |
+| `NYXID_PROXY_SERVICE_SCOPE_FORBIDDEN` | **Aevatar caller-authority admission** | The caller credential lacks authority for the exact selected service scope. Preserve the selected UserService/service identity and caller scope; do not collapse this into "not connected", provider rejection, or a generic 403. |
 | "credential not found" / connector slug missing | **NyxID** (vault / not connected) | Compare catalog with authoritative `/api/v1/keys` for this caller. `/api/v1/user-services` is only a route projection and cannot prove execution readiness. |
 | `404` on a thing you reference | **whichever registry owns it** | skill -> Ornn; connector/service -> NyxID; team/member/scope -> Aevatar |
 | `502` / timeout on an external call | **proxy chain** | which hop? Aevatar tool layer vs NyxID proxy vs the target itself |
@@ -158,8 +159,8 @@ typically flows `your agent -> Aevatar runtime -> NyxID proxy -> third-party`, a
 | **inbound bot doesn't reply** (Lark/Telegram) | **cross-layer — walk it** | did NyxID relay webhook fire? is the bot connector connected? did the Aevatar channel run start (observatory)? credential = the *sender's* NyxID, present and live? |
 | Lark Base returns `91403` while `bitable:app:readonly` is enabled | **Lark document ACL / usage configuration** | The API scope and Base document sharing are separate. In the Base `...`/More menu choose **Add Applications** and add the exact Bot application used by the selected NyxID UserService; view access is enough for read-only calls. |
 | **`/whoami` says "bound" but tool calls get `credential_denied`** | **NyxID** (grant revoked — false green) | live token-exchange returns `invalid_grant` while the local readmodel still reads "bound"; whoami checks only the local mirror, not the live grant |
-| approval prompt stuck | **NyxID approvals + Aevatar suspension** | NyxID approval request id; Aevatar workflow wait/suspend state |
-| skill search/pull/upload/generate fails | **Ornn** | which `/api/v1/skill...` route? validator violations? version format? |
+| approval prompt stuck | **NyxID approvals + Aevatar suspension** | Read the typed run step. Tool approval identity is `executionId + toolName + toolCallId + approvalRequestId`; never infer it from prompt text or a generic bag. Check the matching NyxID request and Aevatar suspend/resume state. |
+| skill search/pull/upload/generate fails | **Ornn** | Which `/api/v1/skill...` route? For search, did caller-scoped remote token resolution/authorization fail? That is an error, not an empty catalog, and must never fall back to a generic platform token. Also inspect validator violations and exact version format. |
 | **`404` on a control-plane route you believe exists** (e.g. `…/agent-profiles`) | **could be "resource missing" OR "capability not deployed" — these are different verdicts** | probe the *surface*, not the resource: `GET /api/openapi.json` and check whether the **complete** route family is advertised. Family absent ⇒ the deployment does not expose that contract; a single 404 proves nothing either way. See *Deployment-gated capabilities* below |
 
 **Do not stop at the first match.** Gather the disambiguating evidence and *eliminate* — a plausible
@@ -173,10 +174,17 @@ caller credential will propagate into the run or that the downstream service wil
 
 For one failed run, do not invoke again. Read, in order:
 
-1. the stream terminal frame, if available;
+1. the root stream terminal frame, if available (`RUN_FINISHED` or `RUN_ERROR` only; role text,
+   reasoning, tool-call, tool-result, and role terminal frames are progress);
 2. run detail (`completionStatus`, `lastSuccess`, last error, final output);
 3. run audit and its first failed step/tool call;
 4. the binding's exact workflow/revision identity and committed capability admission plan.
+
+Accepted-to-first-observation has a separate 30-second deadline. SSE keepalive does not count as a
+projection-backed business frame. `RUN_OBSERVATION_TIMEOUT` closes the current stream because
+observation stalled; it is **not** a whole-run failure classification. Query the same
+`actorId + commandId` for later committed/read-model state. Do not create another run as a status
+probe.
 
 For a first NyxID HTTP auth failure, test four hypotheses separately: inbound caller credential
 never entered the run; it entered the run but not the external-capability executor; the executor
@@ -184,6 +192,14 @@ selected the wrong exact UserService/route/credential; or the selected downstrea
 expired/unauthorized. Use distinct `memberId`, `workflowId`, and `publishedServiceId` shapes when
 reproducing identity propagation. Preserve the exact error privately; report only a bounded,
 sanitized classification. A failed mutation or run is never blindly retried.
+
+**Recovery never replays uncertain provider/effectful I/O.** Activation recovery may resume typed
+continuations and redispatch an exact safe postcondition, but it must not repeat an interrupted LLM
+request or potentially effectful tool call. If the external operation may have completed before its
+callback/result delivery was lost, keep the outcome uncertain; a committed result lost before
+delivery is an explicit delivery-loss failure with its stable operation lineage. Do not turn either
+case into a silent retry or claim that the real-world effect did/did not happen without external
+evidence.
 
 **Scheduled-run credentials are not one thing.** "It was a scheduled run" tells you nothing about
 its credential. Read `credentialSourceKind` off the run/automation record **first**, then pick the
@@ -247,8 +263,8 @@ failure: **(1)** confirm the code you read **matches the deployed commit/image**
 image tag; if you have a candidate fix, prove it shipped with `git merge-base --is-ancestor <fix>
 <deployed-sha>`); **(2)** confirm the symptom **reproduces on fresh live evidence**, not an old log
 window; **(3)** remember **auto-deploy branches roll forward under you** — re-check the image tag
-mid-investigation. If code and deployment diverge, the bug may already be fixed (an unmerged branch
-or a follow-up commit) or the running build is simply different.
+mid-investigation. If code and deployment diverge, downgrade the source reading to a hypothesis and
+check the commits newer than the deployed image before attributing the live symptom.
 
 Then get the suspected layer's real source (paths below) and read until you can point at the code
 that produces the behavior. **Anchors are subsystem/directory altitude — confirm exact files by

--- a/skills/aevatar-workflow-authoring/SKILL.md
+++ b/skills/aevatar-workflow-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-workflow-authoring
 description: Author, preview, validate, and persist an executable aevatar workflow from a natural-language request. Use it when the user wants to create, build, set up, or automate a multi-step task as a runnable Aevatar workflow. It covers exact NyxID operation and authored-request admission, bounded YAML, file inputs, terminal run verification, and reusable publication. Not for blindly rerunning an existing failed workflow.
-version: "2.2"
+version: "2.4"
 metadata:
   category: tool-based
   tool-list:
@@ -23,9 +23,9 @@ metadata:
 
 You turn a user's natural-language request into a **valid, test-run, reusable** aevatar workflow. A workflow is a YAML document of `roles` + `steps` that the engine executes; once validated you persist it as a skill so the user can re-run it and watch it in the observatory.
 
-Everything you need is in this document — the DSL, the engine rules, the tools, and worked examples. Follow the protocol in order.
+The core DSL, engine rules, and tool protocol are here. Load the linked REST or worked-example reference only when that surface is relevant. Follow the protocol in order.
 
-> **Two execution surfaces — know which one you are *before* step 3.** Steps 3 / 5 / 6 below call the *server-side agent tools* `nyxid_services`, `aevatar_start_workflow`, and `ornn_publish_skill`. Those exist **only** when you are the model running **inside** an aevatar session with the nyxid MCP connected. If instead you are an external **client** holding only a NyxID bearer token — driving the aevatar backend through the NyxID broker (`nyxid proxy request aevatar`), the same identity the sibling skills (`aevatar-team-builder`, `aevatar-service-publisher`, `aevatar-scheduler`) assume — **those three tools are not callable**, and you dry-run + publish over plain authenticated REST instead. Jump to **[Client path (no nyxid MCP)](#client-path-no-nyxid-mcp--dry-run--publish-over-rest)** at the end; the DSL, engine rules, and examples in between apply to both surfaces.
+> **Two execution surfaces — know which one you are *before* step 3.** Steps 3 / 5 / 6 below call the *server-side agent tools* `nyxid_services`, `aevatar_start_workflow`, and `ornn_publish_skill`. Those exist **only** when you are the model running **inside** an aevatar session with the nyxid MCP connected. If instead you are an external **client** holding only a NyxID bearer token — driving the aevatar backend through the NyxID broker (`nyxid proxy request aevatar`), the same identity the sibling skills (`aevatar-team-builder`, `aevatar-service-publisher`, `aevatar-scheduler`) assume — **those three tools are not callable**. Read **[references/client-rest.md](references/client-rest.md)** for the client dry-run, publication, and invocation path; the core DSL and engine rules below apply to both surfaces.
 
 ---
 
@@ -59,6 +59,8 @@ These are the failure modes that break generated workflows. Check every one befo
 - **Side effects are at-least-once.** `tool_call` / `connector_call` may run more than once on retry. Keep them idempotent where it matters.
 - **External calls go through tools, not raw hosts.** Use `nyxid_proxy` (or a typed tool) — never embed a vendor base URL as a direct target. See **Accessing external services**.
 - **Files are typed inputs.** `input_file_refs` is not `$input` text and not an interpolation variable. Use `foreach` with `items_source: input_file_refs` to process multiple files; file tools are still invoked through `type: tool_call`.
+- **Ambient files are fallback inputs.** When the caller supplies no explicit `fileRef`, the workflow start appends deduplicated ambient file refs from the current tool context. Any explicit `fileRef` suppresses ambient refs, so never merge the two sets client-side. An empty `inputs` object is valid when ambient refs exist. Role LLM tool loops receive the same typed refs; do not flatten them into prompt text or reconstruct them from IDs.
+- **Template programs are static and bounded.** `transform op: template` accepts bounded JSON input plus a typed `template` program. The program is not supplied by upstream workflow `${...}` data. It exposes only `append`, `date`, `get`, `json`, `keys`, `number`, and `round`; default builtins, CLR access, template loaders, files, and network are unavailable. Limits are 256 KiB for the template, 4 MiB each for input and output, 10,000 loop iterations or mutable-array items, and depth 64. Missing variables, mutation of input data, invalid JSON/template syntax, evaluation errors, and limit violations fail closed.
 
 ---
 
@@ -164,6 +166,18 @@ Do not call external services or LLMs from `code_execute`; use `nyxid_proxy` for
   parameters: { op: group_by, key: category, value: amount, aggregate: sum, precision: "2" }
 ```
 
+For deterministic aggregation or JSON/report rendering that exceeds the fixed operations, use the typed bounded template transform. The input must be JSON and is exposed as `data`:
+```yaml
+- id: summarize_items
+  type: transform
+  parameters:
+    op: template
+    template: >-
+      {{ total = 0 }}
+      {{ for item in data.items; total = total + number(item.amount); end }}
+      {{ json({ count: data.items.size, total: round(total, 2) }) }}
+```
+
 `json_parse` — parse a JSON string selected by `path` into structured JSON.
 ```yaml
 - id: parse_embedded_json
@@ -215,6 +229,8 @@ For multiple workflow input files, use `items_source: input_file_refs`; each chi
 ```
 
 Keep `items_source`, `sub_step_type`, and `sub_param_tool` under `parameters`; root-level `items_source` / `sub_param_tool` are not reliably lifted by the parser. Use `sub_param_arguments: "{}"` when the tool should read the per-item file ref instead of treating the file id input as arguments.
+
+Each `foreach` child expands every `sub_param_*` value against that child, after fan-out. Use `${input}` or `${output}` inside `sub_param_arguments`, paths, or prompts to refer to the current item; both names resolve to the same per-item value at expansion time. Do not pre-expand those fields against the parent input.
 
 ### Parallelism: concurrent fan-out → merge
 
@@ -364,6 +380,8 @@ Dispatch **one** test run with `aevatar_start_workflow`, passing the draft inlin
 
 Interpret evidence in order:
 - `accepted`/`streaming` means only that dispatch started.
+- After acceptance, require the first projection-backed business frame within 30 seconds. SSE `: keepalive` is transport-only and does not satisfy or extend this deadline. If the stream closes with root `RUN_ERROR(code=RUN_OBSERVATION_TIMEOUT)`, observation timed out, not necessarily the workflow itself; query the same `actorId + commandId` for later state and never create another run as a status probe.
+- Only root `RUN_FINISHED` and root `RUN_ERROR` are terminal for the workflow stream. Role text, reasoning, tool-call, tool-result, or role-level terminal frames are progress and must not end observation.
 - A typed parse, admission, identity, or resource-limit error is a structural failure; fix the document before another run.
 - For the same run, inspect terminal completion, run detail, and audit. Success requires completed terminal state, `lastSuccess=true`, expected non-empty step output, and non-empty final output.
 - On failure, locate the first failed audit step and classify it before retrying. For NyxID HTTP auth failures, distinguish missing caller credential propagation, missing executor propagation, wrong exact route/credential selection, and downstream UserService authorization.
@@ -392,387 +410,13 @@ Choose a clear `name`/`description` so the user (and future searches) can find i
 
 ---
 
-## Client path (no nyxid MCP) — dry-run + publish over REST
+## Client REST path
 
-Use this whole section when you hold a **NyxID bearer token** but the server-side tools
-(`aevatar_start_workflow` / `ornn_publish_skill` / `use_skill` / `nyxid_services`) are **not** in
-your tool list. Everything here is plain authenticated REST against the same control-plane base
-the sibling aevatar skills use. (All of it is verified live; none of it requires reading aevatar
-source.)
+When the server-side Aevatar/NyxID tools are absent, read [references/client-rest.md](references/client-rest.md) before validating, publishing, or invoking through the NyxID broker.
 
-### Bootstrap
-```bash
-# Drive the aevatar backend THROUGH the NyxID broker: it injects your scope_id claim AND
-# auto-refreshes your token. A raw curl with ~/.nyxid/access_token resolves NO scope
-# (scopeResolved:false) and the stored token expires — it is not a usable path.
-# Prerequisite once: the `aevatar` service must be connected — `nyxid service add aevatar`.
-aev() { nyxid proxy request aevatar "$@"; }   # aev "<path>" [-m POST|PUT|DELETE] [-d '<json>'] [--stream]
-scopeId=$(aev "api/studio/context" | jq -r .scopeId)
-```
-No `jq`? Any JSON reader works, e.g.
-`... | python3 -c 'import sys,json;print(json.load(sys.stdin)["scopeId"])'`.
+## Worked examples
 
-### Connectors
-The `nyxid_services` inventory tool is server-side. As a client, discover exact connected-service
-instances through the NyxID CLI or the authenticated Aevatar preview surface. `/api/v1/keys` is the
-authoritative instance/readiness inventory; `/api/v1/user-services` is not. Never invent a slug,
-UserService identity, endpoint, method, or path.
-
-### Dry-run (the client replacement for `aevatar_start_workflow`) — `draft-run`
-`aevatar_start_workflow` is a **server-side agent tool dispatched through the engine, not a REST
-endpoint** — a client cannot call it. The client dry-run is the **draft-run** endpoint, which
-takes the YAML inline (long runs stream, so the broker holds the connection open):
-```bash
-aev "api/scopes/$scopeId/workflow/draft-run" -m POST --stream \
-  -d "$(python3 -c 'import json;print(json.dumps({"prompt":"<test input>","workflowYamls":[open("workflow.yaml").read()]}))')"
-```
-Body (JSON, **camelCase**): `prompt` (string) + `workflowYamls` (array of YAML strings,
-**required** — omitting it returns 400). The response is an **SSE stream** and the run executes
-synchronously through the connection. Judge it like the server-side validate step:
-- **HTTP 200 + lifecycle frames** proves only dispatch. For execution acceptance, continue to the terminal frame and read the resulting run detail/audit.
-- A parse/validation/4xx error → fix the YAML and retry (cap **2**).
-
-**Reading the SSE frames** (so a naive parser doesn't see "nothing"): each `data:` line is JSON,
-and two kinds interleave — there is **no flat `type` field**:
-- *Lifecycle*, keyed by a top-level field: `{"stepStarted":{"stepName":…}}`,
-  `{"stepFinished":{"stepName":…}}`, `{"usage":{…}}`, `{"runFinished":{…}}`,
-  `{"stateSnapshot":{…}}`. A matched `stepStarted`+`stepFinished` per step proves each step ran;
-  `runFinished` marks the end.
-- *Raw observation*: `{"custom":{"name":"aevatar.raw.observed",…}}` — these carry the actual step
-  **output text** (search recursively under `output` / `content`).
-
-`draft-run` is **not** observable in `/workflow/observatory` (it is a throwaway validation run).
-For an observable run, publish + invoke (below / sibling skills).
-
-### Publish the workflow skill to ornn (the client replacement for `ornn_publish_skill`) — REST zip
-`ornn_publish_skill` is also server-side. The client publishes a **zip** through the nyxid proxy
-(slug **`ornn-api`**, not `ornn`). Build this exact layout — a **root folder**, `SKILL.md` at the
-root, and the workflow YAML under **`assets/`** (the validator **rejects a `workflows/` root dir**):
-```
-demo-skill/
-  SKILL.md
-  assets/
-    my_workflow.yaml      # top-level `name:` + `steps:` → auto-extracted; its `name` is the workflow id
-```
-The platform's extractor scans `assets/*.{yaml,yml}` and treats any YAML having **both** a
-top-level `name` and `steps` as a runnable workflow whose `workflow_id` equals that `name`.
-
-`SKILL.md` frontmatter **must nest under `metadata:`** (flat top-level `category`/`output_type`/
-`tool_list` is rejected). A workflow skill is **`category: mixed`** with these **kebab-case** keys —
-all three are required for `mixed` (and for `runtime-based`):
-```yaml
----
-name: demo-skill
-description: <one line — what it does>
-version: "1.0"
-metadata:
-  category: mixed
-  output-type: text                 # required for mixed / runtime-based
-  runtime:                          # required; MUST be a YAML array — a bare string is rejected
-    - aevatar-workflow              # the workflow runtime (NOT node/python)
-  tool-list:                        # required for mixed
-    - aevatar_start_workflow
-  tag: [demo, workflow, aevatar]    # singular `tag`, ≤10
----
-```
-Then **validate first** (the format oracle — read every `violations[].rule`/`message` and fix),
-then **upload** (re-uploading the **same `name`** later creates a **new version**):
-```bash
-cd <parent>; zip -r demo-skill.zip demo-skill                 # root folder MUST be included
-# 1) validate → {"data":{"valid":bool,"violations":[{"rule","message"}]}}
-nyxid proxy request ornn-api /api/v1/skill-format/validate -m POST \
-  -H 'Content-Type:application/zip' -d @demo-skill.zip
-# 2) publish (private by default; promote to public separately)
-nyxid proxy request ornn-api /api/v1/skills -m POST \
-  -H 'Content-Type:application/zip' -d @demo-skill.zip
-# verify
-nyxid proxy request ornn-api /api/v1/skills/demo-skill
-```
-The server normalizes the kebab frontmatter into its stored model
-(`runtimes:[{runtime,dependencies,envs}]`, `tools:[{tool,type:mcp}]`, `outputType`).
-
-### Run a published workflow skill as a client
-The `use_skill` → `aevatar_start_workflow` mount path is server-side. As a client you take the
-control-plane route instead: bind the workflow to a **team member**, then invoke the published
-service. Binding a member **is** publishing a service; its `chat:stream` invoke runs the workflow
-and shows in the observatory. See `aevatar-team-builder` then `aevatar-service-publisher`.
-
----
-
-## Worked examples (generic — adapt, don't copy verbatim)
-
-### A. Linear LLM chain
-
-```yaml
-name: summarize_then_title
-roles:
-  - id: writer
-    system_prompt: "You are a concise writer."
-steps:
-  - id: summarize
-    type: llm_call
-    target_role: writer
-    parameters: { prompt_prefix: "Summarize the input in 3 bullets:" }
-    next: make_title
-  - id: make_title
-    type: llm_call
-    target_role: writer
-    parameters: { prompt_prefix: "Write a one-line title for this summary:" }
-```
-`make_title` is last and has no `next` → it is the single terminal step.
-
-### B. Fetch → classify → branch → converge (single terminal)
-
-```yaml
-name: fetch_and_route
-roles:
-  - id: analyst
-    system_prompt: "You classify and draft responses."
-steps:
-  - id: fetch
-    type: tool_call
-    capability:
-      nyxid_operation:
-        user_service_id: <copied-user-service-id>
-        operation_id: <listed-operation-id>
-    parameters:
-      tool: nyxid_proxy
-      arguments: '{"query":{}}'
-    next: classify
-  - id: classify
-    type: llm_call
-    target_role: analyst
-    parameters: { prompt_prefix: "Reply with one word, 'urgent' or 'normal':" }
-    next: route
-  - id: route
-    type: switch
-    parameters:
-      on: "$input"
-      branch.urgent: handle_urgent
-      branch.normal: handle_normal
-      branch._default: handle_normal   # fallback for unexpected output
-    branches: { urgent: handle_urgent, normal: handle_normal, _default: handle_normal }
-  - id: handle_urgent
-    type: llm_call
-    target_role: analyst
-    parameters: { prompt_prefix: "Draft an urgent response:" }
-    next: finalize
-  - id: handle_normal
-    type: llm_call
-    target_role: analyst
-    parameters: { prompt_prefix: "Draft a standard response:" }
-    next: finalize
-  - id: finalize
-    type: assign
-    parameters: { target: final_summary, value: "$input" }
-```
-Both branches converge to `finalize` via explicit `next`; `finalize` is last → single terminal. (No step sits after it, so nothing fall-through-overwrites the output.)
-
-### C. Per-item processing (foreach)
-
-```yaml
-name: process_each_line
-roles:
-  - id: worker
-    system_prompt: "You process one item."
-steps:
-  - id: per_item
-    type: foreach
-    parameters:
-      delimiter: "\n"
-      sub_step_type: llm_call
-      sub_target_role: worker
-      sub_param_prompt_prefix: "Process this item:"
-    next: collect
-  - id: collect
-    type: assign
-    parameters: { target: final_summary, value: "$input" }
-```
-
-### D. Multiple files → extract → upload files
-
-```yaml
-name: extract_files_then_upload_files
-description: Extract text from multiple uploaded files, submit each original file to a NyxID upload service, and return a structured upload summary.
-steps:
-  - id: extract_each_file
-    type: foreach
-    parameters:
-      items_source: input_file_refs
-      sub_step_type: tool_call
-      sub_param_tool: document_extract
-      sub_param_arguments: '{"maxChars":2000}'
-    next: build_submit_requests
-
-  - id: build_submit_requests
-    type: tool_call
-    parameters:
-      tool: code_execute
-      arguments:
-        language: javascript
-        code: |
-          const raw = "${json(json(input))}";
-          const requests = [];
-          const fileRefKeys = [
-            "file_id",
-            "artifact_id",
-            "source_kind",
-            "source_message_id",
-            "source_resource_key",
-            "owner_run_id",
-            "owner_scope_id"
-          ];
-
-          for (const [index, part] of raw.split("\n---\n").filter(part => part.trim()).entries()) {
-            const extracted = JSON.parse(part);
-            const file = extracted.file || {};
-            const fileRef = {};
-            for (const key of fileRefKeys) {
-              if (file[key]) fileRef[key] = file[key];
-            }
-
-            const itemIndex = index + 1;
-            requests.push({
-              file_ref: fileRef,
-              slug: "<upload-service-slug>",
-              path: "<upload-endpoint-path>",
-              method: "POST",
-              file_field_name: "<file-form-field-name>",
-              form: {
-                file_name: file.file_name || "workflow-upload-" + itemIndex + ".bin",
-                size: file.size_bytes ? String(file.size_bytes) : "",
-                source: "multiple-files-" + itemIndex
-              },
-              output: {
-                kind: "provider_file_token",
-                selector: "<response-json-path-for-upload-token>"
-              },
-              max_file_bytes: 31457280
-            });
-          }
-
-          console.log(JSON.stringify(requests));
-    next: parse_submit_requests
-
-  - id: parse_submit_requests
-    type: transform
-    parameters:
-      op: json_parse
-      path: output.stdout
-    next: submit_each_file
-
-  - id: submit_each_file
-    type: foreach
-    parameters:
-      sub_step_type: tool_call
-      sub_param_tool: workflow_file_submit
-    next: build_upload_summary
-
-  - id: build_upload_summary
-    type: tool_call
-    parameters:
-      tool: code_execute
-      arguments:
-        language: javascript
-        code: |
-          const raw = "${json(json(input))}";
-          const uploads = [];
-          const submitResults = [];
-
-          for (const part of raw.split("\n---\n").filter(item => item.trim())) {
-            const submitted = JSON.parse(part);
-            submitResults.push(submitted);
-            if (submitted.output_code) {
-              uploads.push({
-                file_name: submitted.file && submitted.file.file_name ? submitted.file.file_name : "",
-                output_code: submitted.output_code,
-                output_kind: submitted.output_kind || ""
-              });
-            }
-          }
-
-          const summary = {
-            upload_count: uploads.length,
-            uploads,
-            submit_results: submitResults
-          };
-
-          console.log(JSON.stringify(summary));
-    next: parse_upload_summary
-
-  - id: parse_upload_summary
-    type: transform
-    parameters:
-      op: json_parse
-      path: output.stdout
-    next: finish
-
-  - id: finish
-    type: assign
-    parameters:
-      target: final_summary
-      value: '{"run_tag":"multiple-files-upload","uploaded_files":${steps.parse_upload_summary.output}}'
-```
-`extract_each_file` produces one JSON result per file. `build_submit_requests` projects only the stable workflow file-ref identity keys into `file_ref`; keep display metadata such as file name and size in `form` only when the upload service needs it. `parse_submit_requests` turns `code_execute` stdout into a JSON array so `submit_each_file` can upload each original file with `workflow_file_submit`. `build_upload_summary` collects returned provider codes without writing to any vendor-specific record system. Replace the upload service slug, endpoint path, file field name, and response selector before validation.
-
-### E. code_execute → json_parse
-
-```yaml
-name: code_execute_then_parse
-steps:
-  - id: build_json
-    type: tool_call
-    parameters:
-      tool: code_execute
-      arguments:
-        language: javascript
-        code: |
-          console.log(JSON.stringify({"route":"approved","score":91}));
-    next: parse_stdout
-  - id: parse_stdout
-    type: transform
-    parameters:
-      op: json_parse
-      path: output.stdout
-    next: route
-  - id: route
-    type: switch
-    parameters:
-      on: "${steps.parse_stdout.json.route}"
-      branch.approved: finalize
-      branch._default: finalize
-    branches: { approved: finalize, _default: finalize }
-  - id: finalize
-    type: assign
-    parameters: { target: final_summary, value: "${steps.parse_stdout.output}" }
-```
-`code_execute` returns a sandbox envelope; the business JSON is a string at `output.stdout`. `json_parse` promotes that string to structured output so later steps can read `steps.parse_stdout.json.route`.
-
-### F. Fan-out in parallel → merge (the n8n "multiple sources → merge" shape)
-
-```yaml
-name: sources_digest
-roles:
-  - id: analyst
-    system_prompt: "Summarize one source's content into 3 bullet highlights."
-  - id: editor
-    system_prompt: "Merge per-source highlights into one digest, deduping overlaps."
-steps:
-  # The N sources arrive as ONE list — a JSON array, or a "\n---\n"-delimited string —
-  # produced upstream (the run input, an assign, or transform op: rss_extract_items).
-  - id: digest
-    type: map_reduce
-    parameters:
-      delimiter: "\n---\n"
-      map_step_type: llm_call
-      map_target_role: analyst         # every source analyzed concurrently — the fan-out
-      reduce_step_type: llm_call
-      reduce_target_role: editor        # one merge over all results — the fan-in
-      reduce_prompt_prefix: "Combine these per-source highlights into one digest:"
-```
-One `map_reduce` step is n8n's "N source branches → merge node": the map phase analyzes every source concurrently (default ≤20 at once), the reduce phase merges them into one result. Want the per-source outputs concatenated with **no** synthesis? Use `foreach` (Example C) and drop the reduce. Need to **fetch** each source first (each item is e.g. a feed URL or file)? Do that with a `foreach` of `sub_step_type: tool_call` — its `sub_param_*` give each fetch its tool + arguments — then pipe the fetched text into this `map_reduce` to analyze-and-merge. (Don't use `map_reduce` for the fetch: its map sub-steps get no per-step parameters.)
-
----
+Read [references/worked-examples.md](references/worked-examples.md) when you need complete YAML shapes for branching, per-item calls, typed files, bounded templates, or fan-out/reduce.
 
 ## Self-check before publishing
 
@@ -781,5 +425,5 @@ One `map_reduce` step is n8n's "N source branches → merge node": the map phase
 - [ ] No hardcoded `model:` unless the user demanded one.
 - [ ] Arithmetic / totals / dedup use `transform`, not `llm_call`.
 - [ ] Every workflow external call copied an exact listed selector, passed readiness for its execution mode, and puts only runtime operation values in `nyxid_proxy.arguments`; raw current-turn proxy calls use exact `service_id + slug + path`.
-- [ ] One `aevatar_start_workflow` dispatch returned a `run_id` with no parse error — you did **not** wait for/poll `run_finished` (the run finishes async; report the `run_id` + observatory).
+- [ ] One authorized dispatch was observed to root `RUN_FINISHED` / `RUN_ERROR`, or a `RUN_OBSERVATION_TIMEOUT` was reconciled by querying the same `actorId + commandId`; no second run was created as a status check.
 - [ ] Any parallel fan-out uses the right primitive: same input → `parallel` / `race`; a list of different items → `foreach` (concatenate) or `map_reduce` (synthesize). Per-item `tool_call` fetches use `foreach`, not `map_reduce`.

--- a/skills/aevatar-workflow-authoring/references/client-rest.md
+++ b/skills/aevatar-workflow-authoring/references/client-rest.md
@@ -1,0 +1,104 @@
+# Client REST path
+
+Read this reference only when the caller has the NyxID CLI or bearer-backed broker path but does not have the server-side `aevatar_start_workflow`, `ornn_publish_skill`, `use_skill`, or `nyxid_services` tools.
+
+## Contents
+
+- Bootstrap and capability discovery
+- Draft-run validation
+- Publishing a workflow skill to Ornn
+- Running a published workflow
+
+## Bootstrap and capability discovery
+
+Drive Aevatar through the NyxID broker so the request receives the caller's `scope_id` and token refresh behavior:
+
+```bash
+aev() { nyxid proxy request aevatar "$@"; }
+scopeId=$(aev "api/studio/context" | jq -r .scopeId)
+```
+
+The `aevatar` service must already be connected. Do not send the stored NyxID access token directly to the Aevatar backend: that route can authenticate while resolving no scope. `jq` is optional; use any structured JSON reader.
+
+The `nyxid_services` tool is server-side. As a client, discover exact connected-service instances through the NyxID CLI or the authenticated Aevatar preview surface. `/api/v1/keys` is the authoritative UserService instance/readiness inventory; `/api/v1/user-services` is only a routing projection. Never invent a slug, UserService identity, endpoint, method, or path.
+
+## Draft-run validation
+
+`aevatar_start_workflow` is not an HTTP endpoint. Validate client-authored YAML with the scoped draft-run endpoint:
+
+```bash
+aev "api/scopes/$scopeId/workflow/draft-run" -m POST --stream \
+  -d "$(python3 -c 'import json;print(json.dumps({"prompt":"<test input>","workflowYamls":[open("workflow.yaml").read()]}))')"
+```
+
+The JSON body uses camelCase and requires `workflowYamls`. The response is SSE. Interpret it as follows:
+
+- HTTP 200 and lifecycle frames prove only dispatch.
+- A parse, validation, or typed 4xx failure requires a document fix before another attempt.
+- Root `RUN_FINISHED` or root `RUN_ERROR` is terminal. Role text, reasoning, tool-call, tool-result, and role terminal frames are progress only.
+- Acceptance starts a 30-second deadline for the first projection-backed business frame. `: keepalive` does not satisfy or extend it.
+- Root `RUN_ERROR(code=RUN_OBSERVATION_TIMEOUT)` closes the stream because observation stalled; it is not proof that the workflow failed. Query the same `actorId + commandId` for later state. Do not create a second run to check the first.
+- After a real terminal frame, read run detail and audit. Require completed state, `lastSuccess=true`, expected non-empty step outputs, and non-empty final output before reporting execution success.
+
+SSE `data:` lines contain JSON. Lifecycle shapes use top-level keys such as `stepStarted`, `stepFinished`, `usage`, `runFinished`, and `stateSnapshot`. Raw observation frames use `custom.name: aevatar.raw.observed` and carry step output under nested `output` or `content`. There is no universal flat `type` field.
+
+A draft-run is throwaway validation and is not listed in the workflow observatory. Publish and invoke for an observable run.
+
+## Publishing a workflow skill to Ornn
+
+`ornn_publish_skill` is also server-side. A client publishes a zip through the NyxID proxy service slug `ornn-api`. The zip must contain one root directory, with `SKILL.md` at that root and workflow YAML under `assets/`:
+
+```text
+demo-skill/
+  SKILL.md
+  assets/
+    my-workflow.yaml
+```
+
+The extractor recognizes `assets/*.{yaml,yml}` files that have top-level `name` and `steps`. Do not use a `workflows/` root directory.
+
+`SKILL.md` frontmatter must nest Ornn fields under `metadata`. A workflow skill is
+`category: mixed` and requires kebab-case `output-type`, an array-valued `runtime`, and
+`tool-list`:
+
+```markdown
+---
+name: demo-skill
+description: Run the demo workflow when the user asks for its task.
+version: "1.0"
+metadata:
+  category: mixed
+  output-type: text
+  runtime:
+    - aevatar-workflow
+  tool-list:
+    - aevatar_start_workflow
+  tag: [demo, workflow, aevatar]
+---
+
+# Demo workflow
+
+Load and run `my-workflow` with the user's input.
+```
+
+Validate the zip before publishing, then publish it through the caller-scoped Ornn service. Send
+the zip itself as `application/zip`, not multipart form data:
+
+```bash
+nyxid proxy request ornn-api "/api/v1/skill-format/validate" -m POST \
+  -H 'Content-Type:application/zip' -d @demo-skill.zip
+nyxid proxy request ornn-api "/api/v1/skills" -m POST \
+  -H 'Content-Type:application/zip' -d @demo-skill.zip
+```
+
+Require `valid:true` from validation and fix every `violations[].rule`/`message`. Updating an
+existing skill uses `PUT /api/v1/skills/{skillGuid}` with the same zip body; do not create a second
+skill name. Read back the returned skill GUID, exact version, parsed JSON, and workflow list before
+reporting publication. Publication is private by default unless a separate authorized visibility
+operation changes it.
+
+## Running a published workflow
+
+Mount or select the exact published skill/version through the supported client surface, then invoke its workflow using the member or service contract created by the platform. Do not attempt to call `use_skill` as HTTP.
+
+For a streaming invocation, apply the same root-terminal and 30-second first-projection rules as draft-run. For a non-streaming accepted receipt, retain `actorId + commandId` and observe/query that exact run. An accepted receipt, opened SSE stream, role completion, or keepalive is never execution success.

--- a/skills/aevatar-workflow-authoring/references/worked-examples.md
+++ b/skills/aevatar-workflow-authoring/references/worked-examples.md
@@ -1,0 +1,170 @@
+# Workflow authoring examples
+
+Read this reference when a concrete YAML shape is useful. Adapt names, roles, tools, selectors, and inputs; do not copy capability identities or routes from an example.
+
+## Contents
+
+- Linear LLM chain
+- Branch and converge
+- Per-item tool calls
+- Multiple typed files
+- Bounded template aggregation
+- Fan-out and reduce
+
+## Linear LLM chain
+
+```yaml
+name: summarize_and_title
+roles:
+  - id: analyst
+    system_prompt: Summarize faithfully.
+  - id: editor
+    system_prompt: Produce one concise title.
+steps:
+  - id: summarize
+    type: llm_call
+    target_role: analyst
+    parameters:
+      prompt_prefix: "Summarize:"
+    next: make_title
+  - id: make_title
+    type: llm_call
+    target_role: editor
+    parameters:
+      prompt_prefix: "Title this summary:"
+```
+
+The last document step is the only step without `next`, so it is the single terminal step.
+
+## Branch and converge
+
+```yaml
+name: classify_and_route
+roles:
+  - id: classifier
+    system_prompt: Return exactly urgent or normal.
+  - id: writer
+    system_prompt: Draft the requested response.
+steps:
+  - id: classify
+    type: llm_call
+    target_role: classifier
+    next: route
+  - id: route
+    type: switch
+    parameters:
+      on: "$input"
+      branch.urgent: urgent_reply
+      branch._default: normal_reply
+    branches:
+      urgent: urgent_reply
+      _default: normal_reply
+  - id: urgent_reply
+    type: llm_call
+    target_role: writer
+    parameters:
+      prompt_prefix: "Draft an urgent response:"
+    next: finalize
+  - id: normal_reply
+    type: llm_call
+    target_role: writer
+    parameters:
+      prompt_prefix: "Draft a normal response:"
+    next: finalize
+  - id: finalize
+    type: assign
+    parameters:
+      target: final_summary
+      value: "$input"
+```
+
+Both branches converge explicitly. Never put another step after `finalize`.
+
+## Per-item tool calls
+
+Use `foreach` when each item needs its own tool arguments. `${input}` and `${output}` inside any `sub_param_*` value both resolve to the current item after fan-out:
+
+```yaml
+- id: fetch_each_instance
+  type: foreach
+  parameters:
+    delimiter: "\n"
+    sub_step_type: tool_call
+    sub_param_tool: nyxid_proxy
+    sub_param_arguments: >-
+      {"path_params":{"instance_id":"${input}"}}
+  next: synthesize
+```
+
+Keep all `sub_param_*` fields under `parameters`. Do not use `map_reduce` for per-item tool calls because its map phase does not carry per-step parameters.
+
+## Multiple typed files
+
+Fan typed refs out directly. The child tool receives one current file ref; it does not receive a file ID string as prompt input:
+
+```yaml
+name: extract_files
+roles:
+  - id: editor
+    system_prompt: Combine extracted text faithfully.
+steps:
+  - id: extract_each_file
+    type: foreach
+    parameters:
+      items_source: input_file_refs
+      sub_step_type: tool_call
+      sub_param_tool: document_extract
+      sub_param_arguments: "{}"
+    next: summarize
+  - id: summarize
+    type: llm_call
+    target_role: editor
+```
+
+When the start request has no explicit `fileRef`, deduplicated ambient refs may supply `input_file_refs`; empty `inputs` is valid in that case. If any explicit `fileRef` is present, ambient refs are suppressed. Role LLM tool loops receive the same typed refs.
+
+For uploads, call `workflow_file_submit` in a `foreach` child with the current typed ref. Preserve the full ref fields supplied by the platform; do not manufacture an `artifact_id`, owner run, source message, or resource key.
+
+## Bounded template aggregation
+
+Use the typed `template` transform for deterministic multi-item aggregation or JSON/report rendering:
+
+```yaml
+name: aggregate_budget
+steps:
+  - id: aggregate
+    type: transform
+    parameters:
+      op: template
+      template: >-
+        {{ total = 0 }}
+        {{ for item in data.items; total = total + number(item.amount); end }}
+        {{ json({ count: data.items.size, total: round(total, 2) }) }}
+    next: finalize
+  - id: finalize
+    type: assign
+    parameters:
+      target: final_summary
+      value: "$input"
+```
+
+The step input must be bounded JSON and is exposed as `data`. The template is a typed static program, not upstream `${...}` code. Only `append`, `date`, `get`, `json`, `keys`, `number`, and `round` are available; the limits and fail-closed rules are in `SKILL.md`.
+
+## Fan-out and reduce
+
+Use `map_reduce` for different items that need concurrent LLM analysis followed by one synthesis:
+
+```yaml
+- id: analyze_sources
+  type: map_reduce
+  parameters:
+    delimiter: "\n---\n"
+    map_step_type: llm_call
+    map_target_role: analyst
+    reduce_step_type: llm_call
+    reduce_target_role: editor
+    reduce_prompt_prefix: "Combine these analyses into one digest:"
+  next: finalize
+```
+
+Use `foreach` instead when concatenated per-item outputs are sufficient. Use `parallel` or `race` only when every branch should receive the same input. To fetch different sources, first use `foreach` with `sub_step_type: tool_call`, then pass the fetched outputs into `map_reduce`.


### PR DESCRIPTION
## Problem

The bundled Aevatar platform skills in NyxID predate the Aevatar changes shipped on 2026-08-03 and 2026-08-04. They do not describe the new workflow template/file contracts, first-projection observation deadline, exact invocation readiness, typed Studio/NyxID failures, caller-scoped Ornn search authority, or recovery/approval semantics.

## Solution

- Refresh six bundled skills from the Aevatar change audit:
  - `aevatar-workflow-authoring@2.4`
  - `aevatar-team-builder@1.5`
  - `aevatar-service-publisher@1.7`
  - `aevatar-platform-map@1.12`
  - `aevatar-feasibility-advisor@1.6`
  - `aevatar-triage@1.8`
- Split workflow REST guidance and worked examples into one-level references so the primary `SKILL.md` stays under 500 lines.
- Bump Claude plugin/marketplace metadata to `0.8.2` and Codex/Cursor manifests to `0.7.4`.
- Publish and verify the corresponding public Ornn skill versions and `aevatar-platform@1.16`.

## Impact

Only plugin distribution metadata and the six bundled skill packages change. NyxID backend, CLI, frontend, mobile, SDK, and runtime behavior are untouched.

## Verification

- Ornn `/api/v1/skill-format/validate`: 6/6 valid, zero violations.
- Ornn read-back: 6/6 exact package ZIP SHA-256 and `SKILL.md` content matches.
- `aevatar-platform@1.16`: 15 unique members, all public/readable, local versions match closure.
- `quick_validate.py`: 6/6 valid after removing only Ornn's supported top-level `version` extension in temporary copies.
- `plugin-creator/scripts/validate_plugin.py .`: passed.
- `jq empty .codex-plugin/plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/plugin.json`: passed.
- Link/version assertions and `git diff --check`: passed.
- No Rust or frontend tests were run because no application code changed.