### PR TITLE
fix(assistant): connect an action card through the managed popup

### DIFF
--- a/frontend/src/components/assistant/blocks/action-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.test.tsx
@@ -11,8 +11,15 @@ import {
   resetChatActivityForTests,
 } from "@/lib/assistant/connect-watch";
 import type { ActionReport } from "@/schemas/assistant-actions";
+import { usePendingConnectStore } from "@/stores/pending-connect-store";
 import type { ActionCardContentBlock } from "@/types/assistant";
 import { ActionCard } from "./action-card";
+
+// The pending-authorization store outlives any one card by design, so it also
+// outlives any one test. Reset it or a stranded attempt leaks forward.
+beforeEach(() => {
+  usePendingConnectStore.setState({ attempts: {} });
+});
 
 const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
 
@@ -45,6 +52,9 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     prefillCustom,
     onSuccess,
     onAuthorizationPending,
+    launch,
+    flow,
+    onPopupViewResult,
   }: {
     readonly open: boolean;
     readonly onOpenChange: (open: boolean) => void;
@@ -53,13 +63,24 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     readonly prefillCustom?: { readonly name?: string };
     readonly onSuccess?: (result: AddKeyDialogCompletion) => void;
     readonly onAuthorizationPending?: (keyId: string) => void;
+    readonly launch?: string;
+    readonly flow?: string;
+    readonly onPopupViewResult?: (keyId: string) => boolean;
   }) =>
     open ? (
       <div
         role="dialog"
         data-prefill={prefillSlug ?? prefillCustom?.name ?? ""}
         data-prefill-include-all={String(prefillIncludeAllCatalog ?? false)}
+        data-launch={launch ?? ""}
+        data-flow={flow ?? ""}
       >
+        <button
+          type="button"
+          onClick={() => onPopupViewResult?.("key-pending-1")}
+        >
+          Return from popup
+        </button>
         <button
           type="button"
           onClick={() =>
@@ -182,6 +203,61 @@ describe("ActionCard", () => {
         },
       },
     });
+  });
+
+  it("hands the connect journey to the managed popup, not the chat tab", async () => {
+    // Provider consent pages cannot be iframed, so the popup is the only
+    // handoff that keeps the conversation alive underneath it. Without these
+    // two props the dialog silently takes the legacy path: a second click on
+    // a `target="_blank"` link, and a callback that redirects the chat tab to
+    // the key page.
+    const user = userEvent.setup();
+    renderCard(
+      <ActionCard
+        block={catalogBlock()}
+        onProgress={vi.fn()}
+        onBlock={vi.fn()}
+        onResolve={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("data-launch", "popup");
+    expect(dialog).toHaveAttribute("data-flow", "cc");
+  });
+
+  it("closes the dialog on return from the popup without abandoning the connection", async () => {
+    const user = userEvent.setup();
+    const onProgress = vi.fn();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+    const { rerender } = renderCard(
+      <ActionCard
+        block={catalogBlock()}
+        onProgress={onProgress}
+        onBlock={vi.fn()}
+        onResolve={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
+    rerender(
+      <ActionCard
+        block={catalogBlock({ status: "in_progress" })}
+        onProgress={onProgress}
+        onBlock={vi.fn()}
+        onResolve={vi.fn()}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Hand off to provider" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Return from popup" }));
+
+    // Back in the transcript, and still owned by the card's watch — the
+    // outcome belongs in the conversation, not on a detour to the keys page.
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onProgress).not.toHaveBeenCalledWith("action-card-1", false);
   });
 
   it("rolls a rejected completed report out of its busy projection", async () => {
@@ -744,5 +820,90 @@ describe("ActionCard background authorization watch", () => {
       "action-card-1",
       expect.stringContaining("stopped waiting"),
     );
+  });
+
+  it("carries a live authorization across a remount", async () => {
+    // The regression this exists for: the busy projection lives in the
+    // transport mirror and survives a history refetch, but the watch that
+    // clears it used to be component state. Anything that remounts the card
+    // — switching conversations, a focus refetch that re-keys the message
+    // group — destroyed the exit and left the card spinning at "Connecting"
+    // with every control disabled and no writer able to move it.
+    const user = userEvent.setup();
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+
+    const { rerender, unmount } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
+    await handOffAndDismiss(user, rerender, props);
+    unmount();
+
+    renderCard(
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
+    );
+
+    expect(props.onProgress).not.toHaveBeenCalledWith("action-card-1", false);
+    expect(
+      await screen.findByRole("button", { name: /Waiting for authorization/ }),
+    ).toBeInTheDocument();
+
+    // And it is a live watch, not just preserved copy: the remounted card
+    // still settles itself off the key's terminal status. The window spans a
+    // poll interval, so it outlasts waitFor's default.
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "active" });
+    await waitFor(
+      () => {
+        expect(props.onResolve).toHaveBeenCalledWith({
+          actionRequestId: "act-1",
+          originTurnId: "turn-origin-1",
+          disposition: "completed",
+          resource: { userService: { userServiceId: "key-pending-1" } },
+        });
+      },
+      { timeout: 4_000 },
+    );
+  });
+
+  it("returns a stranded busy card to actionable on mount", async () => {
+    // No authorization behind the busy projection and no dialog open: the
+    // card can only have been orphaned, so it must not mount into a disabled
+    // spinner. Rolling back to `pending` is what makes retry possible.
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+
+    renderCard(
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
+    );
+
+    await waitFor(() => {
+      expect(props.onProgress).toHaveBeenCalledWith("action-card-1", false);
+    });
+  });
+
+  it("keeps decline reachable while a connection is in flight", async () => {
+    // The manual floor under every automatic settlement. A busy card whose
+    // watch is gone still has to be abandonable.
+    const user = userEvent.setup();
+    const props = watchProps();
+    mockGet.mockResolvedValue({ id: "key-pending-1", status: "pending_auth" });
+    usePendingConnectStore.setState({
+      attempts: {
+        "action-card-1": { keyId: "key-pending-1", startedAt: Date.now() },
+      },
+    });
+
+    renderCard(
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
+    );
+
+    const decline = screen.getByRole("button", { name: "Decline" });
+    expect(decline).toBeEnabled();
+    await user.click(decline);
+    expect(props.onResolve).toHaveBeenCalledWith({
+      actionRequestId: "act-1",
+      originTurnId: "turn-origin-1",
+      disposition: "declined",
+    });
   });
 });

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/assistant/action-registry";
 import { connectWatchDeadline } from "@/lib/assistant/connect-watch";
 import type { ActionReport } from "@/schemas/assistant-actions";
