### PR TITLE
feat(assistant): gate mock scenarios behind an admin feature flag

### DIFF
--- a/backend/src/handlers/admin_feature_flags.rs
+++ b/backend/src/handlers/admin_feature_flags.rs
@@ -349,6 +349,67 @@ mod tests {
         ));
     }
 
+    /// The assistant mock-scenario gate replaced a build-time `DEV` boundary,
+    /// so the admin console is now the *only* way to turn it on. Pin the
+    /// end-to-end surface: it reaches the list response with no override rows,
+    /// off by default, and takes a per-user override like any other flag.
+    #[tokio::test]
+    async fn assistant_mock_scenarios_flag_is_admin_configurable() {
+        let Some((state, admin_id, _operator_id, target_id)) =
+            setup("admin_feature_flags_mock_scenarios").await
+        else {
+            eprintln!("skipping admin feature flag handler test: no local MongoDB available");
+            return;
+        };
+        let auth = test_auth_user(&admin_id);
+        let flag_key =
+            crate::services::feature_flag_service::ASSISTANT_MOCK_SCENARIOS_FLAG_KEY.to_string();
+
+        let Json(list) = list_feature_flags(State(state.clone()), auth.clone())
+            .await
+            .expect("list flags");
+        let item = list
+            .flags
+            .iter()
+            .find(|flag| flag.key == flag_key)
+            .expect("mock-scenario flag is listed in the admin console");
+        assert!(!item.default_enabled, "the QA interceptor must default off");
+        assert!(item.global_override.is_none());
+        assert!(item.org_overrides.is_empty());
+        assert!(item.user_overrides.is_empty());
+
+        set_feature_flag(
+            State(state.clone()),
+            auth.clone(),
+            Path(flag_key.clone()),
+            Json(SetAdminFeatureFlagRequest {
+                target_kind: AdminFlagTargetKind::User,
+                target_key: Some(target_id.clone()),
+                enabled: true,
+            }),
+        )
+        .await
+        .expect("admin enables the flag for one user");
+
+        // The targeted user now resolves it on their personal surface (what
+        // `/users/me` capabilities and therefore `useFeature` read)...
+        let enabled = crate::services::feature_flag_service::resolve_personal_features(
+            &state.db,
+            &target_id,
+        )
+        .await
+        .expect("resolve target");
+        assert!(enabled.contains(&flag_key));
+
+        // ...and nobody else does.
+        let others = crate::services::feature_flag_service::resolve_personal_features(
+            &state.db, &admin_id,
+        )
+        .await
+        .expect("resolve admin");
+        assert!(!others.contains(&flag_key));
+    }
+
     #[tokio::test]
     async fn set_list_clear_round_trip_and_unknown_rejection() {
         let Some((state, admin_id, _operator_id, target_id)) =

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -98,9 +98,26 @@ const AEVATAR_CHAT_WIRE_LOG_FLAG: FeatureFlagDef = FeatureFlagDef {
     default_enabled: false,
 };
 
+/// Operator gate for the scripted mock chat scenarios in the assistant. Off by
+/// default: when enabled the browser intercepts matching messages and plays a
+/// scripted turn instead of calling Aevatar, so this is a QA/demo rehearsal
+/// tool that must never be on for ordinary users. Runtime-toggled so a preview
+/// deployment can be armed for one person without a redeploy.
+pub const ASSISTANT_MOCK_SCENARIOS_FLAG_KEY: &str = "experimental:assistant-mock-scenarios";
+
+const ASSISTANT_MOCK_SCENARIOS_FLAG: FeatureFlagDef = FeatureFlagDef {
+    key: ASSISTANT_MOCK_SCENARIOS_FLAG_KEY,
+    description: "Scripted mock chat scenarios in the assistant (QA rehearsal; intercepts sends).",
+    default_enabled: false,
+};
+
 #[cfg(not(test))]
-pub const FEATURE_FLAGS: &[FeatureFlagDef] =
-    &[AI_ASSISTANT_FLAG, BILLING_FLAG, AEVATAR_CHAT_WIRE_LOG_FLAG];
+pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
+    AI_ASSISTANT_FLAG,
+    BILLING_FLAG,
+    AEVATAR_CHAT_WIRE_LOG_FLAG,
+    ASSISTANT_MOCK_SCENARIOS_FLAG,
+];
 
 /// Test builds carry a placeholder flag so the resolution / override pipeline
 /// can exercise multiple definitions alongside the production registry entry.
@@ -109,6 +126,7 @@ pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
     AI_ASSISTANT_FLAG,
     BILLING_FLAG_TEST,
     AEVATAR_CHAT_WIRE_LOG_FLAG,
