### PR TITLE
feat(billing): capture per-class LLM token breakdown

### DIFF
--- a/backend/src/handlers/billing.rs
+++ b/backend/src/handlers/billing.rs
@@ -67,6 +67,10 @@ pub struct BillingUsageRow {
     /// observability only, no cost, never pushed to Lago.
     pub billable: bool,
     pub estimated_credits_micros: Option<i64>,
+    /// Provider-reported token classes summed over the group (LLM traffic
+    /// only). None when no row in the group carried a breakdown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_breakdown: Option<crate::models::service_billing::TokenBreakdown>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -236,6 +240,12 @@ pub async fn get_usage(
                 },
                 "quantity": { "$sum": "$quantity" },
                 "events": { "$sum": 1 },
+                // Token-class observability sums; absent on non-LLM rows
+                // and rows written before breakdown capture shipped.
+                "prompt_tokens": { "$sum": { "$ifNull": ["$token_breakdown.prompt_tokens", 0] } },
+                "completion_tokens": { "$sum": { "$ifNull": ["$token_breakdown.completion_tokens", 0] } },
+                "cached_tokens": { "$sum": { "$ifNull": ["$token_breakdown.cached_tokens", 0] } },
+                "cache_creation_tokens": { "$sum": { "$ifNull": ["$token_breakdown.cache_creation_tokens", 0] } },
             }
         },
         doc! { "$sort": { "_id.service_slug": 1, "_id.layer": 1, "_id.metric": 1 } },
@@ -290,6 +300,7 @@ pub async fn get_usage(
             lago_acked: id_doc.get_bool("lago_acked").unwrap_or(false),
             billable,
             estimated_credits_micros,
+            token_breakdown: usage_row_breakdown(&doc),
         });
     }
 
@@ -795,6 +806,18 @@ fn parse_metric(value: &str) -> Option<BillingMetric> {
         "bytes" => Some(BillingMetric::Bytes),
         _ => None,
     }
+}
+
+/// Summed token-class breakdown for one aggregation group; None when every
+/// class summed to zero (non-LLM rows, or rows predating breakdown capture).
+fn usage_row_breakdown(doc: &Document) -> Option<crate::models::service_billing::TokenBreakdown> {
+    let breakdown = crate::models::service_billing::TokenBreakdown {
+        prompt_tokens: doc_i64(doc, "prompt_tokens").unwrap_or(0),
+        completion_tokens: doc_i64(doc, "completion_tokens").unwrap_or(0),
+        cached_tokens: doc_i64(doc, "cached_tokens").unwrap_or(0),
+        cache_creation_tokens: doc_i64(doc, "cache_creation_tokens").unwrap_or(0),
+    };
+    (!breakdown.is_empty()).then_some(breakdown)
 }
 
 fn doc_i64(doc: &Document, key: &str) -> Option<i64> {

--- a/backend/src/handlers/llm_gateway.rs
+++ b/backend/src/handlers/llm_gateway.rs
@@ -70,6 +70,7 @@ pub(crate) fn llm_platform_usage(
         fallback_bytes,
         llm_usage_service::token_quantity_or_estimate(usage, fallback_bytes),
     )
+    .with_token_breakdown(usage.map(llm_usage_service::ReportedLlmUsage::token_breakdown))
 }
 
 pub(crate) fn enforce_llm_billing_classification(
@@ -1766,6 +1767,8 @@ mod tests {
             prompt_tokens: 8,
             completion_tokens: 12,
             total_tokens: 20,
+            cached_tokens: 3,
+            cache_creation_tokens: 0,
             reported_cost: None,
         };
 

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -3637,6 +3637,7 @@ pub(crate) fn llm_platform_usage(
         fallback_bytes,
         llm_usage_service::token_quantity_or_estimate(usage, fallback_bytes),
     )
+    .with_token_breakdown(usage.map(llm_usage_service::ReportedLlmUsage::token_breakdown))
 }
 
 fn websocket_realtime_usage_enabled(
@@ -3656,6 +3657,13 @@ fn websocket_platform_usage(stats: &ConnectionUsageStats) -> PlatformUsage {
         PlatformUsage::llm_completion(
             stats.total_bytes(),
             stats.realtime_llm_usage.token_quantity(),
+        )
+        .with_token_breakdown(
+            stats
+                .realtime_llm_usage
+                .reported_usage
+                .as_ref()
+                .map(llm_usage_service::ReportedLlmUsage::token_breakdown),
         )
     } else {
         llm_platform_usage(None, stats.total_bytes())
@@ -5560,6 +5568,8 @@ mod tests {
                     prompt_tokens: 20,
                     completion_tokens: 10,
                     total_tokens: 30,
+                    cached_tokens: 0,
+                    cache_creation_tokens: 0,
                     reported_cost: None,
                 }),
                 uncovered_bytes: 20,

--- a/backend/src/models/service_billing.rs
+++ b/backend/src/models/service_billing.rs
@@ -70,12 +70,41 @@ impl ServiceBilling {
     }
 }
 
