### PR TITLE
feat(admin): editable feature-flag description and owner

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1803,6 +1803,19 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
         )
         .await?;
 
+    // ── feature_flag_metadata ──
+    // At most one admin-authored description/owner row per registry flag key.
+    let feature_flag_metadata =
+        db.collection::<Document>(crate::models::feature_flag_metadata::COLLECTION_NAME);
+    feature_flag_metadata
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "flag_key": 1 })
+                .options(IndexOptions::builder().unique(true).build())
+                .build(),
+        )
+        .await?;
+
     // ── org_invites ──
     let org_invites = db.collection::<Document>("org_invites");
     org_invites

--- a/backend/src/handlers/admin_feature_flags.rs
+++ b/backend/src/handlers/admin_feature_flags.rs
@@ -12,6 +12,7 @@ use utoipa::ToSchema;
 use crate::AppState;
 use crate::errors::{AppError, AppResult};
 use crate::handlers::admin_helpers::{require_admin, require_admin_or_operator};
+use crate::models::feature_flag_metadata::FeatureFlagMetadata;
 use crate::models::feature_flag_override::{FeatureFlagOverride, FlagTargetKind};
 use crate::mw::auth::AuthUser;
 use crate::services::{audit_service, feature_flag_service};
@@ -83,7 +84,18 @@ impl AdminOrgFeatureFlagOverride {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AdminFeatureFlagItem {
     pub key: String,
+    /// The description to show: the admin-authored one when set, otherwise the
+    /// code-declared fallback.
     pub description: String,
+    /// The code-declared description, always present. Rendered as the
+    /// placeholder / reset target in the admin editor.
+    pub code_description: String,
+    /// The admin-authored description, when one has been written.
+    pub custom_description: Option<String>,
+    /// Who owns this flag (person, team, or contact). Admin-authored.
+    pub owner: Option<String>,
+    pub metadata_updated_at: Option<String>,
+    pub metadata_updated_by: Option<String>,
     pub default_enabled: bool,
     pub global_override: Option<bool>,
     pub org_overrides: Vec<AdminOrgFeatureFlagOverride>,
@@ -168,6 +180,7 @@ pub async fn list_feature_flags(
     let org_rows = feature_flag_service::list_all_org_scope_overrides(&state.db).await?;
     let users = feature_flag_service::fetch_platform_override_users(&state.db, &overrides).await?;
     let orgs = feature_flag_service::fetch_override_org_display(&state.db, &org_rows).await?;
+    let metadata = feature_flag_service::list_metadata(&state.db).await?;
     let mut flags = Vec::with_capacity(feature_flag_service::FEATURE_FLAGS.len());
 
     for def in feature_flag_service::FEATURE_FLAGS {
@@ -187,9 +200,18 @@ pub async fn list_feature_flags(
             .cloned()
             .map(|row| AdminUserFeatureFlagOverride::from_row(row, &users))
             .collect::<AppResult<Vec<_>>>()?;
+        let meta = metadata.get(def.key);
+        let custom_description = meta.and_then(|row| row.description.clone());
         flags.push(AdminFeatureFlagItem {
             key: def.key.to_string(),
-            description: def.description.to_string(),
+            description: custom_description
+                .clone()
+                .unwrap_or_else(|| def.description.to_string()),
+            code_description: def.description.to_string(),
+            custom_description,
+            owner: meta.and_then(|row| row.owner.clone()),
+            metadata_updated_at: meta.map(|row| row.updated_at.to_rfc3339()),
+            metadata_updated_by: meta.map(|row| row.updated_by.clone()),
             default_enabled: def.default_enabled,
             global_override,
             org_overrides,
@@ -270,6 +292,86 @@ impl From<FeatureFlagOverride> for AdminUserFeatureFlagOverrideOrGlobal {
             updated_by: row.updated_by,
         }
     }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateFeatureFlagMetadataRequest {
+    /// Replaces the code-declared description. Blank or absent clears it.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Who owns the flag. Blank or absent clears it.
+    #[serde(default)]
+    pub owner: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AdminFeatureFlagMetadataResponse {
+    pub key: String,
+    /// Effective description after the write: the admin text when set,
+    /// otherwise the code-declared fallback.
+    pub description: String,
+    pub code_description: String,
+    pub custom_description: Option<String>,
+    pub owner: Option<String>,
+    pub metadata_updated_at: Option<String>,
+    pub metadata_updated_by: Option<String>,
+}
+
+impl AdminFeatureFlagMetadataResponse {
+    fn build(def: &feature_flag_service::FeatureFlagDef, row: Option<FeatureFlagMetadata>) -> Self {
+        let custom_description = row.as_ref().and_then(|meta| meta.description.clone());
+        Self {
+            key: def.key.to_string(),
+            description: custom_description
+                .clone()
+                .unwrap_or_else(|| def.description.to_string()),
+            code_description: def.description.to_string(),
+            custom_description,
+            owner: row.as_ref().and_then(|meta| meta.owner.clone()),
+            metadata_updated_at: row.as_ref().map(|meta| meta.updated_at.to_rfc3339()),
+            metadata_updated_by: row.map(|meta| meta.updated_by),
+        }
+    }
+}
+
+/// PUT /api/v1/admin/feature-flags/{flag_key}/metadata
+///
+/// Full replace: whichever of `description` / `owner` is blank or absent is
+/// cleared, and clearing both drops the row so the flag falls back to its
+/// code-declared description.
+pub async fn update_feature_flag_metadata(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(flag_key): Path<String>,
+    Json(body): Json<UpdateFeatureFlagMetadataRequest>,
+) -> AppResult<Json<AdminFeatureFlagMetadataResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let def = feature_flag_service::find_flag(&flag_key)
+        .ok_or_else(|| AppError::BadRequest(format!("unknown feature flag '{flag_key}'")))?;
+    let row = feature_flag_service::set_metadata(
+        &state.db,
+        &flag_key,
+        body.description.as_deref(),
+        body.owner.as_deref(),
+        &auth_user.user_id.to_string(),
+    )
+    .await?;
+
+    audit_service::log_for_user(
+        state.db.clone(),
+        &auth_user,
+        "admin_feature_flag_metadata_set",
+        // Metadata is staff-authored documentation, not user data — the values
+        // are safe to record so an owner change is reconstructible.
+        Some(serde_json::json!({
+            "flag_key": flag_key,
+            "description": row.as_ref().and_then(|meta| meta.description.clone()),
+            "owner": row.as_ref().and_then(|meta| meta.owner.clone()),
+            "cleared": row.is_none(),
+        })),
+    );
+
+    Ok(Json(AdminFeatureFlagMetadataResponse::build(def, row)))
 }
 
 /// DELETE /api/v1/admin/feature-flags/{flag_key}
@@ -531,6 +633,109 @@ mod tests {
             .expect("list after clear");
         let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
         assert!(item.org_overrides.is_empty());
+    }
+
+    #[tokio::test]
+    async fn metadata_edit_round_trip_and_access_control() {
+        let Some((state, admin_id, operator_id, _target_id)) =
+            setup("admin_feature_flags_metadata").await
+        else {
+            eprintln!("skipping admin feature flag metadata test: no local MongoDB available");
+            return;
+        };
+        let admin = test_auth_user(&admin_id);
+        let operator = test_auth_user(&operator_id);
+        let flag_key = "example_ui".to_string();
+
+        // Before any edit, the list serves the code-declared description with
+        // no owner.
+        let Json(list) = list_feature_flags(State(state.clone()), admin.clone())
+            .await
+            .expect("list flags");
+        let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
+        assert_eq!(item.description, "Test-only placeholder flag.");
+        assert_eq!(item.code_description, "Test-only placeholder flag.");
+        assert!(item.custom_description.is_none());
+        assert!(item.owner.is_none());
+        assert!(item.metadata_updated_at.is_none());
+
+        let Json(saved) = update_feature_flag_metadata(
+            State(state.clone()),
+            admin.clone(),
+            Path(flag_key.clone()),
+            Json(UpdateFeatureFlagMetadataRequest {
+                description: Some("Gates the redesigned panel.".to_string()),
+                owner: Some("Platform team".to_string()),
+            }),
+        )
+        .await
+        .expect("write metadata");
+        assert_eq!(saved.description, "Gates the redesigned panel.");
+        assert_eq!(saved.code_description, "Test-only placeholder flag.");
+        assert_eq!(saved.owner.as_deref(), Some("Platform team"));
+        assert_eq!(
+            saved.metadata_updated_by.as_deref(),
+            Some(admin_id.as_str())
+        );
+
+        // The list now serves the admin description while still exposing the
+        // code fallback, so the editor can offer a reset.
+        let Json(list) = list_feature_flags(State(state.clone()), operator.clone())
+            .await
+            .expect("operator list");
+        let item = list.flags.iter().find(|flag| flag.key == flag_key).unwrap();
+        assert_eq!(item.description, "Gates the redesigned panel.");
+        assert_eq!(item.code_description, "Test-only placeholder flag.");
+        assert_eq!(
+            item.custom_description.as_deref(),
+            Some("Gates the redesigned panel.")
+        );
+        assert_eq!(item.owner.as_deref(), Some("Platform team"));
+
+        // Operators may read but not write.
+        let forbidden = update_feature_flag_metadata(
+            State(state.clone()),
+            operator,
+            Path(flag_key.clone()),
+            Json(UpdateFeatureFlagMetadataRequest {
+                description: Some("nope".to_string()),
+                owner: None,
+            }),
+        )
+        .await
+        .expect_err("operator metadata write is forbidden");
+        assert!(matches!(forbidden, AppError::Forbidden(_)));
+
+        // Clearing both fields falls back to the code description.
+        let Json(cleared) = update_feature_flag_metadata(
+            State(state.clone()),
+            admin.clone(),
+            Path(flag_key.clone()),
+            Json(UpdateFeatureFlagMetadataRequest {
+                description: None,
+                owner: Some("   ".to_string()),
+            }),
+        )
+        .await
+        .expect("clear metadata");
+        assert_eq!(cleared.description, "Test-only placeholder flag.");
+        assert!(cleared.custom_description.is_none());
+        assert!(cleared.owner.is_none());
+        assert!(cleared.metadata_updated_at.is_none());
+
+        // Unknown keys are rejected rather than creating orphan rows.
+        let unknown = update_feature_flag_metadata(
+            State(state),
+            admin,
+            Path("does-not-exist".to_string()),
+            Json(UpdateFeatureFlagMetadataRequest {
+                description: Some("x".to_string()),
+                owner: None,
+            }),
+        )
+        .await
+        .expect_err("unknown flag rejected");
+        assert!(matches!(unknown, AppError::BadRequest(_)));
     }
 
     #[tokio::test]

--- a/backend/src/models/feature_flag_metadata.rs
+++ b/backend/src/models/feature_flag_metadata.rs
@@ -1,0 +1,85 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const COLLECTION_NAME: &str = "feature_flag_metadata";
+
+/// Admin-authored documentation for a code-declared feature flag.
+///
+/// The flag registry (`feature_flag_service::FEATURE_FLAGS`) stays the source
+/// of truth for which flags exist and what they default to; this collection
+/// only carries the editorial fields staff need to keep a growing flag list
+/// legible — what the flag is actually about, and who owns it. One row per
+/// `flag_key`, created lazily on first edit and deleted again when an admin
+/// clears every field.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeatureFlagMetadata {
+    #[serde(rename = "_id")]
+    pub id: String,
+    /// Registry key this documents. Unknown keys are rejected at the service
+    /// layer, not stored.
+    pub flag_key: String,
+    /// Admin-written description replacing the code-declared one in admin
+    /// surfaces. `None` falls back to `FeatureFlagDef::description`.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Free-form owner: a person, a team, or a contact address. `None` when
+    /// nobody has claimed the flag.
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub updated_at: DateTime<Utc>,
+    /// User id of the platform admin who last wrote this row.
+    pub updated_by: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_name() {
+        assert_eq!(COLLECTION_NAME, "feature_flag_metadata");
+    }
+
+    #[test]
+    fn bson_roundtrip() {
+        let row = FeatureFlagMetadata {
+            id: uuid::Uuid::new_v4().to_string(),
+            flag_key: "example_ui".to_string(),
+            description: Some("Gates the new panel.".to_string()),
+            owner: Some("Platform team".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            updated_by: uuid::Uuid::new_v4().to_string(),
+        };
+        let doc = bson::to_document(&row).expect("serialize");
+        let restored: FeatureFlagMetadata = bson::from_document(doc).expect("deserialize");
+        assert_eq!(restored.flag_key, "example_ui");
+        assert_eq!(
+            restored.description.as_deref(),
+            Some("Gates the new panel.")
+        );
+        assert_eq!(restored.owner.as_deref(), Some("Platform team"));
+    }
+
+    #[test]
+    fn missing_optional_fields_default_to_none() {
+        let mut doc = bson::to_document(&FeatureFlagMetadata {
+            id: "x".to_string(),
+            flag_key: "example_ui".to_string(),
+            description: Some("d".to_string()),
+            owner: Some("o".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            updated_by: "actor".to_string(),
+        })
+        .expect("serialize");
+        doc.remove("description");
+        doc.remove("owner");
+        let restored: FeatureFlagMetadata = bson::from_document(doc).expect("deserialize");
+        assert!(restored.description.is_none());
+        assert!(restored.owner.is_none());
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -22,6 +22,7 @@ pub mod device_code;
 pub mod device_onboard_credential;
 pub mod device_pubkey_lockout;
 pub mod downstream_service;
+pub mod feature_flag_metadata;
 pub mod feature_flag_override;
 pub mod group;
 pub mod invite_code;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -666,6 +666,10 @@ pub fn build_router(
                 .delete(handlers::admin_feature_flags::clear_feature_flag),
         )
         .route(
+            "/feature-flags/{flag_key}/metadata",
+            put(handlers::admin_feature_flags::update_feature_flag_metadata),
+        )
+        .route(
             "/users",
             get(handlers::admin::list_users).post(handlers::admin::create_user),
         )

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -28,6 +28,11 @@
 //! and consume its key on the frontend. Toggling an existing flag globally /
 //! per org / per user is a runtime write, no deploy. Mirror new keys in
 //! `frontend/src/lib/feature-flags.ts`.
+//!
+//! Each definition ships a code-declared `description`. Platform admins can
+//! replace that text and record an owner at runtime (`feature_flag_metadata`,
+//! see [`set_metadata`]) so a growing flag list stays legible without a deploy;
+//! the registry still owns which flags exist and what they default to.
 
 use std::collections::{HashMap, HashSet};
 
@@ -38,6 +43,9 @@ use mongodb::options::{FindOneAndUpdateOptions, ReturnDocument};
 use uuid::Uuid;
 
 use crate::errors::{AppError, AppResult};
+use crate::models::feature_flag_metadata::{
+    COLLECTION_NAME as METADATA_COLLECTION, FeatureFlagMetadata,
+};
 use crate::models::feature_flag_override::{COLLECTION_NAME, FeatureFlagOverride, FlagTargetKind};
 use crate::models::org_membership::OrgRole;
 use crate::models::user::{COLLECTION_NAME as USERS, User};
@@ -743,6 +751,109 @@ pub async fn fetch_override_org_display(
         .collect())
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Metadata (admin-authored documentation)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Upper bound on an admin-written flag description.
+pub const MAX_FLAG_DESCRIPTION_LEN: usize = 512;
+/// Upper bound on an admin-written flag owner (a person, team, or contact).
+pub const MAX_FLAG_OWNER_LEN: usize = 128;
+
+/// Trim a free-text metadata field, treating blank input as "cleared", and
+/// enforce its length budget.
+fn normalize_metadata_field(
+    value: Option<&str>,
+    max_len: usize,
+    field: &str,
+) -> AppResult<Option<String>> {
+    let Some(trimmed) = value.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    if trimmed.chars().count() > max_len {
+        return Err(AppError::BadRequest(format!(
+            "{field} must be at most {max_len} characters"
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+/// Every metadata row, keyed by flag key. Rows for flags that have since left
+/// the registry are dropped so a stale row can never resurrect a retired flag.
+pub async fn list_metadata(
+    db: &mongodb::Database,
+) -> AppResult<HashMap<String, FeatureFlagMetadata>> {
+    let rows: Vec<FeatureFlagMetadata> = db
+        .collection::<FeatureFlagMetadata>(METADATA_COLLECTION)
+        .find(doc! {})
+        .await?
+        .try_collect()
+        .await?;
+    Ok(rows
+        .into_iter()
+        .filter(|row| find_flag(&row.flag_key).is_some())
+        .map(|row| (row.flag_key.clone(), row))
+        .collect())
+}
+
+/// Replace the admin-authored description and owner for one flag.
+///
+/// Full-replace semantics: whatever is passed becomes the stored state, and a
+/// blank or absent value clears that field. Clearing both fields deletes the
+/// row entirely (the flag falls back to its code-declared description with no
+/// owner) and returns `None`.
+pub async fn set_metadata(
+    db: &mongodb::Database,
+    flag_key: &str,
+    description: Option<&str>,
+    owner: Option<&str>,
+    actor_id: &str,
+) -> AppResult<Option<FeatureFlagMetadata>> {
+    find_flag(flag_key)
+        .ok_or_else(|| AppError::BadRequest(format!("unknown feature flag '{flag_key}'")))?;
+    let description =
+        normalize_metadata_field(description, MAX_FLAG_DESCRIPTION_LEN, "description")?;
+    let owner = normalize_metadata_field(owner, MAX_FLAG_OWNER_LEN, "owner")?;
+
+    let collection = db.collection::<FeatureFlagMetadata>(METADATA_COLLECTION);
+    if description.is_none() && owner.is_none() {
+        collection
+            .find_one_and_delete(doc! { "flag_key": flag_key })
+            .await?;
+        return Ok(None);
+    }
+
+    let now = bson::DateTime::from_chrono(Utc::now());
+    let row = collection
+        .find_one_and_update(
+            doc! { "flag_key": flag_key },
+            doc! {
+                "$set": {
+                    "description": description.clone().map(bson::Bson::String).unwrap_or(bson::Bson::Null),
+                    "owner": owner.clone().map(bson::Bson::String).unwrap_or(bson::Bson::Null),
+                    "updated_at": now,
+                    "updated_by": actor_id,
+                },
+                "$setOnInsert": {
+                    "_id": Uuid::new_v4().to_string(),
+                    "flag_key": flag_key,
+                    "created_at": now,
+                },
+            },
+        )
+        .with_options(
+            FindOneAndUpdateOptions::builder()
+                .upsert(true)
+                .return_document(ReturnDocument::After)
+                .build(),
+        )
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal("feature flag metadata upsert did not return the row".to_string())
+        })?;
+    Ok(Some(row))
+}
+
 /// Cascade helper: drop every override for an org (used when the org is deleted).
 pub async fn delete_all_for_org(db: &mongodb::Database, org_user_id: &str) -> AppResult<()> {
     db.collection::<FeatureFlagOverride>(COLLECTION_NAME)
@@ -1317,6 +1428,153 @@ mod tests {
                 .await
                 .expect("resolve after clear")
                 .contains(&"example_ui".to_string())
+        );
+    }
+
+    #[test]
+    fn metadata_fields_normalize_and_bound() {
+        assert_eq!(normalize_metadata_field(None, 10, "owner").unwrap(), None);
+        assert_eq!(
+            normalize_metadata_field(Some("   "), 10, "owner").unwrap(),
+            None
+        );
+        assert_eq!(
+            normalize_metadata_field(Some("  team  "), 10, "owner").unwrap(),
+            Some("team".to_string())
+        );
+        // The budget counts characters, not bytes, so multi-byte owners get
+        // the same allowance as ASCII ones.
+        assert_eq!(
+            normalize_metadata_field(Some("平台团队"), 4, "owner").unwrap(),
+            Some("平台团队".to_string())
+        );
+        assert!(matches!(
+            normalize_metadata_field(Some("平台团队五"), 4, "owner"),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn metadata_crud_round_trip() {
+        let Some(db) = connect_test_database("feature_flag_metadata").await else {
+            eprintln!("skipping feature flag metadata test: no local MongoDB available");
+            return;
+        };
+        let actor = Uuid::new_v4().to_string();
+
+        // No row until an admin writes one.
+        assert!(list_metadata(&db).await.expect("empty list").is_empty());
+
+        let stored = set_metadata(
+            &db,
+            "example_ui",
+            Some("  Gates the redesigned panel.  "),
+            Some("  Platform team  "),
+            &actor,
+        )
+        .await
+        .expect("set metadata")
+        .expect("row present");
+        assert_eq!(
+            stored.description.as_deref(),
+            Some("Gates the redesigned panel.")
+        );
+        assert_eq!(stored.owner.as_deref(), Some("Platform team"));
+        assert_eq!(stored.updated_by, actor);
+
+        // Full-replace: an omitted field is cleared, and the row keeps its id.
+        let updated = set_metadata(&db, "example_ui", None, Some("Growth team"), &actor)
+            .await
+            .expect("update metadata")
+            .expect("row present");
+        assert_eq!(updated.id, stored.id);
+        assert!(updated.description.is_none());
+        assert_eq!(updated.owner.as_deref(), Some("Growth team"));
+
+        let listed = list_metadata(&db).await.expect("list metadata");
+        assert_eq!(
+            listed
+                .get("example_ui")
+                .and_then(|row| row.owner.as_deref()),
+            Some("Growth team")
+        );
+
+        // Clearing every field deletes the row rather than leaving a husk.
+        assert!(
+            set_metadata(&db, "example_ui", Some("  "), None, &actor)
+                .await
+                .expect("clear metadata")
+                .is_none()
+        );
+        assert!(
+            list_metadata(&db)
+                .await
+                .expect("list after clear")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_rejects_unknown_flag_and_overlong_fields() {
+        let Some(db) = connect_test_database("feature_flag_metadata_validation").await else {
+            eprintln!("skipping feature flag metadata validation test: no local MongoDB available");
+            return;
+        };
+        let actor = Uuid::new_v4().to_string();
+
+        assert!(matches!(
+            set_metadata(&db, "nope", Some("x"), None, &actor).await,
+            Err(AppError::BadRequest(_))
+        ));
+        assert!(matches!(
+            set_metadata(
+                &db,
+                "example_ui",
+                Some(&"x".repeat(MAX_FLAG_DESCRIPTION_LEN + 1)),
+                None,
+                &actor,
+            )
+            .await,
+            Err(AppError::BadRequest(_))
+        ));
+        assert!(matches!(
+            set_metadata(
+                &db,
+                "example_ui",
+                None,
+                Some(&"x".repeat(MAX_FLAG_OWNER_LEN + 1)),
+                &actor,
+            )
+            .await,
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn metadata_for_retired_flags_is_not_listed() {
+        let Some(db) = connect_test_database("feature_flag_metadata_retired").await else {
+            eprintln!("skipping feature flag retired metadata test: no local MongoDB available");
+            return;
+        };
+        // A row left behind by a flag that has since been deleted from the
+        // registry must never surface as if the flag still existed.
+        db.collection::<FeatureFlagMetadata>(METADATA_COLLECTION)
+            .insert_one(FeatureFlagMetadata {
+                id: Uuid::new_v4().to_string(),
+                flag_key: "retired_flag".to_string(),
+                description: Some("Long gone.".to_string()),
+                owner: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                updated_by: "actor".to_string(),
+            })
+            .await
+            .expect("insert stale row");
+        assert!(
+            !list_metadata(&db)
+                .await
+                .expect("list metadata")
+                .contains_key("retired_flag")
         );
     }
 

--- a/frontend/src/hooks/use-admin-feature-flags.test.tsx
+++ b/frontend/src/hooks/use-admin-feature-flags.test.tsx
@@ -6,6 +6,7 @@ import {
   useAdminFeatureFlags,
   useClearAdminFeatureFlag,
   useSetAdminFeatureFlag,
+  useUpdateAdminFeatureFlagMetadata,
 } from "./use-admin-feature-flags";
 
 const { mockGet, mockPut, mockDelete } = vi.hoisted(() => ({
@@ -53,6 +54,21 @@ describe("admin feature-flag hooks", () => {
     expect(mockPut).toHaveBeenCalledWith(
       "/admin/feature-flags/experimental%3Aai-assistant",
       { target_kind: "global", target_key: null, enabled: true },
+    );
+  });
+
+  it("writes flag metadata to the encoded metadata sub-route", async () => {
+    mockPut.mockResolvedValue({});
+    const { result } = renderHook(() => useUpdateAdminFeatureFlagMetadata(), {
+      wrapper: createWrapper(),
+    });
+    await result.current.mutateAsync({
+      flagKey: "experimental:ai-assistant",
+      body: { description: "What it gates.", owner: "Platform team" },
+    });
+    expect(mockPut).toHaveBeenCalledWith(
+      "/admin/feature-flags/experimental%3Aai-assistant/metadata",
+      { description: "What it gates.", owner: "Platform team" },
     );
   });
 

--- a/frontend/src/hooks/use-admin-feature-flags.ts
+++ b/frontend/src/hooks/use-admin-feature-flags.ts
@@ -4,6 +4,7 @@ import type {
   AdminFeatureFlagListResponse,
   AdminFeatureFlagTargetKind,
   SetAdminFeatureFlagRequest,
+  UpdateAdminFeatureFlagMetadataRequest,
 } from "@/schemas/admin-feature-flags";
 
 const QUERY_KEY = ["admin", "feature-flags"] as const;
@@ -31,6 +32,30 @@ export function useSetAdminFeatureFlag() {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
       void queryClient.invalidateQueries({ queryKey: ["orgs"] });
       void queryClient.invalidateQueries({ queryKey: ["user"] });
+    },
+  });
+}
+
+/**
+ * Edit a flag's admin-authored description and owner. Documentation only — it
+ * never changes rollout, so it only invalidates the admin list.
+ */
+export function useUpdateAdminFeatureFlagMetadata() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      flagKey,
+      body,
+    }: {
+      flagKey: string;
+      body: UpdateAdminFeatureFlagMetadataRequest;
+    }): Promise<unknown> =>
+      api.put(
+        `/admin/feature-flags/${encodeURIComponent(flagKey)}/metadata`,
+        body,
+      ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
     },
   });
 }

--- a/frontend/src/pages/admin-feature-flags.test.tsx
+++ b/frontend/src/pages/admin-feature-flags.test.tsx
@@ -4,20 +4,24 @@ import { AdminFeatureFlagsPage } from "./admin-feature-flags";
 import { useAuthStore } from "@/stores/auth-store";
 import type { User } from "@/types/api";
 
-const { mockUseFlags, mockUseUsers, mockSetFlag, mockClearFlag } = vi.hoisted(
-  () => ({
+const { mockUseFlags, mockUseUsers, mockSetFlag, mockClearFlag, mockSetMeta } =
+  vi.hoisted(() => ({
     mockUseFlags: vi.fn(),
     mockUseUsers: vi.fn(),
     mockSetFlag: vi.fn(),
     mockClearFlag: vi.fn(),
-  }),
-);
+    mockSetMeta: vi.fn(),
+  }));
 
 vi.mock("@/hooks/use-admin-feature-flags", () => ({
   useAdminFeatureFlags: mockUseFlags,
   useSetAdminFeatureFlag: () => ({ mutateAsync: mockSetFlag, isPending: false }),
   useClearAdminFeatureFlag: () => ({
     mutateAsync: mockClearFlag,
+    isPending: false,
+  }),
+  useUpdateAdminFeatureFlagMetadata: () => ({
+    mutateAsync: mockSetMeta,
     isPending: false,
   }),
 }));
@@ -28,6 +32,11 @@ vi.mock("@/hooks/use-admin", () => ({
 
 function flagFixture(
   overrides: Partial<{
+    description: string;
+    code_description: string;
+    custom_description: string | null;
+    owner: string | null;
+    metadata_updated_at: string | null;
     global_override: boolean | null;
     org_overrides: unknown[];
     user_overrides: unknown[];
@@ -36,6 +45,11 @@ function flagFixture(
   return {
     key: "experimental:ai-assistant",
     description: "AI Assistant chat surface.",
+    code_description: "AI Assistant chat surface.",
+    custom_description: null,
+    owner: null,
+    metadata_updated_at: null,
+    metadata_updated_by: null,
     default_enabled: false,
     global_override: null,
     org_overrides: [],
@@ -105,6 +119,7 @@ function operatorUser(): User {
 beforeEach(() => {
   mockSetFlag.mockReset().mockResolvedValue(undefined);
   mockClearFlag.mockReset().mockResolvedValue(undefined);
+  mockSetMeta.mockReset().mockResolvedValue(undefined);
   mockUseUsers.mockReset().mockReturnValue({
     data: { users: [], total: 201, page: 1, per_page: 20 },
     isLoading: false,
@@ -365,6 +380,134 @@ describe("AdminFeatureFlagsPage", () => {
 
     render(<AdminFeatureFlagsPage />);
     expect(screen.getByText("experimental:ai-assistant")).toBeInTheDocument();
+  });
+
+  it("saves an edited description and owner as a full replace", async () => {
+    mockUseFlags.mockReturnValue({
+      data: { flags: [flagFixture()] },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    fireEvent.click(screen.getByText("experimental:ai-assistant"));
+
+    // The editor starts empty and shows the code description as a hint, so an
+    // untouched flag never silently persists a copy of it.
+    const description = screen.getByLabelText(
+      "Description — what this flag controls",
+    );
+    expect(description).toHaveValue("");
+    expect(description).toHaveAttribute(
+      "placeholder",
+      "AI Assistant chat surface.",
+    );
+    expect(screen.getByText("Save details")).toBeDisabled();
+
+    fireEvent.change(description, {
+      target: { value: "  Gates the assistant sidebar entry.  " },
+    });
+    fireEvent.change(screen.getByLabelText("Owner — who to ask about it"), {
+      target: { value: " Platform team " },
+    });
+    fireEvent.click(screen.getByText("Save details"));
+
+    await waitFor(() =>
+      expect(mockSetMeta).toHaveBeenCalledWith({
+        flagKey: "experimental:ai-assistant",
+        body: {
+          description: "Gates the assistant sidebar entry.",
+          owner: "Platform team",
+        },
+      }),
+    );
+  });
+
+  it("shows the admin description plus owner and can reset to the code default", async () => {
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          flagFixture({
+            description: "Custom explanation.",
+            custom_description: "Custom explanation.",
+            owner: "Growth team",
+            metadata_updated_at: "2026-08-04T00:00:00Z",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    // The owner is visible on the collapsed card, so a flag list reads as
+    // owned without expanding every row.
+    expect(screen.getByText("Growth team")).toBeInTheDocument();
+    expect(screen.getByText("Custom explanation.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("experimental:ai-assistant"));
+    expect(
+      screen.getByLabelText("Description — what this flag controls"),
+    ).toHaveValue("Custom explanation.");
+
+    // Clearing the description sends null, which restores the code default.
+    fireEvent.click(screen.getByText("Use code default"));
+    fireEvent.click(screen.getByText("Save details"));
+    await waitFor(() =>
+      expect(mockSetMeta).toHaveBeenCalledWith({
+        flagKey: "experimental:ai-assistant",
+        body: { description: null, owner: "Growth team" },
+      }),
+    );
+  });
+
+  it("matches a search against the owner", () => {
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          flagFixture({ owner: "Growth team" }),
+          { ...flagFixture(), key: "experimental:billing", owner: null },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    fireEvent.change(screen.getByLabelText("Search feature flags"), {
+      target: { value: "growth" },
+    });
+
+    expect(screen.getByText("experimental:ai-assistant")).toBeInTheDocument();
+    expect(
+      screen.queryByText("experimental:billing"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows operators the flag details read-only", () => {
+    useAuthStore.setState({ user: operatorUser() });
+    mockUseFlags.mockReturnValue({
+      data: {
+        flags: [
+          flagFixture({
+            description: "Custom explanation.",
+            custom_description: "Custom explanation.",
+            owner: "Growth team",
+          }),
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<AdminFeatureFlagsPage />);
+    fireEvent.click(screen.getByText("experimental:ai-assistant"));
+
+    expect(
+      screen.queryByLabelText("Description — what this flag controls"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Save details")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Growth team").length).toBeGreaterThan(0);
   });
 
   it("shows operators a read-only view without pickers or apply controls", () => {

--- a/frontend/src/pages/admin-feature-flags.tsx
+++ b/frontend/src/pages/admin-feature-flags.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useState } from "react";
-import { ChevronDown, Search } from "lucide-react";
+import { ChevronDown, Search, User } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
 import { PowerButtonIcon } from "@/components/icons/empty-state";
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
@@ -15,14 +16,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 import { useAdminUsers } from "@/hooks/use-admin";
 import type { AdminUser } from "@/types/admin";
 import {
   useAdminFeatureFlags,
   useClearAdminFeatureFlag,
   useSetAdminFeatureFlag,
+  useUpdateAdminFeatureFlagMetadata,
 } from "@/hooks/use-admin-feature-flags";
+import {
+  MAX_FEATURE_FLAG_DESCRIPTION_LENGTH,
+  MAX_FEATURE_FLAG_OWNER_LENGTH,
+} from "@/schemas/admin-feature-flags";
 import { useAuthStore } from "@/stores/auth-store";
 import { canAdminWrite } from "@/types/api";
 
@@ -38,7 +44,14 @@ interface Assignment {
 }
 interface FlagRow {
   readonly key: string;
+  /** Effective description: the admin-authored one when set, else the code one. */
   readonly description: string;
+  /** The code-declared description — what a reset falls back to. */
+  readonly codeDescription: string;
+  /** The admin-authored description, when one exists. */
+  readonly customDescription: string | null;
+  readonly owner: string | null;
+  readonly metadataUpdatedAt: string | null;
   readonly kind: FlagKind;
   readonly defaultEnabled: boolean;
   global: ScopeState;
@@ -64,6 +77,10 @@ export function AdminFeatureFlagsPage() {
   const flags: FlagRow[] = (data?.flags ?? []).map((flag) => ({
     key: flag.key,
     description: flag.description,
+    codeDescription: flag.code_description ?? flag.description,
+    customDescription: flag.custom_description ?? null,
+    owner: flag.owner ?? null,
+    metadataUpdatedAt: flag.metadata_updated_at ?? null,
     kind: flag.key.startsWith("experimental:") ? "experiment" : "ops",
     defaultEnabled: flag.default_enabled,
     global:
@@ -143,7 +160,8 @@ export function AdminFeatureFlagsPage() {
     ? flags.filter(
         (f) =>
           f.key.toLowerCase().includes(q) ||
-          f.description.toLowerCase().includes(q),
+          f.description.toLowerCase().includes(q) ||
+          (f.owner?.toLowerCase().includes(q) ?? false),
       )
     : flags;
   const isOpen = (key: string) => (q ? true : openKeys.includes(key));
@@ -325,6 +343,16 @@ function FlagCard({
             <Badge variant={kindVariant(flag.kind)} className="text-[11px]">
               {flag.kind}
             </Badge>
+            {flag.owner && (
+              <Badge
+                variant="secondary"
+                className="max-w-[200px] gap-1 text-[11px] font-normal"
+                title={`Owner: ${flag.owner}`}
+              >
+                <User className="h-3 w-3 shrink-0" aria-hidden />
+                <span className="min-w-0 truncate">{flag.owner}</span>
+              </Badge>
+            )}
           </div>
           <p className="truncate text-xs text-muted-foreground">
             {flag.description}
@@ -360,6 +388,10 @@ function FlagCard({
 
       {open && (
         <div className="space-y-4 border-t border-border/60 bg-muted/20 px-3 py-3">
+          <Group label="Documentation">
+            <FlagMetadataEditor flag={flag} canWrite={canWrite} />
+          </Group>
+
           <Group label="Global">
             <ScopeRow
               label="All users (rollout / killswitch)"
@@ -439,6 +471,130 @@ function FlagCard({
         </div>
       )}
     </Card>
+  );
+}
+
+/**
+ * Inline editor for a flag's admin-authored description and owner.
+ *
+ * Seeded once when the card opens: a background list refetch must never
+ * overwrite what an admin is mid-way through typing. Saving is a full replace,
+ * so a blank field clears that side of the metadata (description falls back to
+ * the code-declared text).
+ */
+function FlagMetadataEditor({
+  flag,
+  canWrite,
+}: {
+  readonly flag: FlagRow;
+  readonly canWrite: boolean;
+}) {
+  const update = useUpdateAdminFeatureFlagMetadata();
+  const [description, setDescription] = useState(flag.customDescription ?? "");
+  const [owner, setOwner] = useState(flag.owner ?? "");
+
+  const trimmedDescription = description.trim();
+  const trimmedOwner = owner.trim();
+  const dirty =
+    trimmedDescription !== (flag.customDescription ?? "") ||
+    trimmedOwner !== (flag.owner ?? "");
+
+  async function save() {
+    try {
+      await update.mutateAsync({
+        flagKey: flag.key,
+        body: {
+          description: trimmedDescription || null,
+          owner: trimmedOwner || null,
+        },
+      });
+      toast.success("Flag details saved");
+    } catch {
+      toast.error("Failed to save flag details");
+    }
+  }
+
+  if (!canWrite) {
+    return (
+      <dl className="space-y-2 px-3 py-2.5 text-[12px]">
+        <div className="space-y-0.5">
+          <dt className="text-[11px] text-muted-foreground">Description</dt>
+          <dd className="text-foreground">{flag.description}</dd>
+        </div>
+        <div className="space-y-0.5">
+          <dt className="text-[11px] text-muted-foreground">Owner</dt>
+          <dd className={cn(!flag.owner && "text-muted-foreground")}>
+            {flag.owner ?? "Unassigned"}
+          </dd>
+        </div>
+      </dl>
+    );
+  }
+
+  return (
+    <div className="space-y-2.5 px-3 py-2.5">
+      <div className="space-y-1">
+        <Label
+          htmlFor={`flag-description-${flag.key}`}
+          className="text-[11px] font-normal"
+        >
+          Description — what this flag controls
+        </Label>
+        <Input
+          id={`flag-description-${flag.key}`}
+          value={description}
+          maxLength={MAX_FEATURE_FLAG_DESCRIPTION_LENGTH}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder={flag.codeDescription}
+          className="h-8 text-[12px]"
+        />
+      </div>
+      <div className="space-y-1">
+        <Label
+          htmlFor={`flag-owner-${flag.key}`}
+          className="text-[11px] font-normal"
+        >
+          Owner — who to ask about it
+        </Label>
+        <Input
+          id={`flag-owner-${flag.key}`}
+          value={owner}
+          maxLength={MAX_FEATURE_FLAG_OWNER_LENGTH}
+          onChange={(event) => setOwner(event.target.value)}
+          placeholder="Unassigned — e.g. Platform team"
+          className="h-8 text-[12px]"
+        />
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-[11px] text-muted-foreground">
+          {flag.customDescription == null
+            ? "Using the description declared in code."
+            : flag.metadataUpdatedAt
+              ? `Edited ${formatRelativeTime(flag.metadataUpdatedAt)}.`
+              : "Edited by an admin."}
+        </p>
+        <div className="flex items-center gap-2">
+          {description !== "" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setDescription("")}
+              disabled={update.isPending}
+            >
+              Use code default
+            </Button>
+          )}
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={save}
+            disabled={!dirty || update.isPending}
+          >
+            {update.isPending ? "Saving…" : "Save details"}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/schemas/admin-feature-flags.ts
+++ b/frontend/src/schemas/admin-feature-flags.ts
@@ -30,15 +30,44 @@ export type AdminOrgFeatureFlagOverride = z.infer<
   typeof adminOrgFeatureFlagOverrideSchema
 >;
 
+/** Mirrors `feature_flag_service::MAX_FLAG_DESCRIPTION_LEN`. */
+export const MAX_FEATURE_FLAG_DESCRIPTION_LENGTH = 512;
+/** Mirrors `feature_flag_service::MAX_FLAG_OWNER_LEN`. */
+export const MAX_FEATURE_FLAG_OWNER_LENGTH = 128;
+
 export const adminFeatureFlagSchema = z.object({
   key: z.string(),
+  /** Effective description: the admin-authored one when set, else the code one. */
   description: z.string(),
+  /** The code-declared description — the reset target for the editor. */
+  code_description: z.string(),
+  /** The admin-authored description, when one exists. */
+  custom_description: z.string().nullable(),
+  owner: z.string().nullable(),
+  metadata_updated_at: z.string().nullable(),
+  metadata_updated_by: z.string().nullable(),
   default_enabled: z.boolean(),
   global_override: z.boolean().nullable(),
   org_overrides: z.array(adminOrgFeatureFlagOverrideSchema),
   user_overrides: z.array(adminUserFeatureFlagOverrideSchema),
 });
 export type AdminFeatureFlag = z.infer<typeof adminFeatureFlagSchema>;
+
+/**
+ * Full replace: a blank or omitted field clears that side of the metadata, and
+ * clearing both restores the code-declared description with no owner.
+ */
+export const updateAdminFeatureFlagMetadataRequestSchema = z.object({
+  description: z
+    .string()
+    .trim()
+    .max(MAX_FEATURE_FLAG_DESCRIPTION_LENGTH)
+    .nullable(),
+  owner: z.string().trim().max(MAX_FEATURE_FLAG_OWNER_LENGTH).nullable(),
+});
+export type UpdateAdminFeatureFlagMetadataRequest = z.infer<
+  typeof updateAdminFeatureFlagMetadataRequestSchema
+>;
 
 export const adminFeatureFlagListResponseSchema = z.object({
   flags: z.array(adminFeatureFlagSchema),


### PR DESCRIPTION
## Why

Feature flags carried only a code-declared description, so a growing flag list gave staff no way to record what a flag actually gates or who to ask about it — short of shipping a deploy to edit the registry string.

## What

Adds a `feature_flag_metadata` collection holding an admin-written description and owner per registry key. The row is created lazily on first edit and deleted again when both fields are cleared, so an untouched flag stores nothing.

The code registry stays the source of truth for **which flags exist** and **what they default to**. Metadata is documentation only and never enters flag resolution.

### Backend

- `PUT /api/v1/admin/feature-flags/{flag_key}/metadata` — admin-only (`require_admin`), audited as `admin_feature_flag_metadata_set`. Full replace: a blank or omitted field clears that side; unknown flag keys are rejected rather than creating orphan rows.
- `GET /api/v1/admin/feature-flags` now returns the effective `description` alongside `code_description`, `custom_description`, `owner`, `metadata_updated_at`, and `metadata_updated_by`. The existing `description` field keeps its meaning (admin text when set, else code text), so nothing downstream breaks.
- `list_metadata` filters out rows whose flag has left the registry, so a stale row can never resurrect a retired flag.
- Length budgets counted in characters, not bytes: 512 description / 128 owner. Unique index on `flag_key`.

### Frontend

- Expanded flag card gains a **Documentation** section: description + owner inputs, the code-declared text as placeholder, a "Use code default" reset, and a Save button gated on dirty state.
- Owner renders as a badge on the collapsed row and is matched by the page search.
- The editor seeds once when the card opens, so a background list refetch can't clobber in-progress typing.
- Operators see the same details read-only, matching the existing read/write split on this page.

## Note for reviewers

The metadata endpoint is PUT-style full replace — a scripted caller sending only `description` will clear `owner`. The UI always sends both.

## Verification

- `cargo test feature_flag` — 38 passed (6 new: metadata CRUD, validation bounds, retired-flag filtering, handler round-trip incl. operator-forbidden write)
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Frontend: 19 passed across both feature-flag suites (4 new page tests, 1 new hook test)
- `npm run lint` — no new warnings; `npm run build` (the CI gate) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)