+    ASSISTANT_MOCK_SCENARIOS_FLAG,
     FeatureFlagDef {
         key: "example_ui",
         description: "Test-only placeholder flag.",
@@ -1115,6 +1133,25 @@ mod tests {
         assert!(find_flag("example_ui").is_some());
     }
 
+    /// The mock-scenario gate replaces a build-time `import.meta.env.DEV`
+    /// boundary, so a stray `default_enabled: true` would arm a send-intercepting
+    /// QA tool for every production user. (The key literal itself is pinned by
+    /// `shipped_registry_key_literals_are_pinned`.)
+    #[test]
+    fn assistant_mock_scenarios_flag_is_registered_and_off_by_default() {
+        let def = find_flag(ASSISTANT_MOCK_SCENARIOS_FLAG_KEY).expect("flag registered");
+        assert!(!def.default_enabled);
+        // No override rows anywhere => the flag stays out of both resolutions.
+        assert!(
+            !resolve_from_overrides(&[], &[], "user-1", OrgRole::Member)
+                .contains(&ASSISTANT_MOCK_SCENARIOS_FLAG_KEY.to_string())
+        );
+        assert!(
+            !resolve_personal_from_overrides(&[], &[], &[], "user-1")
+                .contains(&ASSISTANT_MOCK_SCENARIOS_FLAG_KEY.to_string())
+        );
+    }
+
     /// Registry keys are a wire contract with `frontend/src/lib/feature-flags.ts`
     /// (`FEATURE_FLAG`). A key that drifts on one side silently disables the
     /// surface it gates instead of failing, so the literals are pinned on both
@@ -1133,6 +1170,7 @@ mod tests {
                 "experimental:ai-assistant",
                 "experimental:billing",
                 "experimental:aevatar-chat-wire-log",
+                "experimental:assistant-mock-scenarios",
             ]
         );
         assert_eq!(

--- a/docs/chat/README.md
+++ b/docs/chat/README.md
@@ -15,7 +15,7 @@ The live Aevatar contract wins over prose. If the deployed or pinned upstream co
 5. [Frontend UI](05-frontend-ui.md) specifies rendering, composer, navigation, loading, error, and accessibility behavior.
 6. [Actions registry](06-actions-registry.md) specifies the public action manifest consumed by Aevatar composition.
 7. [Testing and gaps](07-testing-and-gaps.md) identifies executable coverage, fault-injection controls, and current operational gaps.
-8. [Mock scenario interception](mock-scenario-intercept-spec.md) specifies the implemented developer-only scripted-flow interceptor; its accepted adversarial findings are preserved in the [spec review](mock-scenario-intercept-spec.review.md).
+8. [Mock scenario interception](mock-scenario-intercept-spec.md) specifies the implemented scripted-flow interceptor, gated behind the platform feature flag `experimental:assistant-mock-scenarios` (default off — see §8.3 for the gate and the operator runbook); its accepted adversarial findings are preserved in the [spec review](mock-scenario-intercept-spec.review.md).
 9. [Mock scenario implementation plan](mock-scenario-intercept-plan.md) records the ordered work packages and verification gates; its accepted planning findings are preserved in the [plan review](mock-scenario-intercept-plan.review.md).
 
 ## Scope

--- a/docs/chat/mock-scenario-intercept-plan.md
+++ b/docs/chat/mock-scenario-intercept-plan.md
@@ -13,6 +13,13 @@ Open-question defaults locked: dev-only gating (§14.1), pass-through kept /
 no strict toggle (§14.2), no world seeding (§14.3), scenario set per WP3
 (§14.4), post-hoc verification only — no AddKeyDialog change (§14.5).
 
+> **Superseded (2026-08-04):** §14.1 was answered after the fact — gating moved
+> from the `import.meta.env.DEV` boundary this plan describes (WP5, WP6) to the
+> platform feature flag `experimental:assistant-mock-scenarios`, default off.
+> Everything else below still describes what shipped. The current gate is
+> specified in [the spec](mock-scenario-intercept-spec.md) §8.3; this document
+> is kept as the record of the original plan.
+
 ## Ground rules for the implementer
 
 - Branch: `mock-github-chat-calls` in this worktree. Commit after each work

--- a/docs/chat/mock-scenario-intercept-spec.md
+++ b/docs/chat/mock-scenario-intercept-spec.md
@@ -31,7 +31,9 @@ continue → resume UI path end to end, deterministically, without Aevatar.
   auth, real connect journeys — only the assistant's replies are scripted.
 - G5: World state (`connected` services) so `need`-gated flows branch like
   reality and feel alive across repeated asks.
-- G6: Zero footprint when off; zero scenario code in the prod entry chunk.
+- G6: Zero footprint when off — a session without the
+  `experimental:assistant-mock-scenarios` flag fetches no scenario chunk, and
+  no scenario code reaches the entry graph or the assistant page chunk.
 
 ### Non-goals (v1)
 - N1: No changes to the existing full-mock transport (`?mock` /
@@ -80,14 +82,14 @@ lib/assistant/transport.ts
                 └─ scenarios from lib/assistant/scenarios.config.ts (new; authored file)
 ```
 
-The interceptor, engine, and config load via a dev-only boot-time dynamic
-`import()` per §8.3 — `transport.ts` keeps zero static mock references, and
-the boot path reports `loading`/`error` engine states to the store so a
-failed install is visible rather than silently passing through (drafted
-differently in v1 as a store-triggered load; the implementation follows §8.3,
-deviation declared and accepted). `MockScenariosAction` is the only static
-importer of the store; the component is gated (§8) so prod chunks carry none
-of this.
+The interceptor, engine, config, and store load via flag-gated dynamic
+`import()`s per §8.3 — `transport.ts` keeps zero static mock references, and
+the install path reports `loading`/`error` engine states to the store so a
+failed install is visible rather than silently passing through (drafted in v1
+as a store-triggered load, shipped as a dev-only boot install, and now driven
+by the platform feature flag; deviations declared and accepted).
+`MockScenariosAction` is the only static importer of the store, and nothing
+statically imports either.
 
 ---
 
@@ -468,38 +470,92 @@ against DESIGN.md before implementation):
 No API calls from the popover. All state is the store.
 
 ### 8.3 Gating
-v1: dev-only, enforced at a **module boundary**, not a render branch (CodexSol
-F12 — a static `pages/assistant.tsx → action component → store` import chain
-keeps the side-effectful `create(persist(...))` store module in the prod
-graph even when the render branch folds away; "tree-shaking will get it" is
-not a plan). Two boundaries:
+**Platform feature flag** `experimental:assistant-mock-scenarios`, declared in
+`backend/src/services/feature_flag_service.rs::FEATURE_FLAGS` with
+`default_enabled: false` and mirrored in `frontend/src/lib/feature-flags.ts`.
+Platform admins toggle it globally, per org cohort, or per user from Admin →
+Feature Flags; no redeploy, and a deployed preview can be armed for one person.
+This supersedes the v1 dev-only (`import.meta.env.DEV`) gate — §14.1 answered.
+
+Enforced at a **module boundary**, not a render branch (CodexSol F12 — a static
+`pages/assistant.tsx → action component → store` import chain keeps the
+side-effectful `create(persist(...))` store module in the eager graph even when
+the render branch folds away; "tree-shaking will get it" is not a plan). Three
+boundaries:
 
 - **Transport**: `transport.ts` keeps zero static references to any mock
-  module. The `"aevatar"` branch returns a ~15-line
-  `DelegatingAssistantTransport` shell around the real transport; dev-only
-  boot code (`if (import.meta.env.DEV)` guarding a **dynamic** `import()`)
-  loads the interceptor module, which wraps the delegate in place. In prod
-  the dead branch is eliminated and no interceptor/engine/store/config chunk
-  exists in the artifact.
-- **UI**: the header action mounts via a dev-gated
-  `lazy(() => import(...))`; in prod the expression is `null` and the
-  component + store modules are unreachable.
+  module. The `"aevatar"` branch always returns a `DelegatingAssistantTransport`
+  shell around the real transport, and installs nothing on its own.
+  `applyAssistantScenarioFeature(featureEnabled)` is the sole install path: on
+  a flag-off session it returns before loading anything, so the
+  interceptor/engine/config/store chunks are never fetched and no localStorage
+  is read.
+- **UI**: the header action mounts through `MockScenariosGate`, which reads
+  `useFeature(FEATURE_FLAG.ASSISTANT_MOCK_SCENARIOS)` and renders `null` —
+  never requesting the lazy chunk — while the flag is off. Fail-closed:
+  loading, unknown, and an older backend that omits the key all read as off.
+- **Runtime**: `ScenarioInterceptTransport.sendMessage` requires
+  `featureEnabled && enabled`. `featureEnabled` is the flag mirrored into the
+  store by the gate (the same bridge `AssistantWireLogAction` uses) and is
+  never persisted, so a flag revoked mid-session disarms an already-installed
+  tab and every send falls back to the live delegate. The user's own popover
+  toggle is left untouched.
 
-Build assertion, run in CI tests: the production `dist/` contains no
-`mockchat-`, `scenario-engine`, or `mockscenarios` symbols (grep over built
-assets). `npm run build` succeeding is not a footprint test.
+#### Operator runbook — turning it on
 
-A follow-up may add a capability-flag gate (e.g. `experimental:assistant-mock`)
-for preview deployments — §14.1, not in v1.
+Requires the platform-admin role. The flag itself never appears to ordinary
+users, and it is a QA tool that **intercepts real sends**, so scope it as
+narrowly as the situation allows.
+
+1. Sign in as a platform admin and open **Admin → Feature Flags**
+   (`/admin/feature-flags`). `experimental:assistant-mock-scenarios` is listed
+   from the backend registry with its code default (off).
+2. Add an override at the narrowest scope that works:
+   - **User** — one person, on any deployment. The default choice: this is a
+     rehearsal tool, not a rollout.
+   - **Org** — everyone in one org cohort. Reaches members' personal surfaces
+     too (the resolver unions org grants into `/users/me`).
+   - **Global** — everyone on the deployment. Preview/staging only; a global
+     enable arms the send interceptor for every user who then flips their own
+     popover toggle.
+3. The target picks it up within about a minute — the flag ships in
+   `/users/me` capabilities, which `useUser` refetches on a 60 s interval for
+   visible tabs; a reload is immediate. A flask icon appears in the assistant
+   header, with the popover's master switch still off: the flag only *offers*
+   the tool, it does not start intercepting.
+4. To revoke, clear the override. Already-open tabs disarm on that same
+   refetch without a reload — the gate clears the store mirror and every send
+   goes straight back to the live Aevatar transport, whatever the user's own
+   toggle says.
+
+Local development is the same path — there is no longer a dev-only bypass, so
+a local backend needs the override too.
+
+Build assertion, run as the last step of `npm run build`
+(`frontend/scripts/assert-mock-footprint.mjs`): the mock modules must remain
+**dynamic-import only**. Read from vite's `dist/.vite/manifest.json`, it fails
+if any chunk statically reaches an entry point, if the entry graph or the
+assistant page chunk carries `mockchat-` / `mockscenarios`, or if the
+credential-accept entry does. "Absent from `dist/`" is no longer the invariant
+— the code has to ship for an operator to switch it on; "nobody without the
+flag downloads it" is.
 
 ---
 
 ## 9. transport.ts changes (complete list)
 
 1. `createAssistantTransport()`: `"aevatar"` branch returns the
-   `DelegatingAssistantTransport` shell; a dev-only dynamic import installs
-   `ScenarioInterceptTransport` around the delegate at boot (§8.3).
-2. Nothing else. `selectAssistantTransportKind`, `MockAssistantTransport`, the
+   `DelegatingAssistantTransport` shell and installs nothing.
+2. `applyAssistantScenarioFeature(featureEnabled, transport?, loaders?)`: the
+   sole install path, called by `MockScenariosGate` with the resolved flag
+   (§8.3). Off-and-never-armed returns before loading any chunk; on, it mirrors
+   the flag into the store and dynamically imports the interceptor; off after
+   arming clears the mirror. Never rejects — a failed chunk surfaces through
+   `engineState: "error"`. A full-mock transport is left alone.
+3. `installAssistantTransportInterceptor` evicts a rejected installation from
+   its `WeakMap` so a transient chunk failure can be retried on the next flag
+   resolution rather than poisoning the shell for the tab's lifetime.
+4. Nothing else. `selectAssistantTransportKind`, `MockAssistantTransport`, the
    fault hooks, and `resetAssistantTransport` are untouched.
 
 ---
@@ -624,8 +680,10 @@ final gate — WP7/WP8 files included by construction.
 
 ## 14. Open questions for Calvin
 
-1. **Prod/preview access** — is DEV-only right for v1, or do you want the
-   capability-flag gate now so deployed previews can use it?
+1. ~~**Prod/preview access** — is DEV-only right for v1, or do you want the
+   capability-flag gate now so deployed previews can use it?~~ **Answered
+   (2026-08-04):** flag gate. Shipped as `experimental:assistant-mock-scenarios`,
+   default off, admin-toggled — see §8.3.
 2. **Fallback scenario** — in *real* conversations an unmatched message
    passes through to Aevatar (specced). Claimed mock-only chats (§6.5)
    already give you a fully offline surface. Do you additionally want a

--- a/docs/chat/mock-scenario-intercept-spec.md
+++ b/docs/chat/mock-scenario-intercept-spec.md
@@ -533,7 +533,9 @@ a local backend needs the override too.
 
 Build assertion, run as the last step of `npm run build`
 (`frontend/scripts/assert-mock-footprint.mjs`): the mock modules must remain
-**dynamic-import only**. Read from vite's `dist/.vite/manifest.json`, it fails
+**dynamic-import only**. It reads vite's `dist/.vite/manifest.json`
+(`build.manifest` is enabled for this purpose alone, and the script deletes the
+manifest once it passes so the deployed artifact gains no new file) and fails
 if any chunk statically reaches an entry point, if the entry graph or the
 assistant page chunk carries `mockchat-` / `mockscenarios`, or if the
 credential-accept entry does. "Absent from `dist/`" is no longer the invariant

--- a/frontend/scripts/assert-mock-footprint.mjs
+++ b/frontend/scripts/assert-mock-footprint.mjs
@@ -1,3 +1,27 @@
+/**
+ * Mock scenario footprint gate.
+ *
+ * The assistant's scripted mock scenarios used to be kept out of production
+ * builds entirely by an `import.meta.env.DEV` module boundary, and this script
+ * asserted the symbols were absent from `dist/`. They now ship behind the
+ * platform feature flag `experimental:assistant-mock-scenarios` (off by
+ * default, admin-toggled at runtime), so "absent from dist" is no longer the
+ * invariant — the code has to be there for an operator to switch on.
+ *
+ * What must still hold is that nobody pays for it. Every mock module has to
+ * stay in an async chunk reachable **only** through a dynamic import, so a
+ * session without the flag never fetches the interceptor, the scenario engine,
+ * the scripted config, or the persisted store. Rollup folding any of them into
+ * the assistant page chunk or a shared vendor chunk would silently break that
+ * and is exactly what this gate catches.
+ *
+ * Checks:
+ *   R1 the flag-gated modules are present as their own manifest entries (the
+ *      gate is not passing vacuously against a build that dropped them);
+ *   R2 no chunk outside the mock set statically imports a chunk inside it;
+ *   R3 nothing `dist/index.html` references at boot is a mock chunk;
+ *   R4 the separate credential-accept entry carries none of it.
+ */
 import { readFile, readdir, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -5,7 +29,34 @@ import path from "node:path";
 const frontendRoot = fileURLToPath(new URL("../", import.meta.url));
 const distRoot = path.join(frontendRoot, "dist");
 const credentialAcceptRoot = path.join(distRoot, "credential-accept");
-const forbiddenSymbols = ["mockchat-", "scenario-engine", "mockscenarios"];
+const manifestPath = path.join(distRoot, ".vite", "manifest.json");
+const indexHtmlPath = path.join(distRoot, "index.html");
+
+/**
+ * Dynamic-import entry points of the mock layer. Vite always keys these by
+ * source path in the manifest because `pages/assistant.tsx` and
+ * `lib/assistant/transport.ts` reach them through `import()`.
+ *
+ * Renaming or removing one of these is a deliberate edit — update this list
+ * and the reasoning above with it.
+ */
+const requiredLazyModules = [
+  "src/lib/assistant/scenario-intercept-transport.ts",
+  "src/stores/assistant-mock-scenarios-store.ts",
+  "src/components/assistant/mock-scenarios-action.tsx",
+];
+
+/** The page that owns the flag gate; it must not carry the payload itself. */
+const assistantPageModule = "src/pages/assistant.tsx";
+
+/**
+ * Symbols that only appear inside built mock scenario code and survive
+ * minification: the mock id prefix carried by the engine and scripted config,
+ * and the persisted store's localStorage key. The graph checks below prove the
+ * lazy entry points are dynamic-only; these catch the other shape of the same
+ * regression, where a mock module's *contents* get merged into an eager chunk.
+ */
+const forbiddenSymbols = ["mockchat-", "mockscenarios"];
 
 async function filesBelow(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -33,8 +84,85 @@ if (!credentialAcceptStat.isDirectory()) {
   throw new Error("dist/credential-accept exists but is not a directory.");
 }
 
+let manifest;
+try {
+  manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+} catch {
+  throw new Error(
+    `Production build is missing ${path.relative(frontendRoot, manifestPath)}; ` +
+      "the mock footprint gate needs vite's `build.manifest` to read the import graph.",
+  );
+}
+
+// ── R1: the flag-gated modules shipped as their own manifest entries ──
+// A module loses its manifest entry when it stops being a dynamic-import
+// boundary — which is exactly what adding a static import to it does, so this
+// is usually the first thing to fire on a regression.
+const missing = requiredLazyModules.filter((key) => !manifest[key]);
+if (missing.length > 0) {
+  throw new Error(
+    "Flag-gated mock scenario modules have no chunk of their own — they were " +
+      "folded into an eager chunk (check for a new static import of them), or " +
+      `this script's module list is stale:\n${missing.join("\n")}`,
+  );
+}
+
 const violations = [];