+/// Provider-reported token classes for one LLM exchange. `prompt_tokens`
+/// follows each provider's own accounting: OpenAI includes cached tokens
+/// inside `prompt_tokens`, Anthropic reports cache reads and writes
+/// outside `input_tokens`. Observability only for now; billing still
+/// charges the single total-token quantity.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+pub struct TokenBreakdown {
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    /// Cache-read tokens (OpenAI `prompt_tokens_details.cached_tokens`,
+    /// Anthropic `cache_read_input_tokens`).
+    #[serde(default)]
+    pub cached_tokens: i64,
+    /// Cache-write tokens (Anthropic `cache_creation_input_tokens`).
+    #[serde(default)]
+    pub cache_creation_tokens: i64,
+}
+
+impl TokenBreakdown {
+    pub fn is_empty(&self) -> bool {
+        self.prompt_tokens == 0
+            && self.completion_tokens == 0
+            && self.cached_tokens == 0
+            && self.cache_creation_tokens == 0
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 pub struct PlatformUsage {
     pub requests: i64,
     pub bytes: i64,
     #[serde(default)]
     pub tokens: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_breakdown: Option<TokenBreakdown>,
 }
 
 impl PlatformUsage {
@@ -84,6 +113,7 @@ impl PlatformUsage {
             requests: 1,
             bytes,
             tokens: 0,
+            token_breakdown: None,
         }
     }
 
@@ -92,7 +122,13 @@ impl PlatformUsage {
             requests: 1,
             bytes,
             tokens,
+            token_breakdown: None,
         }
+    }
+
+    pub fn with_token_breakdown(mut self, breakdown: Option<TokenBreakdown>) -> Self {
+        self.token_breakdown = breakdown.filter(|breakdown| !breakdown.is_empty());
+        self
     }
 }
 

