### PR TITLE
feat(billing): rework wallet card and break usage down by model and agent

### DIFF
--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -51,6 +51,13 @@ pub struct BillingUsageRow {
     pub metric: BillingMetric,
     pub lago_metric_code: String,
     pub layer: String,
+    /// Downstream model for LLM-shaped usage; None for other services.
+    pub model: Option<String>,
+    /// Agent (API key) the usage is attributed to; None for session auth.
+    pub api_key_id: Option<String>,
+    /// Resolved display name for `api_key_id`. The ledger stores only the id,
+    /// so this is looked up per response — never render the bare UUID.
+    pub api_key_name: Option<String>,
     pub quantity: i64,
     pub requests: i64,
     pub bytes: i64,
@@ -217,6 +224,11 @@ pub async fn get_usage(
                     "lago_metric_code": "$lago_metric_code",
                     "layer": "$layer",
                     "lago_acked": "$lago_acked",
+                    // Model and agent split the per-service total into the
+                    // breakdown the billing page expands into. Both are
+                    // optional on the ledger, so absent values group together.
+                    "model": "$model",
+                    "api_key_id": "$api_key_id",
                     // Rows without a wallet were metered for observability
                     // only (service not platform_billable); they carry no
                     // cost and are never pushed to Lago.
@@ -260,6 +272,9 @@ pub async fn get_usage(
             metric,
             lago_metric_code,
             layer: id_doc.get_str("layer").unwrap_or("platform").to_string(),
+            model: id_doc.get_str("model").ok().map(ToString::to_string),
+            api_key_id: id_doc.get_str("api_key_id").ok().map(ToString::to_string),
+            api_key_name: None,
             quantity,
             requests: if metric == BillingMetric::Requests {
                 quantity
@@ -277,6 +292,8 @@ pub async fn get_usage(
             estimated_credits_micros,
         });
     }
+
+    resolve_api_key_names(&state.db, &owner_id, &mut rows).await?;
 
     let totals = BillingUsageTotals {
         quantity: rows.iter().map(|row| row.quantity).sum(),
@@ -731,6 +748,44 @@ async fn find_rate(
         .find_one(doc! { "_id": BillingRateCache::cache_id(lago_metric_code, None) })
         .await
         .map_err(Into::into)
+}
+
+/// Fill `api_key_name` on usage rows with one batched lookup.
+///
+/// The ledger stores only `api_key_id`, so the page would otherwise render raw
+/// UUIDs. The lookup is scoped to keys owned by `owner_id`: a row referencing
+/// anything else keeps `None` and the UI falls back to a neutral label rather
+/// than leaking another owner's key name. Deleted keys resolve to `None` too.
+async fn resolve_api_key_names(
+    db: &mongodb::Database,
+    owner_id: &str,
+    rows: &mut [BillingUsageRow],
+) -> AppResult<()> {
+    let key_ids: Vec<&str> = rows
+        .iter()
+        .filter_map(|row| row.api_key_id.as_deref())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    if key_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut names: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut cursor = db
+        .collection::<crate::models::api_key::ApiKey>(crate::models::api_key::COLLECTION_NAME)
+        .find(doc! { "_id": { "$in": &key_ids }, "user_id": owner_id })
+        .await?;
+    while let Some(key) = cursor.try_next().await? {
+        names.insert(key.id, key.name);
+    }
+
+    for row in rows.iter_mut() {
+        if let Some(id) = row.api_key_id.as_deref() {
+            row.api_key_name = names.get(id).cloned();
+        }
+    }
+    Ok(())
 }
 
 fn parse_metric(value: &str) -> Option<BillingMetric> {

--- a/docs/BILLING_UI_GLOSSARY.md
+++ b/docs/BILLING_UI_GLOSSARY.md
@@ -1,0 +1,313 @@
+# Billing UI Glossary
+
+What every term on `/billing` actually means, where the number comes from, and where the label
+lies to you.
+
+**Scope:** the logged-in Billing page (https://nyx.chrono-ai.fun/billing). Source of truth is the
+code in this worktree — `frontend/src/pages/billing.tsx` + `backend/src/handlers/billing.rs`,
+identical to `main` at time of writing (last billing UI commit `f0691e23`).
+
+**Design background:** [ADR-014](./ADR-014-usage-billing-lago.md) (decisions) and
+[USAGE_BILLING_LAGO_SPEC.md](./USAGE_BILLING_LAGO_SPEC.md) (implementation). Lago is the billing
+engine; NyxID owns the meter, the wallet cache, and the spend gate. Lago owns pricing and invoices.
+Where the ADR's intent and the shipped code disagree, this doc describes **the code**.
+
+> Written by two independent passes (Claude + GPT/Codex) over the same source, then reconciled;
+> every claim below was verified against the code.
+
+---
+
+## 0. The three words everything else is built on
+
+| Term | Meaning |
+|---|---|
+| **Credit** | The billing unit. **1 credit = 1 USD.** NyxID creates every Lago wallet in USD with `rate_amount: "1"`, so credits are 1:1 with the wallet currency (`services/billing/lago_client.rs:93-95`, `:272-278`). Wallet amounts are always whole integers. |
+| **Credit micros** | One millionth of a credit — fixed-point, no floating point. Any field ending in `_credits_micros` is divided by 1,000,000 for display, with up to 6 decimals (`billing.tsx:584-591`). 4,200 micros → `0.0042 credits`. Cost *estimates* use micros; wallet balances never do. |
+| **Layer** | Which of two independent charges produced a usage row. One request can produce one of each. |
+
+| Layer | What is being charged |
+|---|---|
+| **Platform** | NyxID's own fee for brokering the request — the proxy hop itself. Opt-in per service via the admin `platform_billable` flag; services default to free (`models/service_billing.rs:15-19`). |
+| **Resale** | The downstream vendor's value, resold. Charged **only** when NyxID supplied the master credential (`CredentialClass::NyxidManagedMaster`), the catalog service sets `resale_billable` with a Lago metric code, and the operator switch `BILLING_RESALE_ENABLED` is on. Bring your own key — or have an agent binding swap yours in, or keep the credential on a node — and there is no resale line (`services/billing/route_context.rs:52-58`). |
+
+---
+
+## 1. Page header and period selector
+
+| UI element | Meaning | Source |
+|---|---|---|
+| **"Wallet balance, credits, and service usage."** | Page subtitle. Static copy. | `billing.tsx:107-109` |
+| **Period dropdown** (24 hours / 7 days / 30 days / 90 days / All time) | Rolling windows measured back from the server's current UTC time — not calendar periods. Filters **both** the Usage card and the Top-up history card. Defaults to **30 days**; an unrecognized value also falls back to 30 days. | `billing.tsx:56`, `:111-125`; `handlers/billing.rs:706-715` |
+| ↳ **"All time"** | Means two different things. For **Usage** it is the last **3,650 days** (~10 years). For **Top-up history** it genuinely drops the date filter. | `handlers/billing.rs:712`, `:445-450` |
+
+Changing the period remounts the top-up history card (`key={period}`), resetting it to page 1.
+
+**Page access is gated three times:**
+- Capability: `user.capabilities.billing_available` requires billing enabled + Lago configured + the user's billing feature flag.
+- Frontend: `BillingRouteGuard` redirects to `/dashboard` if that capability is false (`components/billing-route-guard.tsx`).
+- Backend: every billing endpoint calls `ensure_billing_rollout()`, a staged-rollout feature flag. Owners outside it get **403 "Billing is not enabled for this account"** (`handlers/billing.rs:304-313`).
+
+**Whose money is this page about?** Always **your personal wallet**. Wallet, top-up, and history all
+call `resolve_for_wallet_management(actor, None)`, which passes your own id and resolves to
+`PaysFrom::Personal` (`services/billing/owner_resolver.rs:50-58`); usage keys directly on
+`auth_user.user_id` (`handlers/billing.rs:188`). Org-billed usage is recorded under the *org's*
+owner id and is **not visible anywhere on this page** — see §7.
+
+---
+
+## 2. Banner: "Billing is not available on this deployment."
+
+Shown when the usage response's capability block says charging is off (`billing.tsx:66-68`,
+`:135-139`). Backed by `BillingReadOnlyBlock` (`handlers/billing.rs:74-80`, `:294-299`):
+
+| Field | Meaning |
+|---|---|
+| `charging_enabled` | Already `BILLING_ENABLED && lago_configured` — despite the name, not just the master switch. False means nothing is charged, only metered. |
+| `lago_configured` | A Lago API URL **and** key are present and the client constructed. **Not** a live health check (`services/billing/mod.rs:33`, `:82`). |
+| `source: "usage_meter"` | Numbers come from NyxID's own durable ledger, not Lago's rating engine. Never rendered. |
+| `rates_are_approximate: true` | **Every cost on this page is an estimate.** Always true. Never rendered. |
+
+While it shows, the Top Up input, Checkout button, and Provision Wallet button are all disabled
+(`billing.tsx:70-75`, `:176`, `:382`). Because the route guard already blocks the same conditions,
+this banner is mostly a defense against stale capability state rather than the normal experience.
+
+---
+
+## 3. Wallet card
+
+Backed by `GET /api/v1/billing/wallet` → `BillingWalletResponse` (`handlers/billing.rs:94-114`;
+model at `models/billing_wallet.rs`).
+
+### Header
+
+| Label | Meaning | API field |
+|---|---|---|
+| **Owner `<uuid>`** | The billing owner id — on this page, always your own person UUID. Rendered raw, with no display name. | `owner_id` |
+| **Status badge** ("Good" / "Past Due" / "Suspended") | The wallet's collection state, title-cased. The badge has no heading, so nothing on screen says it is a *collection* state. | `collection_state` (text) / `suspended` (color) |
+
+| Badge value | Meaning |
+|---|---|
+| **Good** | Normal. Every new wallet starts here. |
+| **Past Due** | An unpaid invoice, service continues. **Nothing in the codebase ever writes this value** — the enum exists in the model and the Zod schema and nowhere else. Aspirational today. |
+| **Suspended** | Requests are refused (`WalletSuspended`, error 11307). Set when the overdraft cap is breached (`services/billing/reservation.rs:1194`). |
+
+### The three big numbers
+
+| Label | Meaning | Formula / source |
+|---|---|---|
+| **Available** | What you can spend right now, excluding overdraft. The number the prepaid gate checks. | `balance − reserved − pending_lago_debits`, saturating (`models/billing_wallet.rs:56-60`) |
+| **Balance** | Your Lago wallet balance **as last cached locally** — not a live read at render time. The client prefers Lago's `credits_ongoing_balance` and rounds decimals to whole credits. Because OSS Lago's balance clock job is premium-gated, the reconciler *itself* subtracts the current period's accrued usage, rounding partial credits up against you (`services/billing/reconcile.rs:166-180`). | `balance_credits` |
+| **Reserved** | Whole-credit holds for in-flight requests. NyxID reserves a pessimistic estimate *before* forwarding, then trues it up on settle. Money not yet spent but not spendable twice. | `reserved_credits` |
+
+The card does **not** display two fields the API returns and Available depends on:
+
+| Hidden field | Meaning |
+|---|---|
+| `pending_lago_debits` | Charges settled locally but not yet reflected in a trusted Lago balance refresh. Subtracted immediately so the next request cannot reserve the same money (spec §3.3, R3.1). **This is why `Balance − Reserved` often does not equal `Available` on screen.** The CLI shows it as "Pending Debits" (`cli/src/commands/billing.rs:278`); the web page hides it. |
+| `available_with_overdraft_credits` | Available plus the full overdraft cap. Returned by the API, parsed by the Zod schema, never rendered. |
+
+### The three details
+
+| Label | Meaning | Reality check |
+|---|---|---|
+| **Plan** (`Prepaid` / `Subscription` / `Hybrid`) | *Prepaid* = hard stop when Available hits zero. *Subscription* / *Hybrid* = the non-prepaid gate branch, which may reserve into overdraft. | **Provisioning always writes `Prepaid` and nothing ever updates it** (`services/billing/provisioning.rs:73` is the only production writer). `Subscription` and `Hybrid` cannot currently appear. |
+| **Overdraft** | The configured cap on extra spend — a *capacity*, not current debt, and not included in Available. Requires the hidden `has_payment_instrument = true` and a non-prepaid plan. Defaults to `BILLING_DEFAULT_OVERDRAFT_CAP_CREDITS` = 0. | **Inert today.** `has_payment_instrument` is only ever written `false` (`provisioning.rs:77`); no production code sets it true. Combined with the always-`Prepaid` plan, the overdraft branch is unreachable. |
+| **Synced** | When `balance_credits` was last refreshed from Lago — by webhook or by the reconcile sweep (`BILLING_RECONCILE_INTERVAL_SECS`, default 300s). | Applies to **Balance only**. Reserved and every usage number are NyxID-local and live. |
+
+### Empty / error states
+
+| State | Trigger |
+|---|---|
+| **"No wallet provisioned." + Provision Wallet** | Only when the wallet request fails with error code **11301 `BillingNotConfigured`** (HTTP 402). The button calls `POST /billing/wallet`, which idempotently ensures the Lago customer, subscription, wallet, and local row. Toast on success: "Billing wallet provisioned" — shown whether or not anything was actually created. |
+| **Error banner + Retry** | Any other wallet failure. Message is the server's, falling back to "Failed to load billing wallet." |
+
+**About 11301.** Across the subsystem it means *Lago client absent* (`services/billing/mod.rs:98-106`),
+*rate-cache entry missing or stale* (`reservation.rs:1073`), or *no Lago client for a receipt*
+(`handlers/billing.rs:583`). On the wallet request specifically it means **Lago is unconfigured** —
+not "you have no wallet", since `GET /billing/wallet` auto-provisions when Lago works
+(`handlers/billing.rs:334-342`). See gap 3.
+
+---
+
+## 4. Top Up card
+
+| UI element | Meaning |
+|---|---|
+| **"Add credits through hosted checkout."** | Payment runs through Stripe *underneath Lago*; NyxID never touches card data. |
+| **Credits input** | Whole credits to buy = whole USD. Range **1 to 10,000,000**, step 1, default 100 — enforced on both sides (`billing.tsx:69-75`; `services/billing/provisioning.rs:119-128`). Not an invoice total: no fees or tax shown. |
+| **Checkout** | `POST /billing/topup` with a fresh browser-generated UUID as `idempotency_key`, then **navigates the current tab** to the hosted `checkout_url` (`openExternal` = `window.location.assign`, `lib/navigation.ts:4-6`). Clicking it does not mean payment succeeded. |
+
+| Concept | Meaning |
+|---|---|
+| **Idempotency key** | Stops a double-click from creating two payments. Reusing a key with a *different* amount is a 409 Conflict; reusing it with the same amount returns the existing checkout (`reused: true`). |
+| **Paid vs granted credits** | A top-up sends `paid_credits` only; `granted_credits` (Lago's free/promotional bucket, which is *additive*) is forced to `"0"` so a purchase never mints double (`lago_client.rs:302-317`, bug #1050). |
+
+**The creation-status enum you never see.** `POST /billing/topup` returns its own lifecycle state,
+distinct from the history table's (`models/billing_topup_session.rs:7-13`):
+
+| Value | Meaning |
+|---|---|
+| `pending` | Local idempotent session stored; the provider call has not completed. |
+| `checkout_created` | Lago produced the wallet transaction, finalized invoice, and hosted URL. Payment still unpaid. |
+| `failed` | Creating the Lago transaction or checkout failed — surfaces as an error toast. |
+
+---
+
+## 5. Usage card
+
+Backed by `GET /api/v1/billing/usage?period=` (`handlers/billing.rs:183-301`), aggregated from the
+`usage_meter` ledger and grouped by service × layer × metric × ack state.
+
+**Which rows exist at all:** only charged usage — a non-null `quantity` and `wallet_id`, and a status
+of `finalized` (or `dead_letter` that was actually forwarded). In-flight `reserved`/`forwarded` work
+and observability-only metering are excluded (`handlers/billing.rs:191-207`).
+
+### Header
+
+| UI element | Meaning |
+|---|---|
+| **"Per-service quantity and estimated cost."** | The only place on the page that says *estimated*. |
+| **Unlabeled number beside the ↻ icon** | The **total estimated cost** for the period, `totals.estimated_credits_micros / 1e6`. `-` when no estimate exists at all. It is not a refresh button. |
+
+### Totals strip
+
+| Label | Meaning | Caveat |
+|---|---|---|
+| **Quantity** | Sum of every row's `quantity`. | Rows use **different units**; tokens, requests, and bytes are added together. |
+| **Requests** | Sum of quantity **for rows whose metric is `requests`**. | A token-metered LLM service contributes 0, even though it served requests. |
+| **Bytes** | Sum of quantity **for rows whose metric is `bytes`**. | Same shape of undercount. |
+| **Events** | Count of underlying ledger documents. | Not a request count: one request can write a platform *and* a resale row, and WS/SSH sessions write one per flush. |
+
+### Table columns
+
+| Column | Meaning | Source |
+|---|---|---|
+| **Service** | `service_slug`, else `service_id`, else **Unknown** (neither present on the row). | `UsageMeterRow.service_slug` |
+| **Layer** | `Platform` or `Resale` — see §0. | `UsageMeterRow.layer` |
+| **Metric** | The unit counted: **Tokens** (LLM tokens), **Requests** (one per call), **Bytes** (payload volume). The admin's `platform_metric` override wins; otherwise the heuristic is WebSocket/SSH → bytes, `llm-` slug → tokens, everything else → requests (`handlers/proxy.rs:3136-3158`). | `UsageMeterRow.metric` |
+| **Quantity** | Metered units for that group, in the unit named by Metric. | `$sum: quantity` |
+| **Cost** | `credits_per_unit_micros × quantity` from the cached rate card (`billing_rate_cache`), in credits to 6 decimals. **Recomputed at read time from the *current* rate** — not a rate captured with the usage — so a repricing retroactively changes the cost shown for old usage. | `handlers/billing.rs:250-256` |
+| **Status → Acked** | Lago accepted the usage event, *or* reported its transaction id as an already-applied duplicate. Says nothing about whether an invoice was paid. | `lago_acked: true` |
+| **Status → Pending** | Lago has not acknowledged the row. Usually a new or retrying row — but forwarded `dead_letter` rows are included by the query and stay unacked **permanently** without operator action, so Pending is not always transient. | `lago_acked: false` |
+| **Status → Free** | Metered without cost, never pushed to Lago. | `billable: false` — unreachable, see gap 4 |
+
+Empty state: **"No usage in this period."** — which does not prove there was no traffic, only no
+finalized wallet-backed rows. On a usage error the page still passes an empty array down, so the
+error banner and this text can appear together.
+
+---
+
+## 6. Top-up history card
+
+Backed by `GET /api/v1/billing/topups?page=&per_page=&period=` (`handlers/billing.rs:429-558`),
+newest first, 10 per page. NyxID stores only that a checkout was created; the payment outcome is read
+live from Lago's credit invoices on each request.
+
+| Column | Meaning |
+|---|---|
+| **Date** | When the **checkout was created** (`created_at`) — not when payment completed, and not Lago's invoice issuing date, even on a Paid row. |
+| **Credits** | Credits requested (= USD). |
+| **Invoice** | Lago's human-facing invoice number. `—` while unresolved — invoice attachment is asynchronous, and the handler backfills the link through Lago's wallet transactions when it can. |
+| **Status** | See below. |
+| **Actions** | **Resume payment** (pending only; **navigates the current tab** to the stored checkout URL). **Download receipt** (paid only; resolves a signed Lago URL and opens it in a **new tab** — `window.open(_blank)`, `use-billing.ts:103`). `—` otherwise. |
+
+### Status values (computed at read time, `handlers/billing.rs:519-535`)
+
+| Status | Meaning |
+|---|---|
+| **Paid** | The Lago credit invoice reports `payment_status = succeeded`. The only status that enables a receipt. |
+| **Pending** | No decisive Lago outcome, the local session is not failed, and it is under 24h old. Covers both local `pending` and `checkout_created`. Resumable when a URL was stored. |
+| **Expired** | No decisive Lago outcome and over 24h old. Stripe checkout sessions expire after 24 hours and Lago returns the same cached session per transaction, so it can no longer be completed — start a new top-up. Computed by NyxID; **not** a Lago status. |
+| **Failed** | Lago reports `payment_status = failed`, or the local session itself failed before checkout existed. |
+| **Voided** | The Lago invoice lifecycle status is `voided`. Checked before payment status. |
+
+**`receipt_available` means eligible, not generated.** It is set `true` for every Paid row
+(`handlers/billing.rs:546`). Clicking asks Lago to produce the PDF and briefly retries; if generation
+is incomplete the backend returns "The receipt is still being generated; try again shortly".
+
+**Degraded mode:** if Lago is unreachable the endpoint does not fail — it falls back to local session
+state (`handlers/billing.rs:470-476`). Everything then reads Pending/Expired/Failed with no invoice
+numbers and no receipts.
+
+> **Two status enums share the same words.** The *history* status above is derived per-request from
+> Lago. The *session* status in MongoDB (§4) is `pending` / `checkout_created` / `failed` and describes
+> only checkout creation. Usage `Pending` (§5) is a third, unrelated meaning: no Lago ack.
+
+---
+
+## 7. Gaps and naming issues
+
+Ranked by how likely a user is to be misled.
+
+1. **Overdraft is inert, but the card shows it as a live capability.** `has_payment_instrument` is
+   only ever written `false` (`provisioning.rs:77`) and `plan_kind` is only ever written `Prepaid`
+   (`provisioning.rs:73`) — the two conditions the overdraft branch requires
+   (`reservation.rs:162-179`). The Overdraft row is a number that can never be spent. Either hide it
+   until a payment instrument exists, or label it "not available".
+
+2. **Plan and collection state advertise values the system cannot produce.** `Subscription` /
+   `Hybrid` have no writer; `past_due` has **no writer anywhere in the tree** (only the enum and the
+   Zod schema). The UI implies a state machine that is not implemented.
+
+3. **The "Provision Wallet" empty state is a dead end — its button is always disabled.** It renders
+   only on 11301 (`billing.tsx:604-606`). `GET /billing/wallet` auto-provisions on miss, so 11301
+   there means Lago is unconfigured — which is exactly what makes `billingReady` false and disables
+   the button (`billing.tsx:382`). The one screen offering "Provision Wallet" is the one where
+   provisioning cannot work. It needs an explanation, not a disabled button.
+
+4. **The "Free" badge is unreachable.** The usage query filters to `wallet_id != null`, then derives
+   `billable` from the presence of that same field (`handlers/billing.rs:196`, `:223`) — so
+   `billable` is always `true`. The `Free` badge and the `—` cost path (`billing.tsx:511-521`) are
+   dead code. Either drop the branch or stop excluding observability rows.
+
+5. **Org-billed usage is invisible here.** Usage keys on `auth_user.user_id` and the wallet resolves
+   to `PaysFrom::Personal`, but an org member's requests are metered under the *org's*
+   `billing_owner_id`. That spend appears on nobody's billing page, and the org wallet has no UI at
+   all. There is no owner switcher.
+
+6. **"Quantity" totals add incompatible units.** Tokens + requests + bytes summed into one unitless
+   number (`billing.tsx:477`, `handlers/billing.rs:282`). Bytes dominate by orders of magnitude, so
+   for any mixed account the number is meaningless.
+
+7. **"Requests" and "Bytes" totals undercount.** They sum only rows whose *metric* is that unit
+   (`handlers/billing.rs:264-273`). The Requests tile is not "requests you made".
+
+8. **Cost is an estimate at the current rate, and the table never says so.** `rates_are_approximate`
+   is always true and never rendered; the estimate is recomputed from today's cached rate, so a
+   repricing rewrites history. Worse, `sum_optional` silently skips rows with no cached rate
+   (`handlers/billing.rs:754-762`) — the total can be **partial with no warning**, and only shows `-`
+   when *every* row lacks a rate. Header should read "Est. cost" and flag partial totals.
+
+9. **`Balance − Reserved ≠ Available` on screen.** `pending_lago_debits` is subtracted but never
+   shown. The CLI displays it; the web page should too, or explain the gap in a tooltip.
+
+10. **Usage "Pending" can be permanent.** Forwarded `dead_letter` rows are included in the query and
+    never become Acked without operator action (`handlers/billing.rs:199-207`). They look like
+    normal in-flight rows.
+
+11. **Top-up history has no error state.** The component never checks `historyQuery.isError` and
+    retries are disabled, so a failed load renders **"No top-ups yet."** (`billing.tsx:216-266`).
+    A payment history that silently reads "empty" on failure is the worst possible default.
+
+12. **History status can regress to "Expired".** `credit_invoices` fetches `per_page=100` with no
+    pagination and turns any fetch error into an empty list (`lago_client.rs:496-502`,
+    `handlers/billing.rs:470-476`). With no matching invoice, age alone relabels an old **paid**
+    top-up as Expired.
+
+13. **Inconsistent navigation.** Checkout and Resume payment **replace the current tab**
+    (`window.location.assign`); Download receipt opens a **new** tab (`window.open(_blank)`). Leaving
+    the app mid-session to pay should at minimum be consistent, and probably a new tab.
+
+14. **"All time" means two different things** — 10 years for Usage, unbounded for Top-up history
+    (`handlers/billing.rs:712`, `:445-450`) — from a single shared selector.
+
+15. **"Synced" reads as if it covers the whole card.** It sits beside Plan and Overdraft but applies
+    only to Balance.
+
+16. **Owner is a raw UUID** with no display name.
+
+17. **The total cost is unlabeled and looks like a control** — it sits next to a `RefreshCw` icon
+    with no caption (`billing.tsx:470-473`). Label it, and either wire up or remove the icon.
+
+18. **`lago_metric_code` is fetched but never shown** (`schemas/billing.ts:28`) — the one field that
+    would let a user reconcile a line against their Lago invoice.

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -3,7 +3,6 @@ import { toast } from "sonner";
 import {
   ChevronDown,
   ChevronRight,
-  CreditCard,
   ExternalLink,
   Info,
   Plus,
@@ -35,6 +34,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -64,7 +72,6 @@ const TOP_UP_PRESETS = [100, 500, 1_000, 5_000] as const;
 
 export function BillingPage() {
   const [period, setPeriod] = useState<BillingUsagePeriod>("30d");
-  const [topUpCredits, setTopUpCredits] = useState(String(DEFAULT_TOP_UP_CREDITS));
   const walletQuery = useBillingWallet();
   const usageQuery = useBillingUsage(period);
   const provisionWallet = useProvisionBillingWallet();
@@ -76,13 +83,6 @@ export function BillingPage() {
   const billingReady =
     Boolean(billingCapability?.charging_enabled) &&
     Boolean(billingCapability?.lago_configured);
-  const topUpAmount = Number(topUpCredits);
-  const topUpDisabled =
-    !billingReady ||
-    !Number.isInteger(topUpAmount) ||
-    topUpAmount <= 0 ||
-    topUpAmount > 10_000_000 ||
-    topUpBilling.isPending;
 
   async function handleProvisionWallet() {
     try {
@@ -93,12 +93,10 @@ export function BillingPage() {
     }
   }
 
-  async function handleTopUp() {
-    if (topUpDisabled) return;
-
+  async function handleTopUp(amountCredits: number) {
     try {
       const checkout = await topUpBilling.mutateAsync({
-        amount_credits: topUpAmount,
+        amount_credits: amountCredits,
         idempotency_key: crypto.randomUUID(),
       });
       openExternal(checkout.checkout_url);
@@ -148,96 +146,18 @@ export function BillingPage() {
         </div>
       )}
 
-      {/* items-start: expanding the wallet breakdown must not stretch Top Up. */}
-      <div className="grid items-start gap-4 xl:grid-cols-[1.2fr_0.8fr]">
-        <WalletCard
-          wallet={wallet}
-          loading={walletQuery.isLoading}
-          unavailable={walletUnavailable}
-          error={walletQuery.error}
-          onRetry={() => void walletQuery.refetch()}
-          onProvision={() => void handleProvisionWallet()}
-          provisioning={provisionWallet.isPending}
-          billingReady={billingReady}
-        />
-
-        <Card>
-          <CardHeader className="flex-row items-center justify-between space-y-0">
-            <div>
-              <CardTitle>Add credits</CardTitle>
-              <p className="mt-1 text-[12px] text-muted-foreground">
-                1 credit = 1 USD. Credits never expire.
-              </p>
-            </div>
-            <CreditCard className="h-4 w-4 text-text-tertiary" />
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <span className="text-[12px] font-medium">Amount</span>
-              <div className="flex flex-wrap gap-2">
-                {TOP_UP_PRESETS.map((preset) => (
-                  <Button
-                    key={preset}
-                    variant={
-                      topUpAmount === preset && topUpCredits !== ""
-                        ? "secondary"
-                        : "outline"
-                    }
-                    size="sm"
-                    disabled={!billingReady || topUpBilling.isPending}
-                    onClick={() => setTopUpCredits(String(preset))}
-                  >
-                    {formatNumber(preset)}
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-[12px] font-medium" htmlFor="topup-credits">
-                Or enter an amount
-              </label>
-              <div className="flex items-center gap-3">
-                <Input
-                  id="topup-credits"
-                  type="number"
-                  min={1}
-                  max={10_000_000}
-                  step={1}
-                  value={topUpCredits}
-                  onChange={(event) => setTopUpCredits(event.target.value)}
-                  disabled={!billingReady || topUpBilling.isPending}
-                  aria-describedby="topup-total"
-                />
-                <span
-                  id="topup-total"
-                  className="shrink-0 text-[13px] text-muted-foreground"
-                >
-                  {formatUsd(topUpAmount)}
-                </span>
-              </div>
-            </div>
-
-            <Button
-              variant="primary"
-              className="w-full"
-              disabled={topUpDisabled}
-              isLoading={topUpBilling.isPending}
-              onClick={() => void handleTopUp()}
-            >
-              <ButtonIcon variant="primary">
-                <ExternalLink className="h-3 w-3" />
-              </ButtonIcon>
-              Continue to payment
-            </Button>
-            <p className="text-[11px] leading-relaxed text-muted-foreground">
-              {billingReady
-                ? "We'll hand you to Stripe to pay, then bring you back here. Credits land once the payment clears."
-                : "Payments aren't enabled on this deployment yet."}
-            </p>
-          </CardContent>
-        </Card>
-      </div>
+      <WalletCard
+        wallet={wallet}
+        loading={walletQuery.isLoading}
+        unavailable={walletUnavailable}
+        error={walletQuery.error}
+        onRetry={() => void walletQuery.refetch()}
+        onProvision={() => void handleProvisionWallet()}
+        provisioning={provisionWallet.isPending}
+        billingReady={billingReady}
+        onTopUp={handleTopUp}
+        topUpPending={topUpBilling.isPending}
+      />
 
       <UsageSummary
         rows={usageQuery.data?.rows ?? []}
@@ -397,6 +317,8 @@ function WalletCard({
   onProvision,
   provisioning,
   billingReady,
+  onTopUp,
+  topUpPending,
 }: {
   readonly wallet: BillingWalletResponse | undefined;
   readonly loading: boolean;
@@ -406,6 +328,8 @@ function WalletCard({
   readonly onProvision: () => void;
   readonly provisioning: boolean;
   readonly billingReady: boolean;
+  readonly onTopUp: (amountCredits: number) => Promise<void>;
+  readonly topUpPending: boolean;
 }) {
   const [showBreakdown, setShowBreakdown] = useState(false);
 
@@ -489,23 +413,26 @@ function WalletCard({
             <div className="mt-1 text-[11px] text-muted-foreground">
               Updated {formatRelativeTime(wallet.balance_synced_at)}
             </div>
+            <button
+              type="button"
+              aria-expanded={showBreakdown}
+              aria-controls="wallet-breakdown"
+              className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+              onClick={() => setShowBreakdown((current) => !current)}
+            >
+              {showBreakdown ? "Hide breakdown" : "View breakdown"}
+              <ChevronDown
+                className={`h-3 w-3 transition-transform ${
+                  showBreakdown ? "rotate-180" : ""
+                }`}
+              />
+            </button>
           </div>
-          <Button
-            variant="outline"
-            size="icon"
-            aria-expanded={showBreakdown}
-            aria-controls="wallet-breakdown"
-            aria-label={
-              showBreakdown ? "Hide balance breakdown" : "Show balance breakdown"
-            }
-            onClick={() => setShowBreakdown((current) => !current)}
-          >
-            <ChevronDown
-              className={`h-3.5 w-3.5 transition-transform ${
-                showBreakdown ? "rotate-180" : ""
-              }`}
-            />
-          </Button>
+          <AddCreditsDialog
+            billingReady={billingReady}
+            pending={topUpPending}
+            onTopUp={onTopUp}
+          />
         </div>
 
         {showBreakdown && (
@@ -552,6 +479,133 @@ function WalletCard({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Adding credits is the wallet's primary verb, so it lives on the wallet card.
+ * The amount form is bulky enough to crowd out the balance, so it opens in a
+ * dialog rather than sitting inline.
+ */
+function AddCreditsDialog({
+  billingReady,
+  pending,
+  onTopUp,
+}: {
+  readonly billingReady: boolean;
+  readonly pending: boolean;
+  readonly onTopUp: (amountCredits: number) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [credits, setCredits] = useState(String(DEFAULT_TOP_UP_CREDITS));
+
+  const amount = Number(credits);
+  const amountValid =
+    Number.isInteger(amount) && amount > 0 && amount <= 10_000_000;
+  const submitDisabled = !billingReady || !amountValid || pending;
+
+  const trigger = (
+    <Button variant="primary" disabled={!billingReady || pending}>
+      <ButtonIcon variant="primary">
+        <Plus className="h-3 w-3" />
+      </ButtonIcon>
+      Add credits
+    </Button>
+  );
+
+  // A disabled trigger swallows pointer events, so the reason has to sit on a
+  // wrapper rather than the button itself.
+  if (!billingReady) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0}>{trigger}</span>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          Payments aren&apos;t enabled on this deployment yet.
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>Add credits</DialogTitle>
+          <DialogDescription>
+            1 credit = 1 USD. Credits never expire.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <span className="text-[12px] font-medium">Amount</span>
+            <div className="flex flex-wrap gap-2">
+              {TOP_UP_PRESETS.map((preset) => (
+                <Button
+                  key={preset}
+                  variant={amount === preset ? "secondary" : "outline"}
+                  size="sm"
+                  disabled={pending}
+                  onClick={() => setCredits(String(preset))}
+                >
+                  {formatNumber(preset)}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-[12px] font-medium" htmlFor="topup-credits">
+              Or enter an amount
+            </label>
+            <div className="flex items-center gap-3">
+              <Input
+                id="topup-credits"
+                type="number"
+                min={1}
+                max={10_000_000}
+                step={1}
+                value={credits}
+                onChange={(event) => setCredits(event.target.value)}
+                disabled={pending}
+                aria-describedby="topup-total"
+              />
+              <span
+                id="topup-total"
+                className="shrink-0 text-[13px] text-muted-foreground"
+              >
+                {formatUsd(amount)}
+              </span>
+            </div>
+          </div>
+
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            We&apos;ll hand you to Stripe to pay, then bring you back here.
+            Credits land once the payment clears.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            disabled={submitDisabled}
+            isLoading={pending}
+            onClick={() => void onTopUp(amount)}
+          >
+            <ButtonIcon variant="primary">
+              <ExternalLink className="h-3 w-3" />
+            </ButtonIcon>
+            Continue to payment
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -1,16 +1,20 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
+  ChevronDown,
+  ChevronRight,
   CreditCard,
   ExternalLink,
+  Info,
   Plus,
-  RefreshCw,
   WalletCards,
 } from "lucide-react";
 import { ApiError } from "@/lib/api-client";
 import { openExternal } from "@/lib/navigation";
+import { formatRelativeTime } from "@/lib/utils";
 import {
   BILLING_USAGE_PERIODS,
+  type BillingMetric,
   type BillingUsagePeriod,
   type BillingUsageRow,
   type BillingWalletResponse,
@@ -40,6 +44,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import {
   Table,
@@ -51,6 +60,7 @@ import {
 } from "@/components/ui/table";
 
 const DEFAULT_TOP_UP_CREDITS = 100;
+const TOP_UP_PRESETS = [100, 500, 1_000, 5_000] as const;
 
 export function BillingPage() {
   const [period, setPeriod] = useState<BillingUsagePeriod>("30d");
@@ -138,7 +148,8 @@ export function BillingPage() {
         </div>
       )}
 
-      <div className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+      {/* items-start: expanding the wallet breakdown must not stretch Top Up. */}
+      <div className="grid items-start gap-4 xl:grid-cols-[1.2fr_0.8fr]">
         <WalletCard
           wallet={wallet}
           loading={walletQuery.isLoading}
@@ -153,29 +164,60 @@ export function BillingPage() {
         <Card>
           <CardHeader className="flex-row items-center justify-between space-y-0">
             <div>
-              <CardTitle>Top Up</CardTitle>
+              <CardTitle>Add credits</CardTitle>
               <p className="mt-1 text-[12px] text-muted-foreground">
-                Add credits through hosted checkout.
+                1 credit = 1 USD. Credits never expire.
               </p>
             </div>
             <CreditCard className="h-4 w-4 text-text-tertiary" />
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <label className="text-[12px] font-medium" htmlFor="topup-credits">
-                Credits
-              </label>
-              <Input
-                id="topup-credits"
-                type="number"
-                min={1}
-                max={10_000_000}
-                step={1}
-                value={topUpCredits}
-                onChange={(event) => setTopUpCredits(event.target.value)}
-                disabled={!billingReady || topUpBilling.isPending}
-              />
+              <span className="text-[12px] font-medium">Amount</span>
+              <div className="flex flex-wrap gap-2">
+                {TOP_UP_PRESETS.map((preset) => (
+                  <Button
+                    key={preset}
+                    variant={
+                      topUpAmount === preset && topUpCredits !== ""
+                        ? "secondary"
+                        : "outline"
+                    }
+                    size="sm"
+                    disabled={!billingReady || topUpBilling.isPending}
+                    onClick={() => setTopUpCredits(String(preset))}
+                  >
+                    {formatNumber(preset)}
+                  </Button>
+                ))}
+              </div>
             </div>
+
+            <div className="space-y-2">
+              <label className="text-[12px] font-medium" htmlFor="topup-credits">
+                Or enter an amount
+              </label>
+              <div className="flex items-center gap-3">
+                <Input
+                  id="topup-credits"
+                  type="number"
+                  min={1}
+                  max={10_000_000}
+                  step={1}
+                  value={topUpCredits}
+                  onChange={(event) => setTopUpCredits(event.target.value)}
+                  disabled={!billingReady || topUpBilling.isPending}
+                  aria-describedby="topup-total"
+                />
+                <span
+                  id="topup-total"
+                  className="shrink-0 text-[13px] text-muted-foreground"
+                >
+                  {formatUsd(topUpAmount)}
+                </span>
+              </div>
+            </div>
+
             <Button
               variant="primary"
               className="w-full"
@@ -186,8 +228,13 @@ export function BillingPage() {
               <ButtonIcon variant="primary">
                 <ExternalLink className="h-3 w-3" />
               </ButtonIcon>
-              Checkout
+              Continue to payment
             </Button>
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              {billingReady
+                ? "We'll hand you to Stripe to pay, then bring you back here. Credits land once the payment clears."
+                : "Payments aren't enabled on this deployment yet."}
+            </p>
           </CardContent>
         </Card>
       </div>
@@ -360,8 +407,10 @@ function WalletCard({
   readonly provisioning: boolean;
   readonly billingReady: boolean;
 }) {
+  const [showBreakdown, setShowBreakdown] = useState(false);
+
   if (loading) {
-    return <Skeleton className="h-[278px] w-full" />;
+    return <Skeleton className="h-[170px] w-full" />;
   }
 
   if (!wallet && unavailable) {
@@ -409,31 +458,135 @@ function WalletCard({
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between space-y-0">
-        <div>
-          <CardTitle>Wallet</CardTitle>
-          <p className="mt-1 text-[12px] text-muted-foreground">
-            Owner {wallet.owner_id}
-          </p>
-        </div>
-        <Badge variant={wallet.suspended ? "destructive" : "success"}>
-          {labelize(wallet.collection_state)}
-        </Badge>
+        <CardTitle>Wallet</CardTitle>
+        {wallet.suspended && <Badge variant="destructive">Suspended</Badge>}
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid gap-3 sm:grid-cols-3">
-          <MetricBlock label="Available" value={formatCredits(wallet.available_credits)} />
-          <MetricBlock label="Balance" value={formatCredits(wallet.balance_credits)} />
-          <MetricBlock label="Reserved" value={formatCredits(wallet.reserved_credits)} />
+      <CardContent>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <span className="text-[11px] text-muted-foreground">Balance</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="What this balance means"
+                    className="text-text-tertiary transition-colors hover:text-foreground"
+                  >
+                    <Info className="h-3 w-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-[260px] leading-relaxed">
+                  Credits held with our billing provider — 1 credit is 1 USD. This
+                  is a synced figure, refreshed periodically rather than read live,
+                  so a top-up or very recent usage can take a few minutes to show.
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <div className="mt-1 truncate text-[28px] font-semibold leading-tight">
+              {formatCredits(wallet.balance_credits)}
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              Updated {formatRelativeTime(wallet.balance_synced_at)}
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-expanded={showBreakdown}
+            aria-controls="wallet-breakdown"
+            aria-label={
+              showBreakdown ? "Hide balance breakdown" : "Show balance breakdown"
+            }
+            onClick={() => setShowBreakdown((current) => !current)}
+          >
+            <ChevronDown
+              className={`h-3.5 w-3.5 transition-transform ${
+                showBreakdown ? "rotate-180" : ""
+              }`}
+            />
+          </Button>
         </div>
-        <div className="grid gap-3 sm:grid-cols-3">
-          <Detail label="Plan" value={labelize(wallet.plan_kind)} />
-          <Detail label="Overdraft" value={formatCredits(wallet.overdraft_cap_credits)} />
-          <Detail label="Synced" value={formatDateTime(wallet.balance_synced_at)} />
-        </div>
+
+        {showBreakdown && (
+          <div id="wallet-breakdown">
+            <hr className="my-4 border-border" />
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Not all of your balance is spendable at any moment — requests in
+              flight hold credits until they finish.
+            </p>
+            <div className="mt-3 space-y-1.5">
+              <BreakdownRow
+                label="Available"
+                hint="Spendable right now"
+                value={formatCredits(wallet.available_credits)}
+                emphasis
+              />
+              <BreakdownRow
+                label="Reserved"
+                hint="Held for requests in flight"
+                value={formatCredits(wallet.reserved_credits)}
+              />
+              <BreakdownRow
+                label="Pending"
+                hint="Charged, awaiting provider sync"
+                value={formatCredits(wallet.pending_lago_debits)}
+              />
+              {wallet.overdraft_cap_credits > 0 && (
+                <BreakdownRow
+                  label="Overdraft"
+                  hint="Extra capacity beyond your balance"
+                  value={formatCredits(wallet.overdraft_cap_credits)}
+                />
+              )}
+            </div>
+            <hr className="my-3 border-border" />
+            <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+              <span>Plan</span>
+              <span className="text-foreground">{labelize(wallet.plan_kind)}</span>
+            </div>
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              Available = Balance − Reserved − Pending.
+            </p>
+          </div>
+        )}
       </CardContent>
     </Card>
   );
 }
+
+function BreakdownRow({
+  label,
+  hint,
+  value,
+  emphasis = false,
+}: {
+  readonly label: string;
+  readonly hint: string;
+  readonly value: string;
+  readonly emphasis?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <div className="min-w-0">
+        <div className={emphasis ? "text-[12px] font-medium" : "text-[12px]"}>
+          {label}
+        </div>
+        <div className="text-[11px] text-muted-foreground">{hint}</div>
+      </div>
+      <div
+        className={
+          emphasis
+            ? "shrink-0 text-[13px] font-semibold"
+            : "shrink-0 text-[13px] text-muted-foreground"
+        }
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
 
 function UsageSummary({
   rows,
@@ -452,7 +605,17 @@ function UsageSummary({
     | undefined;
   readonly loading: boolean;
 }) {
-  const groupedRows = useMemo(() => rows, [rows]);
+  const services = useMemo(() => groupByService(rows), [rows]);
+  const metricTotals = useMemo(() => sumByMetric(rows), [rows]);
+  const [expanded, setExpanded] = useState<readonly string[]>([]);
+
+  function toggle(key: string) {
+    setExpanded((current) =>
+      current.includes(key)
+        ? current.filter((entry) => entry !== key)
+        : [...current, key],
+    );
+  }
 
   if (loading) {
     return <Skeleton className="h-[320px] w-full" />;
@@ -460,69 +623,124 @@ function UsageSummary({
 
   return (
     <Card>
-      <CardHeader className="flex-row items-center justify-between space-y-0">
-        <div>
-          <CardTitle>Usage</CardTitle>
-          <p className="mt-1 text-[12px] text-muted-foreground">
-            Per-service quantity and estimated cost.
-          </p>
-        </div>
-        <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
-          <RefreshCw className="h-3.5 w-3.5" />
-          {formatEstimatedCredits(totals?.estimated_credits_micros)}
-        </div>
+      <CardHeader>
+        <CardTitle>Usage</CardTitle>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          Estimated cost per service. Expand a row for the model, agent, and
+          layer behind it.
+        </p>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid gap-3 sm:grid-cols-4">
-          <MetricBlock label="Quantity" value={formatNumber(totals?.quantity ?? 0)} />
-          <MetricBlock label="Requests" value={formatNumber(totals?.requests ?? 0)} />
-          <MetricBlock label="Bytes" value={formatNumber(totals?.bytes ?? 0)} />
-          <MetricBlock label="Events" value={formatNumber(totals?.events ?? 0)} />
+          <MetricBlock
+            label="Est. cost"
+            value={formatEstimatedCredits(totals?.estimated_credits_micros)}
+          />
+          <MetricBlock label="Tokens" value={formatNumber(metricTotals.tokens)} />
+          <MetricBlock label="Requests" value={formatNumber(metricTotals.requests)} />
+          <MetricBlock label="Bytes" value={formatNumber(metricTotals.bytes)} />
         </div>
         <div className="overflow-hidden rounded-lg border border-border">
           <Table>
             <TableHeader>
               <TableRow>
                 <TableHead>Service</TableHead>
-                <TableHead>Layer</TableHead>
-                <TableHead>Metric</TableHead>
-                <TableHead className="text-right">Quantity</TableHead>
-                <TableHead className="text-right">Cost</TableHead>
+                <TableHead>Usage</TableHead>
+                <TableHead className="text-right">Est. cost</TableHead>
                 <TableHead>Status</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {groupedRows.length === 0 ? (
+              {services.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                  <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
                     No usage in this period.
                   </TableCell>
                 </TableRow>
               ) : (
-                groupedRows.map((row, index) => (
-                  <TableRow key={`${row.service_id ?? row.service_slug ?? "service"}-${row.layer}-${row.metric}-${index}`}>
-                    <TableCell className="font-medium">
-                      {row.service_slug ?? row.service_id ?? "Unknown"}
-                    </TableCell>
-                    <TableCell>{labelize(row.layer)}</TableCell>
-                    <TableCell>{labelize(row.metric)}</TableCell>
-                    <TableCell className="text-right">{formatNumber(row.quantity)}</TableCell>
-                    <TableCell className="text-right">
-                      {row.billable === false
-                        ? "—"
-                        : formatEstimatedCredits(row.estimated_credits_micros)}
-                    </TableCell>
-                    <TableCell>
-                      {row.billable === false ? (
-                        <Badge variant="secondary">Free</Badge>
-                      ) : (
-                        <Badge variant={row.lago_acked ? "success" : "secondary"}>
-                          {row.lago_acked ? "Acked" : "Pending"}
-                        </Badge>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))
+                services.map((service) => {
+                  const isOpen = expanded.includes(service.key);
+                  return (
+                    <Fragment key={service.key}>
+                      <TableRow
+                        className="cursor-pointer"
+                        onClick={() => toggle(service.key)}
+                      >
+                        <TableCell className="font-medium">
+                          <button
+                            type="button"
+                            aria-expanded={isOpen}
+                            aria-label={`${isOpen ? "Collapse" : "Expand"} ${service.label}`}
+                            className="flex items-center gap-1.5 text-left"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              toggle(service.key);
+                            }}
+                          >
+                            <ChevronRight
+                              className={`h-3.5 w-3.5 shrink-0 text-text-tertiary transition-transform ${
+                                isOpen ? "rotate-90" : ""
+                              }`}
+                            />
+                            <span className="truncate">{service.label}</span>
+                          </button>
+                        </TableCell>
+                        <TableCell className="text-muted-foreground">
+                          {describeUsage(service)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatEstimatedCredits(service.costMicros)}
+                        </TableCell>
+                        <TableCell>
+                          <UsageStatusBadge
+                            billable={service.billable}
+                            acked={service.allAcked}
+                          />
+                        </TableCell>
+                      </TableRow>
+                      {isOpen &&
+                        service.rows.map((row, index) => (
+                          <TableRow
+                            key={`${service.key}-detail-${row.layer}-${row.metric}-${row.model ?? ""}-${row.api_key_id ?? ""}-${index}`}
+                            className="bg-overlay hover:bg-overlay"
+                          >
+                            <TableCell className="py-2 pl-9">
+                              <div className="flex flex-wrap items-center gap-1.5 text-[12px]">
+                                <Badge variant="secondary">
+                                  {labelize(row.layer)}
+                                </Badge>
+                                {row.model && <span>{row.model}</span>}
+                                <span className="text-muted-foreground">
+                                  {describeAgent(row)}
+                                </span>
+                              </div>
+                              <div className="mt-0.5 text-[11px] text-text-tertiary">
+                                {formatNumber(row.events)}{" "}
+                                {row.events === 1 ? "event" : "events"} ·{" "}
+                                {row.lago_metric_code}
+                              </div>
+                            </TableCell>
+                            <TableCell className="py-2 align-top text-[12px] text-muted-foreground">
+                              {formatNumber(row.quantity)} {row.metric}
+                            </TableCell>
+                            <TableCell className="py-2 text-right align-top text-[12px] tabular-nums">
+                              {row.billable === false
+                                ? "—"
+                                : formatEstimatedCredits(
+                                    row.estimated_credits_micros,
+                                  )}
+                            </TableCell>
+                            <TableCell className="py-2 align-top">
+                              <UsageStatusBadge
+                                billable={row.billable !== false}
+                                acked={row.lago_acked}
+                              />
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                    </Fragment>
+                  );
+                })
               )}
             </TableBody>
           </Table>
@@ -532,20 +750,112 @@ function UsageSummary({
   );
 }
 
+function UsageStatusBadge({
+  billable,
+  acked,
+}: {
+  readonly billable: boolean;
+  readonly acked: boolean;
+}) {
+  if (!billable) {
+    return <Badge variant="secondary">Free</Badge>;
+  }
+  return (
+    <Badge variant={acked ? "success" : "secondary"}>
+      {acked ? "Acked" : "Pending"}
+    </Badge>
+  );
+}
+
+type ServiceGroup = {
+  readonly key: string;
+  readonly label: string;
+  readonly rows: readonly BillingUsageRow[];
+  readonly costMicros: number | null;
+  readonly metrics: readonly BillingMetric[];
+  readonly quantity: number;
+  readonly allAcked: boolean;
+  readonly billable: boolean;
+};
+
+/**
+ * Collapse the flat ledger rows into one row per service.
+ *
+ * The API already splits a service across layer, metric, model, agent, and ack
+ * state, so a single service routinely spans several rows. Costs are summed
+ * (credits are a common unit); quantities are only summed when every row shares
+ * one metric, because tokens, requests, and bytes cannot be meaningfully added.
+ */
+function groupByService(
+  rows: readonly BillingUsageRow[],
+): readonly ServiceGroup[] {
+  const groups = new Map<string, BillingUsageRow[]>();
+  for (const row of rows) {
+    const key = row.service_slug ?? row.service_id ?? "unknown";
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(row);
+    } else {
+      groups.set(key, [row]);
+    }
+  }
+
+  return [...groups.entries()].map(([key, groupRows]) => {
+    const costs = groupRows
+      .map((row) => row.estimated_credits_micros)
+      .filter((value): value is number => typeof value === "number");
+    const metrics = [...new Set(groupRows.map((row) => row.metric))];
+    return {
+      key,
+      label: groupRows[0]?.service_slug ?? groupRows[0]?.service_id ?? "Unknown",
+      rows: groupRows,
+      costMicros: costs.length > 0 ? costs.reduce((a, b) => a + b, 0) : null,
+      metrics,
+      quantity: groupRows.reduce((total, row) => total + row.quantity, 0),
+      allAcked: groupRows.every((row) => row.lago_acked),
+      billable: groupRows.some((row) => row.billable !== false),
+    };
+  });
+}
+
+/** Per-metric totals, so unlike units are never added into one number. */
+function sumByMetric(rows: readonly BillingUsageRow[]): Record<BillingMetric, number> {
+  const totals: Record<BillingMetric, number> = {
+    tokens: 0,
+    requests: 0,
+    bytes: 0,
+  };
+  for (const row of rows) {
+    totals[row.metric] += row.quantity;
+  }
+  return totals;
+}
+
+function describeUsage(service: ServiceGroup): string {
+  const [metric] = service.metrics;
+  if (service.metrics.length === 1 && metric) {
+    return `${formatNumber(service.quantity)} ${metric}`;
+  }
+  return `${String(service.metrics.length)} metrics`;
+}
+
+/**
+ * A null `api_key_id` only tells us the request was not attributed to an agent
+ * key — it could be browser session, service-account, delegated, or relay auth,
+ * and the ledger does not record which. Say that, rather than guessing
+ * "Session".
+ */
+function describeAgent(row: BillingUsageRow): string {
+  if (row.api_key_name) return row.api_key_name;
+  if (row.api_key_id) return "Unnamed key";
+  return "No agent key";
+}
+
 function MetricBlock({ label, value }: { readonly label: string; readonly value: string }) {
   return (
     <div className="rounded-lg border border-border/70 bg-overlay px-3 py-3">
       <div className="text-[11px] text-muted-foreground">{label}</div>
       <div className="mt-1 truncate text-[20px] font-semibold leading-tight">{value}</div>
-    </div>
-  );
-}
-
-function Detail({ label, value }: { readonly label: string; readonly value: string }) {
-  return (
-    <div>
-      <div className="text-[11px] text-muted-foreground">{label}</div>
-      <div className="mt-1 text-[12px] text-foreground">{value}</div>
     </div>
   );
 }
@@ -577,6 +887,17 @@ function formatCredits(value: number): string {
   return `${formatNumber(value)} credits`;
 }
 
+/** Credits are 1:1 with USD, so the charge is worth stating outright. */
+function formatUsd(credits: number): string {
+  if (!Number.isFinite(credits) || credits <= 0) {
+    return "—";
+  }
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+  }).format(credits);
+}
+
 function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value);
 }
@@ -588,17 +909,6 @@ function formatEstimatedCredits(value: number | null | undefined): string {
   return `${new Intl.NumberFormat(undefined, {
     maximumFractionDigits: 6,
   }).format(value / 1_000_000)} credits`;
-}
-
-function formatDateTime(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "-";
-  }
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
 }
 
 function isBillingNotConfigured(error: unknown): boolean {

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -26,6 +26,11 @@ export const billingUsageRowSchema = z.object({
   metric: billingMetricSchema,
   lago_metric_code: z.string(),
   layer: z.string(),
+  // Optional so an older backend without the model/agent breakdown still
+  // parses; the UI degrades to a service-level row.
+  model: z.string().nullable().optional(),
+  api_key_id: z.string().nullable().optional(),
+  api_key_name: z.string().nullable().optional(),
   quantity: z.number().int(),
   requests: z.number().int(),
   bytes: z.number().int(),


### PR DESCRIPTION
## What

Reworks the Billing page. Three problems it fixes:

1. The wallet showed **Available / Balance / Reserved** as co-equal tiles whose arithmetic did not visibly add up, because `pending_lago_debits` is subtracted from Available but was never displayed.
2. The usage total summed **tokens + requests + bytes** into one unitless number. Bytes dominate by orders of magnitude, so for any mixed account it was meaningless.
3. There was no way to see **which model or agent** produced a charge.

## Wallet card

- Leads with **Balance** alone. Available / Reserved / Pending / Overdraft / Plan move into an inline disclosure under a rule — not a popover, which floated over the neighbouring cards.
- `pending_lago_debits` is surfaced for the first time, so `Balance − Reserved − Pending = Available` is checkable on screen.
- Info tooltip: 1 credit = 1 USD, and the figure is *synced* periodically rather than read live.
- `Updated Nm ago`, from `balance_synced_at`.
- **Add credits** is now the card's primary action rather than a separate card beside it — balance and the verb that changes it are one concern. The amount form would crowd out the balance, so it opens in a dialog. Full CTA path: `Add credits` → pick amount → `Continue to payment` → Stripe. The breakdown toggle drops to a text link so the card has one obvious primary action.

**Two removals worth review attention:**

- **Owner UUID line.** `GET /billing/wallet` resolves via `resolve_for_wallet_management(actor, None)`, which always yields `PaysFrom::Personal` — it could only ever print the viewer's own id.
- **Collection-state badge.** `past_due` has no writer anywhere in the tree, and both `suspend_wallet` call sites (`reservation.rs:142`, `:179`) require a non-prepaid plan or `has_payment_instrument`, neither of which any production path sets (`provisioning.rs:73`, `:77`). It could only ever render a green "Good". A conditional `Suspended` badge remains as a fail-safe.

## Usage card

- Grouped per service, expandable. Detail rows are **real table rows sharing the parent column grid**, so costs align by construction.
- Per-metric totals (Est. cost / Tokens / Requests / Bytes) replace the mixed-unit sum. A service only shows a summed quantity when every row shares one metric; otherwise "N metrics".
- Surfaces `events` and `lago_metric_code` — both already fetched and discarded. The metric code is what lets a user reconcile a line against their Lago invoice.

## Backend

`model` and `api_key_id` added to the usage aggregation's `$group._id`, plus a batched `api_key_name` lookup filtered on `user_id: owner_id`, so the UI shows agent names, never raw UUIDs, and never another owner's key name. Rows for deleted or foreign keys resolve to `None`.

Note the detail label for a null `api_key_id` is **"No agent key"**, not "Session" — a null key could be browser session, service-account, delegated, or relay auth, and the ledger does not record which.

## Add credits (was Top Up)

Preset amounts, a live USD total beside the input, and copy stating that Stripe handles payment and credits land once it clears. Disabled state explains itself via tooltip: *"Payments aren't enabled on this deployment yet."*

Checkout still navigates the current tab deliberately: the URL only exists after an awaited mutation, so `window.open` there is a popup-blocker magnet.

## Docs

`docs/BILLING_UI_GLOSSARY.md` defines every term on the page — meaning, backing API field, and where the number is computed — plus a ranked list of remaining gaps.

## Known gaps, not addressed here

- **Overdraft is inert.** `has_payment_instrument` is only ever written `false` and `plan_kind` only ever `Prepaid`, so the overdraft branch is unreachable. The card still displays the cap.
- **Usage cannot be broken down by session.** `usage_meter` carries no session id. `AuthUser.session_id` exists but is populated only for `AuthMethod::Session` — it is `None` for API-key auth, which is most billable proxy traffic. For WS/SSH, `billing_request_id` already identifies one connection and would be the right basis for a per-session drill-down, but as a separate paginated endpoint rather than more `$group` keys.
- **Top-up history has no error state**; a failed load still renders "No top-ups yet."

## Testing

- Backend: `cargo test` — **6015 passed, 0 failed** (includes the wizard bundle freshness check).
- Frontend: `npm run test` — **2406 passed across 196 files**.
- `tsc -b` and `eslint` clean.
- Verified end to end against a local backend with seeded data (5 services, 2 layers, 4 models, 3 named agents): wallet, usage, and top-up endpoints all return correctly and agent names resolve.

Not visually verified by me — no browser host available in the session that produced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)