### PR TITLE
fix: support sandbox execution delegation

### DIFF
--- a/backend/src/mw/auth.rs
+++ b/backend/src/mw/auth.rs
@@ -263,6 +263,7 @@ pub const SERVICE_DELEGATION_SCOPES: &[&str] = &[
     WIDE_PROXY_SCOPE,
     "llm:status",
     ACCOUNT_READ_SCOPE,
+    "sandbox:execute",
 ];
 
 const DELEGATED_ENDPOINT_FORBIDDEN: &str = "Delegated tokens cannot access this endpoint";

--- a/backend/src/services/user_service_service.rs
+++ b/backend/src/services/user_service_service.rs
@@ -2585,7 +2585,13 @@ mod tests {
 
     #[test]
     fn validate_identity_config_accepts_all_valid_scopes() {
-        for scope in ["llm:proxy", "proxy:*", "llm:status", "account:read"] {
+        for scope in [
+            "llm:proxy",
+            "proxy:*",
+            "llm:status",
+            "account:read",
+            "sandbox:execute",
+        ] {
             let config = IdentityConfig {
                 delegation_token_scope: scope.to_string(),
                 ..IdentityConfig::none()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -939,6 +939,15 @@ pub enum ServiceCommands {
         /// Allow org members with proxy scope to execute this service.
         #[arg(long, conflicts_with = "admin_only")]
         member_access: bool,
+        /// Forward the caller's bearer token to the downstream service.
+        #[arg(long, value_name = "BOOL")]
+        forward_access_token: Option<bool>,
+        /// Inject a short-lived NyxID delegation token for the downstream service.
+        #[arg(long, value_name = "BOOL")]
+        inject_delegation_token: Option<bool>,
+        /// Space-separated scopes carried by the injected delegation token.
+        #[arg(long, value_name = "SCOPES")]
+        delegation_token_scope: Option<String>,
         /// Set or replace a default HTTP header injected on every proxied
         /// request. Format: `name=value`, optionally suffixed with
         /// `:overridable` to let a caller-supplied value win. Repeat the
@@ -2400,6 +2409,43 @@ mod tests {
             } => {
                 assert!(!admin_only);
                 assert!(member_access);
+            }
+            _ => panic!("unexpected parse result"),
+        }
+    }
+
+    #[test]
+    fn service_update_accepts_identity_delegation_flags() {
+        let cli = Cli::try_parse_from([
+            "nyxid",
+            "service",
+            "update",
+            "key-alpha",
+            "--forward-access-token",
+            "true",
+            "--inject-delegation-token",
+            "true",
+            "--delegation-token-scope",
+            "proxy:* sandbox:execute",
+        ])
+        .expect("service update should accept identity delegation flags");
+
+        match cli.command {
+            Commands::Service {
+                command:
+                    ServiceCommands::Update {
+                        forward_access_token,
+                        inject_delegation_token,
+                        delegation_token_scope,
+                        ..
+                    },
+            } => {
+                assert_eq!(forward_access_token, Some(true));
+                assert_eq!(inject_delegation_token, Some(true));
+                assert_eq!(
+                    delegation_token_scope.as_deref(),
+                    Some("proxy:* sandbox:execute")
+                );
             }
             _ => panic!("unexpected parse result"),
         }

--- a/cli/src/commands/service.rs
+++ b/cli/src/commands/service.rs
@@ -1249,6 +1249,9 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             inactive,
             admin_only,
             member_access,
+            forward_access_token,
+            inject_delegation_token,
+            delegation_token_scope,
             default_header,
             clear_default_headers,
             ws_frame_preset,
@@ -1258,9 +1261,9 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             let mut api = ApiClient::from_auth_checked(&auth).await?;
 
             let mut body = serde_json::Map::new();
+            let mut user_service_body = serde_json::Map::new();
             let ws_frame_injections =
                 build_ws_frame_injections_body(ws_frame_preset.as_deref(), ws_frame_clear)?;
-            let has_ws_frame_update = ws_frame_injections.is_some();
 
             if let Some(l) = label {
                 body.insert("label".into(), Value::String(l));
@@ -1307,6 +1310,15 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
             } else if member_access {
                 body.insert("admin_only".into(), Value::Bool(false));
             }
+            if let Some(value) = forward_access_token {
+                user_service_body.insert("forward_access_token".into(), Value::Bool(value));
+            }
+            if let Some(value) = inject_delegation_token {
+                user_service_body.insert("inject_delegation_token".into(), Value::Bool(value));
+            }
+            if let Some(value) = delegation_token_scope {
+                user_service_body.insert("delegation_token_scope".into(), Value::String(value));
+            }
 
             // NyxID#356: default_request_headers.
             //   --clear-default-headers     -> null (clears)
@@ -1322,23 +1334,29 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
                 );
             }
 
-            let mut result: Value = if body.is_empty() && has_ws_frame_update {
+            if let Some(rules) = ws_frame_injections {
+                user_service_body
+                    .insert("ws_frame_injections".into(), serde_json::to_value(rules)?);
+            }
+
+            let has_user_service_update = !user_service_body.is_empty();
+            let mut result: Value = if body.is_empty() && has_user_service_update {
                 api.get(&format!("/keys/{id}")).await?
             } else {
                 api.put(&format!("/keys/{id}"), &Value::Object(body))
                     .await?
             };
 
-            if let Some(rules) = ws_frame_injections {
-                let service_id = result["user_service_id"]
+            if has_user_service_update {
+                let service_id = result["id"]
                     .as_str()
-                    .or(result["id"].as_str())
-                    .or(result["_id"].as_str())
                     .ok_or_else(|| anyhow::anyhow!("Could not resolve user_service_id"))?
                     .to_string();
-                let body = serde_json::json!({ "ws_frame_injections": rules });
                 let _: Value = api
-                    .put(&format!("/user-services/{service_id}"), &body)
+                    .put(
+                        &format!("/user-services/{service_id}"),
+                        &Value::Object(user_service_body),
+                    )
                     .await?;
                 result = api.get(&format!("/keys/{id}")).await?;
             }
@@ -3303,6 +3321,9 @@ mod command_tests {
             inactive: false,
             admin_only: false,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec![],
             clear_default_headers: false,
             ws_frame_preset: None,
@@ -3311,6 +3332,57 @@ mod command_tests {
         })
         .await
         .expect("update should succeed");
+    }
+
+    #[tokio::test]
+    async fn identity_only_update_resolves_and_updates_user_service() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/keys/key-alpha"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "user-service-bravo"
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/api/v1/user-services/user-service-bravo"))
+            .and(body_json(serde_json::json!({
+                "forward_access_token": true,
+                "inject_delegation_token": true,
+                "delegation_token_scope": "proxy:* sandbox:execute"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "user-service-bravo"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        run(ServiceCommands::Update {
+            id: "key-alpha".to_string(),
+            label: None,
+            endpoint_url: None,
+            openapi_spec_url: None,
+            recommended_skill: Vec::new(),
+            clear_recommended_skills: false,
+            node_id: None,
+            no_node: false,
+            active: false,
+            inactive: false,
+            admin_only: false,
+            member_access: false,
+            forward_access_token: Some(true),
+            inject_delegation_token: Some(true),
+            delegation_token_scope: Some("proxy:* sandbox:execute".to_string()),
+            default_header: vec![],
+            clear_default_headers: false,
+            ws_frame_preset: None,
+            ws_frame_clear: false,
+            auth: mock_auth(server.uri()),
+        })
+        .await
+        .expect("identity update should succeed");
     }
 
     #[tokio::test]
@@ -3527,6 +3599,9 @@ mod command_tests {
             inactive: false,
             admin_only: false,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec!["x-api-version=v2".to_string()],
             clear_default_headers: false,
             ws_frame_preset: None,
@@ -3812,6 +3887,9 @@ mod branch_tests {
             inactive: false,
             admin_only: false,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec![],
             clear_default_headers: false,
             ws_frame_preset: None,
@@ -3985,6 +4063,9 @@ mod branch_tests {
             inactive: false,
             admin_only: false,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec![],
             clear_default_headers: true,
             ws_frame_preset: None,
@@ -4020,6 +4101,9 @@ mod branch_tests {
             inactive: false,
             admin_only: false,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec![],
             clear_default_headers: false,
             ws_frame_preset: None,
@@ -4055,6 +4139,9 @@ mod branch_tests {
             inactive: true,
             admin_only: false,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec![],
             clear_default_headers: false,
             ws_frame_preset: None,
@@ -4090,6 +4177,9 @@ mod branch_tests {
             inactive: false,
             admin_only: true,
             member_access: false,
+            forward_access_token: None,
+            inject_delegation_token: None,
+            delegation_token_scope: None,
             default_header: vec![],
             clear_default_headers: false,
             ws_frame_preset: None,

--- a/docs/API.md
+++ b/docs/API.md
@@ -3994,6 +3994,10 @@ This allows the downstream service to use the token as a Bearer token when calli
 | `inject_delegation_token`  | boolean | `false`      | Whether to inject delegation tokens          |
 | `delegation_token_scope`   | string  | `"llm:proxy"`| Space-separated scopes for the injected token|
 
+Service-issued delegation scopes may include `llm:proxy`, `proxy:*`, `llm:status`,
+`account:read`, and `sandbox:execute`. OAuth-client token exchange intentionally
+uses a narrower allowlist and does not gain `account:read` or `sandbox:execute`.
+
 **Downstream Service Usage Example (Python):**
 
 ```python

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -499,6 +499,9 @@ When NyxID proxies MCP tool calls, delegation tokens are only injected for servi
 | **Single use window** | 5-minute TTL; token is generated per tool call; refreshable for long-running workflows |
 | **Service identity** | `act.sub` claim identifies the downstream service for audit purposes |
 
+The service-issued `sandbox:execute` scope is limited to configured downstream
+and user-service rows. It is not available through OAuth-client token exchange.
+
 ### Threat Mitigations
 
 | Threat | Mitigation |

--- a/skills/nyxid/references/managing.md
+++ b/skills/nyxid/references/managing.md
@@ -29,10 +29,14 @@ nyxid service update <id> --default-header 'x-openclaw-scopes=operator.read,oper
 nyxid service update <id> --default-header 'x-api-version=v2:overridable'
 nyxid service update <id> --default-header 'x-secret-token=abc123:sensitive'   # redact value in audit logs / API responses
 nyxid service update <id> --clear-default-headers
+nyxid service update <id> --forward-access-token true
+nyxid service update <id> --inject-delegation-token true --delegation-token-scope 'proxy:* sandbox:execute'
 nyxid service delete <id> --yes                                # remove service (no prompt)
 ```
 
 > Default request header precedence is `catalog defaults -> UserService defaults -> caller`. The default is non-overridable unless `:overridable` is set on the value.
+
+> Identity and delegation flags update the resolved UserService route. Use `forward_access_token` only when the downstream validates the caller's NyxID bearer; keep `delegation_token_scope` to the minimum scopes that downstream requires.
 
 > Node commands accept names (e.g., `--via-node test-server`) in addition to UUIDs.
 > For org-owned node operations, the two-machine VM playbook, and transfer cleanup behavior, see [`nodes.md`](nodes.md#two-machine-org-node-setup).


### PR DESCRIPTION
## Problem

A downstream sandbox validates a forwarded NyxID delegation bearer with the `sandbox:execute` scope. Service-issued delegation currently rejects that scope, and the CLI cannot safely update the UserService identity/delegation fields.

## Solution

- allow `sandbox:execute` only in the service-issued delegation scope allowlist
- expose `forward_access_token`, `inject_delegation_token`, and `delegation_token_scope` through `nyxid service update`
- resolve the UserService identity through `/keys/{candidate}` and write identity fields through `/user-services/{id}`
- document the service-only scope boundary

## Verification

- `cargo test -p nyxid-cli` (1078 passed plus bundle freshness)
- `cargo test -p nyxid` (4975 passed)
- `cargo fmt --all --check`
- `git diff --check`