--- a/backend/src/models/usage_meter.rs
+++ b/backend/src/models/usage_meter.rs
@@ -67,6 +67,10 @@ pub struct UsageMeterRow {
     pub credential_class: CredentialClass,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Provider-reported token classes (LLM traffic only; observability,
+    /// not priced separately). Follows each provider's own accounting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_breakdown: Option<crate::models::service_billing::TokenBreakdown>,
     #[serde(default)]
     pub reserved_credits: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/backend/src/services/billing/meter.rs
+++ b/backend/src/services/billing/meter.rs
@@ -136,6 +136,7 @@ pub(super) async fn persist_settlement_intent(
             BillingLayer::Platform,
             platform_quantity,
             model.clone(),
+            platform.token_breakdown.as_ref(),
             Some(resale_quantity),
             finalized_at,
         )
@@ -170,6 +171,7 @@ pub(super) async fn persist_settlement_intent(
             BillingLayer::Platform,
             platform_quantity,
             model.clone(),
+            platform.token_breakdown.as_ref(),
             None,
             finalized_at,
         )
@@ -185,6 +187,7 @@ pub(super) async fn persist_settlement_intent(
             BillingLayer::Resale,
             resale_quantity,
             model,
+            None,
             None,
             finalized_at,
         )
@@ -294,6 +297,7 @@ async fn insert_reserved_row(
         lago_metric_code,
         credential_class: ctx.credential_class,
         model: None,
+        token_breakdown: None,
         reserved_credits,
         quantity: None,
         pending_resale_quantity: None,
@@ -325,12 +329,14 @@ async fn insert_reserved_row(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn finalize_layer(
     db: &mongodb::Database,
     billing_request_id: &str,
     layer: BillingLayer,
     quantity: i64,
     model: Option<String>,
+    token_breakdown: Option<&crate::models::service_billing::TokenBreakdown>,
     pending_resale_quantity: Option<i64>,
     finalized_at: chrono::DateTime<Utc>,
 ) -> AppResult<Option<UsageMeterRow>> {
@@ -343,6 +349,11 @@ async fn finalize_layer(
         "updated_at": bson::DateTime::from_chrono(finalized_at),
         "finalized_at": bson::DateTime::from_chrono(finalized_at),
     };
+    if let Some(breakdown) = token_breakdown
+        && let Ok(breakdown) = bson::to_bson(breakdown)
+    {
+        set.insert("token_breakdown", breakdown);
+    }
     if let Some(resale_quantity) = pending_resale_quantity {
         set.insert("pending_resale_quantity", resale_quantity);
     }
@@ -384,6 +395,7 @@ async fn materialize_pending_resale_intent(
         BillingLayer::Resale,
         resale_quantity,
         coordinator.model.clone(),
+        None,
         None,
         finalized_at,
     )
@@ -812,6 +824,7 @@ mod tests {
             BillingLayer::Platform,
             42,
             Some("model-before-detach".to_string()),
+            None,
             Some(17),
             finalized_at,
         )
@@ -1417,6 +1430,49 @@ mod tests {
             })
             .await
             .expect("insert wallet");
+    }
+
+    /// The provider-reported token breakdown persists onto the finalized
+    /// platform row and never onto resale rows.
+    #[tokio::test]
+    async fn settle_persists_token_breakdown_on_platform_row() {
+        let Some(db) = connect_test_database("billing_token_breakdown").await else {
+            return;
+        };
+        create_usage_transaction_index(&db).await;
+        let ctx = platform_context("billing-breakdown", "owner-breakdown");
+        let metered = open(&db, &ctx, None).await.expect("open");
+        mark_forwarded(&db, &metered).await.expect("mark forwarded");
+
+        let breakdown = crate::models::service_billing::TokenBreakdown {
+            prompt_tokens: 120,
+            completion_tokens: 40,
+            cached_tokens: 100,
+            cache_creation_tokens: 30,
+        };
+        settle(
+            &db,
+            &metered,
+            PlatformUsage::llm_completion(640, 160).with_token_breakdown(Some(breakdown)),
+            None,
+            Some("test-model".to_string()),
+        )
+        .await
+        .expect("settle");
+
+        let row = db
+            .collection::<UsageMeterRow>(crate::models::usage_meter::COLLECTION_NAME)
+            .find_one(doc! { "billing_request_id": "billing-breakdown" })
+            .await
+            .expect("find row")
+            .expect("row exists");
+        assert_eq!(row.token_breakdown, Some(breakdown));
+
+        // An empty breakdown is dropped instead of stored as zeros.
+        let empty = PlatformUsage::llm_completion(64, 1).with_token_breakdown(Some(
+            crate::models::service_billing::TokenBreakdown::default(),
+        ));
+        assert!(empty.token_breakdown.is_none());
     }
 
     fn platform_context(request_id: &str, owner_id: &str) -> BillingRouteContext {

--- a/backend/src/services/billing/reconcile.rs
+++ b/backend/src/services/billing/reconcile.rs
@@ -615,6 +615,7 @@ mod tests {
             lago_metric_code: "platform_requests".to_string(),
             credential_class: CredentialClass::UserOwned,
             model: None,
+            token_breakdown: None,
             reserved_credits: 0,
             quantity: Some(1),
             pending_resale_quantity: None,

--- a/backend/src/services/billing/webhook.rs
+++ b/backend/src/services/billing/webhook.rs
@@ -442,6 +442,7 @@ mod tests {
             lago_metric_code: "platform_requests".to_string(),
             credential_class: CredentialClass::UserOwned,
             model: None,
+            token_breakdown: None,
             reserved_credits: 1,
             quantity: Some(1),
             pending_resale_quantity: None,

--- a/backend/src/services/llm_usage_service.rs
+++ b/backend/src/services/llm_usage_service.rs
@@ -15,6 +15,11 @@ pub struct ReportedLlmUsage {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
+    /// Cache-read tokens (OpenAI `prompt_tokens_details.cached_tokens`,
+    /// Anthropic `cache_read_input_tokens`).
+    pub cached_tokens: u64,
+    /// Cache-write tokens (Anthropic `cache_creation_input_tokens`).
+    pub cache_creation_tokens: u64,
     pub reported_cost: Option<f64>,
 }
 
@@ -23,7 +28,23 @@ impl ReportedLlmUsage {
         self.prompt_tokens == 0
             && self.completion_tokens == 0
             && self.total_tokens == 0
+            && self.cached_tokens == 0
+            && self.cache_creation_tokens == 0
             && self.reported_cost.is_none()
+    }
+
+    /// Per-class breakdown for the usage meter row, following each
+    /// provider's own accounting (see `TokenBreakdown`).
+    pub fn token_breakdown(&self) -> crate::models::service_billing::TokenBreakdown {
+        fn clamp(value: u64) -> i64 {
+            value.min(i64::MAX as u64) as i64
+        }
+        crate::models::service_billing::TokenBreakdown {
+            prompt_tokens: clamp(self.prompt_tokens),
+            completion_tokens: clamp(self.completion_tokens),
+            cached_tokens: clamp(self.cached_tokens),
+            cache_creation_tokens: clamp(self.cache_creation_tokens),
+        }
     }
 }
 
@@ -32,6 +53,8 @@ pub struct ReportedLlmUsageAccumulator {
     prompt_tokens: u64,
     completion_tokens: u64,
     total_tokens: u64,
+    cached_tokens: u64,
+    cache_creation_tokens: u64,
     reported_cost: Option<f64>,
 }
 
@@ -200,6 +223,8 @@ impl ReportedLlmUsageAccumulator {
         self.prompt_tokens = self.prompt_tokens.max(usage.prompt_tokens);
         self.completion_tokens = self.completion_tokens.max(usage.completion_tokens);
         self.total_tokens = self.total_tokens.max(usage.total_tokens);
+        self.cached_tokens = self.cached_tokens.max(usage.cached_tokens);
+        self.cache_creation_tokens = self.cache_creation_tokens.max(usage.cache_creation_tokens);
 
         if let Some(cost) = usage.reported_cost {
             self.reported_cost = Some(
@@ -216,6 +241,10 @@ impl ReportedLlmUsageAccumulator {
             .completion_tokens
             .saturating_add(usage.completion_tokens);
         self.total_tokens = self.total_tokens.saturating_add(usage.total_tokens);
+        self.cached_tokens = self.cached_tokens.saturating_add(usage.cached_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(usage.cache_creation_tokens);
 
         if let Some(cost) = usage.reported_cost {
             self.reported_cost = Some(self.reported_cost.unwrap_or(0.0) + cost);
@@ -240,6 +269,8 @@ impl ReportedLlmUsageAccumulator {
             prompt_tokens: self.prompt_tokens,
             completion_tokens: self.completion_tokens,
             total_tokens,
+            cached_tokens: self.cached_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
             reported_cost: self.reported_cost,
         };
 
@@ -368,6 +399,32 @@ pub fn extract_reported_usage(value: &serde_json::Value) -> Option<ReportedLlmUs
     )
     .unwrap_or_else(|| prompt_tokens + completion_tokens);
 
+    let cached_tokens = token_at(
+        value,
+        &[
+            "/usage/prompt_tokens_details/cached_tokens",
+            "/usage/input_tokens_details/cached_tokens",
+            "/usage/cache_read_input_tokens",
+            "/cache_read_input_tokens",
+            "/response/usage/prompt_tokens_details/cached_tokens",
+            "/response/usage/input_tokens_details/cached_tokens",
+            "/response/usage/cache_read_input_tokens",
+            "/message/usage/cache_read_input_tokens",
+        ],
+    )
+    .unwrap_or(0);
+
+    let cache_creation_tokens = token_at(
+        value,
+        &[
+            "/usage/cache_creation_input_tokens",
+            "/cache_creation_input_tokens",
+            "/response/usage/cache_creation_input_tokens",
+            "/message/usage/cache_creation_input_tokens",
+        ],
+    )
+    .unwrap_or(0);
+
     let reported_cost = [
         "/usage/reported_cost",
         "/usage/cost_usd",
@@ -392,6 +449,8 @@ pub fn extract_reported_usage(value: &serde_json::Value) -> Option<ReportedLlmUs
         prompt_tokens,
         completion_tokens,
         total_tokens,
+        cached_tokens,
+        cache_creation_tokens,
         reported_cost,
     };
 
@@ -507,6 +566,8 @@ mod tests {
                 prompt_tokens: 12,
                 completion_tokens: 7,
                 total_tokens: 19,
+                cached_tokens: 0,
+                cache_creation_tokens: 0,
                 reported_cost: Some(0.0042),
             }
         );
@@ -670,12 +731,16 @@ mod tests {
             prompt_tokens: 10,
             completion_tokens: 0,
             total_tokens: 0,
+            cached_tokens: 0,
+            cache_creation_tokens: 0,
             reported_cost: None,
         });
         accumulator.observe_snapshot(ReportedLlmUsage {
             prompt_tokens: 10,
             completion_tokens: 20,
             total_tokens: 30,
+            cached_tokens: 0,
+            cache_creation_tokens: 0,
             reported_cost: Some(0.012),
         });
 
@@ -739,12 +804,16 @@ mod tests {
             prompt_tokens: 10,
             completion_tokens: 5,
             total_tokens: 15,
+            cached_tokens: 0,
+            cache_creation_tokens: 0,
             reported_cost: Some(0.001),
         });
         accumulator.observe_delta(ReportedLlmUsage {
             prompt_tokens: 3,
             completion_tokens: 7,
             total_tokens: 10,
+            cached_tokens: 0,
+            cache_creation_tokens: 0,
             reported_cost: Some(0.002),
         });
 
@@ -782,6 +851,8 @@ mod tests {
             prompt_tokens: 20,
             completion_tokens: 10,
             total_tokens: 30,
+            cached_tokens: 0,
+            cache_creation_tokens: 0,
             reported_cost: None,
         };
 
@@ -803,6 +874,8 @@ mod tests {
             prompt_tokens: 0,
             completion_tokens: 0,
             total_tokens: 0,
+            cached_tokens: 0,
+            cache_creation_tokens: 0,
             reported_cost: Some(0.01),
         };
 
@@ -833,5 +906,101 @@ mod tests {
         // Also with whitespace
         let result2 = extract_reported_usage_from_sse_event(Some("message"), "  [DONE]  ");
         assert!(result2.is_none());
+    }
+
+    #[test]
+    fn extracts_openai_cached_tokens() {
+        let value = serde_json::json!({
+            "usage": {
+                "prompt_tokens": 120,
+                "completion_tokens": 40,
+                "total_tokens": 160,
+                "prompt_tokens_details": { "cached_tokens": 100 }
+            }
+        });
+
+        let usage = extract_reported_usage(&value).expect("usage");
+        assert_eq!(usage.prompt_tokens, 120);
+        assert_eq!(usage.completion_tokens, 40);
+        assert_eq!(usage.cached_tokens, 100);
+        assert_eq!(usage.cache_creation_tokens, 0);
+    }
+
+    #[test]
+    fn extracts_anthropic_cache_read_and_creation_tokens() {
+        let value = serde_json::json!({
+            "usage": {
+                "input_tokens": 25,
+                "output_tokens": 60,
+                "cache_read_input_tokens": 900,
+                "cache_creation_input_tokens": 300
+            }
+        });
+
+        let usage = extract_reported_usage(&value).expect("usage");
+        assert_eq!(usage.prompt_tokens, 25);
+        assert_eq!(usage.completion_tokens, 60);
+        assert_eq!(usage.cached_tokens, 900);
+        assert_eq!(usage.cache_creation_tokens, 300);
+    }
+
+    #[test]
+    fn extracts_anthropic_stream_message_usage_cache_tokens() {
+        let value = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 1,
+                    "cache_read_input_tokens": 500
+                }
+            }
+        });
+
+        let usage = extract_reported_usage(&value).expect("usage");
+        assert_eq!(usage.cached_tokens, 500);
+    }
+
+    #[test]
+    fn accumulator_sums_cache_tokens_across_deltas() {
+        let mut accumulator = ReportedLlmUsageAccumulator::default();
+        accumulator.observe_delta(ReportedLlmUsage {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+            cached_tokens: 8,
+            cache_creation_tokens: 2,
+            reported_cost: None,
+        });
+        accumulator.observe_delta(ReportedLlmUsage {
+            prompt_tokens: 4,
+            completion_tokens: 6,
+            total_tokens: 10,
+            cached_tokens: 3,
+            cache_creation_tokens: 0,
+            reported_cost: None,
+        });
+
+        let usage = accumulator.finalize().expect("usage");
+        assert_eq!(usage.cached_tokens, 11);
+        assert_eq!(usage.cache_creation_tokens, 2);
+    }
+
+    #[test]
+    fn token_breakdown_maps_all_classes() {
+        let usage = ReportedLlmUsage {
+            prompt_tokens: 1,
+            completion_tokens: 2,
+            total_tokens: 3,
+            cached_tokens: 4,
+            cache_creation_tokens: 5,
+            reported_cost: None,
+        };
+        let breakdown = usage.token_breakdown();
+        assert_eq!(breakdown.prompt_tokens, 1);
+        assert_eq!(breakdown.completion_tokens, 2);
+        assert_eq!(breakdown.cached_tokens, 4);
+        assert_eq!(breakdown.cache_creation_tokens, 5);
+        assert!(!breakdown.is_empty());
     }
 }

--- a/frontend/src/pages/billing.tsx
+++ b/frontend/src/pages/billing.tsx
@@ -776,6 +776,11 @@ function UsageSummary({
                             </TableCell>
                             <TableCell className="py-2 align-top text-[12px] text-muted-foreground">
                               {formatNumber(row.quantity)} {row.metric}
+                              {row.token_breakdown ? (
+                                <div className="mt-0.5 text-[11px] text-text-tertiary">
+                                  {formatTokenBreakdown(row.token_breakdown)}
+                                </div>
+                              ) : null}
                             </TableCell>
                             <TableCell className="py-2 text-right align-top text-[12px] tabular-nums">
                               {row.billable === false
@@ -912,6 +917,22 @@ function MetricBlock({ label, value }: { readonly label: string; readonly value:
       <div className="mt-1 truncate text-[20px] font-semibold leading-tight">{value}</div>
     </div>
   );
+}
+
+function formatTokenBreakdown(
+  breakdown: NonNullable<BillingUsageRow["token_breakdown"]>,
+): string {
+  const parts = [
+    `in ${formatNumber(breakdown.prompt_tokens)}`,
+    `out ${formatNumber(breakdown.completion_tokens)}`,
+  ];
+  if (breakdown.cached_tokens > 0) {
+    parts.push(`cached ${formatNumber(breakdown.cached_tokens)}`);
+  }
+  if (breakdown.cache_creation_tokens > 0) {
+    parts.push(`cache write ${formatNumber(breakdown.cache_creation_tokens)}`);
+  }
+  return parts.join(" / ");
 }
 
 function periodLabel(period: BillingUsagePeriod): string {

--- a/frontend/src/schemas/billing.test.ts
+++ b/frontend/src/schemas/billing.test.ts
@@ -6,6 +6,7 @@ import {
   topUpBillingRequestSchema,
   topUpBillingResponseSchema,
   billingUsageResponseSchema,
+  billingUsageRowSchema,
 } from "./billing";
 
 describe("billing schemas", () => {
@@ -107,5 +108,41 @@ describe("billing schemas", () => {
         reused: false,
       }).success,
     ).toBe(true);
+  });
+});
+
+describe("billing token breakdown", () => {
+  it("accepts rows with a token breakdown and defaults cache fields", () => {
+    const row = billingUsageRowSchema.parse({
+      metric: "tokens",
+      lago_metric_code: "platform_tokens",
+      layer: "platform",
+      quantity: 160,
+      requests: 0,
+      bytes: 0,
+      events: 1,
+      lago_acked: true,
+      token_breakdown: { prompt_tokens: 120, completion_tokens: 40 },
+    });
+    expect(row.token_breakdown).toEqual({
+      prompt_tokens: 120,
+      completion_tokens: 40,
+      cached_tokens: 0,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  it("accepts rows without a breakdown", () => {
+    const row = billingUsageRowSchema.parse({
+      metric: "requests",
+      lago_metric_code: "platform_requests",
+      layer: "platform",
+      quantity: 3,
+      requests: 3,
+      bytes: 0,
+      events: 3,
+      lago_acked: true,
+    });
+    expect(row.token_breakdown).toBeUndefined();
   });
 });

--- a/frontend/src/schemas/billing.ts
+++ b/frontend/src/schemas/billing.ts
@@ -20,6 +20,13 @@ export const billingReadOnlyBlockSchema = z.object({
   rates_are_approximate: z.literal(true),
 });
 
+export const billingTokenBreakdownSchema = z.object({
+  prompt_tokens: z.number().int().nonnegative(),
+  completion_tokens: z.number().int().nonnegative(),
+  cached_tokens: z.number().int().nonnegative().optional().default(0),
+  cache_creation_tokens: z.number().int().nonnegative().optional().default(0),
+});
+
 export const billingUsageRowSchema = z.object({
   service_slug: z.string().nullable().optional(),
   service_id: z.string().nullable().optional(),
@@ -38,6 +45,7 @@ export const billingUsageRowSchema = z.object({
   lago_acked: z.boolean(),
   billable: z.boolean().optional().default(true),
   estimated_credits_micros: z.number().int().nullable().optional(),
+  token_breakdown: billingTokenBreakdownSchema.nullable().optional(),
 });
 
 export const billingUsageTotalsSchema = z.object({
@@ -104,6 +112,7 @@ export type BillingPlanKind = z.infer<typeof billingPlanKindSchema>;
 export type BillingCollectionState = z.infer<typeof billingCollectionStateSchema>;
 export type BillingTopUpStatus = z.infer<typeof billingTopUpStatusSchema>;
 export type BillingReadOnlyBlock = z.infer<typeof billingReadOnlyBlockSchema>;
+export type BillingTokenBreakdown = z.infer<typeof billingTokenBreakdownSchema>;
 export type BillingUsageRow = z.infer<typeof billingUsageRowSchema>;
 export type BillingUsageTotals = z.infer<typeof billingUsageTotalsSchema>;
 export type BillingUsageResponse = z.infer<typeof billingUsageResponseSchema>;


### PR DESCRIPTION
## Summary

- Extend the LLM usage extractor to capture **cached tokens** (OpenAI `prompt_tokens_details.cached_tokens`, Responses-API `input_tokens_details.cached_tokens`, Anthropic `cache_read_input_tokens`) and **cache-write tokens** (Anthropic `cache_creation_input_tokens`) alongside the existing prompt/completion split, across all response shapes: buffered JSON, SSE streaming deltas (summed by the accumulator), and realtime WS sessions.
- Persist the per-class breakdown onto finalized platform usage meter rows (`token_breakdown`: prompt / completion / cached / cache-write), following each provider's own accounting (OpenAI counts cached inside prompt tokens; Anthropic reports cache reads/writes outside input tokens). **Observability only**: billing still charges the single total-token quantity — differential per-class pricing is deliberately deferred to the marketplace's per-listing rates where it belongs.
- Surface it: `GET /billing/usage` sums the breakdown per row group (tolerant of pre-feature rows), and the billing usage table shows an "in / out / cached / cache write" line under the token quantity when present.

## Test Plan

- [x] Extractor tests: OpenAI cached shape, Anthropic cache read+creation, Anthropic streaming message_start, accumulator delta summing, breakdown mapping
- [x] Meter test: breakdown persists onto the finalized platform row via settle; empty breakdowns are dropped, resale rows never carry one
- [x] Frontend schema tests: rows with breakdown (cache fields defaulted) and without
- [x] cargo test -p nyxid: 5121 passed, 0 failed
- [x] Frontend: build clean, 2761 tests passed, eslint clean
- [x] cargo fmt + clippy clean (pre-commit hooks)

## Checklist

- [x] Code follows the project's architecture rules
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Documentation: field-level doc comments; no env or setup changes needed