### PR TITLE
perf(assistant): make streamed replies flow instead of stepping

### DIFF
--- a/frontend/src/components/assistant/blocks/text-block.split.test.tsx
+++ b/frontend/src/components/assistant/blocks/text-block.split.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { splitStableMarkdown } from "@/lib/assistant/markdown-stream";
+
+/**
+ * The streaming optimisation is only allowed to be faster, never different.
+ * These render each document twice — once through the real splitter, once with
+ * splitting stubbed out — and require the resulting DOM to be identical.
+ *
+ * A whole-text parse is the reference implementation, so any divergence here is
+ * the optimisation changing meaning: an ordered list renumbering, a table
+ * losing its header, a fence swallowing prose.
+ */
+async function renderTextBlock(
+  text: string,
+  { split }: { readonly split: boolean },
+): Promise<string> {
+  vi.resetModules();
+  if (split) {
+    vi.doUnmock("@/lib/assistant/markdown-stream");
+  } else {
+    vi.doMock("@/lib/assistant/markdown-stream", () => ({
+      splitStableMarkdown: (value: string) => ({ prefix: "", tail: value }),
+    }));
+  }
+  const { TextBlock } = await import("@/components/assistant/blocks/text-block");
+  const { container } = render(<TextBlock text={text} />);
+  const html = container.innerHTML;
+  cleanup();
+  return html;
+}
+
+/** One paragraph, long enough on its own to make each document splittable. */
+const INTRO =
+  "NyxID brokered the call with a scoped credential and never handed the raw " +
+  "token to the agent. The node injected it at the edge, so the transcript " +
+  "below records only metadata: which service, which scope, and how long the " +
+  "hop took end to end. Nothing in this paragraph is a list marker, a table " +
+  "row, a blockquote or an indented line, so it is exactly the shape the " +
+  "splitter is allowed to freeze once what follows has settled into its own " +
+  "block, which makes it a useful preamble for every case below here. It " +
+  "runs on for a few more clauses purely so that the fixture clears the " +
+  "splitter's minimum length without any document needing to pad it.";
+
+const DOCUMENTS: ReadonlyArray<readonly [string, string]> = [
+  ["headings and prose", `${INTRO}\n\n## Result\n\nThe call succeeded.`],
+  ["an ordered list", `${INTRO}\n\n1. First item\n\n2. Second item\n\n3. Third`],
+  ["a loose unordered list", `${INTRO}\n\n- alpha\n\n- beta\n\n- gamma`],
+  ["a task list", `${INTRO}\n\n- [x] Brokered\n\n- [ ] Pending`],
+  [
+    "a table",
+    `${INTRO}\n\n| Step | Status |\n| --- | --- |\n| resolve | ok |\n\nAfter the table.`,
+  ],
+  [
+    "a closed code fence",
+    `${INTRO}\n\n\`\`\`ts\nconst a = 1;\n\nconst b = 2;\n\`\`\`\n\nDone.`,
+  ],
+  ["an open code fence", `${INTRO}\n\n\`\`\`ts\nconst a = 1;\n\nconst b = 2;`],
+  ["a blockquote", `${INTRO}\n\n> Quoted\n\n> Still quoted\n\nOut again.`],
+  ["nested lists", `${INTRO}\n\n1. outer\n\n   - inner\n\n2. outer again`],
+  [
+    "a footnote",
+    `${INTRO}\n\nSee the note.[^1]\n\nMore prose here.\n\n[^1]: The note body.`,
+  ],
+  [
+    "a link reference definition",
+    `${INTRO}\n\nSee [the docs][d].\n\nMore prose.\n\n[d]: https://example.com`,
+  ],
+  ["a horizontal rule", `${INTRO}\n\n---\n\nBelow the rule.`],
+  ["inline emphasis across the seam", `${INTRO}\n\n**Bold** and \`code\`.`],
+];
+
+afterEach(() => {
+  vi.doUnmock("@/lib/assistant/markdown-stream");
+});
+
+describe("TextBlock splitting", () => {
+  it.each(DOCUMENTS)("renders %s identically split and unsplit", async (
+    _case,
+    text,
+  ) => {
+    // Sequential, never concurrent: each render swaps the module registry.
+    const split = await renderTextBlock(text, { split: true });
+    const whole = await renderTextBlock(text, { split: false });
+    expect(split).toBe(whole);
+  });
+
+  it("actually exercises the split path across the corpus", () => {
+    const splittable = DOCUMENTS.filter(
+      ([, text]) => splitStableMarkdown(text).prefix !== "",
+    );
+    // Without this the equivalence above passes vacuously: two identical
+    // whole-text parses always match. The declined cases (lists, footnotes,
+    // reference links) are deliberately still in the corpus — they assert the
+    // splitter's refusals, and their equivalence IS trivially true.
+    expect(splittable.map(([name]) => name)).toContain("headings and prose");
+    expect(splittable.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("renders every prefix of a streaming answer identically to a whole parse", async () => {
+    const full = `${INTRO}\n\n## Result\n\nThe call succeeded and the token never left the node.\n\n- one\n\n- two`;
+    for (let length = 620; length <= full.length; length += 37) {
+      const text = full.slice(0, length);
+      const split = await renderTextBlock(text, { split: true });
+      const whole = await renderTextBlock(text, { split: false });
+      expect(split, `diverged at ${String(length)} chars`).toBe(whole);
+    }
+  });
+});

--- a/frontend/src/components/assistant/blocks/text-block.tsx
+++ b/frontend/src/components/assistant/blocks/text-block.tsx
@@ -1,6 +1,8 @@
 import {
   createContext,
+  memo,
   useContext,
+  useMemo,
   type ComponentProps,
   type CSSProperties,
 } from "react";
@@ -8,6 +10,8 @@ import type { Root } from "mdast";
 import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
+import { useSmoothReveal } from "@/hooks/use-smooth-reveal";
+import { splitStableMarkdown } from "@/lib/assistant/markdown-stream";
 
 // Everything the assistant may stream should actually render (issue: results
 // were flattened). rehype-sanitize still scrubs attributes/urls; these are the
@@ -346,31 +350,86 @@ const COMPONENTS: Components = {
   },
 };
 
-export function TextBlock({
+// Hoisted so the plugin arrays keep a stable identity across renders — rebuilt
+// inline they defeat every memo react-markdown applies internally.
+type MarkdownProps = ComponentProps<typeof ReactMarkdown>;
+const REMARK_PLUGINS: MarkdownProps["remarkPlugins"] = [
+  remarkGfm,
+  remarkSafeModelContent,
+];
+const REHYPE_PLUGINS: MarkdownProps["rehypePlugins"] = [
+  [rehypeSanitize, SANITIZE_SCHEMA],
+];
+const urlTransform: MarkdownProps["urlTransform"] = (url) =>
+  allowedHref(url) ?? "";
+
+/**
+ * One parse, memoized on the text it parsed.
+ *
+ * react-markdown holds no internal cache: a parent re-render re-runs remark,
+ * rehype-sanitize and the whole JSX build for text that has not changed by a
+ * character. Measured at ~15 ms for a 4 000-character answer — per re-render,
+ * per block. Memoizing here is what keeps a settled transcript out of the
+ * streaming block's frame budget.
+ *
+ * Rendered WITHOUT a wrapper element, deliberately: react-markdown emits its
+ * blocks into a fragment, so a split block's prefix and tail remain siblings
+ * under one parent and the `first:mt-0` rhythm still resolves across the seam.
+ */
+const MarkdownSegment = memo(function MarkdownSegment({
+  text,
+}: {
+  readonly text: string;
+}) {
+  return (
+    <ReactMarkdown
+      allowedElements={ALLOWED_ELEMENTS}
+      remarkPlugins={REMARK_PLUGINS}
+      rehypePlugins={REHYPE_PLUGINS}
+      urlTransform={urlTransform}
+      components={COMPONENTS}
+    >
+      {text}
+    </ReactMarkdown>
+  );
+});
+
+export const TextBlock = memo(function TextBlock({
   text,
   streaming = false,
 }: {
   readonly text: string;
   /**
-   * True for the actively-streaming text block: renders a blinking caret glued
-   * to the end of the last line so the turn reads as "still writing" rather
-   * than freezing between chunks.
+   * True for the actively-streaming text block: paces the reveal against the
+   * frame clock and renders a blinking caret glued to the end of the last line,
+   * so the turn reads as "still writing" rather than freezing between chunks.
    */
   readonly streaming?: boolean;
 }) {
+  const revealed = useSmoothReveal(text, streaming);
+  // Everything above the last settled block is frozen and memoized; only the
+  // live tail is re-parsed per frame. Splitting is refused wherever it could
+  // change meaning, in which case this is a whole-text parse as before.
+  const { prefix, tail } = useMemo(
+    () => splitStableMarkdown(revealed),
+    [revealed],
+  );
+
   return (
     <div
       className={`text-[12px] ${streaming ? "[&>p:has(+_[data-streaming-caret])]:inline" : ""}`}
     >
-      <ReactMarkdown
-        allowedElements={ALLOWED_ELEMENTS}
-        remarkPlugins={[remarkGfm, remarkSafeModelContent]}
-        rehypePlugins={[[rehypeSanitize, SANITIZE_SCHEMA]]}
-        urlTransform={(url) => allowedHref(url) ?? ""}
-        components={COMPONENTS}
-      >
-        {text}
-      </ReactMarkdown>
+      {prefix ? (
+        <>
+          <MarkdownSegment text={prefix} />
+          {/* mdast-util-to-hast separates top-level blocks with a newline text
+              node. Two parses each produce their own but none at the seam, so
+              this restores it and keeps split output byte-identical to a whole
+              parse — see text-block.split.test.tsx. */}
+          {"\n"}
+        </>
+      ) : null}
+      <MarkdownSegment text={tail} />
       {streaming ? (
         <span
           aria-hidden
@@ -380,4 +439,4 @@ export function TextBlock({
       ) : null}
     </div>
   );
-}
+});

--- a/frontend/src/components/assistant/chat-thread.tsx
+++ b/frontend/src/components/assistant/chat-thread.tsx
@@ -426,6 +426,7 @@ export function ChatThread({
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const [scrolledFromTop, setScrolledFromTop] = useState(false);
   const thinkingPresence = useFadingPresence(thinking, 500);
   const following = useRef(true);
@@ -447,7 +448,10 @@ export function ChatThread({
     setScrolledFromTop(element.scrollTop > 1);
   }, []);
 
-  useEffect(() => {
+  // Before paint, not after: adjusting the scroll in a passive effect lets the
+  // browser paint one frame at the stale offset first, and that one-frame
+  // rebound at every update is a large part of what reads as juddering.
+  useLayoutEffect(() => {
     const element = scrollRef.current;
     if (!element) return;
     // Sending always pulls the view back to the tail; assistant streaming still
@@ -460,6 +464,23 @@ export function ChatThread({
     if (following.current) element.scrollTop = element.scrollHeight;
     setScrolledFromTop(element.scrollTop > 1);
   }, [messages, thinking, streaming, bottomInset]);
+
+  // Streamed text grows INSIDE a memoized block, so the thread does not
+  // re-render as the answer writes itself and the effect above never fires for
+  // it. Following the tail is therefore driven off the content box itself,
+  // which is the thing that actually changes height.
+  useEffect(() => {
+    const element = scrollRef.current;
+    const content = contentRef.current;
+    if (!element || !content || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (following.current) element.scrollTop = element.scrollHeight;
+    });
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMessages]);
 
   useLayoutEffect(() => {
     const root = rootRef.current;
@@ -586,6 +607,7 @@ export function ChatThread({
         style={{ maskImage: fadeMask, WebkitMaskImage: fadeMask }}
       >
         <div
+          ref={contentRef}
           className="mx-auto flex w-full max-w-[758px] flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8"
           style={{ paddingBottom: `calc(${String(bottomInset)}px + 1.5rem)` }}
         >

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -358,7 +358,7 @@ describe("assistant hooks", () => {
     queryClient.clear();
   });
 
-  it("projects a large text backlog sooner than a sparse text delta", async () => {
+  it("projects on a flat interval whatever the text backlog", async () => {
     const { queryClient, Wrapper } = createHarness();
     const historySpy = vi.spyOn(assistantTransport, "getHistory");
     const sendSpy = vi
@@ -385,8 +385,9 @@ describe("assistant hooks", () => {
     });
     historySpy.mockClear();
 
+    // A single sparse character.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(88);
+      await vi.advanceTimersByTimeAsync(49);
     });
     expect(historySpy).not.toHaveBeenCalled();
     await act(async () => {
@@ -407,8 +408,12 @@ describe("assistant hooks", () => {
     });
     historySpy.mockClear();
 
+    // A backlog 120x larger projects on the SAME interval. Sampling React
+    // faster under load used to be how arriving prose was kept from landing in
+    // large jumps; `useSmoothReveal` now paces the reveal against the frame
+    // clock, so the projection cadence no longer carries that job.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(23);
+      await vi.advanceTimersByTimeAsync(49);
     });
     expect(historySpy).not.toHaveBeenCalled();
     await act(async () => {
@@ -453,7 +458,7 @@ describe("assistant hooks", () => {
     historySpy.mockClear();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(23);
+      await vi.advanceTimersByTimeAsync(49);
     });
     expect(historySpy).not.toHaveBeenCalled();
 

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -54,28 +54,14 @@ const APPROVAL_HISTORY_PAGE_SIZE = 20;
 // sits well above the observed worst-case time-to-first-event.
 const STREAM_START_DEADLINE_MS = 30_000;
 const PROJECTION_DEADLINE_MS = 5_000;
-// Streaming events update the transport mirror synchronously. Sparse text can
-// arrive at a relaxed cadence, while a growing backlog needs shorter samples
-// to avoid landing as large Markdown jumps. The lower bound still limits a
-// busy stream to about 42 projections per second on the main thread.
-const STREAM_PROJECTION_MIN_INTERVAL_MS = 24;
-const STREAM_PROJECTION_MAX_INTERVAL_MS = 90;
+// Streaming events update the transport mirror synchronously; a projection is
+// what publishes the mirror to React. This used to shorten under text backlog
+// (down to 24 ms) so that arriving prose would not land as large Markdown
+// jumps — a job the view layer now does properly, pacing the reveal against
+// the frame clock in `useSmoothReveal`. Sampling faster than that only bought
+// re-renders nobody could see, so the cadence is a flat interval again: fewer
+// projections, more frame budget left for the block actually being written.
 const STREAM_PROJECTION_INTERVAL_MS = 50;
-const STREAM_PROJECTION_FAST_BACKLOG_CHARS = 120;
-
-function streamProjectionInterval(pendingTextChars: number): number {
-  if (pendingTextChars <= 0) return STREAM_PROJECTION_INTERVAL_MS;
-  const pressure = Math.min(
-    pendingTextChars / STREAM_PROJECTION_FAST_BACKLOG_CHARS,
-    1,
-  );
-  return Math.round(
-    STREAM_PROJECTION_MAX_INTERVAL_MS -
-      pressure *
-        (STREAM_PROJECTION_MAX_INTERVAL_MS -
-          STREAM_PROJECTION_MIN_INTERVAL_MS),
-  );
-}
 
 const activeHandles = new Map<string, TurnHandle>();
 const episodeOwners = new WeakMap<QueryClient, Map<string, symbol>>();
@@ -577,7 +563,6 @@ function createTurnEventPump(
   let startDeadline: ReturnType<typeof setTimeout> | undefined;
   let projectionTimer: ReturnType<typeof setTimeout> | undefined;
   let projectionDueAt: number | undefined;
-  let pendingTextChars = 0;
   const ownsEpisode = () => owners.get(targetId) === owner;
   const clearStartDeadline = () => {
     if (startDeadline !== undefined) {
@@ -602,7 +587,6 @@ function createTurnEventPump(
   const project = () => {
     projectionTimer = undefined;
     projectionDueAt = undefined;
-    pendingTextChars = 0;
     if (!ownsEpisode()) return;
     projections += 1;
     publish();
@@ -621,7 +605,7 @@ function createTurnEventPump(
       project();
       return;
     }
-    const delay = streamProjectionInterval(pendingTextChars);
+    const delay = STREAM_PROJECTION_INTERVAL_MS;
     const dueAt = Date.now() + delay;
     if (
       projectionTimer !== undefined &&
@@ -667,7 +651,6 @@ function createTurnEventPump(
     clearStartDeadline();
     if (event.cursor <= lastSeenCursor) return;
     lastSeenCursor = event.cursor;
-    if (event.event === "block.delta") pendingTextChars += event.text.length;
     if (eventPrintsContent(event)) printed = true;
     if (event.event === "turn.completed") open = false;
     const turn = turnFromEvent(event);

--- a/frontend/src/hooks/use-smooth-reveal.test.tsx
+++ b/frontend/src/hooks/use-smooth-reveal.test.tsx
@@ -1,0 +1,136 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSmoothReveal } from "./use-smooth-reveal";
+
+/** Roughly one frame at 60Hz, which is what the fake clock drives rAF at. */
+const FRAME_MS = 16;
+
+function runFrames(count: number): void {
+  for (let frame = 0; frame < count; frame += 1) {
+    act(() => {
+      vi.advanceTimersByTime(FRAME_MS);
+    });
+  }
+}
+
+/**
+ * Frames until the reveal catches up. The first frame only establishes the
+ * clock baseline — there is no previous timestamp to measure against — so a
+ * converged reveal always costs at least two.
+ */
+function framesToConverge(text: string): number {
+  const { result, rerender, unmount } = renderHook(
+    ({ value }: { value: string }) => useSmoothReveal(value, true),
+    { initialProps: { value: "" } },
+  );
+  rerender({ value: text });
+  let frames = 0;
+  while (result.current !== text && frames < 500) {
+    runFrames(1);
+    frames += 1;
+  }
+  unmount();
+  return frames;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useSmoothReveal", () => {
+  it("returns the whole text when the block is not streaming", () => {
+    const { result } = renderHook(() => useSmoothReveal("Settled answer.", false));
+    expect(result.current).toBe("Settled answer.");
+  });
+
+  it("withholds arrived characters while streaming, then converges", () => {
+    const text = "a".repeat(400);
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useSmoothReveal(value, true),
+      { initialProps: { value: "" } },
+    );
+
+    rerender({ value: text });
+    runFrames(2);
+    // Paced, not painted whole: a 400-character chunk does not land at once.
+    expect(result.current.length).toBeGreaterThan(0);
+    expect(result.current.length).toBeLessThan(text.length);
+
+    // ...and it is never anything but a prefix of what actually arrived.
+    expect(text.startsWith(result.current)).toBe(true);
+
+    runFrames(30);
+    expect(result.current).toBe(text);
+  });
+
+  it("makes the wait grow with the logarithm of the backlog, not with it", () => {
+    const short = framesToConverge("b".repeat(200));
+    const long = framesToConverge("b".repeat(1200));
+    // The drain rate is proportional to the backlog, so the backlog decays
+    // exponentially and the wait grows logarithmically: six times the text
+    // costs well under twice the frames. A fixed characters-per-second rate —
+    // the obvious implementation — would have cost six times as long, which is
+    // exactly how a typewriter effect makes long answers crawl.
+    expect(long).toBeLessThan(short * 2);
+    // And neither is allowed to feel like a stall.
+    expect(long * FRAME_MS).toBeLessThan(500);
+  });
+
+  it("snaps a backlog too large to be a stream", () => {
+    const bulk = "c".repeat(4000);
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useSmoothReveal(value, true),
+      { initialProps: { value: "" } },
+    );
+    rerender({ value: bulk });
+    // A re-mount or history projection is not typing; it appears at once, on
+    // the first frame that carries a clock delta.
+    runFrames(2);
+    expect(result.current).toBe(bulk);
+  });
+
+  it("never slices past a block whose text was replaced with a shorter one", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useSmoothReveal(value, true),
+      { initialProps: { value: "d".repeat(500) } },
+    );
+    runFrames(30);
+    rerender({ value: "short" });
+    runFrames(1);
+    expect(result.current).toBe("short");
+  });
+
+  it("hands over the full text the moment the block settles", () => {
+    const text = "e".repeat(600);
+    const { result, rerender } = renderHook(
+      ({ value, active }: { value: string; active: boolean }) =>
+        useSmoothReveal(value, active),
+      { initialProps: { value: "", active: true } },
+    );
+    rerender({ value: text, active: true });
+    runFrames(1);
+    expect(result.current.length).toBeLessThan(text.length);
+
+    rerender({ value: text, active: false });
+    // No content may be left stranded behind the animation when a turn ends.
+    expect(result.current).toBe(text);
+  });
+
+  it("does not pace when the reader asked for reduced motion", () => {
+    const matchMedia = vi
+      .spyOn(window, "matchMedia")
+      .mockReturnValue({ matches: true } as MediaQueryList);
+    const text = "f".repeat(800);
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useSmoothReveal(value, true),
+      { initialProps: { value: "" } },
+    );
+    rerender({ value: text });
+    expect(result.current).toBe(text);
+    matchMedia.mockRestore();
+  });
+});

--- a/frontend/src/hooks/use-smooth-reveal.ts
+++ b/frontend/src/hooks/use-smooth-reveal.ts
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * The backlog is drained over roughly this long, so the text on screen trails
+ * what has arrived by a small and — crucially — CONSTANT amount. A fixed lag
+ * reads as flow; a lag that varies with chunk size reads as stutter.
+ */
+const DRAIN_MS = 90;
+
+/**
+ * Floor, so the last few characters of a chunk still visibly move. The
+ * proportional term decays towards zero as the backlog empties; without a floor
+ * the final handful of characters would take longer than all the rest.
+ */
+const MIN_CHARS_PER_SECOND = 700;
+
+/**
+ * A jump this large is a load, not a stream — a re-mount mid-answer, a
+ * reconnect, or a history projection landing at once. Typing it out would be a
+ * lie about when it arrived, so it snaps.
+ */
+const SNAP_BACKLOG_CHARS = 1500;
+
+/** A frame this long is a stall; crediting it in full would jerk the text. */
+const MAX_FRAME_SECONDS = 0.05;
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * Decouple the rate text APPEARS from the rate it ARRIVES.
+ *
+ * Upstream deltas land in bursts at whatever cadence the network and the
+ * projection scheduler produce; painting them the instant they land makes the
+ * answer advance in visible steps. This paces the reveal against the frame
+ * clock instead, chasing the arrived length with a proportional controller, so
+ * the text flows continuously however lumpy its supply is.
+ *
+ * It only ever WITHHOLDS characters that have already arrived, and only while
+ * `active`. The moment a block settles — or motion is suppressed, or there is
+ * no frame clock to pace against — the full text is returned, so nothing can
+ * strand content behind an animation.
+ */
+export function useSmoothReveal(text: string, active: boolean): string {
+  const [revealed, setRevealed] = useState(() => text.length);
+  // The frame loop must see the newest arrival without being torn down and
+  // rebuilt on every delta — restarting it would drop the timestamp baseline
+  // each time and the reveal would never accumulate.
+  const targetRef = useRef(text.length);
+
+  const paced =
+    active &&
+    typeof requestAnimationFrame === "function" &&
+    !prefersReducedMotion();
+
+  useEffect(() => {
+    targetRef.current = text.length;
+  }, [text.length]);
+
+  // React's "adjust state when a prop changes" pattern. Crossing into paced
+  // mode has to start from what is already on screen: a block that settles and
+  // then resumes — an approval continuation appends to the one the reader is
+  // already looking at — must stream only what is new, never re-type itself.
+  const [pacedPreviously, setPacedPreviously] = useState(paced);
+  if (pacedPreviously !== paced) {
+    setPacedPreviously(paced);
+    setRevealed(text.length);
+  }
+
+  useEffect(() => {
+    if (!paced) return;
+    let previous: number | undefined;
+    let frame = 0;
+    const step = (now: number) => {
+      frame = requestAnimationFrame(step);
+      const elapsed = previous === undefined ? 0 : (now - previous) / 1000;
+      previous = now;
+      if (elapsed <= 0) return;
+      const seconds = Math.min(elapsed, MAX_FRAME_SECONDS);
+      setRevealed((current) => {
+        const target = targetRef.current;
+        // Identity return: React bails out of the re-render, so a caught-up
+        // stream costs one comparison per frame rather than a paint.
+        if (current >= target) return current;
+        const backlog = target - current;
+        if (backlog > SNAP_BACKLOG_CHARS) return target;
+        const rate = Math.max(MIN_CHARS_PER_SECOND, backlog / (DRAIN_MS / 1000));
+        const advance = Math.max(1, Math.round(rate * seconds));
+        return Math.min(target, current + advance);
+      });
+    };
+    frame = requestAnimationFrame(step);
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [paced]);
+
+  // Clamped rather than trusted: a block whose text was REPLACED (completed, or
+  // re-projected shorter) must never slice past its own end.
+  return paced ? text.slice(0, Math.min(revealed, text.length)) : text;
+}

--- a/frontend/src/lib/assistant/markdown-stream.test.ts
+++ b/frontend/src/lib/assistant/markdown-stream.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { splitStableMarkdown } from "./markdown-stream";
+
+/**
+ * One paragraph — so it contributes no boundaries of its own — long enough to
+ * clear the module's minimum-length and minimum-prefix guards on its own.
+ */
+const INTRO =
+  "NyxID brokered the call with a scoped credential and never handed the raw " +
+  "token to the agent. The node injected it at the edge, so the transcript " +
+  "below records only metadata: which service, which scope, and how long the " +
+  "hop took end to end. Nothing in this paragraph is a list marker, a table " +
+  "row, a blockquote or an indented line, and it contains no footnote or link " +
+  "reference, so it is exactly the shape the splitter is allowed to freeze " +
+  "once the text that follows it has settled into its own block. It runs on " +
+  "for a few more clauses purely so that the fixture clears the minimum " +
+  "length on its own, without any test needing to pad it further.";
+
+describe("splitStableMarkdown", () => {
+  it("uses a fixture long enough to be eligible for splitting", () => {
+    expect(INTRO.length).toBeGreaterThan(600);
+  });
+
+  it("splits before a line that provably starts a new top-level block", () => {
+    const text = `${INTRO}\n\n## Result\n\nThe call succeeded.`;
+    const { prefix, tail } = splitStableMarkdown(text);
+    expect(prefix).toBe(`${INTRO}\n\n## Result\n\n`);
+    expect(tail).toBe("The call succeeded.");
+  });
+
+  it.each([
+    ["short text", "Too short to be worth splitting.\n\nSecond paragraph."],
+    ["an ordered list", `${INTRO}\n\n1. First item\n\n2. Second item`],
+    ["an unordered list", `${INTRO}\n\n- First item\n\n- Second item`],
+    ["a blockquote", `${INTRO}\n\n> Quoted line\n\n> Continued`],
+    ["a table row", `${INTRO}\n\n| a | b |\n| - | - |\n\n| 1 | 2 |`],
+    ["an indented block", `${INTRO}\n\n    indented code\n\n    more code`],
+    ["a footnote reference", `${INTRO}[^1]\n\nProse.\n\n[^1]: The note.`],
+    [
+      "a link reference definition",
+      `${INTRO}\n\nSee [the docs][d].\n\n[d]: https://example.com`,
+    ],
+  ])("declines to split around %s", (_case, text) => {
+    expect(splitStableMarkdown(text).prefix).toBe("");
+  });
+
+  it("never splits inside a fenced code block", () => {
+    const text = `${INTRO}\n\n\`\`\`ts\nconst a = 1;\n\nconst b = 2;\n\`\`\`\n\nDone.`;
+    const { prefix, tail } = splitStableMarkdown(text);
+    // The blank line INSIDE the fence is not a boundary; the only safe split is
+    // the settled text after the fence closed.
+    expect(prefix).toBe(`${INTRO}\n\n\`\`\`ts\nconst a = 1;\n\nconst b = 2;\n\`\`\`\n\n`);
+    expect(tail).toBe("Done.");
+  });
+
+  it("keeps an unterminated fence whole in the tail", () => {
+    const text = `${INTRO}\n\n\`\`\`ts\nconst a = 1;\n\nconst b = 2;`;
+    const { prefix, tail } = splitStableMarkdown(text);
+    // Splitting AT the opening fence is safe — the tail still parses it as the
+    // same incomplete fence — but nothing inside it may be frozen.
+    expect(prefix).toBe(`${INTRO}\n\n`);
+    expect(tail).toBe("```ts\nconst a = 1;\n\nconst b = 2;");
+  });
+
+  it("does not treat an indented tilde run inside a fence as a closer", () => {
+    const text = `${INTRO}\n\n~~~\nplain\n\n\`\`\`\nnested-looking\n\n~~~\n\nAfter.`;
+    const { prefix } = splitStableMarkdown(text);
+    expect(prefix.endsWith("~~~\n\n")).toBe(true);
+  });
+
+  it("always partitions the input exactly", () => {
+    const corpus = [
+      "",
+      INTRO,
+      `${INTRO}\n\n## Result\n\nThe call succeeded.`,
+      `${INTRO}\n\n1. one\n\n2. two`,
+      `${INTRO}\n\n\`\`\`\ncode\n\`\`\`\n\nAfter.`,
+      `${INTRO}\n\n\n\n\nExtra blank lines.`,
+      `${INTRO}\n\nTrailing newline.\n`,
+    ];
+    for (const text of corpus) {
+      const { prefix, tail } = splitStableMarkdown(text);
+      expect(prefix + tail).toBe(text);
+    }
+  });
+
+  it("advances the boundary monotonically as text streams in", () => {
+    const full = `${INTRO}\n\n## Result\n\nThe call succeeded.\n\nAnd then some more prose arrived after it, which should move the boundary forward.`;
+    let previous = 0;
+    for (let length = 1; length <= full.length; length += 7) {
+      const { prefix } = splitStableMarkdown(full.slice(0, length));
+      expect(prefix.length).toBeGreaterThanOrEqual(previous);
+      previous = prefix.length;
+    }
+  });
+});

--- a/frontend/src/lib/assistant/markdown-stream.ts
+++ b/frontend/src/lib/assistant/markdown-stream.ts
@@ -1,0 +1,126 @@
+/**
+ * Splitting streamed Markdown into a settled prefix and a live tail.
+ *
+ * A streaming text block re-parses its ENTIRE accumulated text on every paint,
+ * and that parse is linear in length — so a long answer writes itself more and
+ * more slowly, which is what reads as choppiness. Everything above the last
+ * completed block, though, can no longer be reinterpreted by characters that
+ * have not arrived yet: it can be parsed once and memoized by string identity,
+ * leaving only a short tail to re-parse per frame.
+ *
+ * "Can no longer be reinterpreted" is the entire difficulty, and this module is
+ * deliberately conservative about it. A split is only offered where the
+ * boundary is provably inert; anywhere it cannot prove that, it declines and
+ * returns the whole text as the tail — which is exactly the un-split behaviour,
+ * so declining costs speed and never correctness.
+ */
+
+export interface StableMarkdownSplit {
+  /** Parsed once and memoized. Empty when no safe boundary exists. */
+  readonly prefix: string;
+  /** Re-parsed per frame. The whole text when there is no safe boundary. */
+  readonly tail: string;
+}
+
+/**
+ * A line that the construct above it could still absorb. Splitting immediately
+ * before one of these would re-parse it as a NEW construct: an ordered list
+ * would restart its numbering at 1, a table row would lose its header, and an
+ * indented line would lose its nesting. Blank-line separation is not enough to
+ * rule this out, because loose lists carry blank lines between their items.
+ */
+const ABSORBABLE_LINE = /^(?:[ \t]|[-*+>|]|\d+[.)])/;
+
+/**
+ * Constructs whose meaning depends on text that arrives LATER: footnote
+ * references and link reference definitions both resolve against definitions
+ * collected from the whole document. A prefix frozen before its definitions
+ * stream in would render them as literal text permanently, so a text carrying
+ * either never splits. Both patterns are matched loosely on purpose — a false
+ * positive only forgoes the optimisation.
+ */
+const RESOLVES_LATER = /\[\^|^ {0,3}\[[^\]\n]+\]:/m;
+
+const FENCE = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * Below this there is nothing to win: the whole-text parse is already cheap and
+ * splitting would just pay two parser start-ups instead of one.
+ */
+const MIN_SPLIT_CHARS = 600;
+
+/** A prefix smaller than this saves less than the second parse costs. */
+const MIN_PREFIX_CHARS = 200;
+
+interface OpenFence {
+  readonly char: string;
+  readonly length: number;
+}
+
+/** CommonMark: same character, at least as long, and no trailing info string. */
+function closesFence(line: string, open: OpenFence): boolean {
+  const match = FENCE.exec(line);
+  const run = match?.[1];
+  if (match === null || run === undefined) return false;
+  return (
+    run.startsWith(open.char) &&
+    run.length >= open.length &&
+    line.slice(match[0].length).trim() === ""
+  );
+}
+
+/**
+ * The last offset in `text` that provably begins a new top-level block, or -1.
+ *
+ * Single pass, because this runs on every frame of a live stream: fence state
+ * and boundary tracking advance together rather than rescanning the text once
+ * per candidate.
+ *
+ * An unterminated trailing fence does NOT invalidate earlier boundaries. Every
+ * boundary is recorded while outside a fence, and the fence's own opening line
+ * is itself a boundary — splitting there leaves the incomplete fence in the
+ * tail, where it parses exactly as it would have unsplit.
+ */
+function lastSettledBoundary(text: string): number {
+  let openFence: OpenFence | null = null;
+  let previousBlank = false;
+  let offset = 0;
+  let boundary = -1;
+
+  for (const line of text.split("\n")) {
+    const start = offset;
+    offset += line.length + 1;
+
+    if (openFence) {
+      if (closesFence(line, openFence)) openFence = null;
+      previousBlank = false;
+      continue;
+    }
+
+    if (line.trim() === "") {
+      previousBlank = true;
+      continue;
+    }
+
+    if (previousBlank && !ABSORBABLE_LINE.test(line)) boundary = start;
+    previousBlank = false;
+
+    const run = FENCE.exec(line)?.[1];
+    if (run !== undefined) {
+      openFence = { char: run.slice(0, 1), length: run.length };
+    }
+  }
+
+  return boundary;
+}
+
+export function splitStableMarkdown(text: string): StableMarkdownSplit {
+  if (text.length < MIN_SPLIT_CHARS || RESOLVES_LATER.test(text)) {
+    return { prefix: "", tail: text };
+  }
+  const boundary = lastSettledBoundary(text);
+  if (boundary < MIN_PREFIX_CHARS || boundary >= text.length) {
+    return { prefix: "", tail: text };
+  }
+  return { prefix: text.slice(0, boundary), tail: text.slice(boundary) };
+}


### PR DESCRIPTION
## Problem

The chat stream painted its answer in discrete jumps that got worse the longer the reply ran.

In a browser trace of a real streamed turn, **only 4 of 36 frames advanced the text at all, by a median of 60 characters each** — four jumps of roughly a full line, not a stream.

Two independent causes:

**1. The whole transcript re-parsed on every tick.** `react-markdown` v10 keeps no internal cache and `TextBlock` had no `memo`, so every projection re-ran remark → rehype-sanitize → JSX for *every block in the conversation*, changed or not:

| | cost per UI update |
|---|---|
| 4 000-char answer, re-rendered with **identical text** | 14.97 ms |
| same, with text **growing** by 40 chars | 15.06 ms |
| 8-message transcript + streaming tail | **39.58 ms** |

The first two lines are the tell: unchanged text cost the same as changed text. And since parse cost is linear in accumulated text, a long answer progressively starved the main thread — which is exactly when it read as choppy.

**2. Nothing paced the reveal.** Text was painted the instant it arrived, so the answer advanced in whatever lumps the network and the projection scheduler produced.

## Change

- **Memoize each parse on the text it parsed**, and split a streaming block into a settled prefix (frozen, memoized) and a short live tail — so only the tail re-parses per frame.
- **New `lib/assistant/markdown-stream.ts`** decides where that split is safe. It is deliberately conservative: it refuses to split anywhere the boundary could change meaning — loose lists (ordered lists would renumber), tables, blockquotes, fences, footnotes, link reference definitions — and falls back to the whole-text parse. Declining costs speed, never correctness.
- **New `hooks/use-smooth-reveal.ts`** paces the reveal against the frame clock with a proportional controller, so the lag stays small and *constant* however lumpy the supply. It only withholds characters that have already arrived, and only while streaming: a settled block, reduced motion, or a missing frame clock all return the full text, so nothing can strand content behind an animation.
- **`use-assistant.ts`**: the adaptive 24–90 ms projection backoff is deleted. It existed to stop prose landing in large jumps — now the view layer's job — so the cadence is a flat interval again, which is also fewer re-renders.
- **`chat-thread.tsx`**: scroll-follow moves to `useLayoutEffect` (it was painting one frame at the stale offset, then rebounding) and onto a `ResizeObserver`, since text now grows inside a memoized block the thread does not re-render for.

## Result

Same mock stream, real headless Chromium, before vs after:

| | before | after |
|---|---|---|
| frames that advanced the text | 4 of 36 (**11 %**) | 33 of 46 (**72 %**) |
| chars per advancing frame (p50 / p90) | **60 / 84** | **6 / 7** |
| frames over 32 ms | 0 | 0 |

Render path:

| | before | after |
|---|---|---|
| re-render, identical text | 14.97 ms | **0.05 ms** |
| 8-message transcript + streaming tail | 39.58 ms | **0.19 ms** |

Per-frame cost is now flat in answer length rather than growing, which is what removes the "gets worse as it goes" behaviour.

## Correctness

`text-block.split.test.tsx` is the load-bearing test: it renders each document twice — real splitter vs. splitting stubbed out — and requires **byte-identical DOM**, including a sweep across every prefix of a streaming answer. One genuine divergence surfaced during development (a missing `\n` text node at the seam, which `mdast-util-to-hast` emits between top-level blocks) and is fixed rather than argued away.

It also carries an anti-vacuity assertion that the corpus actually exercises the split path — which caught a fixture bug that would have made all 14 equivalence cases pass trivially.

## Verification

- 2727 tests pass (233 files) on current `main`
- `npm run lint` — 0 errors (23 pre-existing warnings, none in changed files)
- `npm run build` (the CI gate: `tsc -b` + prod build) — green
- Screenshots mid-stream and settled confirm markdown, run/connect cards, caret and composer all render correctly

## Notes for review

- **The reference site (`nyx-chat-wf.surge.sh`) is not streaming.** It's a scripted playback engine: assistant messages are pre-rendered and revealed *whole* behind a typing-dots bubble with one 240 ms CSS rise; only the composer types character-by-character, and `2×` just divides every `beat(ms)`. Its smoothness comes from never re-laying-out content already on screen — the lesson that applies here — but its reveal model can't be copied to a live token stream without hiding the answer until it's complete.
- **One residual, measured not assumed.** When a paragraph completes and the settled boundary advances, that frame re-parses the whole prefix: 9.4 ms in jsdom (~3 ms in Chrome) at 10 000 chars, once per paragraph — comfortably inside a frame budget. Splitting into per-paragraph segments would shave it further; I measured first and judged the extra complexity not worth it.
- **Scope of the browser verification:** it used the dev-mode `?mock` transport, so it exercises the render path but not the real Aevatar transport. Upstream arrival cadence is unchanged — this PR changes how it is painted, not how fast it arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
