### PR TITLE
fix(oauth): run plugins-page OAuth in the managed popup

### DIFF
--- a/frontend/src/components/assistant/plugins-view.test.tsx
+++ b/frontend/src/components/assistant/plugins-view.test.tsx
@@ -15,23 +15,34 @@ const mocks = vi.hoisted(() => ({
   useUpdateKey: vi.fn(),
   useDeleteKey: vi.fn(),
   useUpdateExternalApiKey: vi.fn(),
+  addDialogProps: null as {
+    readonly launch?: "popup";
+    readonly flow?: "cc";
+    readonly onPopupViewResult?: (keyId: string) => boolean;
+  } | null,
 }));
 
 // The full add-service dialog has its own test suite and many hooks; stub it
-// to a marker so this test only asserts Connect opens it with the right slug.
+// to a marker so this test only asserts Connect opens it with the right slug
+// and hands it the popup contract.
 vi.mock("@/components/dashboard/add-key-dialog", () => ({
   AddKeyDialog: ({
     open,
     prefillSlug,
+    ...props
   }: {
     readonly open: boolean;
     readonly prefillSlug?: string;
+    readonly launch?: "popup";
+    readonly flow?: "cc";
+    readonly onPopupViewResult?: (keyId: string) => boolean;
   }) =>
+    ((mocks.addDialogProps = props),
     open ? (
       <div role="dialog" aria-label="Add service" data-prefill={prefillSlug}>
         Add service dialog
       </div>
-    ) : null,
+    ) : null),
 }));
 
 vi.mock("@/hooks/use-keys", () => ({
@@ -155,6 +166,7 @@ describe("PluginsView", () => {
     vi.clearAllMocks();
     resetSkillCatalog();
     mockLoaded();
+    mocks.addDialogProps = null;
     // Manage-modal hooks: a fully-shaped key + no-op mutations.
     mocks.useKey.mockReturnValue({
       data: {
@@ -202,6 +214,32 @@ describe("PluginsView", () => {
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     const dialog = await screen.findByRole("dialog", { name: "Add service" });
     expect(dialog).toHaveAttribute("data-prefill", "github");
+  });
+
+  it("runs plugin OAuth in the managed popup and opens the result in place", async () => {
+    const user = userEvent.setup();
+    render(<PluginsView />);
+    await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
+    await screen.findByRole("dialog", { name: "Add service" });
+    // Both props are load-bearing: the backend mints an attempt nonce only for
+    // `cc`, and without one the popup opens and immediately closes again.
+    expect(mocks.addDialogProps).toMatchObject({ launch: "popup", flow: "cc" });
+
+    const onPopupViewResult = mocks.addDialogProps?.onPopupViewResult;
+    expect(onPopupViewResult).toBeTypeOf("function");
+    let handled = false;
+    act(() => {
+      handled = onPopupViewResult?.("key-popup") ?? false;
+    });
+    // Handled === true is what makes the popup ack and stop waiting.
+    expect(handled).toBe(true);
+
+    expect(
+      screen.queryByRole("dialog", { name: "Add service" }),
+    ).not.toBeInTheDocument();
+    // Falls through to the same manage modal an Added card opens.
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(mocks.useKey).toHaveBeenCalledWith("key-popup");
   });
 
   it("connects from the keyboard", async () => {

--- a/frontend/src/components/assistant/plugins-view.tsx
+++ b/frontend/src/components/assistant/plugins-view.tsx
@@ -253,6 +253,16 @@ function ConnectorsTab({ query }: { readonly query: string }) {
   const catalogQuery = useCatalog();
   const [manageCardId, setManageCardId] = useState<string | null>(null);
   const [connectSlug, setConnectSlug] = useState<string | null>(null);
+  // Settled result of a managed-popup OAuth connect. The popup's "view result"
+  // action hands back the key it authorized, and the grid opens the same
+  // manage modal the Added cards use. The label rides along because
+  // `connectSlug` is cleared as the dialog closes and the freshly minted key
+  // has not landed in `items` yet.
+  const [popupResult, setPopupResult] = useState<{
+    readonly keyId: string;
+    readonly name: string;
+    readonly iconSlug: string | null;
+  } | null>(null);
 
   const items = useMemo(
     () => deriveConnectorItems(keysQuery.data ?? [], catalogQuery.data ?? []),
@@ -365,15 +375,45 @@ function ConnectorsTab({ query }: { readonly query: string }) {
       )}
 
       {/* The same add-service dialog the Studio /keys page uses — handles every
-          connect flavor (OAuth popup, API-key paste, device-code) and
-          invalidates the keys query on success, so the card moves to Added. */}
+          connect flavor (API-key paste, device-code) and invalidates the keys
+          query on success, so the card moves to Added. OAuth opts into the
+          managed popup on the same `cc` contract as the assistant's connect
+          card, so the grid stays on screen while the user authorizes instead
+          of the tab navigating away to the provider. */}
       {connectSlug !== null && (
         <AddKeyDialog
           open
           prefillSlug={connectSlug}
+          launch="popup"
+          flow="cc"
+          onPopupViewResult={(keyId) => {
+            const connecting = items.available.find(
+              (candidate) => candidate.connectSlug === connectSlug,
+            );
+            setConnectSlug(null);
+            // Deferred a tick so the add dialog unmounts before the manage
+            // modal mounts; two overlapping Radix dialogs fight over focus.
+            window.setTimeout(() => {
+              setPopupResult({
+                keyId,
+                name: connecting?.name ?? connectSlug,
+                iconSlug: connecting?.iconSlug ?? connectSlug,
+              });
+            }, 0);
+            return true;
+          }}
           onOpenChange={(next) => {
             if (!next) setConnectSlug(null);
           }}
+        />
+      )}
+
+      {popupResult && (
+        <ManageConnectionModal
+          keyIds={[popupResult.keyId]}
+          serviceName={popupResult.name}
+          iconSlug={popupResult.iconSlug}
+          onClose={() => setPopupResult(null)}
         />
       )}
     </>


### PR DESCRIPTION
## What

The assistant **Plugins** grid (`/assistant/plugins`) connected services through the legacy full-tab path. `AddKeyDialog` was mounted without `launch`, so OAuth rendered the `target="_blank"` anchor and navigated the user out to the provider in a new tab — the chat conversation and the grid both left behind.

Only `blocks/connect-card.tsx` opted into the managed popup from #1349. The comment directly above this call site already claimed the dialog *"handles every connect flavor (OAuth popup, API-key paste, device-code)"*, which is what made it look wired.

Reported against GitHub OAuth from `/assistant/plugins`, reproduced on `main`.

## How

Pass `launch="popup"` and `flow="cc"` **together**. Both are load-bearing:

```rust
// user_token_service.rs:740
let attempt_nonce =
    (flow_kind == Some(OAuthFlowKind::ChatConnect)).then(|| Uuid::new_v4().to_string());
```

The nonce is minted only for `cc`. Without one, the OAuth step hits `if (!nonce) { popup?.close(); return; }` and falls straight back to the anchor — so `launch` on its own would ship a popup that flickers shut and still opens a tab.

On `view_result` the grid closes the add dialog and opens the same `ManageConnectionModal` an Added card opens. Two details that are deliberate:

- **The label is captured at callback time**, not re-derived. `connectSlug` is cleared as the dialog closes, and the freshly minted key has not landed in `items` yet.
- **`onPopupViewResult` returns `true`** — that is what makes the receiver post the ack (`use-oauth-popup.ts:56`) so the popup stops waiting.

## Gates

All run locally on this branch.

| gate | result |
|---|---|
| `npm run lint` | 0 errors, 23 warnings (pre-existing, unchanged) |
| `npm run build` (`tsc -b` + vite) | passed |
| `npm run test` | **2632/2632**, 221 files (+1 new) |
| `cargo test -p nyxid-cli --test wizard_bundle_freshness` | passed — `plugins-view.tsx` is outside the wizard source closure, no rebuild needed |

New test verified to actually execute, not just counted:

```
✓ PluginsView > runs plugin OAuth in the managed popup and opens the result in place
```

## Known limitation, not introduced here

Prod's edge 301s bare `/oauth` to `/oauth/`, which 404s:

```
/oauth?status=complete&…  →  301  →  /oauth/?…  →  404
```

The backend redirects to `{FRONTEND_URL}/oauth` (`user_tokens.rs:999`), so the popup dead-ends after an otherwise successful connect — the token exchange already completed at `/api/v1/providers/callback`, but the completion page never renders, never scrubs the query, and never fires the `BroadcastChannel` wakeup.

This affects the chat connect card on `main` today and is unchanged by this PR. **It will look fine locally** (`vite.config.ts` proxies only `^/oauth/`, so the SPA owns `/oauth`) and only bite on deploy. Worth fixing at the edge before this reaches users.

## Out of scope

Still on the legacy full-tab path:

- `blocks/action-card.tsx:485`
- `manage-connection-modal.tsx:549`

Same edit if wanted; scoped to the Plugins page as asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)