+import { usePendingConnectStore } from "@/stores/pending-connect-store";
 import type { ActionCardContentBlock } from "@/types/assistant";
 
 interface ActionCardProps {
@@ -195,17 +196,23 @@ export function ActionCard({
   const [dialogOpen, setDialogOpen] = useState(false);
   const resolvingRef = useRef(false);
   /**
-   * An out-of-band authorization handed to a provider, still settling. Held on
-   * the card rather than in the dialog because the dialog is the short-lived
-   * surface: the user goes to GitHub, comes back to the chat, and never
-   * reopens it. `startedAt` anchors both the poll cadence and the deadline.
+   * An out-of-band authorization handed to a provider, still settling. Held
+   * outside React (keyed by block id) rather than in the dialog or in this
+   * component: the dialog is the short-lived surface — the user goes to
+   * GitHub, comes back to the chat, and never reopens it — and the card
+   * itself outlives neither a conversation switch nor a history refetch that
+   * re-keys message groups. The busy projection it clears lives in the
+   * transport mirror and survives both, so the watch has to as well.
    */
-  const [pendingAuth, setPendingAuth] = useState<{
-    readonly keyId: string;
-    readonly startedAt: number;
-  } | null>(null);
+  const pendingAuth = usePendingConnectStore(
+    (state) => state.attempts[block.block_id] ?? null,
+  );
+  const beginPendingAuth = usePendingConnectStore((state) => state.begin);
+  const endPendingAuth = usePendingConnectStore((state) => state.end);
   /** Guards one auto-settlement per watched key against effect re-entry. */
   const watchSettledRef = useRef<string | null>(null);
+  /** One mount-time reconciliation, whatever the deps churn afterwards. */
+  const reconciledRef = useRef(false);
   const { visible, lastActivityAt } = useChatPresence();
 
   useEffect(() => {
@@ -213,6 +220,19 @@ export function ActionCard({
       resolvingRef.current = false;
     }
   }, [block.status]);
+
+  // A card that mounts busy with no authorization behind it and no dialog open
+  // was stranded: `in_progress` disables every control, and its only writers
+  // (dialog dismissal, the watch, an explicit report) are all gone. Roll it
+  // back to actionable instead of leaving a "Connecting" spinner nobody can
+  // clear. Fresh cards mount `pending`, and a remount mid-authorization finds
+  // its attempt in the store, so neither is touched.
+  useEffect(() => {
+    if (reconciledRef.current) return;
+    reconciledRef.current = true;
+    if (block.status !== "in_progress" || pendingAuth !== null) return;
+    onProgress(block.block_id, false);
+  }, [block.block_id, block.status, pendingAuth, onProgress]);
 
   const settled =
     block.status === "completed" ||
@@ -242,7 +262,7 @@ export function ActionCard({
       resolvingRef.current = true;
       void Promise.resolve()
         .then(() => {
-          setPendingAuth(null);
+          endPendingAuth(block.block_id);
           return onResolve({
             actionRequestId: block.action_request_id,
             originTurnId: block.origin_turn_id,
@@ -265,7 +285,7 @@ export function ActionCard({
           : AUTHORIZATION_TIMEOUT_NOTE;
       void Promise.resolve()
         .then(() => {
-          setPendingAuth(null);
+          endPendingAuth(block.block_id);
           return onBlock(block.block_id, note);
         })
         .catch(() => undefined);
@@ -279,6 +299,7 @@ export function ActionCard({
     block.block_id,
     block.action_request_id,
     block.origin_turn_id,
+    endPendingAuth,
     onResolve,
     onBlock,
     onProgress,
@@ -304,7 +325,12 @@ export function ActionCard({
   const blocked = block.status === "blocked";
   const conflicted = block.status === "conflicted";
   const primaryDisabled = busy || blocked || conflicted;
-  const secondaryDisabled = busy || conflicted;
+  // Decline stays live through `in_progress`. Abandoning a connection the user
+  // started is always their call, and it is the manual floor under every
+  // automatic settlement: with it disabled, a busy card that lost its watch
+  // had no reachable control at all. `report` supersedes any watch still
+  // running, and the transport de-duplicates a report already queued.
+  const secondaryDisabled = conflicted;
   const params = block.params;
 
   function setOpen(next: boolean) {
@@ -330,7 +356,7 @@ export function ActionCard({
     // A manual outcome supersedes any watch still running for this card.
     if (pendingAuth) {
       watchSettledRef.current = pendingAuth.keyId;
-      setPendingAuth(null);
+      endPendingAuth(block.block_id);
     }
     if (disposition === "completed" && !userServiceId?.trim()) {
       resolvingRef.current = true;
@@ -509,10 +535,25 @@ export function ActionCard({
                 }
               : undefined
           }
+          // Provider consent pages can never be iframed, so a top-level popup
+          // is the only handoff that keeps this conversation alive underneath
+          // it. Without this the action card fell back to the legacy path — a
+          // `target="_blank"` link needing a second click, and a callback that
+          // redirects to the key page, taking the chat tab with it.
+          launch="popup"
+          flow="cc"
+          onPopupViewResult={() => {
+            // The popup is done and the user asked to come back. Close the
+            // dialog and let the card settle itself from the key's terminal
+            // status — the outcome belongs in the transcript, not on a
+            // detour to the keys page.
+            setOpen(false);
+            return true;
+          }}
           onSuccess={({ userServiceId }) => report("completed", userServiceId)}
           onAuthorizationPending={(keyId) => {
             watchSettledRef.current = null;
-            setPendingAuth({ keyId, startedAt: Date.now() });
+            beginPendingAuth(block.block_id, { keyId, startedAt: Date.now() });
           }}
         />
       ) : null}

--- a/frontend/src/stores/pending-connect-store.ts
+++ b/frontend/src/stores/pending-connect-store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+
+export interface PendingConnectAuthorization {
+  /** Placeholder key whose terminal status settles the card. */
+  readonly keyId: string;
+  /** Anchors both the poll cadence and the give-up deadline. */
+  readonly startedAt: number;
+}
+
+interface PendingConnectState {
+  readonly attempts: Readonly<Record<string, PendingConnectAuthorization>>;
+  begin(blockId: string, attempt: PendingConnectAuthorization): void;
+  end(blockId: string): void;
+}
+
+/**
+ * Out-of-band authorizations an assistant action card is still waiting on,
+ * keyed by block id.
+ *
+ * This lives outside React on purpose. The card's busy projection
+ * (`status: "in_progress"`) is held in the transport's conversation mirror and
+ * survives a history refetch — `applyHistoryResponse` deliberately preserves
+ * local structured blocks because Aevatar's transcript is text-only. The
+ * authorization that is supposed to *clear* that projection used to be
+ * component state, so the two had different lifetimes: any remount (switching
+ * conversations, navigating to a key page and back, a window-focus refetch
+ * that re-keys message groups) destroyed the exit condition while the
+ * disabling condition lived on. The card was then stuck at "Connecting" with
+ * every control disabled and no writer left to move it.
+ *
+ * Module scope gives the watch the same lifetime as the projection it clears.
+ * A full reload drops both together, which is consistent: the local block is
+ * gone too, and the card comes back from the wire as `pending`.
+ */
+export const usePendingConnectStore = create<PendingConnectState>((set) => ({
+  attempts: {},
+  begin: (blockId, attempt) => {
+    set((state) => ({ attempts: { ...state.attempts, [blockId]: attempt } }));
+  },
+  end: (blockId) => {
+    set((state) => {
+      if (!(blockId in state.attempts)) return state;
+      return {
+        attempts: Object.fromEntries(
+          Object.entries(state.attempts).filter(([id]) => id !== blockId),
+        ),
+      };
+    });
+  },
+}));


### PR DESCRIPTION
## Summary

Two production bugs on the chat connect card the assistant actually raises (`action_card` / `nyxid.action.request`), both visible in one screenshot: OAuth opening as a tab instead of a popup, and the card spinning at **Connecting** forever after the connection succeeded.

- **OAuth never used the popup.** The managed-popup pilot (#1349) wired `launch="popup"` / `flow="cc"` into `ConnectCard` only — the compact row raised when a tool call hits an authorization blocker. `ActionCard` is a different block type and never opted in, so it silently kept the legacy path: an in-dialog `target="_blank"` link needing a second click, plus `redirectPath: /keys/{id}` on the callback, which takes the chat tab off the conversation. #1349's own status doc §6 lists the out-of-scope surfaces (providers grid, keys dashboard, SA, wizard, social login) but not this one, so the gap was never recorded as a gap.
- **"Connecting" was a deadlock, not a slow poll.** `status: "in_progress"` lives in the transport mirror and survives a history refetch — `applyHistoryResponse` deliberately preserves local structured blocks because Aevatar's transcript is text-only. The `pendingAuth` that clears it was component state. Different lifetimes: any remount (conversation switch, a trip to a key page and back, a focus refetch that re-keys the message group) destroyed the exit condition while the disabling condition lived on. With `primaryDisabled = busy` and `secondaryDisabled = busy || conflicted`, the card was left with no reachable control and no writer able to move it. #1341 gave the card a watch that settles without clicks, but anchored it in the state that does not survive; its tests drive the card with `rerender`, so a remount was never exercised.

Fix, in `action-card.tsx` plus one new store:

- the pending authorization moves to a module-scoped store keyed by block id (`stores/pending-connect-store.ts`), giving the watch the same lifetime as the projection it clears — a remount re-arms it instead of losing it
- a card that mounts busy with no authorization behind it and no dialog open rolls back to actionable; the orphan case was previously terminal
- Decline stays live through `in_progress` — abandoning a connection is always the user's call, and it is the manual floor under every automatic settlement
- `AddKeyDialog` gets `launch="popup"`, `flow="cc"`, and an `onPopupViewResult` that closes the dialog and lets the card settle in the transcript rather than detouring to the keys page

No backend, contract, or wire-format change. `flow=cc` is the same pilot token the initiate endpoint already accepts.

## Test Plan

- [x] Existing tests pass — frontend suite green (221 files / 2636 tests), `npm run build` (the real `tsc -b` gate) and `npm run lint` clean
- [x] New tests added: remount preserves a live authorization *and* still settles from the key's terminal status; a stranded busy card returns to actionable on mount; Decline is reachable and reports while busy; the dialog receives `launch=popup` + `flow=cc`; returning from the popup closes the dialog without abandoning the connection
- [x] `cargo test -p nyxid-cli --test wizard_bundle_freshness` green — none of these files are in the wizard manifest closure, so no bundle rebuild
- [ ] Manual browser matrix for real windowing semantics (jsdom cannot cover it) — the residual #1349 §7 already flags for the popup path, now reaching a second surface

## Checklist

- [x] Code follows the project's [architecture rules](CONTRIBUTING.md#architecture-rules)
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Documentation updated (if applicable) — n/a, no contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)