### PR TITLE
fix(assistant): keep the connect card on a settled outcome

### DIFF
--- a/frontend/src/components/assistant/blocks/action-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.test.tsx
@@ -433,22 +433,51 @@ describe("ActionCard", () => {
     });
   });
 
-  it("renders terminal receipts and the unsupported decline-only state", () => {
+  it("keeps the whole card on a terminal outcome and drops only its controls", () => {
     const onBlock = vi.fn();
     const onResolve = vi.fn();
     const { rerender } = renderCard(
       <ActionCard
         block={catalogBlock({
           status: "completed",
-          outcome_note: "Reported — awaiting assistant verification.",
+          outcome_note: "Connected. The assistant can use this service now.",
         })}
         onProgress={vi.fn()}
         onBlock={onBlock}
         onResolve={onResolve}
       />,
     );
+    // The service, scopes, and routing the user consented to survive the
+    // verdict; only the CTA row and the connect dialog go away.
     expect(
-      screen.getByText("Reported — awaiting assistant verification"),
+      screen.getByRole("heading", { name: "Connect GitHub" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("repo")).toBeInTheDocument();
+    expect(screen.getByText("Node node-1")).toBeInTheDocument();
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(
+      screen.getByText("Connected. The assistant can use this service now."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    rerender(
+      <ActionCard
+        block={catalogBlock({
+          status: "failed",
+          outcome_note:
+            "The connection did not complete. Ask the assistant to request this service again.",
+        })}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The connection did not complete. Ask the assistant to request this service again.",
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
 

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -14,7 +14,6 @@ import { Button } from "@/components/ui/button";
 import { useChatPresence } from "@/hooks/use-chat-presence";
 import { KEY_AUTH_FAILED, useKeyAuthorizationWatch } from "@/hooks/use-keys";
 import {
-  actionServiceLabel,
   clampServiceLabel,
   descriptorForAction,
 } from "@/lib/assistant/action-registry";
@@ -122,52 +121,40 @@ function ParameterSummary({
   );
 }
 
-const RECEIPT = {
+/**
+ * A settled card keeps the whole connect card — service icon, title, scopes,
+ * routing — and swaps only its verdict surfaces. Collapsing it to a bare
+ * receipt used to erase what the user had just agreed to.
+ */
+const SETTLED = {
   completed: {
-    title: "Reported — awaiting assistant verification",
+    badge: "Connected",
+    badgeVariant: "success",
+    frame: "border-success/30 bg-success/10",
     icon: ShieldCheck,
-    container: "border-border bg-overlay",
-    iconClass: "text-nyx-secondary-400",
+    iconClass: "text-success",
+    footer:
+      "Your credential stays in NyxID. The assistant only received a reference to this service.",
   },
   declined: {
-    title: "Action declined",
+    badge: "Declined",
+    badgeVariant: "secondary",
+    frame: "border-border bg-overlay",
     icon: X,
-    container: "border-border bg-overlay",
     iconClass: "text-muted-foreground",
+    footer: null,
   },
   failed: {
-    title: "Connection failed",
+    badge: "Failed",
+    badgeVariant: "destructive",
+    frame: "border-destructive/30 bg-destructive/10",
     icon: AlertTriangle,
-    container: "border-destructive/30 bg-destructive/[0.06]",
     iconClass: "text-destructive",
+    footer: null,
   },
 } as const;
 
-function Receipt({ block }: { readonly block: ActionCardContentBlock }) {
-  if (
-    block.status !== "completed" &&
-    block.status !== "declined" &&
-    block.status !== "failed"
-  ) {
-    return null;
-  }
-  const receipt = RECEIPT[block.status];
-  const Icon = receipt.icon;
-  return (
-    <section className={`rounded-xl border p-4 ${receipt.container}`}>
-      <div className="flex items-center gap-2 text-[12px] font-semibold text-foreground">
-        <Icon className={`h-4 w-4 ${receipt.iconClass}`} />
-        {receipt.title}
-      </div>
-      <p className="mt-2 text-[12px] leading-relaxed text-muted-foreground">
-        {block.outcome_note}
-      </p>
-      <p className="mt-1.5 text-[10px] text-text-tertiary">
-        {actionServiceLabel(block.params)}
-      </p>
-    </section>
-  );
-}
+type SettledStatus = keyof typeof SETTLED;
 
 function StatusNotice({ block }: { readonly block: ActionCardContentBlock }) {
   if (block.status !== "blocked" && block.status !== "conflicted") {
@@ -323,9 +310,8 @@ export function ActionCard({
     block.status !== "unsupported",
   );
 
-  if (settled) {
-    return <Receipt block={block} />;
-  }
+  const verdict = settled ? SETTLED[block.status as SettledStatus] : null;
+  const VerdictIcon = verdict?.icon;
 
   // Trust the descriptor too: a card whose verb has no journey behind it must
   // never render a CTA, whatever status the block carries.
@@ -413,9 +399,11 @@ export function ActionCard({
       <div className="flex items-start gap-3 px-4 py-3.5">
         <div
           className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border ${
-            unsupported
-              ? "border-destructive/30 bg-destructive/10"
-              : "border-nyx-secondary-400/30 bg-nyx-secondary-400/10"
+            verdict
+              ? verdict.frame
+              : unsupported
+                ? "border-destructive/30 bg-destructive/10"
+                : "border-nyx-secondary-400/30 bg-nyx-secondary-400/10"
           }`}
         >
           {params.variant === "catalog" ? (
@@ -433,28 +421,34 @@ export function ActionCard({
             </h3>
             <Badge
               variant={
-                unsupported || conflicted
-                  ? "destructive"
-                  : blocked
-                    ? "warning"
-                    : "accent"
+                verdict
+                  ? verdict.badgeVariant
+                  : unsupported || conflicted
+                    ? "destructive"
+                    : blocked
+                      ? "warning"
+                      : "accent"
               }
             >
-              {unsupported
-                ? "Unsupported"
-                : conflicted
-                  ? "Conflict"
-                  : blocked
-                    ? "Blocked"
-                    : awaitingAuthorization
-                      ? "Authorizing"
-                      : busy
-                        ? "In progress"
-                        : "Action required"}
+              {verdict
+                ? verdict.badge
+                : unsupported
+                  ? "Unsupported"
+                  : conflicted
+                    ? "Conflict"
+                    : blocked
+                      ? "Blocked"
+                      : awaitingAuthorization
+                        ? "Authorizing"
+                        : busy
+                          ? "In progress"
+                          : "Action required"}
             </Badge>
           </div>
           <p className="mt-1.5 text-[12px] leading-relaxed text-muted-foreground">
-            {descriptor.body(params)}
+            {/* A settled card states its outcome; the pitch for an action the
+                user already answered would only read as stale. */}
+            {verdict ? block.outcome_note : descriptor.body(params)}
           </p>
         </div>
       </div>
@@ -462,7 +456,18 @@ export function ActionCard({
       <ParameterSummary block={block} />
       <StatusNotice block={block} />
 
-      {!unsupported ? (
+      {verdict?.footer && VerdictIcon ? (
+        <div className="flex items-start gap-2 border-t border-border bg-muted px-4 py-3">
+          <VerdictIcon
+            className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${verdict.iconClass}`}
+          />
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {verdict.footer}
+          </p>
+        </div>
+      ) : null}
+
+      {!verdict && !unsupported ? (
         <div className="flex items-start gap-2 px-4 py-3">
           <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0 text-nyx-secondary-400" />
           <p className="text-[11px] leading-relaxed text-muted-foreground">
@@ -472,54 +477,58 @@ export function ActionCard({
         </div>
       ) : null}
 
-      <div className="flex flex-wrap items-center gap-2 border-t border-border bg-muted px-4 py-3">
-        {!unsupported ? (
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            disabled={primaryDisabled}
-            onClick={() => {
-              onProgress(block.block_id, true);
-              setDialogOpen(true);
-            }}
-          >
-            {busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
-            {awaitingAuthorization
-              ? "Waiting for authorization"
-              : busy
-                ? "Connecting"
-                : descriptor.cta(params)}
-          </Button>
-        ) : null}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={secondaryDisabled}
-          onClick={() => report("declined")}
-        >
-          <X />
-          Decline
-        </Button>
-        {blocked ? (
+      {!verdict ? (
+        <div className="flex flex-wrap items-center gap-2 border-t border-border bg-muted px-4 py-3">
+          {!unsupported ? (
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              disabled={primaryDisabled}
+              onClick={() => {
+                onProgress(block.block_id, true);
+                setDialogOpen(true);
+              }}
+            >
+              {busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
+              {awaitingAuthorization
+                ? "Waiting for authorization"
+                : busy
+                  ? "Connecting"
+                  : descriptor.cta(params)}
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="outline"
             size="sm"
             disabled={secondaryDisabled}
-            onClick={() => report("failed")}
+            onClick={() => report("declined")}
           >
-            <AlertTriangle />
-            Report failure
+            <X />
+            Decline
           </Button>
-        ) : null}
-        <span className="ml-auto text-[10px] text-muted-foreground">
-          Nothing is shared until you finish.
-        </span>
-      </div>
+          {blocked ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={secondaryDisabled}
+              onClick={() => report("failed")}
+            >
+              <AlertTriangle />
+              Report failure
+            </Button>
+          ) : null}
+          <span className="ml-auto text-[10px] text-muted-foreground">
+            Nothing is shared until you finish.
+          </span>
+        </div>
+      ) : null}
 
-      {!unsupported ? (
+      {/* A settled card unmounts the dialog: its journey is over, and leaving
+          it mounted would let a stale flow write onto a reported outcome. */}
+      {!verdict && !unsupported ? (
         <AddKeyDialog
           open={dialogOpen}
           onOpenChange={setOpen}

--- a/frontend/src/components/assistant/chat-composer.tsx
+++ b/frontend/src/components/assistant/chat-composer.tsx
@@ -519,7 +519,7 @@ function DraftedChatComposer({
       >
         <div
           ref={composerRef}
-          className={`relative ml-[30px] flex gap-1.5 rounded-xl border border-hairline bg-card p-1.5 transition-colors focus-within:border-hairline-strong ${
+          className={`relative ml-[30px] flex gap-1.5 rounded-xl border border-hairline bg-card px-3 py-2 transition-colors focus-within:border-hairline-strong ${
             multiline ? "flex-col items-stretch" : "items-start"
           }`}
         >

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -4457,7 +4457,7 @@ describe("chat action cards", () => {
     expect(card).toMatchObject({
       type: "action_card",
       status: "completed",
-      outcome_note: "Reported — awaiting assistant verification.",
+      outcome_note: "Connected. The assistant can use this service now.",
     });
   });
 
@@ -4694,10 +4694,10 @@ describe("chat action cards", () => {
       .find((block) => block.type === "action_card");
     expect(card).toMatchObject({ status: "completed" });
     expect(card?.type === "action_card" ? card.outcome_note : "").toContain(
-      "has not reached the assistant",
+      "has not been told yet",
     );
     expect(card?.type === "action_card" ? card.outcome_note : "").not.toContain(
-      "assistant received",
+      "can use this service now",
     );
 
     await collectTurn(transport, "Continue when idle");
@@ -4710,7 +4710,7 @@ describe("chat action cards", () => {
       .flatMap((message) => message.blocks)
       .find((block) => block.type === "action_card");
     expect(card?.type === "action_card" ? card.outcome_note : "").toBe(
-      "Reported — awaiting assistant verification.",
+      "Connected. The assistant can use this service now.",
     );
   });
 
@@ -8946,7 +8946,7 @@ describe("studio new chats and typed actor compatibility", () => {
           event.event === "block.updated" &&
           "outcome_note" in event.patch &&
           event.patch.outcome_note ===
-            "Reported — awaiting assistant verification.",
+            "Connected. The assistant can use this service now.",
       ),
     ).toBe(true);
   });

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -3216,12 +3216,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
 
   private actionOutcomeNote(disposition: ActionReport["disposition"]): string {
     if (disposition === "completed") {
-      return "Reporting the new service reference to the assistant.";
+      return "Connected. Telling the assistant it can use this service…";
     }
     if (disposition === "declined") {
-      return "You declined this request. Sending the decision to the assistant; no credential was shared.";
+      return "You declined. Nothing was connected and no credential was shared. Telling the assistant…";
     }
-    return "The connection could not be completed. Sending the failure to the assistant.";
+    return "The connection did not complete. Telling the assistant…";
   }
 
   private settledActionOutcomeNote(
@@ -3230,17 +3230,17 @@ export class AevatarAssistantTransport implements AssistantTransport {
   ): string {
     if (disposition === "completed") {
       return delivered
-        ? "Reported — awaiting assistant verification."
-        : "The new service reference has not reached the assistant; delivery will retry after the next turn.";
+        ? "Connected. The assistant can use this service now."
+        : "Connected, but the assistant has not been told yet — NyxID will retry after your next message.";
     }
     if (disposition === "declined") {
       return delivered
-        ? "You declined this request. The assistant received the decision; no credential was shared."
-        : "You declined this request. The decision has not reached the assistant; delivery will retry after the next turn.";
+        ? "You declined. Nothing was connected and no credential was shared."
+        : "You declined. The assistant has not been told yet — NyxID will retry after your next message. No credential was shared.";
     }
     return delivered
-      ? "The assistant received the connection failure. Ask it to request the service again."
-      : "The connection failure has not reached the assistant; delivery will retry after the next turn.";
+      ? "The connection did not complete. Ask the assistant to request this service again."
+      : "The connection did not complete, and the assistant has not been told yet — NyxID will retry after your next message.";
   }
 
   private updateActionBatchOutcomeNotes(

--- a/frontend/src/lib/assistant/scenario-engine.ts
+++ b/frontend/src/lib/assistant/scenario-engine.ts
@@ -529,18 +529,18 @@ function actionOutcome(disposition: ActionReport["disposition"]): {
   if (disposition === "completed") {
     return {
       status: "completed",
-      note: "Reported — awaiting assistant verification.",
+      note: "Connected. The assistant can use this service now.",
     };
   }
   if (disposition === "declined") {
     return {
       status: "declined",
-      note: "You declined this request. No service was connected and no credential was shared.",
+      note: "You declined. Nothing was connected and no credential was shared.",
     };
   }
   return {
     status: "failed",
-    note: "The connection could not be completed. Ask the assistant to request it again.",
+    note: "The connection did not complete. Ask the assistant to request this service again.",
   };
 }
 

--- a/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
@@ -814,7 +814,7 @@ describe("ScenarioInterceptTransport journey verification", () => {
         event: "block.updated",
         patch: {
           status: "completed",
-          outcome_note: "Reported — awaiting assistant verification.",
+          outcome_note: "Connected. The assistant can use this service now.",
         },
       });
       await flushAsync();

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -306,10 +306,10 @@ class MockAssistantTransport implements AssistantTransport {
             : "failed";
       const outcomeNote =
         report.disposition === "completed"
-          ? "Reported — awaiting assistant verification."
+          ? "Connected. The assistant can use this service now."
           : report.disposition === "declined"
-            ? "You declined this request. No service was connected and no credential was shared."
-            : "The connection could not be completed. Ask the assistant to request it again.";
+            ? "You declined. Nothing was connected and no credential was shared."
+            : "The connection did not complete. Ask the assistant to request this service again.";
       this.emitLocalActionPatch(
         conversationId,
         card.block_id,

--- a/frontend/src/lib/oauth-popup.test.ts
+++ b/frontend/src/lib/oauth-popup.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { oauthChannelName, openOAuthPopup } from "./oauth-popup";
 
+function stubWindowGeometry(geometry: Readonly<Record<string, number>>) {
+  for (const [key, value] of Object.entries(geometry)) {
+    vi.spyOn(window, key as "outerWidth", "get").mockReturnValue(value);
+  }
+}
+
 describe("OAuth popup manager", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -23,11 +29,58 @@ describe("OAuth popup manager", () => {
       1,
       "/oauth-launching",
       expect.stringMatching(/^nyxid_oauth_/),
-      "popup,width=760,height=820",
+      expect.stringContaining("popup,width="),
     );
     expect(first?.launchId).not.toBe(second?.launchId);
     first?.close();
     second?.close();
+  });
+
+  it("centers the popup over the opener window, not the primary display", () => {
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    const open = vi.spyOn(window, "open").mockReturnValue(popup);
+    // A window on a second monitor to the right, taller than the popup.
+    stubWindowGeometry({
+      screenX: 1920,
+      screenY: 100,
+      outerWidth: 1400,
+      outerHeight: 1000,
+    });
+
+    openOAuthPopup()?.close();
+
+    expect(open).toHaveBeenCalledWith(
+      "/oauth-launching",
+      expect.any(String),
+      "popup,width=760,height=820,left=2240,top=190",
+    );
+  });
+
+  it("clamps the popup to a window smaller than its natural size", () => {
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    const open = vi.spyOn(window, "open").mockReturnValue(popup);
+    stubWindowGeometry({
+      screenX: 0,
+      screenY: 0,
+      outerWidth: 600,
+      outerHeight: 500,
+    });
+
+    openOAuthPopup()?.close();
+
+    expect(open).toHaveBeenCalledWith(
+      "/oauth-launching",
+      expect.any(String),
+      "popup,width=600,height=500,left=0,top=0",
+    );
   });
 
   it("returns null when blocked and isolates channel names by nonce", () => {

--- a/frontend/src/lib/oauth-popup.ts
+++ b/frontend/src/lib/oauth-popup.ts
@@ -22,6 +22,34 @@ export interface PopupLaunchMetadata {
   readonly serviceName?: string;
 }
 
+const POPUP_WIDTH = 760;
+const POPUP_HEIGHT = 820;
+
+/**
+ * Center the popup over the window that opened it, not the primary display:
+ * `screenX`/`outerWidth` are what put it on the same monitor as the chat on a
+ * multi-screen desk. Sizes are clamped so a small window still gets a popup
+ * that fits on screen, and the offsets are floored at the window origin so a
+ * clamped popup can never land off-screen.
+ */
+function popupFeatures(view: Window = window): string {
+  const screenWidth = view.screen?.availWidth || view.screen?.width || 0;
+  const screenHeight = view.screen?.availHeight || view.screen?.height || 0;
+  const frameWidth = view.outerWidth || view.innerWidth || screenWidth;
+  const frameHeight = view.outerHeight || view.innerHeight || screenHeight;
+  const originX = view.screenX ?? view.screenLeft ?? 0;
+  const originY = view.screenY ?? view.screenTop ?? 0;
+
+  const width = frameWidth ? Math.min(POPUP_WIDTH, frameWidth) : POPUP_WIDTH;
+  const height = frameHeight
+    ? Math.min(POPUP_HEIGHT, frameHeight)
+    : POPUP_HEIGHT;
+  const left = Math.round(originX + Math.max(0, (frameWidth - width) / 2));
+  const top = Math.round(originY + Math.max(0, (frameHeight - height) / 2));
+
+  return `popup,width=${width},height=${height},left=${left},top=${top}`;
+}
+
 export interface OAuthPopupHandle {
   readonly launchId: string;
   readonly ready: Promise<void>;
@@ -109,7 +137,7 @@ export function openOAuthPopup(): OAuthPopupHandle | null {
   const popup = window.open(
     "/oauth-launching",
     `nyxid_oauth_${launchId}`,
-    "popup,width=760,height=820",
+    popupFeatures(),
   );
   if (!popup) return null;
 


### PR DESCRIPTION
Four chat fixes from live review of the connect flow.

## 1. A settled card no longer erases itself

`ActionCard` did `if (settled) return <Receipt block={block} />` — the whole connect card was replaced by a two-line receipt, so the service, scopes, node, and org the user had just consented to disappeared the moment the connection landed.

The card now survives its own outcome and swaps only the verdict surfaces:

| status | badge | icon frame | body |
|---|---|---|---|
| completed | `Connected` (success) | success tint | outcome note + "Your credential stays in NyxID. The assistant only received a reference to this service." |
| declined | `Declined` (secondary) | neutral | outcome note |
| failed | `Failed` (destructive) | destructive tint | outcome note |

The CTA row, the pre-connect assurance line, and `AddKeyDialog` unmount on a settled card — the dialog deliberately, so a stale flow cannot write onto a reported outcome.

## 2. Outcome copy

The old card printed `Reported — awaiting assistant verification` as **both** the title and the body — one internal protocol sentence, said twice. Status now lives in the badge and the note says what happened, across all three note producers (`transport.ts`, `aevatar-transport.ts`, `scenario-engine.ts`):

- completed, delivered → "Connected. The assistant can use this service now."
- completed, queued → "Connected, but the assistant has not been told yet — NyxID will retry after your next message."
- declined → "You declined. Nothing was connected and no credential was shared."
- failed → "The connection did not complete. Ask the assistant to request this service again."

The delivered-vs-retry distinction the old copy was reaching for is preserved.

## 3. OAuth popup centering

`window.open(..., "popup,width=760,height=820")` passed no position, so the browser placed the managed popup wherever it liked. It now computes `left`/`top` from the opener's `screenX`/`outerWidth`, which centers it on the window the chat is in rather than the primary display. Size clamps to the opener frame and offsets floor at the window origin, so a small window cannot push it off-screen.

The in-app connect dialog was already centered (`md:left-[50%] md:top-[50%]` in `dialog.tsx`) — untouched.

## 4. Chat composer padding

`p-1.5` (6px) left the placeholder and the send button tight against the border. Now `px-3 py-2` (8px/12px), both on the 4px scale in DESIGN.md. Composer height goes 44px → 48px; the 32px icon button and 32px `min-h-8` textarea stay aligned, and `syncComposerLayout` reads padding via `getComputedStyle` so the multiline threshold recomputes itself.

## Verification

- Full frontend suite green: 235 files / 2763 tests.
- `npm run build` (the CI gate — `tsc -b` + prod build) and lint clean.
- No wizard-bundle input touched (checked every changed path against `cli/src/wizard/bundle-meta/index.manifest`), so no rebuild is needed.
- Rebased onto `main` after #1391 and #1384 reworked the same file; card settlement logic from those commits is untouched by this change.
- Rollup PRs get no CI (`ci.yml` gates `main`/`dev` only) — the above was run locally.

Not verified in a real browser: the popup's on-screen position is asserted only at the `window.open` feature-string level, and the composer padding was eyeballed in jsdom text output rather than pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)