### PR TITLE
fix(connect-links): align hosted page schema with wire timestamps

### DIFF
--- a/backend/src/handlers/connect_links.rs
+++ b/backend/src/handlers/connect_links.rs
@@ -222,7 +222,7 @@ pub async fn create_connect_link(
             "connect_link_id": &created.link.id,
             "service_id": &created.link.service_id,
             "service_slug": &created.link.service_slug,
-            "expires_at": created.link.expires_at.to_rfc3339(),
+            "expires_at": created.link.expires_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             "has_callback_url": created.link.callback_url.is_some(),
         })),
     );
@@ -230,7 +230,10 @@ pub async fn create_connect_link(
     Ok(Json(CreateConnectLinkResponse {
         id: created.link.id,
         connect_url,
-        expires_at: created.link.expires_at.to_rfc3339(),
+        expires_at: created
+            .link
+            .expires_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
     }))
 }
 
@@ -300,8 +303,14 @@ pub async fn preview_connect_link(
         service_slug: view.service.service_slug,
         label: view.link.label,
         requested_by: view.link.requested_by,
-        created_at: view.link.created_at.to_rfc3339(),
-        expires_at: view.link.expires_at.to_rfc3339(),
+        created_at: view
+            .link
+            .created_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        expires_at: view
+            .link
+            .expires_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         status: status_name(view.link.status).to_string(),
         connect_method,
         auth_key_name: view.service.auth_key_name,
@@ -543,14 +552,23 @@ fn status_response(view: connect_link_service::LinkView) -> AppResult<ConnectLin
         status: status_name(view.link.status).to_string(),
         service_name: view.service.service_name,
         service_slug: view.service.service_slug,
-        expires_at: view.link.expires_at.to_rfc3339(),
-        completed_at: view.link.completed_at.map(|date| date.to_rfc3339()),
+        expires_at: view
+            .link
+            .expires_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        completed_at: view
+            .link
+            .completed_at
+            .map(|date| date.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
         connected_service,
         callback_url,
         requesting_app_id: view.link.requesting_app_id,
         requesting_app_name: view.link.requesting_app_name,
         last_error: view.link.last_error,
-        last_error_at: view.link.last_error_at.map(|date| date.to_rfc3339()),
+        last_error_at: view
+            .link
+            .last_error_at
+            .map(|date| date.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     })
 }
 
