### PR TITLE
fix(oauth): retheme the MCP authorize flow to the current design system

### DIFF
--- a/backend/src/handlers/oauth.rs
+++ b/backend/src/handlers/oauth.rs
@@ -1179,33 +1179,31 @@ fn oauth_success_page(redirect_url: &str) -> Response {
 <title>NyxID — Authenticated</title>
 <style>
 *{{margin:0;padding:0;box-sizing:border-box}}
-body{{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;display:flex;align-items:center;justify-content:center;flex-direction:column;min-height:100vh;background:#0a0a0b;color:#e4e4e7}}
-.wrap{{display:flex;flex-direction:column;align-items:center;gap:2rem;width:100%;max-width:26rem;padding:1.5rem}}
-.logo{{display:flex;align-items:center;gap:.6rem}}
-.logo svg{{width:28px;height:28px}}
-.logo span{{font-size:1.2rem;font-weight:700;letter-spacing:-.02em;background:linear-gradient(135deg,#c084fc,#818cf8);-webkit-background-clip:text;-webkit-text-fill-color:transparent}}
-.card{{width:100%;text-align:center;padding:2.5rem 2rem;border:1px solid #27272a;border-radius:.75rem;background:#18181b}}
-.icon{{width:3rem;height:3rem;margin:0 auto 1.25rem;border-radius:50%;background:rgba(52,211,153,.12);display:flex;align-items:center;justify-content:center}}
-.icon svg{{width:1.25rem;height:1.25rem;color:#34d399}}
-h1{{font-size:1.125rem;font-weight:600;margin-bottom:.375rem}}
-.sub{{font-size:.8125rem;color:#a1a1aa;line-height:1.5}}
-.bar{{margin-top:1.5rem;height:3px;border-radius:2px;background:#27272a;overflow:hidden}}
-.bar .fill{{height:100%;width:0;border-radius:2px;background:linear-gradient(90deg,#818cf8,#c084fc);animation:progress 1.8s ease-in-out forwards}}
+body{{font-family:"Mona Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;display:flex;align-items:center;justify-content:center;flex-direction:column;min-height:100vh;background:#0D0D0D;color:#FAFAFA;line-height:1.4;-webkit-font-smoothing:antialiased}}
+.wrap{{display:flex;flex-direction:column;align-items:center;gap:2rem;width:100%;max-width:28.75rem;padding:1rem}}
+.logo svg{{display:block;height:30px;width:auto}}
+.card{{width:100%;text-align:center;padding:1.25rem;border:1px solid rgba(16,185,129,.25);border-radius:12px;background:rgba(16,185,129,.03);box-shadow:0 1px 2px 0 rgba(0,0,0,.05)}}
+.icon{{width:2.75rem;height:2.75rem;margin:0 auto 1rem;border-radius:12px;border:1px solid rgba(16,185,129,.30);background:rgba(16,185,129,.10);display:flex;align-items:center;justify-content:center}}
+.icon svg{{width:1.25rem;height:1.25rem;color:#10B981}}
+h1{{font-size:15px;font-weight:600;margin-bottom:.25rem}}
+.sub{{font-size:12px;color:#A3A3A3}}
+.bar{{margin-top:1.25rem;height:3px;border-radius:2px;background:#262626;overflow:hidden}}
+.bar .fill{{height:100%;width:0;border-radius:2px;background:linear-gradient(to right,#A672FB 0%,#5E00F5 100%);animation:progress 1.8s ease-in-out forwards}}
 @keyframes progress{{to{{width:100%}}}}
-.foot{{font-size:.6875rem;color:#52525b}}
+@media (prefers-reduced-motion:reduce){{.bar .fill{{animation:none;width:100%}}}}
+.foot{{font-size:11px;color:#525252}}
 </style>
 </head>
 <body>
 <div class="wrap">
   <div class="logo">
-    <svg viewBox="0 0 32 32" fill="none"><circle cx="16" cy="16" r="14" stroke="url(#pg)" stroke-width="2.5"/><circle cx="16" cy="16" r="4" fill="url(#pg)"/><defs><linearGradient id="pg" x1="4" y1="4" x2="28" y2="28"><stop stop-color="#c084fc"/><stop offset="1" stop-color="#818cf8"/></linearGradient></defs></svg>
-    <span>NyxID</span>
+    <svg role="img" aria-label="NyxID" viewBox="0 0 1062 301" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M258.614 53.8457V205.377C258.614 234.778 234.78 258.612 205.38 258.612H131.074C130.268 258.612 129.613 257.957 129.613 257.15V117.358C129.613 115.867 127.645 115.332 126.891 116.619L44.0376 257.889C43.7745 258.337 43.2951 258.612 42.7777 258.612H2.073C1.26616 258.612 0.611328 257.957 0.611328 257.15V2.07323C0.611328 1.26639 1.26616 0.611557 2.073 0.611557H85.1516C85.9584 0.611557 86.6133 1.26639 86.6133 2.07323V141.865C86.6133 143.356 88.5807 143.891 89.3349 142.604L172.191 1.33362C172.454 0.886352 172.934 0.611557 173.451 0.611557H205.377C234.777 0.611557 258.611 24.4456 258.611 53.8457H258.614Z" fill="url(#paint0_linear_5_302)"/> <g filter="url(#filter0_f_5_302)"> <path d="M2.07324 1.37621H85.1514C85.536 1.37621 85.8486 1.68882 85.8486 2.07347V141.864C85.8486 144.134 88.845 144.95 89.9941 142.991L172.85 1.71996L172.851 1.72093C172.977 1.50652 173.206 1.37625 173.451 1.37621H205.377C234.355 1.37621 257.847 24.868 257.847 53.8459V54.6106H257.85V205.377C257.85 234.355 234.358 257.847 205.38 257.847H131.074C130.69 257.847 130.377 257.534 130.377 257.15V117.359C130.377 115.089 127.38 114.272 126.231 116.232L43.3789 257.502C43.2526 257.717 43.0228 257.847 42.7773 257.847H2.07324C1.68859 257.847 1.37598 257.534 1.37598 257.15V2.07347C1.37598 1.68882 1.68859 1.37621 2.07324 1.37621Z" stroke="url(#paint1_linear_5_302)" stroke-opacity="0.5" stroke-width="1.52891"/> </g> <path d="M581.159 193.441L587.61 215.028H589.099L595.302 193.441L615.648 125.951H654.604L602.994 265.148C599.52 274.411 595.385 281.607 590.588 286.735C585.791 291.862 580.332 295.42 574.212 297.405C568.092 299.39 561.226 300.381 553.617 300.381H531.038V270.359H546.67C550.474 270.359 553.617 269.863 556.099 268.87C558.745 268.043 560.896 266.554 562.55 264.404C564.369 262.419 565.858 259.855 567.016 256.712L570.144 248.577L519.128 125.951H559.324L581.159 193.441ZM462.01 204.606H463.498L461.762 148.034V78.0637H499.228V258.946H454.317L378.641 133.891H377.151L378.641 186.245V258.946H339.188V78.0637H386.58L462.01 204.606ZM731.847 163.17L734.824 168.132H736.065L739.043 163.17L762.614 125.951H804.051L759.885 189.719L808.765 258.946H765.592L738.05 217.012L734.824 211.306H733.584L730.11 217.012L701.328 258.946H660.388L710.509 190.711L665.102 125.951H708.275L731.847 163.17ZM867.114 258.946H828.407V78.0637H867.114V258.946ZM978.508 78.0637C996.372 78.0637 1011.51 81.8679 1023.91 89.4768C1036.32 96.9204 1045.75 107.425 1052.2 120.989C1058.65 134.553 1061.88 150.433 1061.88 168.628C1061.88 182.027 1060.06 194.351 1056.42 205.599C1052.78 216.682 1047.4 226.193 1040.29 234.133C1033.18 242.073 1024.41 248.193 1013.99 252.493C1003.73 256.794 991.906 258.946 978.508 258.946H901.342V78.0637H978.508ZM940.049 225.945H972.057C979.335 225.945 986.035 224.952 992.155 222.967C998.275 220.982 1003.57 217.756 1008.04 213.29C1012.5 208.824 1015.97 202.869 1018.46 195.426C1020.94 187.982 1022.18 178.801 1022.18 167.884C1022.18 153.658 1020.03 142.41 1015.73 134.139C1011.59 125.868 1005.72 119.914 998.109 116.275C990.666 112.636 981.981 110.816 972.057 110.816H940.049V225.945Z" fill="white"/> <defs> <filter id="filter0_f_5_302" x="-0.000234365" y="-5.48363e-06" width="259.226" height="259.223" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"> <feFlood flood-opacity="0" result="BackgroundImageFix"/> <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/> <feGaussianBlur stdDeviation="0.305781" result="effect1_foregroundBlur_5_302"/> </filter> <linearGradient id="paint0_linear_5_302" x1="129.613" y1="0.611557" x2="129.613" y2="258.612" gradientUnits="userSpaceOnUse"> <stop stop-color="#A672FB"/> <stop offset="1" stop-color="#5E00F5"/> </linearGradient> <linearGradient id="paint1_linear_5_302" x1="129.613" y1="0.611557" x2="129.613" y2="258.612" gradientUnits="userSpaceOnUse"> <stop stop-color="white"/> <stop offset="1" stop-color="white" stop-opacity="0"/> </linearGradient> </defs> </svg>
   </div>
   <div class="card">
     <div class="icon">
-      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+      <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
     </div>
-    <h1>Authentication Successful</h1>
+    <h1>Authentication successful</h1>
     <p class="sub">Redirecting you back to the application&hellip;</p>
     <div class="bar"><div class="fill"></div></div>
   </div>

--- a/frontend/src/components/auth/auth-flow.tsx
+++ b/frontend/src/components/auth/auth-flow.tsx
@@ -43,7 +43,7 @@ function getPasswordStrength(password: string): {
   if (/[^A-Za-z0-9]/.test(password)) score += 1;
 
   if (score <= 2) return { score, label: "Weak", color: "bg-destructive" };
-  if (score <= 4) return { score, label: "Fair", color: "bg-amber-400" };
+  if (score <= 4) return { score, label: "Fair", color: "bg-warning" };
   return { score, label: "Strong", color: "bg-success" };
 }
 
@@ -344,9 +344,9 @@ export function AuthFlow({
                     const url = `${window.location.origin}/api/v1/auth/social/${encodeURIComponent(provider.id)}${qs ? `?${qs}` : ""}`;
                     void openExternal(url);
                   }}
-                  className="flex h-[46px] w-full cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-4 text-[13.5px] font-medium text-foreground transition-colors duration-300 hover:border-border/80 hover:bg-white/[0.03] active:scale-[0.99]"
+                  className="flex h-[46px] w-full cursor-pointer items-center gap-3 rounded-lg border border-border bg-background px-4 text-[13.5px] font-medium text-foreground transition-colors duration-300 hover:border-border/80 hover:bg-overlay active:scale-[0.99]"
                 >
-                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-white/[0.06]">
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] bg-overlay-strong">
                     {provider.icon}
                   </span>
                   {provider.label}
@@ -581,7 +581,7 @@ export function AuthFlow({
                   key={provider.id}
                   type="button"
                   onClick={() => handleRegisterSocialLogin(provider.id)}
-                  className="flex h-[44px] w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg border border-border bg-transparent text-[13px] font-medium text-foreground transition-colors duration-200 hover:border-white/[0.15] hover:bg-white/[0.03] active:scale-[0.99]"
+                  className="flex h-[44px] w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg border border-border bg-transparent text-[13px] font-medium text-foreground transition-colors duration-200 hover:border-hairline-strong hover:bg-overlay active:scale-[0.99]"
                 >
                   {provider.icon}
                   {provider.label}
@@ -592,7 +592,7 @@ export function AuthFlow({
                 <button
                   type="button"
                   onClick={() => { if (requireInviteCode()) slideToPanel(2); }}
-                  className="flex h-[44px] w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg border border-border bg-transparent text-[13px] font-medium text-foreground transition-colors duration-200 hover:border-white/[0.15] hover:bg-white/[0.03] active:scale-[0.99]"
+                  className="flex h-[44px] w-full cursor-pointer items-center justify-center gap-2.5 rounded-lg border border-border bg-transparent text-[13px] font-medium text-foreground transition-colors duration-200 hover:border-hairline-strong hover:bg-overlay active:scale-[0.99]"
                 >
                   <svg
                     className="h-4 w-4"
@@ -637,7 +637,7 @@ export function AuthFlow({
             <button
               type="button"
               onClick={() => slideToPanel(1)}
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-transparent text-muted-foreground transition-colors duration-300 hover:border-border/80 hover:bg-white/[0.03] hover:text-foreground"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-transparent text-muted-foreground transition-colors duration-300 hover:border-border/80 hover:bg-overlay hover:text-foreground"
               aria-label="Back to sign-up methods"
             >
               <svg
@@ -784,7 +784,7 @@ export function AuthFlow({
                               className={`h-[2.5px] flex-1 rounded-full ${
                                 i < strength.score
                                   ? strength.color
-                                  : "bg-white/[0.06]"
+                                  : "bg-overlay-strong"
                               }`}
                             />
                           ))}

--- a/frontend/src/components/shared/detail-row.tsx
+++ b/frontend/src/components/shared/detail-row.tsx
@@ -15,6 +15,8 @@ interface DetailRowProps {
     | "destructive"
     | "success"
     | "warning";
+  /** Render the value as code (IDs, URIs, user agents). */
+  readonly mono?: boolean;
 }
 
 /* ── NyxID Detail Row ── */
@@ -24,15 +26,24 @@ export function DetailRow({
   copyable = false,
   badge = false,
   badgeVariant = "secondary",
+  mono = false,
 }: DetailRowProps) {
   return (
-    <div className="flex items-center justify-between px-4 py-2.5 text-[12px]">
-      <span className="text-muted-foreground">{label}</span>
-      <div className="flex items-center gap-1.5">
+    <div className="flex items-center justify-between gap-4 px-4 py-2.5 text-[12px]">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <div className="flex min-w-0 items-center gap-1.5">
         {badge ? (
           <Badge variant={badgeVariant}>{value}</Badge>
         ) : (
-          <span className="font-medium text-foreground">{value}</span>
+          <span
+            className={
+              mono
+                ? "min-w-0 break-words text-right font-mono text-[11px] text-foreground"
+                : "min-w-0 break-words text-right font-medium text-foreground"
+            }
+          >
+            {value}
+          </span>
         )}
         {copyable && (
           <Button

--- a/frontend/src/components/shared/detail-section.tsx
+++ b/frontend/src/components/shared/detail-section.tsx
@@ -1,14 +1,35 @@
+import { cn } from "@/lib/utils";
+
 /* ── NyxID Detail Section ── */
 interface DetailSectionProps {
   readonly title: string;
   readonly children: React.ReactNode;
+  /** Trailing control rendered in the title strip (e.g. an edit toggle). */
+  readonly action?: React.ReactNode;
+  /**
+   * Override the section fill. Defaults to `bg-card`, which is correct on the
+   * page background; pass `bg-overlay` when the section is nested inside a
+   * Card so it still reads as a distinct layer.
+   */
+  readonly className?: string;
 }
 
-export function DetailSection({ title, children }: DetailSectionProps) {
+export function DetailSection({
+  title,
+  children,
+  action,
+  className,
+}: DetailSectionProps) {
   return (
-    <div className="rounded-xl border border-border/50 bg-card overflow-hidden">
-      <div className="border-b border-border/50 px-4 py-2.5">
+    <div
+      className={cn(
+        "rounded-xl border border-border/50 bg-card overflow-hidden",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-2.5">
         <h3 className="text-[13px] font-semibold text-foreground">{title}</h3>
+        {action}
       </div>
       <div className="divide-y divide-border/30">{children}</div>
     </div>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -10,15 +10,14 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "border border-white/[0.08] bg-white/[0.04] text-foreground hover:border-white/[0.15] hover:bg-white/[0.06]",
+          "border border-hairline bg-overlay text-foreground hover:border-hairline-strong hover:bg-overlay-strong",
         destructive:
           "border border-destructive/30 bg-destructive/10 text-destructive hover:border-destructive/50 hover:bg-destructive/15",
         outline:
-          "border border-white/[0.08] bg-transparent text-muted-foreground hover:border-white/[0.15] hover:text-foreground",
+          "border border-hairline bg-transparent text-muted-foreground hover:border-hairline-strong hover:text-foreground",
         secondary:
-          "border border-white/[0.08] bg-white/[0.04] text-muted-foreground hover:border-white/[0.15] hover:text-foreground",
-        ghost:
-          "text-muted-foreground hover:bg-white/[0.04] hover:text-foreground",
+          "border border-hairline bg-overlay text-muted-foreground hover:border-hairline-strong hover:text-foreground",
+        ghost: "text-muted-foreground hover:bg-overlay hover:text-foreground",
         link: "text-nyx-secondary-400 underline-offset-4 hover:underline",
         primary:
           "nyx-gradient-vivid text-white shadow-[0_0_12px_rgba(90,42,241,0.25)] hover:shadow-[0_0_18px_rgba(90,42,241,0.35)] hover:brightness-110",
@@ -44,8 +43,10 @@ export function ButtonIcon({ children, className, variant }: { readonly children
       variant === "destructive"
         ? "border border-destructive/20 bg-destructive/10"
         : variant === "primary"
-          ? "border border-white/20 bg-white/10"
-          : "border border-white/[0.08] bg-white/[0.04]",
+          ? // Sits on the purple gradient fill, so white-alpha is correct in
+            // both themes and must NOT become a theme-aware token.
+            "border border-white/20 bg-white/10"
+          : "border border-hairline bg-overlay",
       className,
     )}>
       {children}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -70,16 +70,16 @@ export const OAUTH_SCOPE_META: Readonly<Record<string, OAuthScopeMeta>> = {
   },
 };
 
-// Risk/severity pill colors are theme-split with the same convention as the Badge
-// component: dark (base, unprefixed) is the primary surface and keeps the tuned tint;
-// light mode deviates to a solid semantic fill (`light:`) because the tint washes out on
-// a light canvas. This is the fix for the reported light-mode legibility bug.
-export function scopeRiskClass(risk: OAuthScopeRisk): string {
-  if (risk === "high")
-    return "border-red-500/30 bg-red-500/10 text-red-200 light:border-transparent light:bg-destructive light:text-white";
-  if (risk === "medium")
-    return "border-yellow-500/30 bg-yellow-500/10 text-yellow-200 light:border-transparent light:bg-warning light:text-white";
-  return "border-emerald-500/30 bg-emerald-500/10 text-emerald-200 light:border-transparent light:bg-success light:text-white";
+// Risk/severity pills render as a shared `Badge`, mapped onto semantic tokens
+// per DESIGN.md ("Severity / risk pills"): high → destructive, medium → warning,
+// low → success. The Badge variants already carry the theme-split (dark tint /
+// light solid fill) that the hand-rolled raw-palette classes used to duplicate.
+export function scopeRiskBadgeVariant(
+  risk: OAuthScopeRisk,
+): "destructive" | "warning" | "success" {
+  if (risk === "high") return "destructive";
+  if (risk === "medium") return "warning";
+  return "success";
 }
 
 export function scopeRiskLabel(risk: OAuthScopeRisk): string {

--- a/frontend/src/pages/integration-guide.tsx
+++ b/frontend/src/pages/integration-guide.tsx
@@ -8,7 +8,7 @@ import { Copy } from "lucide-react";
 import { toast } from "sonner";
 import {
   OAUTH_SCOPE_META,
-  scopeRiskClass,
+  scopeRiskBadgeVariant,
   scopeRiskLabel,
 } from "@/lib/constants";
 import {
@@ -218,11 +218,12 @@ export function IntegrationGuidePage() {
                   {meta.description}
                 </p>
               </div>
-              <span
-                className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${scopeRiskClass(meta.risk)}`}
+              <Badge
+                variant={scopeRiskBadgeVariant(meta.risk)}
+                className="shrink-0"
               >
                 {scopeRiskLabel(meta.risk)}
-              </span>
+              </Badge>
             </div>
           ))}
         </CardContent>

--- a/frontend/src/pages/oauth-consent.tsx
+++ b/frontend/src/pages/oauth-consent.tsx
@@ -1,26 +1,57 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, ButtonIcon } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { AlertTriangle, ShieldCheck } from "lucide-react";
 import {
   OAUTH_SCOPE_META,
-  scopeRiskClass,
+  scopeRiskBadgeVariant,
   scopeRiskLabel,
 } from "@/lib/constants";
 import { useApplyTheme } from "@/hooks/use-theme";
 import { NyxidLogo } from "@/components/brand/nyxid-logo";
+import { DetailSection } from "@/components/shared/detail-section";
+import { DetailRow } from "@/components/shared/detail-row";
+import { ErrorBanner } from "@/components/shared/error-banner";
 import { useUserServices } from "@/hooks/use-user-services";
 import { oauthConsentServiceAccessSchema } from "@/schemas/oauth-consent";
+
+/**
+ * Standalone shell for the consent surface, matching `login-device.tsx` — the
+ * sibling "a human reviews and approves an access request" page. The
+ * `bg-background` is load-bearing: the document body carries an inline dark
+ * colour as an anti-flash guard for the never-themed public pages, so a themed
+ * standalone page that doesn't paint its own canvas renders a light card on a
+ * black void.
+ */
+function ConsentShell({ children }: { readonly children: ReactNode }) {
+  return (
+    <main
+      className="flex min-h-dvh items-start justify-center bg-background px-4 py-8 text-foreground sm:items-center sm:py-10"
+      style={{
+        paddingTop: "max(2rem, var(--sat))",
+        paddingBottom: "max(2rem, var(--sab))",
+      }}
+    >
+      <div className="flex w-full max-w-xl flex-col gap-5">
+        <div className="flex justify-center">
+          <NyxidLogo className="h-8 w-auto" />
+        </div>
+        {children}
+      </div>
+    </main>
+  );
+}
+
+/**
+ * Fill for sections nested inside the Card. `bg-overlay` is the theme-aware
+ * successor to the `white/[α]` idiom (app.css "Interactive chrome"): identical
+ * in dark, black-alpha on light, so the nested layer survives both themes.
+ */
+const NESTED_SECTION = "bg-overlay";
 
 function readParam(search: URLSearchParams, key: string): string {
   return search.get(key) ?? "";
@@ -252,107 +283,55 @@ export function OAuthConsentPage() {
 
   if (missing) {
     return (
-      <div
-        className="mx-auto flex min-h-dvh w-full max-w-2xl items-center px-6 py-10"
-        style={{
-          paddingTop: "max(2.5rem, var(--sat))",
-          paddingBottom: "max(2.5rem, var(--sab))",
-        }}
-      >
-        <Card className="w-full">
-          <CardHeader>
-            <CardTitle>Invalid consent request</CardTitle>
-            <CardDescription>
-              Missing required OAuth parameters. Please restart the sign-in
-              flow.
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
+      <ConsentShell>
+        <header className="flex flex-col gap-2 text-center">
+          <h1 className="text-[22px] font-bold leading-tight tracking-tight text-foreground sm:text-[28px]">
+            Invalid consent request
+          </h1>
+        </header>
+        <ErrorBanner message="Missing required OAuth parameters. Please restart the sign-in flow." />
+      </ConsentShell>
     );
   }
 
   return (
-    <div
-      className="mx-auto flex min-h-dvh w-full max-w-2xl items-center px-6 py-10"
-      style={{
-        paddingTop: "max(2.5rem, var(--sat))",
-        paddingBottom: "max(2.5rem, var(--sab))",
-      }}
-    >
-      <Card className="w-full">
-        <CardHeader className="space-y-4">
-          <div className="flex items-center">
-            <NyxidLogo className="h-7 w-auto" />
-          </div>
-          <CardTitle>
-            {bindingReview
-              ? isLarkBinding
-                ? "Review Lark bot access"
-                : "Review application access"
-              : isLarkBinding
-                ? "Authorize Lark bot"
-                : "Authorize application"}
-          </CardTitle>
-          <CardDescription>
-            {bindingReview ? (
-              <>
-                Review the NyxID services available to{" "}
-                <span className="font-medium text-foreground">
-                  {clientName}
-                </span>
-                .
-              </>
-            ) : (
-              <>
-                <span className="font-medium text-foreground">
-                  {clientName}
-                </span>{" "}
-                wants to access your account via OAuth.
-              </>
-            )}
-          </CardDescription>
-        </CardHeader>
+    <ConsentShell>
+      <header className="flex flex-col gap-2 text-center">
+        <h1 className="text-[22px] font-bold leading-tight tracking-tight text-foreground sm:text-[28px]">
+          {bindingReview
+            ? isLarkBinding
+              ? "Review Lark bot access"
+              : "Review application access"
+            : isLarkBinding
+              ? "Authorize Lark bot"
+              : "Authorize application"}
+        </h1>
+        <p className="mx-auto max-w-md text-[12px] text-muted-foreground">
+          {bindingReview ? (
+            <>
+              Review the NyxID services available to{" "}
+              <span className="font-medium text-foreground">{clientName}</span>.
+            </>
+          ) : (
+            <>
+              <span className="font-medium text-foreground">{clientName}</span>{" "}
+              wants to access your account via OAuth.
+            </>
+          )}
+        </p>
+      </header>
 
-        <CardContent className="space-y-6">
-          <div className="rounded-lg border border-border bg-muted px-4 py-3">
-            <div className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-              <ShieldCheck className="h-4 w-4 text-primary" />
-              App verification details
-            </div>
-            <div className="mt-2 space-y-1 text-xs text-muted-foreground">
-              <p>
-                Application:{" "}
-                <span className="font-medium text-foreground">
-                  {clientName}
-                </span>
-              </p>
-              <p>
-                Redirect host:{" "}
-                <span className="text-foreground">{redirectHost}</span>
-              </p>
-            </div>
-          </div>
+      <Card className="border-border/50">
+        <CardContent className="flex flex-col gap-4 pt-4">
+          <DetailSection title="App details" className={NESTED_SECTION}>
+            <DetailRow label="Application" value={clientName} />
+            <DetailRow label="Redirect host" value={redirectHost} />
+            <DetailRow label="Client ID" value={clientId} mono copyable />
+            <DetailRow label="Redirect URI" value={redirectUri} mono copyable />
+          </DetailSection>
 
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-wide text-text-tertiary">
-              Requested scopes
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {scopes.map((item) => (
-                <Badge key={item} variant="secondary">
-                  {item}
-                </Badge>
-              ))}
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-wide text-text-tertiary">
-              Scope impact
-            </p>
-            <div className="space-y-2">
-              {scopes.map((item) => {
+          <DetailSection title="Requested access" className={NESTED_SECTION}>
+            {scopes.map((item) => {
                 const meta = OAUTH_SCOPE_META[item] ?? {
                   title: "Custom permission",
                   description:
@@ -360,51 +339,33 @@ export function OAuthConsentPage() {
                   risk: "medium" as const,
                 };
                 return (
-                  <div
-                    key={`meta-${item}`}
-                    className="rounded-lg border border-border bg-muted/50 px-3 py-2"
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <p className="min-w-0 break-words text-xs text-foreground pt-0.5">
-                        {item}
+                  <div key={`meta-${item}`} className="px-4 py-2.5">
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="min-w-0 break-words text-[12px] font-medium text-foreground">
+                        {meta.title}
                       </p>
-                      <span
-                        className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${scopeRiskClass(meta.risk)}`}
+                      <Badge
+                        variant={scopeRiskBadgeVariant(meta.risk)}
+                        className="shrink-0"
                       >
                         {scopeRiskLabel(meta.risk)}
-                      </span>
+                      </Badge>
                     </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground">
-                        {meta.title}
-                      </span>
-                      {" - "}
+                    <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
                       {meta.description}
+                    </p>
+                    <p className="mt-1.5 break-all font-mono text-[11px] text-text-tertiary">
+                      {item}
                     </p>
                   </div>
                 );
               })}
-            </div>
-          </div>
+          </DetailSection>
 
-          <div className="space-y-3 rounded-lg border border-border bg-muted/30 px-4 py-3">
-            <div className="flex items-center justify-between gap-4">
-              <div className="min-w-0">
-                <p className="text-xs uppercase tracking-wide text-text-tertiary">
-                  Service access
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {serviceAccess.allow_all_services
-                    ? bindingReview && currentBindingAllowsAllServices
-                      ? "This binding currently authorizes all available services."
-                      : "This app will be able to use all of your available services through the proxy."
-                    : summaryServices.length > 0
-                      ? bindingReview
-                        ? "Review the current grant and select any additional services."
-                        : "This app will be able to use these services through the proxy:"
-                      : "No service access requested. This app only signs you in."}
-                </p>
-              </div>
+          <DetailSection
+            title="Service access"
+            className={NESTED_SECTION}
+            action={
               <Button
                 type="button"
                 variant="ghost"
@@ -414,19 +375,31 @@ export function OAuthConsentPage() {
               >
                 {customize ? "Done" : "Customize"}
               </Button>
-            </div>
+            }
+          >
+            <p className="px-4 py-2.5 text-[12px] leading-relaxed text-muted-foreground">
+              {serviceAccess.allow_all_services
+                ? bindingReview && currentBindingAllowsAllServices
+                  ? "This binding currently authorizes all available services."
+                  : "This app will be able to use all of your available services through the proxy."
+                : summaryServices.length > 0
+                  ? bindingReview
+                    ? "Review the current grant and select any additional services."
+                    : "This app will be able to use these services through the proxy:"
+                  : "No service access requested. This app only signs you in."}
+            </p>
 
             {!customize &&
               !serviceAccess.allow_all_services &&
               (summaryServices.length > 0 || unmatchedDefaults.length > 0) && (
-                <div className="space-y-2 border-t border-border pt-3">
+                <div className="divide-y divide-border/30">
                   {summaryServices.map((item) => (
                     <div
                       key={item.id}
-                      className="flex items-start justify-between gap-2 rounded-md border border-border bg-background/60 px-3 py-2"
+                      className="flex items-start justify-between gap-3 px-4 py-2.5"
                     >
                       <div className="min-w-0">
-                        <p className="break-words text-xs font-medium text-foreground">
+                        <p className="break-words text-[12px] font-medium text-foreground">
                           {item.primary}
                         </p>
                         {item.secondary && (
@@ -471,11 +444,8 @@ export function OAuthConsentPage() {
                     </div>
                   ))}
                   {unmatchedDefaults.map((name) => (
-                    <div
-                      key={`unmatched-${name}`}
-                      className="rounded-md border border-dashed border-border bg-background/40 px-3 py-2"
-                    >
-                      <p className="break-words text-xs text-muted-foreground">
+                    <div key={`unmatched-${name}`} className="px-4 py-2.5">
+                      <p className="break-words text-[12px] leading-relaxed text-muted-foreground">
                         <span className="font-medium text-foreground">
                           {name}
                         </span>{" "}
@@ -488,8 +458,8 @@ export function OAuthConsentPage() {
               )}
 
             {customize && (
-              <div className="space-y-3 border-t border-border pt-3">
-                <div className="flex items-center justify-between gap-2">
+              <div className="divide-y divide-border/30">
+                <div className="flex items-center justify-between gap-2 px-4 py-2.5">
                   <Label htmlFor="oauth-allow-all-services">All services</Label>
                   <Switch
                     id="oauth-allow-all-services"
@@ -500,9 +470,9 @@ export function OAuthConsentPage() {
                 </div>
 
                 {!allowAllServices && (
-                  <div className="space-y-2">
+                  <div className="divide-y divide-border/30">
                     {userServicesLoading ? (
-                      <p className="text-xs text-muted-foreground">
+                      <p className="px-4 py-2.5 text-[12px] text-muted-foreground">
                         Loading services...
                       </p>
                     ) : selectableServices.length > 0 ? (
@@ -511,7 +481,7 @@ export function OAuthConsentPage() {
                         return (
                           <div
                             key={service.id}
-                            className="flex items-start gap-2 rounded-md border border-border bg-background/60 px-3 py-2"
+                            className="flex items-start gap-2.5 px-4 py-2.5"
                           >
                             <Checkbox
                               id={`oauth-service-${service.id}`}
@@ -526,7 +496,7 @@ export function OAuthConsentPage() {
                             <div className="min-w-0">
                               <Label
                                 htmlFor={`oauth-service-${service.id}`}
-                                className="cursor-pointer text-xs leading-5 text-foreground"
+                                className="cursor-pointer text-[12px] leading-5 text-foreground"
                               >
                                 <span className="block break-words font-medium">
                                   {serviceDisplayName(service)}
@@ -593,7 +563,7 @@ export function OAuthConsentPage() {
                         );
                       })
                     ) : (
-                      <p className="text-xs text-muted-foreground">
+                      <p className="px-4 py-2.5 text-[12px] text-muted-foreground">
                         No active services are available.
                       </p>
                     )}
@@ -601,36 +571,21 @@ export function OAuthConsentPage() {
                 )}
               </div>
             )}
-          </div>
+          </DetailSection>
 
-          <div className="space-y-1">
-            <p className="text-xs uppercase tracking-wide text-text-tertiary">
-              Client ID
-            </p>
-            <p className="text-xs text-foreground">{clientId}</p>
-          </div>
-
-          <div className="space-y-1">
-            <p className="text-xs uppercase tracking-wide text-text-tertiary">
-              Redirect URI
-            </p>
-            <p className="break-all text-xs text-foreground">{redirectUri}</p>
-          </div>
-
-          <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 light:border-warning/40 light:bg-warning/10">
-            <div className="flex items-start gap-2">
-              <AlertTriangle className="mt-0.5 h-4 w-4 text-yellow-300 light:text-warning" />
-              <p className="text-xs text-yellow-100/90 light:text-warning">
-                Only continue if you trust this application. You can revoke this
-                access later from <strong>Authorized Applications</strong>.
-              </p>
+          <div className="flex gap-3 rounded-xl border border-warning/15 bg-warning/[0.04] px-4 py-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-warning/10">
+              <AlertTriangle className="h-4 w-4 text-warning" />
             </div>
+            <p className="text-[12px] leading-relaxed text-warning">
+              Only continue if you trust this application.
+            </p>
           </div>
 
           <form
             method="POST"
             action="/oauth/authorize/decision"
-            className="flex flex-wrap items-center gap-3 pt-1"
+            className="flex flex-col gap-2 sm:flex-row sm:justify-end"
           >
             <input type="hidden" name="response_type" value={responseType} />
             <input type="hidden" name="client_id" value={clientId} />
@@ -706,6 +661,7 @@ export function OAuthConsentPage() {
               variant="outline"
               name="decision"
               value="deny"
+              className="w-full sm:w-auto"
             >
               {bindingReview ? "Cancel" : "Deny"}
             </Button>
@@ -714,12 +670,20 @@ export function OAuthConsentPage() {
               type="submit"
               name="decision"
               value="allow"
+              className="w-full sm:w-auto"
             >
+              <ButtonIcon variant="primary">
+                <ShieldCheck />
+              </ButtonIcon>
               {bindingReview ? "Update access" : "Allow"}
             </Button>
           </form>
         </CardContent>
       </Card>
-    </div>
+
+      <p className="text-center text-[11px] text-text-tertiary">
+        You can revoke this access at any time from Authorized Applications.
+      </p>
+    </ConsentShell>
   );
 }

--- a/frontend/src/pages/oauth-error.tsx
+++ b/frontend/src/pages/oauth-error.tsx
@@ -49,11 +49,11 @@ export function OAuthErrorPage() {
 
         <Card className="w-full">
           <CardHeader className="space-y-3">
-            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-red-500/10">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-destructive/10">
               {isMissingRequiredService ? (
                 <ServiceIcon slug={serviceSlug} size="xs" />
               ) : (
-                <ShieldAlert className="h-4 w-4 text-red-400" />
+                <ShieldAlert className="h-4 w-4 text-destructive" />
               )}
             </div>
             <CardTitle>{title}</CardTitle>


### PR DESCRIPTION
## Why

The OAuth consent screen — what a user sees when authorizing the NyxID MCP server from Claude Code, Cursor, or claude.ai — **rendered a white card on a black void in light mode**, and used a layout no other page in the app shares.

`index.html` sets an inline `background-color:#0D0D0D` on `<body>` as an anti-flash guard for the never-themed public pages. Inline style beats the `bg-background` class, so a themed standalone page that doesn't paint its own canvas shows black gutters. Every other themed surface (`auth-layout`, `dashboard-layout`, `docs-layout`, cli-wizard shell, legal pages, and the sibling `/error` page) paints one — `oauth-consent` was the only one that didn't.

## What changed

**Consent page** now mirrors `login-device.tsx`, its closest sibling (the other standalone "a human reviews and approves an access request" surface): same shell, `h1` header outside the Card, shared `DetailSection`/`DetailRow` blocks, shared `ErrorBanner` for the invalid-request state, semantic warning callout, responsive action row with `ButtonIcon` on the primary.

**Shared components** (the part worth review attention):

- `DetailSection` gains optional `action` + `className`; `DetailRow` gains `mono` plus `min-w-0`/`break-words`/`shrink-0` so long client IDs and redirect URIs wrap instead of overflowing.
- `button.tsx` and `auth-flow.tsx` migrate `white/[α]` chrome to the `hairline`/`overlay` tokens, which is the migration `app.css` "Interactive chrome" explicitly calls for. **The token dark values reproduce the originals 1:1, so dark mode is pixel-unchanged**; light mode gains the borders and hover states it was missing (this is why "Deny" and the social buttons read as bare text on a light canvas today).
- Risk pills move from raw `red-*`/`yellow-*`/`emerald-*` to shared `Badge` variants per DESIGN.md (high→destructive, medium→warning, low→success). `scopeRiskClass` is deleted and both callers migrated.
- `oauth-error.tsx`: `bg-red-500/10`/`text-red-400` → `destructive` tokens.

**Backend success page** (shown for loopback and custom-scheme redirects — i.e. Claude Code / Cursor) moves onto the app's surfaces, the real `SuccessPanel` treatment, the correct `nyx-gradient-vivid` direction (it was reversed and using the wrong endpoint), and an inlined vector wordmark instead of typed text that depended on a font the page can't load.

## Review notes

- **Blast radius:** `button.tsx`, `detail-row.tsx`, `detail-section.tsx`, and `auth-flow.tsx` are shared. Dark mode is unchanged by construction; light mode changes wherever buttons and detail rows appear. That's the intended fix, but it's the part to look at hardest.
- The change was cross-checked by an independent reviewer pass; seven findings applied, two declined (see below).

## Verification

Rollup PRs don't run CI, so this was verified locally **on this branch, against the rollup base**:

- `cargo check -p nyxid` — 0
- `tsc -b` — 0
- `npm run lint` — 0 errors (23 pre-existing warnings elsewhere)
- `npm run build` — 0
- `npx vitest run` — **208 files / 2533 tests, all passing**
- Rendered and screenshotted in both themes at 1280px and 390px: consent (default, Customize expanded, binding-review), invalid-request, error page, success page. Reviewed and accepted.

## Known follow-ups (not in this PR)

1. The success page is still a hand-maintained replica of the design system in Rust string literals — correct today, will drift on the next token change. `frontend/credential-accept.html` has the same problem and is **off-theme right now** (Inter, `#0c111d`, its own button/panel CSS). Both want the wizard-bundle treatment: a built artifact + `rust_embed`, which `vite.wizard.config.ts` + `cli/src/wizard/server.rs` already implement end to end, including per-request config injection and a CSP nonce.
2. `login-device.tsx:261` still carries `bg-white/[0.02]` — the same debt removed from consent here.
3. `oauth-error.tsx` still uses its own shell composition. The real consolidation is one shared standalone approval shell across consent, oauth-error, and login-device — a refactor rather than a styling pass.
4. Mona Sans isn't loaded on the backend success page; body copy falls back to the system stack. The wordmark is now a vector, so the brand mark itself is exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)