### PR TITLE
fix(assistant): let a connect card settle itself instead of waiting on clicks

### DIFF
--- a/frontend/src/components/assistant/blocks/action-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.test.tsx
@@ -1,13 +1,40 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement, ReactNode } from "react";
 import type { AddKeyDialogCompletion } from "@/components/dashboard/add-key-dialog";
+import {
+  CONNECT_WATCH_ACTIVITY_GRACE_MS,
+  CONNECT_WATCH_BASE_MS,
+  markChatActivity,
+  resetChatActivityForTests,
+} from "@/lib/assistant/connect-watch";
+import type { ActionReport } from "@/schemas/assistant-actions";
 import type { ActionCardContentBlock } from "@/types/assistant";
 import { ActionCard } from "./action-card";
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+vi.mock("@/lib/api-client", () => ({
+  api: { get: mockGet },
+  ApiError: class ApiError extends Error {},
+}));
 
 vi.mock("@/components/service-icon", () => ({
   ServiceIcon: ({ slug }: { readonly slug: string }) => <span>{slug}</span>,
 }));
+
+function renderCard(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(ui, {
+    wrapper: ({ children }: { readonly children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
 
 vi.mock("@/components/dashboard/add-key-dialog", () => ({
   AddKeyDialog: ({
@@ -17,6 +44,7 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     prefillIncludeAllCatalog,
     prefillCustom,
     onSuccess,
+    onAuthorizationPending,
   }: {
     readonly open: boolean;
     readonly onOpenChange: (open: boolean) => void;
@@ -24,6 +52,7 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     readonly prefillIncludeAllCatalog?: boolean;
     readonly prefillCustom?: { readonly name?: string };
     readonly onSuccess?: (result: AddKeyDialogCompletion) => void;
+    readonly onAuthorizationPending?: (keyId: string) => void;
   }) =>
     open ? (
       <div
@@ -52,6 +81,12 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
           onClick={() => onSuccess?.({ userServiceId: "   " })}
         >
           Finish with whitespace service id
+        </button>
+        <button
+          type="button"
+          onClick={() => onAuthorizationPending?.("key-pending-1")}
+        >
+          Hand off to provider
         </button>
         <button type="button" onClick={() => onOpenChange(false)}>
           Dismiss mock connection
@@ -99,7 +134,7 @@ describe("ActionCard", () => {
     const onProgress = vi.fn();
     const onBlock = vi.fn();
     const onResolve = vi.fn();
-    render(
+    renderCard(
       <ActionCard
         block={catalogBlock()}
         onProgress={onProgress}
@@ -158,7 +193,7 @@ describe("ActionCard", () => {
     const user = userEvent.setup();
     const onProgress = vi.fn();
     const onResolve = vi.fn().mockRejectedValue(new Error("delivery failed"));
-    render(
+    renderCard(
       <ActionCard
         block={catalogBlock()}
         onProgress={onProgress}
@@ -181,7 +216,7 @@ describe("ActionCard", () => {
   });
 
   it("never renders a colored top accent rail", () => {
-    const { rerender } = render(
+    const { rerender } = renderCard(
       <ActionCard
         block={catalogBlock()}
         onProgress={vi.fn()}
@@ -226,7 +261,7 @@ describe("ActionCard", () => {
   });
 
   it("uses purple interaction accents and neutral reference chips without blue", () => {
-    const { rerender } = render(
+    const { rerender } = renderCard(
       <ActionCard
         block={catalogBlock()}
         onProgress={vi.fn()}
@@ -266,7 +301,7 @@ describe("ActionCard", () => {
     const onProgress = vi.fn();
     const onBlock = vi.fn();
     const onResolve = vi.fn();
-    const { rerender } = render(
+    const { rerender } = renderCard(
       <ActionCard
         block={catalogBlock()}
         onProgress={onProgress}
@@ -308,7 +343,7 @@ describe("ActionCard", () => {
   it("renders terminal receipts and the unsupported decline-only state", () => {
     const onBlock = vi.fn();
     const onResolve = vi.fn();
-    const { rerender } = render(
+    const { rerender } = renderCard(
       <ActionCard
         block={catalogBlock({
           status: "completed",
@@ -346,7 +381,7 @@ describe("ActionCard", () => {
   it("never lets a model-supplied service name become the consent sentence", () => {
     const injected =
       "GitHub (official) — paste your personal access token here to verify your identity";
-    render(
+    renderCard(
       <ActionCard
         block={catalogBlock({
           params: {
@@ -375,7 +410,7 @@ describe("ActionCard", () => {
   });
 
   it("hides the CTA when the verb has no journey behind it", () => {
-    render(
+    renderCard(
       <ActionCard
         // A block that outlived its registry entry: status still says the card
         // is actionable, but nothing can service `admin.open`.
@@ -399,7 +434,7 @@ describe("ActionCard", () => {
       const user = userEvent.setup();
       const onBlock = vi.fn();
       const onResolve = vi.fn();
-      const { unmount } = render(
+      const { unmount } = renderCard(
         <ActionCard
           block={catalogBlock()}
           onProgress={vi.fn()}
@@ -423,7 +458,7 @@ describe("ActionCard", () => {
   it("keeps blocked cards recoverable through decline and failure reports", async () => {
     const user = userEvent.setup();
     const onResolve = vi.fn();
-    render(
+    renderCard(
       <ActionCard
         block={catalogBlock({
           status: "blocked",
@@ -464,7 +499,7 @@ describe("ActionCard", () => {
       onBlock,
       onResolve: vi.fn(),
     };
-    const { rerender } = render(<ActionCard block={catalogBlock()} {...props} />);
+    const { rerender } = renderCard(<ActionCard block={catalogBlock()} {...props} />);
 
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     rerender(
@@ -512,7 +547,7 @@ describe("ActionCard", () => {
     const onBlock = vi.fn(() => {
       throw new Error("sync block failure");
     });
-    render(
+    renderCard(
       <ActionCard
         block={catalogBlock()}
         onProgress={vi.fn()}
@@ -526,5 +561,188 @@ describe("ActionCard", () => {
       user.click(screen.getByRole("button", { name: "Finish without service id" })),
     ).resolves.toBeUndefined();
     expect(onBlock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ActionCard background authorization watch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChatActivityForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function watchProps() {
+    return {
+      onProgress: vi.fn<(blockId: string, inProgress: boolean) => void>(),
+      onBlock: vi.fn<(blockId: string, note: string) => void>(),
+      onResolve: vi
+        .fn<(report: ActionReport) => Promise<void>>()
+        .mockResolvedValue(undefined),
+    };
+  }
+
+  type WatchProps = ReturnType<typeof watchProps>;
+
+  /**
+   * Walk a live card to "provider has the user, dialog dismissed", modelling
+   * the parent's status flip the way the real page does it: the Connect click
+   * reports progress, the transport patches the block to `in_progress`, and
+   * the card re-renders with that status while the dialog stays open.
+   */
+  async function handOffAndDismiss(
+    user: ReturnType<typeof userEvent.setup>,
+    rerender: (ui: ReactElement) => void,
+    props: WatchProps,
+  ): Promise<void> {
+    await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
+    rerender(
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Hand off to provider" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss mock connection" }),
+    );
+  }
+
+  it("keeps the card busy when the dialog is dismissed mid-authorization", async () => {
+    const user = userEvent.setup();
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+
+    const { rerender } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
+    await handOffAndDismiss(user, rerender, props);
+
+    // The regression this exists for: dismissing used to roll the card back to
+    // `pending` even though the connection was mid-flight, which lost the
+    // outcome and invited a duplicate service on the retry.
+    expect(props.onProgress).not.toHaveBeenCalledWith("action-card-1", false);
+    expect(
+      screen.getByRole("button", { name: /Waiting for authorization/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Authorizing")).toBeInTheDocument();
+  });
+
+  it("reports completion once the watched key goes active, with no further clicks", async () => {
+    const user = userEvent.setup();
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "active" });
+
+    const { rerender } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
+    await handOffAndDismiss(user, rerender, props);
+
+    await waitFor(() => {
+      expect(props.onResolve).toHaveBeenCalledWith({
+        actionRequestId: "act-1",
+        originTurnId: "turn-origin-1",
+        disposition: "completed",
+        resource: { userService: { userServiceId: "key-pending-1" } },
+      });
+    });
+    expect(props.onResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks the card with the backend reason when authorization fails", async () => {
+    const user = userEvent.setup();
+    const props = watchProps();
+    mockGet.mockResolvedValue({
+      id: "key-pending-1",
+      status: "failed",
+      error_message: "Account mismatch",
+    });
+
+    const { rerender } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
+    await handOffAndDismiss(user, rerender, props);
+
+    await waitFor(() => {
+      expect(props.onBlock).toHaveBeenCalledWith(
+        "action-card-1",
+        expect.stringContaining("Account mismatch"),
+      );
+    });
+    expect(props.onResolve).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Deadline coverage runs on fake timers, and `userEvent` does not compose
+   * with them here (its pointer bookkeeping awaits timers this test owns).
+   * `fireEvent` is synchronous and act-wrapped, which is all these need.
+   */
+  function handOffAndDismissSync(
+    rerender: (ui: ReactElement) => void,
+    props: WatchProps,
+  ): void {
+    fireEvent.click(screen.getByRole("button", { name: "Connect GitHub" }));
+    rerender(
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Hand off to provider" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss mock connection" }),
+    );
+  }
+
+  it("says so instead of waiting forever once the deadline passes", async () => {
+    vi.useFakeTimers();
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+
+    const { rerender } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
+    handOffAndDismissSync(rerender, props);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONNECT_WATCH_BASE_MS - 5_000);
+    });
+    expect(props.onBlock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(props.onBlock).toHaveBeenCalledWith(
+      "action-card-1",
+      expect.stringContaining("stopped waiting"),
+    );
+  });
+
+  it("extends the deadline while the user keeps using the chat", async () => {
+    vi.useFakeTimers();
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+
+    const { rerender } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
+    handOffAndDismissSync(rerender, props);
+
+    // Chatting about something else just short of the base deadline is
+    // presence, not abandonment: the watch must survive it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONNECT_WATCH_BASE_MS - 5_000);
+    });
+    act(() => markChatActivity(Date.now()));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(props.onBlock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(CONNECT_WATCH_ACTIVITY_GRACE_MS);
+    });
+    expect(props.onBlock).toHaveBeenCalledWith(
+      "action-card-1",
+      expect.stringContaining("stopped waiting"),
+    );
   });
 });

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -11,11 +11,18 @@ import { AddKeyDialog } from "@/components/dashboard/add-key-dialog";
 import { ServiceIcon } from "@/components/service-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useChatPresence } from "@/hooks/use-chat-presence";
+import {
+  KEY_AUTH_ACTIVE,
+  KEY_AUTH_FAILED,
+  useKeyAuthorizationWatch,
+} from "@/hooks/use-keys";
 import {
   actionServiceLabel,
   clampServiceLabel,
   descriptorForAction,
 } from "@/lib/assistant/action-registry";
+import { connectWatchDeadline } from "@/lib/assistant/connect-watch";
 import type { ActionReport } from "@/schemas/assistant-actions";
 import type { ActionCardContentBlock } from "@/types/assistant";
 
@@ -28,6 +35,16 @@ interface ActionCardProps {
 
 const VERIFICATION_BLOCKED_NOTE =
   "Connected, but NyxID could not verify which service was created. Manage it in AI Services, then ask the assistant to request it again.";
+
+const AUTHORIZATION_TIMEOUT_NOTE =
+  "NyxID stopped waiting for this connection to finish authorizing. If you did complete it, find it in AI Services — otherwise ask the assistant to request it again.";
+
+function authorizationFailedNote(reason: string | undefined): string {
+  const detail = reason?.trim();
+  return detail
+    ? `Authorization did not complete: ${detail}`
+    : "Authorization did not complete. Ask the assistant to request this service again.";
+}
 
 function ParameterSummary({
   block,
@@ -177,6 +194,19 @@ export function ActionCard({
 }: ActionCardProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const resolvingRef = useRef(false);
+  /**
+   * An out-of-band authorization handed to a provider, still settling. Held on
+   * the card rather than in the dialog because the dialog is the short-lived
+   * surface: the user goes to GitHub, comes back to the chat, and never
+   * reopens it. `startedAt` anchors both the poll cadence and the deadline.
+   */
+  const [pendingAuth, setPendingAuth] = useState<{
+    readonly keyId: string;
+    readonly startedAt: number;
+  } | null>(null);
+  /** Guards one auto-settlement per watched key against effect re-entry. */
+  const watchSettledRef = useRef<string | null>(null);
+  const { visible, lastActivityAt } = useChatPresence();
 
   useEffect(() => {
     if (block.status === "pending") {
@@ -184,17 +214,83 @@ export function ActionCard({
     }
   }, [block.status]);
 
+  const settled =
+    block.status === "completed" ||
+    block.status === "declined" ||
+    block.status === "failed";
+
+  const watch = useKeyAuthorizationWatch(pendingAuth?.keyId ?? null, {
+    // Presence gate: a hidden tab stops polling and resumes on focus.
+    enabled: pendingAuth !== null && !settled && visible,
+    deadlineAt: pendingAuth
+      ? connectWatchDeadline(pendingAuth.startedAt, lastActivityAt)
+      : 0,
+  });
+
+  // The card's own `wait_for_authorized_key`. `active` is the same verdict the
+  // user would have produced by clicking through Continue and Done, so take it
+  // directly instead of requiring those clicks; `failed` and the deadline both
+  // surface on the card rather than leaving it waiting in silence.
+  useEffect(() => {
+    const keyId = pendingAuth?.keyId;
+    if (!keyId || settled || watchSettledRef.current === keyId) return;
+
+    // The ref is the synchronous re-entry guard; the state clear rides the
+    // microtask so this effect never sets the state it depends on inline.
+    if (watch.status === KEY_AUTH_ACTIVE) {
+      watchSettledRef.current = keyId;
+      resolvingRef.current = true;
+      void Promise.resolve()
+        .then(() => {
+          setPendingAuth(null);
+          return onResolve({
+            actionRequestId: block.action_request_id,
+            originTurnId: block.origin_turn_id,
+            disposition: "completed",
+            resource: { userService: { userServiceId: keyId } },
+          });
+        })
+        .catch(() => {
+          resolvingRef.current = false;
+          onProgress(block.block_id, false);
+        });
+      return;
+    }
+
+    if (watch.status === KEY_AUTH_FAILED || watch.timedOut) {
+      watchSettledRef.current = keyId;
+      const note =
+        watch.status === KEY_AUTH_FAILED
+          ? authorizationFailedNote(watch.errorMessage)
+          : AUTHORIZATION_TIMEOUT_NOTE;
+      void Promise.resolve()
+        .then(() => {
+          setPendingAuth(null);
+          return onBlock(block.block_id, note);
+        })
+        .catch(() => undefined);
+    }
+  }, [
+    pendingAuth,
+    settled,
+    watch.status,
+    watch.timedOut,
+    watch.errorMessage,
+    block.block_id,
+    block.action_request_id,
+    block.origin_turn_id,
+    onResolve,
+    onBlock,
+    onProgress,
+  ]);
+
   const descriptor = descriptorForAction(
     block.action,
     block.params,
     block.status !== "unsupported",
   );
 
-  if (
-    block.status === "completed" ||
-    block.status === "declined" ||
-    block.status === "failed"
-  ) {
+  if (settled) {
     return <Receipt block={block} />;
   }
 
@@ -203,6 +299,8 @@ export function ActionCard({
   const unsupported =
     block.status === "unsupported" || descriptor.risk === "unsupported";
   const busy = block.status === "in_progress";
+  /** Dialog dismissed, provider not finished: the watch is carrying this. */
+  const awaitingAuthorization = pendingAuth !== null && !dialogOpen;
   const blocked = block.status === "blocked";
   const conflicted = block.status === "conflicted";
   const primaryDisabled = busy || blocked || conflicted;
@@ -211,7 +309,16 @@ export function ActionCard({
 
   function setOpen(next: boolean) {
     setDialogOpen(next);
-    if (!next && !resolvingRef.current && block.status === "in_progress") {
+    // Closing the dialog on a still-settling authorization is NOT abandonment:
+    // the provider tab is open, the watch is running, and the card resolves
+    // itself. Rolling back to `pending` here is what used to lose a connection
+    // the user had actually completed — and invite a duplicate on the retry.
+    if (
+      !next &&
+      !resolvingRef.current &&
+      !pendingAuth &&
+      block.status === "in_progress"
+    ) {
       onProgress(block.block_id, false);
     }
   }
@@ -220,6 +327,11 @@ export function ActionCard({
     disposition: "completed" | "declined" | "failed",
     userServiceId?: string,
   ) {
+    // A manual outcome supersedes any watch still running for this card.
+    if (pendingAuth) {
+      watchSettledRef.current = pendingAuth.keyId;
+      setPendingAuth(null);
+    }
     if (disposition === "completed" && !userServiceId?.trim()) {
       resolvingRef.current = true;
       void Promise.resolve()
@@ -296,9 +408,11 @@ export function ActionCard({
                   ? "Conflict"
                   : blocked
                     ? "Blocked"
-                    : busy
-                      ? "In progress"
-                      : "Action required"}
+                    : awaitingAuthorization
+                      ? "Authorizing"
+                      : busy
+                        ? "In progress"
+                        : "Action required"}
             </Badge>
           </div>
           <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
@@ -333,7 +447,11 @@ export function ActionCard({
             }}
           >
             {busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
-            {busy ? "Connecting" : descriptor.cta(params)}
+            {awaitingAuthorization
+              ? "Waiting for authorization"
+              : busy
+                ? "Connecting"
+                : descriptor.cta(params)}
           </Button>
         ) : null}
         <Button
@@ -392,6 +510,10 @@ export function ActionCard({
               : undefined
           }
           onSuccess={({ userServiceId }) => report("completed", userServiceId)}
+          onAuthorizationPending={(keyId) => {
+            watchSettledRef.current = null;
+            setPendingAuth({ keyId, startedAt: Date.now() });
+          }}
         />
       ) : null}
     </section>

--- a/frontend/src/components/dashboard/add-key-dialog.tsx
+++ b/frontend/src/components/dashboard/add-key-dialog.tsx
@@ -1448,6 +1448,7 @@ function OAuthStep({
   onKeyCleared,
   onBack,
   onComplete,
+  onAuthorizationPending,
   platformScopeAllowlist,
   targetOrgId,
   reconnectMode,
@@ -1459,6 +1460,8 @@ function OAuthStep({
   readonly onKeyCleared: () => void;
   readonly onBack: () => void;
   readonly onComplete: (keyId: string) => void;
+  /** See `AddKeyDialog`'s prop of the same name. */
+  readonly onAuthorizationPending?: (keyId: string) => void;
   /**
    * When this connection rides the shared platform app, the scopes it may
    * request (`platform_scope_allowlist`). Passed only on the platform path so
@@ -1542,6 +1545,9 @@ function OAuthStep({
       });
       setPendingKeyId(key.id);
       setAuthorizationUrl(response.authorization_url);
+      // The handoff to the provider is the point of no return for this
+      // dialog's callbacks: from here the user may never come back to it.
+      onAuthorizationPending?.(key.id);
     } catch (err) {
       await cleanupPendingAuthKey(key, { protectExistingKey: reconnectMode });
       if (!reconnectMode) {
@@ -1704,6 +1710,7 @@ function DeviceCodeStep({
   // below now goes through the wrapper without further changes (NyxID#706).
   onBack: parentOnBack,
   onComplete,
+  onAuthorizationPending,
   targetOrgId,
   reconnectMode,
   lockedScopes = [],
@@ -1714,6 +1721,8 @@ function DeviceCodeStep({
   readonly onKeyCleared: () => void;
   readonly onBack: () => void;
   readonly onComplete: (keyId: string) => void;
+  /** See `AddKeyDialog`'s prop of the same name. */
+  readonly onAuthorizationPending?: (keyId: string) => void;
   /** When set, initiate the device-code flow under this org's scope. */
   readonly targetOrgId: string | null;
   readonly reconnectMode: boolean;
@@ -1943,6 +1952,9 @@ function DeviceCodeStep({
       key = await ensureKey();
       if (!isMountedRef.current) return;
       setCreatedKeyId(key.id);
+      // Same rationale as the OAuth step: the user is about to leave for the
+      // provider's verification page and may never return to this dialog.
+      onAuthorizationPending?.(key.id);
       // Only forward scopes for formats that accept them. OpenAI device-code
       // providers reject a `scope` parameter at the backend, so omit the
       // override there entirely. Otherwise send the picker's complete set.
@@ -2456,6 +2468,7 @@ export function AddKeyDialog({
   prefillCustom,
   reconnectKey,
   onSuccess,
+  onAuthorizationPending,
 }: {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
@@ -2477,6 +2490,17 @@ export function AddKeyDialog({
   readonly reconnectKey?: KeyInfo | null;
   /** Fires only when the user finishes the post-connect success step. */
   readonly onSuccess?: (result: AddKeyDialogCompletion) => void;
+  /**
+   * Fires as soon as an out-of-band authorization (OAuth / device code) is
+   * handed to the provider, with the placeholder key that will settle it.
+   *
+   * `onSuccess` is not enough on its own for a caller that must survive the
+   * dialog: it only fires if the user walks back through Continue and Done.
+   * A caller that owns a longer-lived surface (the assistant's connect card)
+   * takes this id and watches the key to its terminal status itself, so a
+   * dismissed dialog stops meaning a lost outcome.
+   */
+  readonly onAuthorizationPending?: (keyId: string) => void;
 }) {
   const createKey = useCreateKey();
   const { data: catalogEntries } = useCatalog({
@@ -3061,6 +3085,7 @@ export function AddKeyDialog({
             ensureKey={ensureAuthKey}
             onKeyCleared={() => setAuthKey(null)}
             onComplete={handleAuthComplete}
+            onAuthorizationPending={onAuthorizationPending}
             targetOrgId={targetOrgId}
             reconnectMode={isReconnect}
             grantedScopes={
@@ -3123,6 +3148,7 @@ export function AddKeyDialog({
               setStep(form.nodeId.trim() ? "node_setup" : "routing");
             }}
             onComplete={handleAuthComplete}
+            onAuthorizationPending={onAuthorizationPending}
           />
         )}
 

--- a/frontend/src/hooks/use-chat-presence.ts
+++ b/frontend/src/hooks/use-chat-presence.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState, useSyncExternalStore } from "react";
+import {
+  getLastChatActivityAt,
+  subscribeChatActivity,
+} from "@/lib/assistant/connect-watch";
+
+function documentVisible(): boolean {
+  if (typeof document === "undefined") return true;
+  return document.visibilityState !== "hidden";
+}
+
+export interface ChatPresence {
+  /** The chat tab is in front of the user right now. */
+  readonly visible: boolean;
+  /** Epoch ms of the last user interaction with the chat; 0 if none yet. */
+  readonly lastActivityAt: number;
+}
+
+/**
+ * Presence signals for background work owned by the chat surface.
+ *
+ * `visible` gates polling: a hidden tab must not keep hitting the API, and it
+ * does not need to — the pending-connect watch refetches on window focus, so
+ * coming back from the provider's tab resolves the card immediately rather
+ * than after the next interval.
+ *
+ * `lastActivityAt` is the liveness signal. A user who finished authorizing and
+ * went back to chatting about something else is still present, and their
+ * pending card should keep waiting rather than time out underneath them.
+ */
+export function useChatPresence(): ChatPresence {
+  const lastActivityAt = useSyncExternalStore(
+    subscribeChatActivity,
+    getLastChatActivityAt,
+    getLastChatActivityAt,
+  );
+  const [visible, setVisible] = useState(documentVisible);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisibilityChange = () => setVisible(documentVisible());
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
+  return { visible, lastActivityAt };
+}

--- a/frontend/src/hooks/use-keys.ts
+++ b/frontend/src/hooks/use-keys.ts
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
+import { connectWatchInterval } from "@/lib/assistant/connect-watch";
 import type {
   KeyInfo,
   KeyListResponse,
@@ -89,6 +90,102 @@ export function useKeyAuthorizationStatus(
   }, [status, queryClient]);
 
   return query;
+}
+
+export interface KeyAuthorizationWatch {
+  /** Latest observed key status; `undefined` before the first read lands. */
+  readonly status: string | undefined;
+  /** Backend-supplied reason when `status` is `failed`. */
+  readonly errorMessage: string | undefined;
+  /** The watch gave up before the row reached a terminal status. */
+  readonly timedOut: boolean;
+}
+
+/**
+ * Watch a placeholder key to a terminal status in the background.
+ *
+ * The difference from `useKeyAuthorizationStatus` is ownership: that hook is
+ * scoped to an open dialog and stops when the dialog closes. This one is
+ * scoped to a *card*, which outlives the dialog, because closing the dialog is
+ * the normal path — the user tabs away to the provider and comes back to the
+ * chat, not to the dialog. It is the browser's `wait_for_authorized_key`.
+ *
+ * Two things bound it: `enabled` (the caller's presence gate — do not poll for
+ * a tab nobody is looking at) and `deadlineAt` (the give-up time, which the
+ * caller extends while the user is active). Past the deadline it stops polling
+ * and reports `timedOut` so the card can say so instead of waiting silently.
+ */
+export function useKeyAuthorizationWatch(
+  keyId: string | null,
+  options: { readonly enabled: boolean; readonly deadlineAt: number },
+): KeyAuthorizationWatch {
+  const { enabled, deadlineAt } = options;
+  const queryClient = useQueryClient();
+  /**
+   * The (key, deadline) pair a timer has already fired for. Storing the pair
+   * rather than a boolean means a new key or a deadline pushed out by fresh
+   * activity un-expires the watch by comparison alone — no reset effect, and
+   * no state written synchronously from an effect.
+   */
+  const [expiredFor, setExpiredFor] = useState<{
+    readonly keyId: string;
+    readonly deadlineAt: number;
+  } | null>(null);
+  const startedAtRef = useRef(0);
+
+  // A new key restarts the cadence window. Ref-only, so render stays pure.
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+  }, [keyId]);
+
+  // Nothing re-renders on its own when a deadline passes, so arm a timer for
+  // it. Re-armed whenever activity pushes `deadlineAt` out.
+  useEffect(() => {
+    if (!enabled || !keyId || deadlineAt <= 0) return;
+    const fire = () => setExpiredFor({ keyId, deadlineAt });
+    // Zero delay rather than a direct call: an effect that sets state inline
+    // re-enters render before the browser can paint.
+    const timer = setTimeout(fire, Math.max(0, deadlineAt - Date.now()));
+    return () => clearTimeout(timer);
+  }, [enabled, keyId, deadlineAt]);
+
+  const expired =
+    expiredFor !== null &&
+    expiredFor.keyId === keyId &&
+    expiredFor.deadlineAt >= deadlineAt;
+  const active = Boolean(keyId) && enabled && !expired;
+  const query = useQuery({
+    queryKey: ["keys", keyId],
+    queryFn: async (): Promise<KeyInfo> => {
+      return api.get<KeyInfo>(`/keys/${keyId ?? ""}`);
+    },
+    enabled: active,
+    refetchInterval: (current) => {
+      const status = current.state.data?.status;
+      if (status === KEY_AUTH_ACTIVE || status === KEY_AUTH_FAILED) {
+        return false;
+      }
+      if (!active) return false;
+      return connectWatchInterval(startedAtRef.current, Date.now());
+    },
+    // The whole point of the background watch: returning from the provider's
+    // tab resolves the card at once rather than after the next interval.
+    refetchOnWindowFocus: active,
+  });
+
+  const status = query.data?.status;
+  useEffect(() => {
+    if (status === KEY_AUTH_ACTIVE || status === KEY_AUTH_FAILED) {
+      void queryClient.invalidateQueries({ queryKey: ["keys"], exact: true });
+    }
+  }, [status, queryClient]);
+
+  const terminal = status === KEY_AUTH_ACTIVE || status === KEY_AUTH_FAILED;
+  return {
+    status,
+    errorMessage: query.data?.error_message ?? undefined,
+    timedOut: expired && !terminal,
+  };
 }
 
 interface UseCatalogOptions {

--- a/frontend/src/lib/assistant/connect-watch.test.ts
+++ b/frontend/src/lib/assistant/connect-watch.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CONNECT_WATCH_ACTIVITY_GRACE_MS,
+  CONNECT_WATCH_BASE_MS,
+  CONNECT_WATCH_FAST_INTERVAL_MS,
+  CONNECT_WATCH_FAST_WINDOW_MS,
+  CONNECT_WATCH_MAX_MS,
+  CONNECT_WATCH_SLOW_INTERVAL_MS,
+  connectWatchDeadline,
+  connectWatchInterval,
+  getLastChatActivityAt,
+  markChatActivity,
+  resetChatActivityForTests,
+  subscribeChatActivity,
+} from "./connect-watch";
+
+const START = 1_000_000;
+
+afterEach(() => {
+  resetChatActivityForTests();
+  vi.restoreAllMocks();
+});
+
+describe("connectWatchDeadline", () => {
+  it("uses the base window when the user has not touched the chat", () => {
+    expect(connectWatchDeadline(START, 0)).toBe(START + CONNECT_WATCH_BASE_MS);
+  });
+
+  it("ignores activity that predates the watch", () => {
+    expect(connectWatchDeadline(START, START - 60_000)).toBe(
+      START + CONNECT_WATCH_BASE_MS,
+    );
+  });
+
+  it("never shortens the base window for activity early in it", () => {
+    // A message sent one second after the handoff must not pull the deadline
+    // in to +5 min; the base window is a floor, not a target.
+    expect(connectWatchDeadline(START, START + 1_000)).toBe(
+      START + CONNECT_WATCH_BASE_MS,
+    );
+  });
+
+  it("extends past the base window while the user stays active", () => {
+    const lateActivity = START + CONNECT_WATCH_BASE_MS - 1_000;
+    expect(connectWatchDeadline(START, lateActivity)).toBe(
+      lateActivity + CONNECT_WATCH_ACTIVITY_GRACE_MS,
+    );
+  });
+
+  it("caps extensions at the hard ceiling", () => {
+    const veryLateActivity = START + CONNECT_WATCH_MAX_MS;
+    expect(connectWatchDeadline(START, veryLateActivity)).toBe(
+      START + CONNECT_WATCH_MAX_MS,
+    );
+  });
+});
+
+describe("connectWatchInterval", () => {
+  it("polls fast while the user is plausibly still on the provider page", () => {
+    expect(connectWatchInterval(START, START)).toBe(
+      CONNECT_WATCH_FAST_INTERVAL_MS,
+    );
+    expect(
+      connectWatchInterval(START, START + CONNECT_WATCH_FAST_WINDOW_MS),
+    ).toBe(CONNECT_WATCH_FAST_INTERVAL_MS);
+  });
+
+  it("backs off to the background cadence afterwards", () => {
+    expect(
+      connectWatchInterval(START, START + CONNECT_WATCH_FAST_WINDOW_MS + 1),
+    ).toBe(CONNECT_WATCH_SLOW_INTERVAL_MS);
+  });
+});
+
+describe("chat activity signal", () => {
+  it("records the latest activity and notifies subscribers", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeChatActivity(listener);
+
+    markChatActivity(START);
+    expect(getLastChatActivityAt()).toBe(START);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    markChatActivity(START + 5_000);
+    expect(getLastChatActivityAt()).toBe(START + 5_000);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    markChatActivity(START + 10_000);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("never moves backwards, so a stale mark cannot shorten a watch", () => {
+    markChatActivity(START);
+    markChatActivity(START - 60_000);
+    expect(getLastChatActivityAt()).toBe(START);
+  });
+});

--- a/frontend/src/lib/assistant/connect-watch.ts
+++ b/frontend/src/lib/assistant/connect-watch.ts
@@ -1,0 +1,96 @@
+/**
+ * Background watch policy for an assistant connect card whose authorization
+ * finishes out of band (OAuth / device-code completing in another tab).
+ *
+ * The CLI settles this with `wait_for_authorized_key`: a blocking loop that
+ * polls `/keys/{id}` until `active` or `failed`. The CLI wizard settles it
+ * with a local axum sidecar that sniffs the same responses, heartbeats the
+ * page, and gives up on a ceiling. Both share one rule — the verdict belongs
+ * to the server row, never to a UI callback — and both can hold that rule
+ * because they run outside the page.
+ *
+ * The browser has no process that outlives the tab, so the two things the
+ * sidecar owns are modelled here instead:
+ *
+ *   - liveness → anything the user does in the chat re-arms the window
+ *     (the analogue of `HEARTBEAT_DEAD_AFTER`, but additive rather than
+ *     a kill switch: chatting about something else is presence, not
+ *     abandonment)
+ *   - ceiling → a hard stop so a walked-away tab eventually gives up and
+ *     says so (the analogue of `WIZARD_MAX_DURATION`)
+ *
+ * Everything here is pure or module-local so the policy is unit-testable
+ * without mounting the chat.
+ */
+
+/** Base window. Long enough for a real OAuth detour incl. 2FA + account switch. */
+export const CONNECT_WATCH_BASE_MS = 10 * 60_000;
+/** Each chat interaction re-arms the deadline to at least this far out. */
+export const CONNECT_WATCH_ACTIVITY_GRACE_MS = 5 * 60_000;
+/** Hard ceiling regardless of activity. Mirrors the wizard's 30-minute cap. */
+export const CONNECT_WATCH_MAX_MS = 30 * 60_000;
+/** Tight cadence while the user is plausibly still on the provider's page. */
+export const CONNECT_WATCH_FAST_INTERVAL_MS = 2_000;
+export const CONNECT_WATCH_FAST_WINDOW_MS = 60_000;
+/** Background cadence afterwards. Window focus still resolves instantly. */
+export const CONNECT_WATCH_SLOW_INTERVAL_MS = 10_000;
+
+/**
+ * When this watch should give up, given when it started and when the user was
+ * last active in the chat. Activity can only ever push the deadline out, and
+ * never past the ceiling.
+ */
+export function connectWatchDeadline(
+  startedAt: number,
+  lastActivityAt: number,
+): number {
+  const base = startedAt + CONNECT_WATCH_BASE_MS;
+  const extended =
+    lastActivityAt > startedAt
+      ? lastActivityAt + CONNECT_WATCH_ACTIVITY_GRACE_MS
+      : base;
+  return Math.min(Math.max(base, extended), startedAt + CONNECT_WATCH_MAX_MS);
+}
+
+/** Poll cadence: fast for the first minute, background thereafter. */
+export function connectWatchInterval(startedAt: number, now: number): number {
+  return now - startedAt > CONNECT_WATCH_FAST_WINDOW_MS
+    ? CONNECT_WATCH_SLOW_INTERVAL_MS
+    : CONNECT_WATCH_FAST_INTERVAL_MS;
+}
+
+// --- Chat activity: the browser's stand-in for the wizard's heartbeat ---
+//
+// Module-local rather than a store because there is exactly one chat surface
+// per tab and every consumer wants the same scalar. Kept out of React state
+// so non-component code (transport, mutations) can mark activity too.
+
+let lastChatActivityAt = 0;
+const activityListeners = new Set<() => void>();
+
+/**
+ * Record that the user did something in the chat — sent a message, decided an
+ * approval, switched conversation. Any of those prove they are still present,
+ * which is what extends a pending connect watch.
+ */
+export function markChatActivity(now: number = Date.now()): void {
+  if (now <= lastChatActivityAt) return;
+  lastChatActivityAt = now;
+  for (const listener of activityListeners) listener();
+}
+
+export function getLastChatActivityAt(): number {
+  return lastChatActivityAt;
+}
+
+export function subscribeChatActivity(listener: () => void): () => void {
+  activityListeners.add(listener);
+  return () => {
+    activityListeners.delete(listener);
+  };
+}
+
+export function resetChatActivityForTests(): void {
+  lastChatActivityAt = 0;
+  activityListeners.clear();
+}

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -38,6 +38,7 @@ import {
   AssistantTurnActiveError,
   AssistantTurnCancelledError,
 } from "@/lib/assistant/errors";
+import { markChatActivity } from "@/lib/assistant/connect-watch";
 import { parseAssistantSearch } from "@/lib/assistant/search";
 import type { ActionReport } from "@/schemas/assistant-actions";
 import { useAssistantContextStore } from "@/stores/assistant-context-store";
@@ -211,6 +212,12 @@ export function AssistantPage({
     reactiveTurnLive || synchronousContinuationsRef.current > 0;
 
   function beginContinuation() {
+    // Every user-initiated turn funnels through here — send, approval
+    // decision, action report. That makes it the natural liveness signal for
+    // background work the chat owns: a card waiting on an out-of-band
+    // authorization treats "still using the chat" as "still here", so moving
+    // on to something else extends its window instead of ending it.
+    markChatActivity();
     synchronousContinuationsRef.current += 1;
     turnLiveRef.current = true;
   }


### PR DESCRIPTION
## Problem

An action card only reached `completed` if the user walked the whole click path: authorize at the provider → come back → **Continue** → **Done**. Dismissing the dialog anywhere after the authorization landed rolled the card back to `pending` even though the `UserService` existed and was active.

Consequences: the outcome was lost, the assistant was never told, and reconnecting minted a **duplicate service** (`-2`, `-3`).

NyxID owned the authorization *detection* (the `/keys/{id}` poll) but not the completion *determination* — that was delegated to two UI callbacks that only fire on the happy path.

## Approach

The verdict already exists server-side. `useKeyAuthorizationStatus` polls the same endpoint for the same `pending_auth → active | failed` terminals as the CLI's `wait_for_authorized_key` — it was just scoped to the dialog and discarded when the dialog closed.

This moves the watch onto the **card**, which outlives the dialog.

| Signal | Card outcome |
|---|---|
| `active` | reports `completed` with the userServiceId, no further clicks |
| `failed` | `blocked`, carrying the backend's `error_message` |
| deadline | `blocked` with copy — says so instead of waiting silently |
| dismissal | nothing; the watch carries it (**the bug**) |

### Bounding it

The CLI wizard bounds its session with a local sidecar (heartbeat + `WIZARD_MAX_DURATION`). The browser has no process that outlives the tab, so the same two jobs are modelled in the page:

- **Presence gate** — a hidden tab stops polling; `refetchOnWindowFocus` resolves the card the moment the user returns from the provider tab
- **Liveness** — any chat interaction (send, approval decision, action report) re-arms the window. Chatting about something else is presence, not abandonment
- **Ceiling** — 10 min base, +5 min per interaction, 30 min hard cap; 2 s poll for the first minute, then 10 s

## Files

| File | |
|---|---|
| `lib/assistant/connect-watch.ts` | new — pure policy (deadline, cadence) + the chat-activity signal |
| `hooks/use-chat-presence.ts` | new — `visible` + `lastActivityAt` |
| `hooks/use-keys.ts` | `useKeyAuthorizationWatch` — card-scoped watch with presence gate and deadline |
| `blocks/action-card.tsx` | owns the pending authorization; auto-settles; "Authorizing" / "Waiting for authorization" |
| `dashboard/add-key-dialog.tsx` | new `onAuthorizationPending(keyId)`, fired at the provider handoff (OAuth + device-code) |
| `pages/assistant.tsx` | `markChatActivity()` in `beginContinuation` |

## Judgement call

**Failure blocks rather than auto-reporting `failed`.** `blocked` keeps Decline and Report failure live and an exact reissue re-arms it. Auto-reporting `failed` is terminal and irreversible — and the backend converges *abandoned* flows to `failed` too, so a user who simply wandered off should not have a terminal failure filed on their behalf.

## Known gap

The watch dies with the tab. Surviving a reload needs the durable connect-intent record (Stage 2), modelled on `CliPairing` — `kind` / `prefill` / `status` / `ack_payload` / `expires_at`. Not in this PR.

## Verification

Rollup PRs get no CI (`ci.yml` gates `main`/`dev` only), so this was run locally against `origin/main` @ `3a392e38`:

- `npm run build` (the CI gate: `tsc -b` + prod build) — **passes**
- Full suite — **211 files / 2571 tests pass**
- `npm run lint` — **0 errors** (23 pre-existing warnings)
- 6 new tests: dismissal keeps the card busy · `active` auto-completes exactly once · failure carries the backend reason · deadline blocks with copy · activity extends the deadline · policy unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)