@@ -677,6 +695,18 @@ mod tests {
         assert_eq!(preview.service_slug, service.slug);
         assert_eq!(preview.requested_by.as_deref(), Some("handler-test"));
         assert_eq!(preview.status, "pending");
+        // The hosted page validates timestamps with a Z-suffix-friendly
+        // parser; keep the wire format UTC-suffixed, never offset form.
+        for timestamp in [
+            &created.expires_at,
+            &preview.created_at,
+            &preview.expires_at,
+        ] {
+            assert!(
+                timestamp.ends_with('Z') && !timestamp.contains('+'),
+                "wire timestamps must use the Z suffix, got {timestamp}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -3251,7 +3251,7 @@ Content-Type: application/json
 {
   "id": "6c02c84a-3d97-430f-8468-c96b609d9563",
   "connect_url": "https://app.nyxid.dev/connect/nyx_clk_<opaque-secret>",
-  "expires_at": "2026-08-05T10:15:00+00:00"
+  "expires_at": "2026-08-05T10:15:00.000Z"
 }
 ```
 
@@ -3265,11 +3265,11 @@ Treat `connect_url` as a single-use secret and hand it only to the browser. The 
   "status": "pending",
   "service_name": "GitHub",
   "service_slug": "github",
-  "expires_at": "2026-08-05T10:15:00+00:00",
+  "expires_at": "2026-08-05T10:15:00.000Z",
   "requesting_app_id": "desktop-client-id",
   "requesting_app_name": "Desktop App",
   "last_error": "provider_access_denied",
-  "last_error_at": "2026-08-05T10:04:12+00:00"
+  "last_error_at": "2026-08-05T10:04:12.000Z"
 }
 ```
 

--- a/frontend/src/schemas/connect-links.test.ts
+++ b/frontend/src/schemas/connect-links.test.ts
@@ -33,6 +33,37 @@ describe("connect link schemas", () => {
     expect(parsed.callback_url).toContain("status=cancelled");
   });
 
+  it("accepts backend wire timestamps and OAuth previews without an auth key name", () => {
+    const parsed = connectLinkPreviewSchema.parse({
+      service_name: "GitHub",
+      service_slug: "api-github",
+      label: null,
+      requested_by: null,
+      created_at: "2026-08-06T01:15:04.123456+00:00",
+      expires_at: "2026-08-06T01:30:04.123+00:00",
+      status: "pending",
+      connect_method: "oauth",
+      auth_key_name: "",
+      credential_mode: "admin",
+      has_platform_oauth_credentials: true,
+      requires_gateway_url: false,
+      api_key_url: null,
+      api_key_instructions: null,
+    });
+    expect(parsed.auth_key_name).toBe("");
+
+    const status = connectLinkStatusResponseSchema.parse({
+      id: "65dd8fe8-9ee8-4c89-af1e-b283a17bcf37",
+      status: "completed",
+      service_name: "GitHub",
+      service_slug: "api-github",
+      expires_at: "2026-08-06T01:30:04+00:00",
+      completed_at: "2026-08-06T01:20:04.500+00:00",
+      last_error_at: "2026-08-06T01:18:04+00:00",
+    });
+    expect(status.status).toBe("completed");
+  });
+
   it("validates BYO OAuth and gateway fields independently", () => {
     const empty = connectOAuthFormSchema.parse({
       endpoint_url: "",

--- a/frontend/src/schemas/connect-links.ts
+++ b/frontend/src/schemas/connect-links.ts
@@ -19,11 +19,11 @@ export const connectLinkPreviewSchema = z.object({
   service_slug: z.string().min(1),
   label: z.string().nullable(),
   requested_by: z.string().nullable(),
-  created_at: z.string().datetime(),
-  expires_at: z.string().datetime(),
+  created_at: z.string().datetime({ offset: true }),
+  expires_at: z.string().datetime({ offset: true }),
   status: connectLinkStatusSchema,
   connect_method: connectMethodSchema,
-  auth_key_name: z.string().min(1),
+  auth_key_name: z.string(),
   credential_mode: z.string().nullable(),
   has_platform_oauth_credentials: z.boolean(),
   requires_gateway_url: z.boolean(),
@@ -80,8 +80,8 @@ export const connectLinkStatusResponseSchema = z.object({
   status: connectLinkStatusSchema,
   service_name: z.string(),
   service_slug: z.string(),
-  expires_at: z.string().datetime(),
-  completed_at: z.string().datetime().nullable().optional(),
+  expires_at: z.string().datetime({ offset: true }),
+  completed_at: z.string().datetime({ offset: true }).nullable().optional(),
   connected_service: z
     .object({ id: z.string(), slug: z.string() })
     .nullable()
@@ -90,7 +90,7 @@ export const connectLinkStatusResponseSchema = z.object({
   requesting_app_id: z.string().nullable().optional(),
   requesting_app_name: z.string().nullable().optional(),
   last_error: z.string().nullable().optional(),
-  last_error_at: z.string().datetime().nullable().optional(),
+  last_error_at: z.string().datetime({ offset: true }).nullable().optional(),
 });
 
 export type ConnectLinkPreview = z.infer<typeof connectLinkPreviewSchema>;


### PR DESCRIPTION
## Summary

Fixes the hosted connect page failing with a raw Zod error array on every link (reported by an integrating app against the hosted deployment). Two frontend/backend contract drifts introduced in #1366:

1. **Timestamps**: handlers serialized with `to_rfc3339()` (offset form, `...+00:00`) while the page schema used `z.string().datetime()`, which only accepts the `Z` suffix. Fixed on both sides: handlers now emit `to_rfc3339_opts(SecondsFormat::Millis, true)` (matching the device-login contract), and the schema accepts `datetime({ offset: true })` as defense in depth — covering `created_at`, `expires_at`, `completed_at`, and `last_error_at`.
2. **`auth_key_name`**: the preview schema required a non-empty string, but OAuth-method catalog services legitimately emit an empty one. The schema now allows it (the credential form that uses it as a label is only rendered for API-key services).

Also updates the connector-integration examples in `docs/API.md` to the canonical `Z` format.

## Test plan
- [x] New frontend regression test parses the exact production wire shape (`+00:00` microsecond timestamps, empty `auth_key_name`, `connect_method: "oauth"`)
- [x] Backend round-trip test now asserts every emitted timestamp is `Z`-suffixed with no offset form
- [x] `cargo test -p nyxid connect_link` 35/35, clippy clean, frontend connect-link suites 11/11, build clean