-for (const file of await filesBelow(distRoot)) {
+const lazyModules = new Set(requiredLazyModules);
+
+// ── R2: no chunk statically reaches a lazy entry point ──
+// Walk `imports` (static only — `dynamicImports` is deliberately not followed)
+// from every other manifest entry. Anything the walk lands on is downloaded
+// whenever its importer is, so a mock entry point turning up here means it is
+// no longer flag-gated in practice.
+const staticallyReachable = new Set();
+const pending = Object.keys(manifest).filter((key) => !lazyModules.has(key));
+while (pending.length > 0) {
+  const key = pending.pop();
+  for (const imported of manifest[key]?.imports ?? []) {
+    if (staticallyReachable.has(imported)) continue;
+    staticallyReachable.add(imported);
+    pending.push(imported);
+  }
+}
+for (const key of requiredLazyModules) {
+  if (staticallyReachable.has(key)) {
+    violations.push(
+      `${key} is statically imported — mock scenario code must be reachable only via dynamic import`,
+    );
+  }
+}
+
+// ── R3: no mock payload inside an eagerly loaded chunk ──
+// index.html carries the entry plus a modulepreload for its whole static
+// graph, so this covers everything the app fetches before any route renders.
+// The assistant page chunk is checked too: opening /assistant without the flag
+// must not download the engine either.
+const indexHtml = await readFile(indexHtmlPath, "utf8");
+const eagerFiles = new Set(
+  [...indexHtml.matchAll(/assets\/[A-Za-z0-9._-]+\.js/g)].map(
+    (match) => match[0],
+  ),
+);
+const assistantChunk = manifest[assistantPageModule]?.file;
+if (!assistantChunk) {
+  throw new Error(
+    `Production build has no manifest entry for ${assistantPageModule}; ` +
+      "the mock footprint gate cannot check the assistant page chunk.",
+  );
+}
+eagerFiles.add(assistantChunk);
+for (const relative of eagerFiles) {
+  const contents = await readFile(path.join(distRoot, relative));
+  for (const symbol of forbiddenSymbols) {
+    if (contents.includes(Buffer.from(symbol))) {
+      violations.push(`${relative} is loaded eagerly and contains ${symbol}`);
+    }
+  }
+}
+
+// ── R4: the credential-accept entry shares none of it ──
+for (const file of await filesBelow(credentialAcceptRoot)) {
   const contents = await readFile(file);
   for (const symbol of forbiddenSymbols) {
     if (contents.includes(Buffer.from(symbol))) {
@@ -45,10 +173,11 @@ for (const file of await filesBelow(distRoot)) {
 
 if (violations.length > 0) {
   throw new Error(
-    `Production build contains dev-only mock scenario code:\n${violations.join("\n")}`,
+    `Mock scenario code escaped its lazy boundary:\n${violations.join("\n")}`,
   );
 }
 
 process.stdout.write(
-  "Mock scenario footprint assertion passed; credential-accept output is present.\n",
+  `Mock scenario footprint assertion passed; ${requiredLazyModules.length} flag-gated ` +
+    "module(s) are dynamic-import only and credential-accept output is present.\n",
 );

--- a/frontend/scripts/assert-mock-footprint.mjs
+++ b/frontend/scripts/assert-mock-footprint.mjs
@@ -22,7 +22,7 @@
  *   R3 nothing `dist/index.html` references at boot is a mock chunk;
  *   R4 the separate credential-accept entry carries none of it.
  */
-import { readFile, readdir, stat } from "node:fs/promises";
+import { readFile, readdir, rm, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -176,6 +176,11 @@ if (violations.length > 0) {
     `Mock scenario code escaped its lazy boundary:\n${violations.join("\n")}`,
   );
 }
+
+// The manifest exists for this script and nothing else — no runtime code reads
+// it. Drop it so enabling `build.manifest` does not add a file to what gets
+// deployed. Left in place on failure so the violation can be inspected.
+await rm(path.dirname(manifestPath), { recursive: true, force: true });
 
 process.stdout.write(
   `Mock scenario footprint assertion passed; ${requiredLazyModules.length} flag-gated ` +

--- a/frontend/src/components/assistant/mock-scenarios-action.test.tsx
+++ b/frontend/src/components/assistant/mock-scenarios-action.test.tsx
@@ -1,10 +1,13 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { lazy } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { lazy, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ScenarioEngine } from "@/lib/assistant/scenario-engine";
 import { compiledScenarios } from "@/lib/assistant/scenarios.config";
+import { FEATURE_FLAG } from "@/lib/feature-flags";
 import { useAssistantMockScenariosStore } from "@/stores/assistant-mock-scenarios-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { MockScenariosAction } from "./mock-scenarios-action";
 
 vi.mock("@/components/assistant/assistant-wire-log-panel", () => ({
@@ -12,6 +15,25 @@ vi.mock("@/components/assistant/assistant-wire-log-panel", () => ({
 }));
 
 import { AssistantHeaderActions } from "@/pages/assistant";
+
+/** Render the header with the platform flag resolved to `featureEnabled`. */
+function renderHeader(children: ReactNode, featureEnabled: boolean) {
+  useAuthStore.setState({
+    user: {
+      capabilities: {
+        enabled_features: featureEnabled
+          ? [FEATURE_FLAG.ASSISTANT_MOCK_SCENARIOS]
+          : [],
+      },
+    } as never,
+  });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+  );
+}
 
 function renderAction() {
   return render(
@@ -30,6 +52,10 @@ describe("MockScenariosAction", () => {
     localStorage.clear();
     useAssistantMockScenariosStore.getState().reset();
     useAssistantMockScenariosStore.setState({ engineState: "ready" });
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({ user: null });
   });
 
   it("shows loading and engine failure states inline (P11)", () => {
@@ -155,12 +181,13 @@ describe("MockScenariosAction", () => {
         }),
     );
 
-    render(
+    renderHeader(
       <div>
         <p>Assistant shell</p>
         <AssistantHeaderActions scenarioAction={DeferredAction} />
         <AssistantHeaderActions scenarioAction={DeferredAction} />
       </div>,
+      true,
     );
 
     expect(screen.getByText("Assistant shell")).toBeInTheDocument();
@@ -184,10 +211,32 @@ describe("MockScenariosAction", () => {
   });
 
   it("omits the developer action when the module gate supplies null (F12, P11)", () => {
-    render(<AssistantHeaderActions scenarioAction={null} />);
+    renderHeader(<AssistantHeaderActions scenarioAction={null} />, true);
 
     expect(
       screen.queryByRole("button", { name: "Mock scenarios" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("omits the developer action when the platform flag is off", () => {
+    const Action = () => <button type="button" aria-label="Mock scenarios" />;
+
+    renderHeader(<AssistantHeaderActions scenarioAction={Action} />, false);
+
+    // Fail-closed: an unflagged user gets no control even though the component
+    // was handed to the header, and the lazy chunk is never requested.
+    expect(
+      screen.queryByRole("button", { name: "Mock scenarios" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the developer action once the platform flag resolves on", () => {
+    const Action = () => <button type="button" aria-label="Mock scenarios" />;
+
+    renderHeader(<AssistantHeaderActions scenarioAction={Action} />, true);
+
+    expect(
+      screen.getByRole("button", { name: "Mock scenarios" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/use-assistant.mock-scenarios.test.tsx
+++ b/frontend/src/hooks/use-assistant.mock-scenarios.test.tsx
@@ -86,10 +86,17 @@ describe("assistant mock-scenario hook integration", () => {
     expect(transportModule.assistantTransport).toBeInstanceOf(
       transportModule.DelegatingAssistantTransport,
     );
+    // Importing the transport installs nothing on its own; the platform flag
+    // is what arms the singleton, exactly as `MockScenariosGate` does it.
+    expect(
+      storeModule.useAssistantMockScenariosStore.getState().engineState,
+    ).toBe("idle");
+    await transportModule.applyAssistantScenarioFeature(true);
     expect(
       storeModule.useAssistantMockScenariosStore.getState().engineState,
     ).toBe("ready");
     storeModule.useAssistantMockScenariosStore.setState({
+      featureEnabled: true,
       enabled: true,
       disabledScenarioIds: [],
       world: { connected: [] },

--- a/frontend/src/hooks/use-feature-flag.test.tsx
+++ b/frontend/src/hooks/use-feature-flag.test.tsx
@@ -114,6 +114,7 @@ describe("feature flag catalog", () => {
       AI_ASSISTANT: "experimental:ai-assistant",
       BILLING: "experimental:billing",
       AEVATAR_CHAT_WIRE_LOG: "experimental:aevatar-chat-wire-log",
+      ASSISTANT_MOCK_SCENARIOS: "experimental:assistant-mock-scenarios",
     });
   });
 });

--- a/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
@@ -232,6 +232,9 @@ class StubTransport implements AssistantTransport {
 
 function resetScenarioStore(): void {
   useAssistantMockScenariosStore.setState({
+    // Armed: these suites cover behaviour once the platform flag has resolved
+    // on. The flag-off path is covered separately below.
+    featureEnabled: true,
     enabled: true,
     disabledScenarioIds: [],
     world: { connected: [] },
@@ -367,6 +370,35 @@ describe("ScenarioInterceptTransport ownership", () => {
       matched: false,
       scenarioId: null,
     });
+  });
+
+  it("passes matching messages through when the platform flag is off", async () => {
+    const { delegate, transport } = await createTransport();
+    useAssistantMockScenariosStore.setState({ featureEnabled: false });
+
+    // "simulate an error" matches a scenario and the user's own toggle is on;
+    // only the revoked platform flag stops the intercept.
+    transport.sendMessage(CONVERSATION_ID, "simulate an error", () => {});
+
+    expect(useAssistantMockScenariosStore.getState().enabled).toBe(true);
+    expect(delegate.sendCalls).toBe(1);
+    // No match was even attempted, so nothing is recorded as scenario activity.
+    expect(useAssistantMockScenariosStore.getState().lastActivity).toBeNull();
+  });
+
+  it("does not report the engine as loading when the platform flag is off", async () => {
+    const { delegate, transport } = await createTransport();
+    useAssistantMockScenariosStore.setState({
+      featureEnabled: false,
+      engineState: "loading",
+    });
+
+    // With the flag on this would throw MockScenariosLoadingError; flag-off
+    // must reach the live delegate instead of blocking the send.
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "simulate an error", () => {}),
+    ).not.toThrow();
+    expect(delegate.sendCalls).toBe(1);
   });
 
   it("rejects send while a mock turn is running (§6.2)", async () => {

--- a/frontend/src/lib/assistant/scenario-intercept-transport.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.ts
@@ -319,7 +319,11 @@ export class ScenarioInterceptTransport implements AssistantTransport {
 
     const store = useAssistantMockScenariosStore.getState();
     let match: ScenarioMatch | null = null;
-    if (store.enabled) {
+    // Two gates: the platform-admin flag (`featureEnabled`, mirrored from
+    // `useFeature`) and the user's own popover toggle. A flag revoked mid-session
+    // reaches an already-armed tab through the first one, and every send falls
+    // straight back to the live delegate.
+    if (store.featureEnabled && store.enabled) {
       if (store.engineState !== "ready") {
         throw new MockScenariosLoadingError(store.engineState);
       }

--- a/frontend/src/lib/assistant/transport-shell.test.ts
+++ b/frontend/src/lib/assistant/transport-shell.test.ts
@@ -2,10 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installScenarioInterceptor } from "@/lib/assistant/scenario-intercept-transport";
 import {
   DelegatingAssistantTransport,
+  applyAssistantScenarioFeature,
   createAssistantTransportForEnvironment,
   installAssistantTransportInterceptor,
+  type AssistantInterceptorLoader,
   type AssistantInterceptorModule,
 } from "@/lib/assistant/transport";
+import * as storeModule from "@/stores/assistant-mock-scenarios-store";
 import { useAssistantMockScenariosStore } from "@/stores/assistant-mock-scenarios-store";
 import { useAuthStore } from "@/stores/auth-store";
 import type { User } from "@/types/api";
@@ -109,7 +112,13 @@ function user(id: string): User {
   };
 }
 
-describe("DelegatingAssistantTransport dev installation", () => {
+/** Loader pair standing in for the two real async chunks. */
+function testLoaders(interceptor: AssistantInterceptorLoader) {
+  const loadStore = vi.fn(async () => storeModule);
+  return { loaders: { loadInterceptor: interceptor, loadStore }, loadStore };
+}
+
+describe("DelegatingAssistantTransport flag-gated installation", () => {
   beforeEach(() => {
     localStorage.clear();
     useAuthStore.setState({
@@ -120,6 +129,7 @@ describe("DelegatingAssistantTransport dev installation", () => {
       mfaToken: null,
     });
     useAssistantMockScenariosStore.setState({
+      featureEnabled: false,
       enabled: false,
       disabledScenarioIds: [],
       world: { connected: [] },
@@ -129,78 +139,124 @@ describe("DelegatingAssistantTransport dev installation", () => {
     });
   });
 
-  it("delegates bare calls before load and intercepts in place after install (P5)", async () => {
+  it("loads nothing at all while the flag is off (never-armed tab)", async () => {
     const live = new RecordingTransport("live");
+    const shell = new DelegatingAssistantTransport(live);
+    const loadInterceptor = vi.fn(
+      async (): Promise<AssistantInterceptorModule> => ({
+        installScenarioInterceptor: () => undefined,
+      }),
+    );
+    const { loaders, loadStore } = testLoaders(loadInterceptor);
+
+    await applyAssistantScenarioFeature(false, shell, loaders);
+
+    // Neither chunk is fetched: no interceptor, no persisted store, no
+    // localStorage read — a flagless session pays nothing.
+    expect(loadInterceptor).not.toHaveBeenCalled();
+    expect(loadStore).not.toHaveBeenCalled();
+    expect(shell.current()).toBe(live);
+    expect(useAssistantMockScenariosStore.getState().engineState).toBe("idle");
+  });
+
+  it("delegates bare calls before load and intercepts in place after the flag arms it (P5)", async () => {
+    const live = new RecordingTransport("live");
+    const shell = new DelegatingAssistantTransport(live);
     let resolveLoader: (module: AssistantInterceptorModule) => void = () =>
       undefined;
-    const loader = vi.fn(
+    const loadInterceptor = vi.fn(
       () =>
         new Promise<AssistantInterceptorModule>((resolve) => {
           resolveLoader = resolve;
         }),
     );
-    const transport = createAssistantTransportForEnvironment(
-      { mode: "development", dev: true, search: "" },
-      {
-        createMock: () => new RecordingTransport("mock"),
-        createAevatar: () => live,
-      },
-      loader,
-      (state) =>
-        useAssistantMockScenariosStore.getState().setEngineState(state),
+    const { loaders } = testLoaders(loadInterceptor);
+
+    const applied = applyAssistantScenarioFeature(true, shell, loaders);
+    await vi.waitFor(() =>
+      expect(useAssistantMockScenariosStore.getState().engineState).toBe(
+        "loading",
+      ),
     );
-    expect(transport).toBeInstanceOf(DelegatingAssistantTransport);
-    const shell = transport as DelegatingAssistantTransport;
-    expect(useAssistantMockScenariosStore.getState().engineState).toBe(
-      "loading",
-    );
+    expect(useAssistantMockScenariosStore.getState().featureEnabled).toBe(true);
 
     await shell.listConversations();
     expect(live.calls).toEqual(["list"]);
     resolveLoader({ installScenarioInterceptor });
-    await installAssistantTransportInterceptor(shell, loader);
+    await applied;
     await shell.listConversations();
 
-    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loadInterceptor).toHaveBeenCalledTimes(1);
     expect(shell.current()).not.toBe(live);
     expect(live.calls).toEqual(["list", "list"]);
     expect(useAssistantMockScenariosStore.getState().engineState).toBe("ready");
   });
 
-  it("keeps the live delegate and reports error when dev installation fails (P5, F6)", async () => {
+  it("clears featureEnabled on an armed tab when the flag is revoked mid-session", async () => {
     const live = new RecordingTransport("live");
-    let rejectLoader: (reason: Error) => void = () => undefined;
-    const loader = vi.fn(
-      () =>
-        new Promise<AssistantInterceptorModule>((_resolve, reject) => {
-          rejectLoader = reject;
-        }),
-    );
-    const transport = createAssistantTransportForEnvironment(
-      { mode: "development", dev: true, search: "" },
-      {
-        createMock: () => new RecordingTransport("mock"),
-        createAevatar: () => live,
-      },
-      loader,
-      (state) =>
-        useAssistantMockScenariosStore.getState().setEngineState(state),
-    );
-    const shell = transport as DelegatingAssistantTransport;
+    const shell = new DelegatingAssistantTransport(live);
+    const { loaders } = testLoaders(async () => ({
+      installScenarioInterceptor,
+    }));
 
-    expect(useAssistantMockScenariosStore.getState().engineState).toBe(
-      "loading",
-    );
-    rejectLoader(new Error("chunk failed"));
+    await applyAssistantScenarioFeature(true, shell, loaders);
+    useAssistantMockScenariosStore.getState().setEnabled(true);
+    expect(useAssistantMockScenariosStore.getState().featureEnabled).toBe(true);
 
-    await expect(
-      installAssistantTransportInterceptor(shell, loader),
-    ).rejects.toThrow("chunk failed");
+    await applyAssistantScenarioFeature(false, shell, loaders);
+
+    // The interceptor stays wrapped (nothing can unwrap it), so the revoked
+    // flag has to reach it through the store — the user's own toggle is left
+    // alone and is no longer sufficient to intercept.
+    expect(shell.current()).not.toBe(live);
+    expect(useAssistantMockScenariosStore.getState()).toMatchObject({
+      featureEnabled: false,
+      enabled: true,
+    });
+  });
+
+  it("keeps the live delegate, reports error, and allows a retry when the chunk fails (P5, F6)", async () => {
+    const live = new RecordingTransport("live");
+    const shell = new DelegatingAssistantTransport(live);
+    const loadInterceptor = vi
+      .fn<AssistantInterceptorLoader>()
+      .mockRejectedValueOnce(new Error("chunk failed"))
+      .mockResolvedValueOnce({ installScenarioInterceptor });
+    const { loaders } = testLoaders(loadInterceptor);
+
+    await applyAssistantScenarioFeature(true, shell, loaders);
     await shell.listConversations();
 
     expect(shell.current()).toBe(live);
     expect(live.calls).toEqual(["list"]);
     expect(useAssistantMockScenariosStore.getState().engineState).toBe("error");
+
+    // A failed load must not poison the shell for the rest of the tab.
+    await applyAssistantScenarioFeature(true, shell, loaders);
+    expect(loadInterceptor).toHaveBeenCalledTimes(2);
+    expect(shell.current()).not.toBe(live);
+    expect(useAssistantMockScenariosStore.getState().engineState).toBe("ready");
+  });
+
+  it("never throws into the caller when the store chunk fails to load", async () => {
+    const shell = new DelegatingAssistantTransport(
+      new RecordingTransport("live"),
+    );
+    const loadInterceptor = vi.fn(
+      async (): Promise<AssistantInterceptorModule> => ({
+        installScenarioInterceptor: () => undefined,
+      }),
+    );
+
+    await expect(
+      applyAssistantScenarioFeature(true, shell, {
+        loadInterceptor,
+        loadStore: async () => {
+          throw new Error("store chunk failed");
+        },
+      }),
+    ).resolves.toBeUndefined();
+    expect(loadInterceptor).not.toHaveBeenCalled();
   });
 
   it("loads and installs at most once per shell (P5)", async () => {
@@ -225,13 +281,14 @@ describe("DelegatingAssistantTransport dev installation", () => {
     expect(shell.current()).toBe(intercepted);
   });
 
-  it("never loads the interceptor for full-mock or production selection (P5)", () => {
+  it("never wraps a full-mock transport, flag on or off (P5)", async () => {
     const mock = new RecordingTransport("mock");
-    const loader = vi.fn(
+    const loadInterceptor = vi.fn(
       async (): Promise<AssistantInterceptorModule> => ({
         installScenarioInterceptor: () => undefined,
       }),
     );
+    const { loaders, loadStore } = testLoaders(loadInterceptor);
     const factories = {
       createMock: () => mock,
       createAevatar: () => new RecordingTransport("live"),
@@ -240,16 +297,28 @@ describe("DelegatingAssistantTransport dev installation", () => {
     const fullMock = createAssistantTransportForEnvironment(
       { mode: "test", dev: false, search: "" },
       factories,
-      loader,
     );
-    createAssistantTransportForEnvironment(
-      { mode: "production", dev: false, search: "" },
-      factories,
-      loader,
-    );
-
     expect(fullMock).toBe(mock);
-    expect(loader).not.toHaveBeenCalled();
+
+    await applyAssistantScenarioFeature(true, fullMock, loaders);
+
+    expect(loadInterceptor).not.toHaveBeenCalled();
+    expect(loadStore).not.toHaveBeenCalled();
+  });
+
+  it("returns a bare shell for every environment — dev no longer installs (P5)", () => {
+    const factories = {
+      createMock: () => new RecordingTransport("mock"),
+      createAevatar: () => new RecordingTransport("live"),
+    };
+    for (const env of [
+      { mode: "development", dev: true, search: "" },
+      { mode: "production", dev: false, search: "" },
+    ]) {
+      const transport = createAssistantTransportForEnvironment(env, factories);
+      expect(transport).toBeInstanceOf(DelegatingAssistantTransport);
+    }
+    expect(useAssistantMockScenariosStore.getState().engineState).toBe("idle");
   });
 
   it("rescopes null -> A -> logout -> B in one module lifetime (P6, F14)", () => {

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -699,7 +699,11 @@ export interface AssistantInterceptorModule {
 export type AssistantInterceptorLoader =
   () => Promise<AssistantInterceptorModule>;
 
-type AssistantInterceptorStateReporter = (state: "loading" | "error") => void;
+export type AssistantMockScenariosStoreModule =
+  typeof import("@/stores/assistant-mock-scenarios-store");
+
+export type AssistantMockScenariosStoreLoader =
+  () => Promise<AssistantMockScenariosStoreModule>;
 
 const interceptorInstallations = new WeakMap<
   DelegatingAssistantTransport,
@@ -715,6 +719,14 @@ export function installAssistantTransportInterceptor(
   const installation = loader().then((module) => {
     module.installScenarioInterceptor(shell);
   });
+  // A failed chunk load must not poison the shell for the rest of the tab:
+  // drop the rejected entry so a later flag resolution can retry. The returned
+  // promise still rejects for this caller.
+  installation.catch(() => {
+    if (interceptorInstallations.get(shell) === installation) {
+      interceptorInstallations.delete(shell);
+    }
+  });
   interceptorInstallations.set(shell, installation);
   return installation;
 }
@@ -726,48 +738,80 @@ export function createAssistantTransportForEnvironment(
     readonly search: string;
   },
   factories: AssistantTransportFactories,
-  interceptorLoader?: AssistantInterceptorLoader,
-  reportInterceptorState?: AssistantInterceptorStateReporter,
 ): AssistantTransport {
   const kind = selectAssistantTransportKind(env);
   if (kind === "mock") return factories.createMock();
-  const shell = new DelegatingAssistantTransport(factories.createAevatar());
-  if (env.dev && interceptorLoader) {
-    reportInterceptorState?.("loading");
-    void installAssistantTransportInterceptor(shell, interceptorLoader).catch(
-      () => reportInterceptorState?.("error"),
-    );
+  return new DelegatingAssistantTransport(factories.createAevatar());
+}
+
+export interface AssistantScenarioFeatureLoaders {
+  readonly loadInterceptor: AssistantInterceptorLoader;
+  readonly loadStore: AssistantMockScenariosStoreLoader;
+}
+
+const defaultScenarioFeatureLoaders: AssistantScenarioFeatureLoaders = {
+  loadInterceptor: () => import("@/lib/assistant/scenario-intercept-transport"),
+  loadStore: () => import("@/stores/assistant-mock-scenarios-store"),
+};
+
+/**
+ * Apply the resolved `experimental:assistant-mock-scenarios` value to the live
+ * transport. Called by the React gate on the assistant page; this is the only
+ * path that installs the scenario interceptor.
+ *
+ * Off (the default for every user) is a hard no-op the first time through: the
+ * interceptor, engine, scenario config, and persisted store all stay in unloaded
+ * async chunks, so a flagless session never fetches them and the live transport
+ * is untouched. Once a tab has armed the interceptor, flipping the flag off
+ * still has to reach it, so from then on the off path loads the store to clear
+ * `featureEnabled` — the second gate `ScenarioInterceptTransport.sendMessage`
+ * checks alongside the user's own toggle.
+ *
+ * Never rejects: a chunk that fails to load reports through `engineState` (the
+ * popover surfaces it) rather than throwing into a `useEffect`.
+ */
+export async function applyAssistantScenarioFeature(
+  featureEnabled: boolean,
+  transport: AssistantTransport = assistantTransport,
+  loaders: AssistantScenarioFeatureLoaders = defaultScenarioFeatureLoaders,
+): Promise<void> {
+  // Full-mock selection (`?mock=1` / test mode) has no shell to wrap.
+  if (!(transport instanceof DelegatingAssistantTransport)) return;
+  const armed = interceptorInstallations.has(transport);
+  if (!featureEnabled && !armed) return;
+
+  let store: AssistantMockScenariosStoreModule;
+  try {
+    store = await loaders.loadStore();
+  } catch {
+    return;
   }
-  return shell;
+  const state = () => store.useAssistantMockScenariosStore.getState();
+  state().setFeatureEnabled(featureEnabled);
+  if (!featureEnabled) return;
+  if (!armed) state().setEngineState("loading");
+  try {
+    await installAssistantTransportInterceptor(
+      transport,
+      loaders.loadInterceptor,
+    );
+  } catch {
+    state().setEngineState("error");
+  }
 }
 
 function createAssistantTransport(): AssistantTransport {
-  const env = {
-    mode: import.meta.env.MODE,
-    dev: import.meta.env.DEV,
-    search: typeof window === "undefined" ? "" : window.location.search,
-  };
-  const factories: AssistantTransportFactories = {
-    createMock: () => new MockAssistantTransport(),
-    createAevatar: () => new AevatarAssistantTransport(),
-  };
-  if (import.meta.env.DEV) {
-    const setState = (state: "loading" | "error") =>
-      void import("@/stores/assistant-mock-scenarios-store")
-        .then((module) =>
-          module.useAssistantMockScenariosStore
-            .getState()
-            .setEngineState(state),
-        )
-        .catch(() => undefined);
-    return createAssistantTransportForEnvironment(
-      env,
-      factories,
-      () => import("@/lib/assistant/scenario-intercept-transport"),
-      setState,
-    );
-  }
-  return createAssistantTransportForEnvironment(env, factories);
+  return createAssistantTransportForEnvironment(
+    {
+      mode: import.meta.env.MODE,
+      dev: import.meta.env.DEV,
+      search: typeof window === "undefined" ? "" : window.location.search,
+    },
+    {
+      createMock: () => new MockAssistantTransport(),
+      createAevatar: () => new AevatarAssistantTransport(),
+    },
+  );
 }
 
 export const assistantTransport: AssistantTransport =

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -19,6 +19,7 @@ export const FEATURE_FLAG = {
   AI_ASSISTANT: "experimental:ai-assistant",
   BILLING: "experimental:billing",
   AEVATAR_CHAT_WIRE_LOG: "experimental:aevatar-chat-wire-log",
+  ASSISTANT_MOCK_SCENARIOS: "experimental:assistant-mock-scenarios",
 } as const;
 
 type FeatureFlagKey = (typeof FEATURE_FLAG)[keyof typeof FEATURE_FLAG];

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -35,40 +35,60 @@ import {
   useSendMessage,
   useTurnEpisode,
 } from "@/hooks/use-assistant";
+import { useFeature } from "@/hooks/use-feature-flag";
 import { ApiError } from "@/lib/api-client";
+import { applyAssistantScenarioFeature } from "@/lib/assistant/transport";
 import { AssistantConversationNotFoundError } from "@/lib/assistant/errors";
 import { parseAssistantSearch } from "@/lib/assistant/search";
+import { FEATURE_FLAG } from "@/lib/feature-flags";
 import type { ActionReport } from "@/schemas/assistant-actions";
 import { useAssistantContextStore } from "@/stores/assistant-context-store";
 import { useAssistantDraftStore } from "@/stores/assistant-draft-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { isTurnActive, type AssistantMessage } from "@/types/assistant";
 
-const MockScenariosAction = import.meta.env.DEV
-  ? lazy(() =>
-      import("@/components/assistant/mock-scenarios-action").then((module) => ({
-        default: module.MockScenariosAction,
-      })),
-    )
-  : null;
+const MockScenariosAction = lazy(() =>
+  import("@/components/assistant/mock-scenarios-action").then((module) => ({
+    default: module.MockScenariosAction,
+  })),
+);
 
 type ScenarioActionComponent =
   | ComponentType
   | LazyExoticComponent<ComponentType>;
+
+function MockScenariosGate({
+  scenarioAction,
+}: {
+  readonly scenarioAction: ScenarioActionComponent | null;
+}) {
+  // Runtime feature flag (`experimental:assistant-mock-scenarios`), resolved
+  // server-side for this user. Fail-closed: unknown, loading, or an older
+  // backend that omits the key all read as off, and off means the scenario
+  // chunks are never fetched and the live transport is never wrapped.
+  const featureEnabled = useFeature(FEATURE_FLAG.ASSISTANT_MOCK_SCENARIOS);
+
+  useEffect(() => {
+    void applyAssistantScenarioFeature(featureEnabled);
+  }, [featureEnabled]);
+
+  if (!featureEnabled || !scenarioAction) return null;
+  const ScenarioAction = scenarioAction;
+  return (
+    <Suspense fallback={null}>
+      <ScenarioAction />
+    </Suspense>
+  );
+}
 
 export function AssistantHeaderActions({
   scenarioAction = MockScenariosAction,
 }: {
   readonly scenarioAction?: ScenarioActionComponent | null;
 } = {}) {
-  const ScenarioAction = scenarioAction;
   return (
     <>
-      {ScenarioAction ? (
-        <Suspense fallback={null}>
-          <ScenarioAction />
-        </Suspense>
-      ) : null}
+      <MockScenariosGate scenarioAction={scenarioAction} />
       <AssistantWireLogAction />
     </>
   );

--- a/frontend/src/stores/assistant-mock-scenarios-store.test.ts
+++ b/frontend/src/stores/assistant-mock-scenarios-store.test.ts
@@ -165,6 +165,37 @@ describe("useAssistantMockScenariosStore", () => {
     });
   });
 
+  it("rehydrates a pre-flag v1 entry fail-closed", async () => {
+    // Written by a dev user back when the layer was gated by
+    // `import.meta.env.DEV`, so the payload predates `featureEnabled`.
+    localStorage.setItem(
+      ASSISTANT_MOCK_SCENARIOS_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: {
+          enabled: true,
+          disabledScenarioIds: ["github-issues"],
+          world: { connected: ["api-github"] },
+          userId: "user-a",
+        },
+      }),
+    );
+
+    await useAssistantMockScenariosStore.persist.rehydrate();
+
+    // Their own settings survive untouched — no migration needed...
+    expect(useAssistantMockScenariosStore.getState()).toMatchObject({
+      enabled: true,
+      disabledScenarioIds: ["github-issues"],
+      world: { connected: ["api-github"] },
+      userId: "user-a",
+    });
+    // ...but a stale `enabled: true` cannot re-arm the tab on its own.
+    expect(useAssistantMockScenariosStore.getState().featureEnabled).toBe(
+      false,
+    );
+  });
+
   it("keeps state when ensureUser receives the current owner", () => {
     const store = useAssistantMockScenariosStore.getState();
     store.ensureUser("user-a");

--- a/frontend/src/stores/assistant-mock-scenarios-store.test.ts
+++ b/frontend/src/stores/assistant-mock-scenarios-store.test.ts
@@ -6,6 +6,7 @@ import {
 
 function resetStore(): void {
   useAssistantMockScenariosStore.setState({
+    featureEnabled: false,
     enabled: false,
     disabledScenarioIds: [],
     world: { connected: [] },
@@ -51,6 +52,42 @@ describe("useAssistantMockScenariosStore", () => {
     expect(persisted.state).not.toHaveProperty("lastActivity");
   });
 
+  it("never persists the platform flag mirror", () => {
+    const store = useAssistantMockScenariosStore.getState();
+    store.ensureUser("user-a");
+    store.setFeatureEnabled(true);
+    store.setEnabled(true);
+
+    const persisted = JSON.parse(
+      localStorage.getItem(ASSISTANT_MOCK_SCENARIOS_STORAGE_KEY)!,
+    ) as { state: Record<string, unknown> };
+
+    // `featureEnabled` is platform-admin state resolved per session. Persisting
+    // it would let a stale localStorage entry re-arm a tab whose flag has since
+    // been revoked.
+    expect(persisted.state).not.toHaveProperty("featureEnabled");
+    expect(useAssistantMockScenariosStore.getState().featureEnabled).toBe(true);
+  });
+
+  it("keeps the platform flag mirror across an account rescope", () => {
+    const store = useAssistantMockScenariosStore.getState();
+    store.ensureUser("user-a");
+    store.setFeatureEnabled(true);
+    store.setEnabled(true);
+    store.connectService("api-github");
+
+    useAssistantMockScenariosStore.getState().ensureUser("user-b");
+
+    // The mock world is user-scoped and resets; the flag is session-scoped and
+    // must survive, or a user switch would silently disarm an enabled tab.
+    expect(useAssistantMockScenariosStore.getState()).toMatchObject({
+      userId: "user-b",
+      featureEnabled: true,
+      enabled: false,
+      world: { connected: [] },
+    });
+  });
+
   it("updates scenario opt-outs and world membership without duplicates", () => {
     const store = useAssistantMockScenariosStore.getState();
     store.setScenarioEnabled("github-issues", false);
@@ -80,6 +117,7 @@ describe("useAssistantMockScenariosStore", () => {
   it("reset restores every default", () => {
     const store = useAssistantMockScenariosStore.getState();
     store.ensureUser("user-a");
+    store.setFeatureEnabled(true);
     store.setEnabled(true);
     store.setScenarioEnabled("error-demo", false);
     store.connectService("api-github");
@@ -89,6 +127,7 @@ describe("useAssistantMockScenariosStore", () => {
     store.reset();
 
     expect(useAssistantMockScenariosStore.getState()).toMatchObject({
+      featureEnabled: false,
       enabled: false,
       disabledScenarioIds: [],
       world: { connected: [] },

--- a/frontend/src/stores/assistant-mock-scenarios-store.ts
+++ b/frontend/src/stores/assistant-mock-scenarios-store.ts
@@ -17,12 +17,21 @@ export interface MockScenarioActivity {
 }
 
 interface AssistantMockScenariosState {
+  /**
+   * Server-resolved `experimental:assistant-mock-scenarios` value, mirrored
+   * here by the React gate so the non-React interceptor can read it
+   * synchronously (same bridge the wire-log panel uses). Never persisted —
+   * it is platform-admin state, not a browser preference — and fail-closed at
+   * `false` so a tab that has not yet resolved the flag cannot intercept.
+   */
+  readonly featureEnabled: boolean;
   readonly enabled: boolean;
   readonly disabledScenarioIds: readonly string[];
   readonly world: MockScenarioWorld;
   readonly userId: string | null;
   readonly engineState: MockScenarioEngineState;
   readonly lastActivity: MockScenarioActivity | null;
+  readonly setFeatureEnabled: (featureEnabled: boolean) => void;
   readonly setEnabled: (enabled: boolean) => void;
   readonly setScenarioEnabled: (scenarioId: string, enabled: boolean) => void;
   readonly setEngineState: (engineState: MockScenarioEngineState) => void;
@@ -35,6 +44,7 @@ interface AssistantMockScenariosState {
 }
 
 const DEFAULT_STATE = {
+  featureEnabled: false,
   enabled: false,
   disabledScenarioIds: [] as readonly string[],
   world: { connected: [] as readonly string[] },
@@ -48,6 +58,7 @@ export const useAssistantMockScenariosStore =
     persist(
       (set) => ({
         ...DEFAULT_STATE,
+        setFeatureEnabled: (featureEnabled) => set({ featureEnabled }),
         setEnabled: (enabled) => set({ enabled }),
         setScenarioEnabled: (scenarioId, enabled) =>
           set((state) => ({
@@ -81,7 +92,11 @@ export const useAssistantMockScenariosStore =
               : {
                   ...DEFAULT_STATE,
                   userId,
+                  // Session-scoped, not user-scoped: the engine chunk stays
+                  // loaded and the flag stays as the gate last resolved it
+                  // across a rescope.
                   engineState: state.engineState,
+                  featureEnabled: state.featureEnabled,
                 },
           ),
         reset: () => set(DEFAULT_STATE),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -219,6 +219,11 @@ export default defineConfig({
     },
   },
   build: {
+    // Emits dist/.vite/manifest.json. Not used at runtime (the SPA loads
+    // hashed assets straight from index.html) — it is the input to
+    // scripts/assert-mock-footprint.mjs, which needs rollup's static-vs-dynamic
+    // import graph to prove the mock scenario chunks stay lazily loaded.
+    manifest: true,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
Follow-up to #1328. The scripted mock chat scenarios were gated by a build-time `import.meta.env.DEV` boundary, so they were invisible in any deployed environment and had no admin-console surface at all — which is what prompted this. The spec left that as open question §14.1 ("is DEV-only right for v1, or do you want the capability-flag gate now?") and defaulted to dev-only without an answer. This answers it the other way.

## What changes

`experimental:assistant-mock-scenarios`, **default off**, toggleable per user / per org / globally from **Admin → Feature Flags** with no redeploy.

**Backend** — one `FeatureFlagDef` in `feature_flag_service.rs` with `default_enabled: false`. `list_feature_flags` already iterates the registry, so the admin console picks it up with no handler change.

**Frontend** — `transport.ts` no longer installs anything at boot. `applyAssistantScenarioFeature()` is the sole install path, driven by `MockScenariosGate` reading `useFeature`.

## Keeping the cost at zero when off

Three boundaries, because a runtime flag means the code now ships in the production bundle:

1. **Nothing loads.** Flag off and never armed → `applyAssistantScenarioFeature` returns before touching a loader. The interceptor, engine, scripted config, and persisted store are never fetched and no `localStorage` is read.
2. **No chunk request.** The header action renders `null` rather than requesting its lazy chunk.
3. **Revocation reaches armed tabs.** `ScenarioInterceptTransport.sendMessage` now requires `featureEnabled && enabled`. The flag is mirrored into the store by the gate — the same bridge `AssistantWireLogAction` uses, and never persisted — so clearing the override disarms an already-armed tab on its next `/users/me` refetch (60s interval) and every send goes back to the live delegate, whatever the user's own toggle says.

Also: a rejected interceptor install is now evicted from its `WeakMap`, so a transient chunk failure can retry on the next flag resolution instead of poisoning the shell for the tab's lifetime.

## The footprint gate

`scripts/assert-mock-footprint.mjs` previously asserted `dist/` contained no `mockchat-` / `scenario-engine` / `mockscenarios` symbols. That invariant is gone by construction — the code has to ship for an operator to switch it on. What replaces it is the property that actually matters: **nobody without the flag downloads it.**

The script now reads vite's build manifest (`build.manifest: true`, newly enabled — output-only, not used at runtime) and asserts the mock modules stay dynamic-import only:

- **R1** they still have chunks of their own (a new static import folds them away, and this fires first);
- **R2** no chunk statically reaches an entry point, walking `imports` and deliberately not `dynamicImports`;
- **R3** neither the `index.html` entry graph nor the assistant page chunk carries their payload — so opening `/assistant` without the flag costs nothing either;
- **R4** the credential-accept entry is clean.

Verified by hand that it fails on a deliberate static-import regression, rather than passing vacuously.

## Turning it on

1. Platform admin → `/admin/feature-flags`.
2. Add an override at the narrowest scope that works — **User** is the default choice (it is a rehearsal tool, not a rollout); **Org** reaches members' personal surfaces too; **Global** is preview/staging only.
3. Target picks it up within ~60s (or immediately on reload). A flask icon appears in the assistant header with the popover's master switch still off — the flag only *offers* the tool.
4. To revoke, clear the override.

Note there is no longer a dev-only bypass: local development needs the override too.

## Tests

- Backend `cargo test -p nyxid feature_flag` — 32 passed. New: flag registered + off by default in both resolvers; existing `shipped_registry_key_literals_are_pinned` updated (it caught the drift).
- Frontend `vitest run` — 208 files / 2532 tests passed. New coverage: never-armed flag-off loads neither chunk; arming installs in place; mid-session revocation clears the mirror without touching the user toggle; chunk-failure retry; store chunk failure never throws into the effect; full-mock transport untouched; flag-off passes matching sends through and does not block on `engineState: "loading"`; `featureEnabled` is not persisted and survives an account rescope; header renders nothing when the flag is off.
- `npm run build` (the CI gate, includes the rewritten footprint assertion) — passes.
- Frontend lint — 0 errors.

Docs: spec §8.3 rewritten with the gate and an operator runbook, §14.1 marked answered, §9 updated; plan doc gets a superseded note rather than a rewrite; `docs/chat/README.md` index updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)