### PR TITLE
Document UserService identity updates through Web API

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "nyxid",
-      "description": "Brokers downstream credentials through the nyxid CLI and bundles synchronized Aevatar platform skills for workflows, teams, services, schedules, channels, and managed Codex.",
-      "version": "0.8.4",
+      "description": "Brokers downstream credentials through the NyxID CLI or authenticated Web API and bundles synchronized Aevatar platform skills for workflows, teams, services, schedules, channels, and managed Codex.",
+      "version": "0.8.5",
       "source": "./",
       "author": {
         "name": "ChronoAIProject"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nyxid",
-  "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
-  "version": "0.8.4",
+  "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the NyxID CLI or authenticated Web API.",
+  "version": "0.8.5",
   "author": {
     "name": "ChronoAIProject"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nyxid",
-  "version": "0.7.6",
-  "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
+  "version": "0.7.7",
+  "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the NyxID CLI or authenticated Web API.",
   "author": {
     "name": "ChronoAIProject",
     "url": "https://github.com/ChronoAIProject"
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "NyxID",
     "shortDescription": "Credential broker so agents never see raw API keys or tokens.",
-    "longDescription": "NyxID brokers credentials for downstream services through the nyxid CLI: discover and configure services, proxy requests with credential injection, manage credential nodes, expose MCP tools, and issue scoped agent keys. The plugin also bundles the synchronized Aevatar platform skill family.",
+    "longDescription": "NyxID brokers credentials for downstream services through the CLI or authenticated Web API: discover and configure services, proxy requests with credential injection, manage credential nodes, expose MCP tools, and issue scoped agent keys. The plugin also bundles the synchronized Aevatar platform skill family.",
     "developerName": "ChronoAIProject",
     "category": "Coding",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "nyxid",
   "displayName": "NyxID",
-  "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the nyxid CLI.",
-  "version": "0.7.6",
+  "description": "Brokers credentials for downstream services so agents never see raw keys or tokens, and bundles the synchronized Aevatar platform skill family. Operates through the NyxID CLI or authenticated Web API.",
+  "version": "0.7.7",
   "author": {
     "name": "ChronoAIProject",
     "url": "https://github.com/ChronoAIProject"

--- a/skills/aevatar-codex-exec-node-setup/SKILL.md
+++ b/skills/aevatar-codex-exec-node-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aevatar-codex-exec-node-setup
 description: Configure and prove Aevatar codex_exec for one NyxID account, choosing operator-managed chrono-sandbox/gVisor for bounded empty-workspace work or private NyxID node-backed SSH for a fixed host workspace. Use for managed eligibility and UserService readiness, private node/SSH hardening, mandatory public-sample verification, or diagnosing typed managed and private-route failures.
-version: "4.2"
+version: "4.3"
 metadata:
   category: tool-based
   tool-list:
@@ -19,7 +19,7 @@ metadata:
     - workflow
   depends-on:
     - aevatar-codex-exec-workflow-sample@3.1
-compatibility: NyxID CLI and an Aevatar deployment that exposes codex_exec; private SSH additionally requires macOS or Linux, OpenSSH, Codex CLI, and Git
+compatibility: NyxID authenticated Web API or CLI and an Aevatar deployment that exposes codex_exec; private SSH additionally requires macOS or Linux, OpenSSH, Codex CLI, and Git
 disable-model-invocation: false
 user-invocable: true
 ---
@@ -62,20 +62,39 @@ Require only these managed prerequisites:
 
 1. The caller is authenticated as the exact intended native NyxID user.
 2. Managed Codex is enabled with `RolloutBoundary=InternalOnly`, and the user is eligible through `Eligibility.Mode=Allowlist` or the internal `All` policy.
-3. That user directly owns exactly one active, usable `chrono-sandbox` UserService and has exactly one usable `chrono-llm-public` route.
+3. That user directly owns exactly one active, usable `chrono-sandbox` UserService with
+   `forward_access_token=true` and has exactly one usable `chrono-llm-public` route.
 4. Operations deployed the approved immutable runner digest under gVisor with fixed resource, output, timeout, and cleanup bounds.
 5. The explicit credential lifecycle reports `execution_ready=true` with
    `execution_readiness_reason=ready`; `status=active` alone is insufficient.
 6. The public `aevatar-codex-exec-workflow-sample@3.1` managed proof returns exact
    `CODEX_EXEC_READY` through Aevatar.
 
-Confirm only the user-facing identity and service inventory before the proof:
+Confirm only the user-facing identity and service inventory before the proof. The CLI form is:
 
 ```bash
 nyxid --version
 nyxid whoami
 nyxid service list
 ```
+
+The CLI is not required for service configuration. An HTTP-only client can inspect the same
+authoritative inventory with authenticated `GET /api/v1/keys`. If the exact account-owned
+`chrono-sandbox` entry reads `forward_access_token=false`, repair that UserService directly:
+
+```http
+PUT /api/v1/user-services/{chronoSandboxUserServiceId}
+Authorization: Bearer <nyxid-token>
+Content-Type: application/json
+
+{"forward_access_token":true}
+```
+
+Read `GET /api/v1/keys` again and verify `forward_access_token=true` on that same UserService ID
+before retesting. The catalog entry's `id` and the account-owned entry's `id` are intentionally
+different; use the latter here. Never send `catalog_service_id` to `/api/v1/user-services/{id}`.
+`POST /api/v1/services/{catalogServiceId}/resync-identity` is a separate admin-only catalog
+recovery operation, not the owner self-service path.
 
 Do not require a personal node, local Codex login, caller-managed OpenSandbox key, separate LLM
 consent, Landlock installation, or sandbox-side credential injection. Prepare the managed
@@ -243,6 +262,7 @@ For managed, all must be true:
 
 - the exact native NyxID user is eligible under the internal rollout policy
 - that user has the required active `chrono-sandbox` and `chrono-llm-public` UserServices
+- the exact `chrono-sandbox` UserService reads back `forward_access_token=true`
 - operations deployed the approved immutable runner under gVisor with bounded output and strict cleanup
 - the public managed workflow returned exact `CODEX_EXEC_READY`
 - no raw persistent key or request-local delegation token appeared in output

--- a/skills/aevatar-codex-exec-node-setup/references/troubleshooting.md
+++ b/skills/aevatar-codex-exec-node-setup/references/troubleshooting.md
@@ -33,7 +33,7 @@ Preserve only the typed code and sanitized `diagnostic_id`. Never request a raw 
 
 | Code | Meaning | Check |
 |---|---|---|
-| `managed_proxy_authorization_denied` | NyxID or chrono-sandbox rejected the invocation authority | Inspect the exact UserService policy and sanitized diagnostic; normal execution does not rotate or repair credentials |
+| `managed_proxy_authorization_denied` or downstream `UNAUTHORIZED` | NyxID or chrono-sandbox rejected the invocation authority; a common cause is `forward_access_token=false` on the caller's exact `chrono-sandbox` UserService | Read the authoritative `GET /api/v1/keys` inventory. If that exact account-owned UserService reads false, send `PUT /api/v1/user-services/{userServiceId}` with `{"forward_access_token":true}`, then read back the same ID before retesting. Never substitute its different `catalog_service_id`; catalog resync is admin-only |
 | `managed_proxy_target_unavailable` | The exact personal `chrono-sandbox` proxy target cannot be resolved | Verify the user's active `chrono-sandbox` UserService and deployment route |
 | `managed_proxy_timeout` | NyxID proxy or chrono-sandbox did not return within the bounded transport wait | Correlate the sanitized diagnostic at NyxID/chrono-sandbox; do not repair local sandbox tooling |
 | `managed_proxy_unavailable` | NyxID proxy or chrono-sandbox is temporarily unavailable or capacity-limited | Retry later and escalate repeated failures with the sanitized diagnostic |

--- a/skills/nyxid-service-skill-authoring/SKILL.md
+++ b/skills/nyxid-service-skill-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nyxid-service-skill-authoring
 description: Find or author an agent skill for a NyxID proxy service that has no OpenAPI spec or typed operations. Use when a NyxID service only exposes the generic proxy tool, `nyxid catalog endpoints` returns nothing for the slug, or you would otherwise have to guess endpoint paths. Searches Ornn for an existing skill bound to the service; if none exists, creates one — researching the official OpenAPI spec on the web for public services, or collecting the contract from the user for private/custom services (never fabricate endpoints) — then uploads it to Ornn, binds it to the service, and records it locally.
-version: "1.1"
+version: "1.2"
 metadata:
   category: plain
   tag:
@@ -53,11 +53,19 @@ e.g. `https://nyx-api.chrono-ai.fun`):
   (`nyxid catalog endpoints <slug>`):
   `GET {BASE}/api/v1/catalog/{slug}/endpoints`.
 - **Mount a spec / set skills** (`nyxid service update ...`):
-  `PUT {BASE}/api/v1/keys/{user_service_id}` with a JSON body — e.g.
+  `PUT {BASE}/api/v1/keys/{id}` with the exact ID returned by the keys inventory and a JSON body — e.g.
   `{"openapi_spec_url": "https://..."}` (empty string clears) or
   `{"recommended_skills": ["name"]}` (empty list clears). The endpoint
   document alone can also be updated via
   `PUT {BASE}/api/v1/endpoints/{endpoint_id}` with the same fields.
+- **Update account-owned routing or identity settings**:
+  resolve the exact UserService ID from `GET {BASE}/api/v1/keys`, then use
+  `PUT {BASE}/api/v1/user-services/{user_service_id}` — for example,
+  `{"forward_access_token": true}`. A catalog service ID is a different
+  identity and must never be used here. Read `GET {BASE}/api/v1/keys`
+  afterward and verify the same UserService ID. Platform-wide catalog
+  recovery is the separate admin-only
+  `POST {BASE}/api/v1/services/{catalog_service_id}/resync-identity` API.
 - **Call the target service through the proxy**
   (`nyxid proxy request <slug> ...`):
   `M {BASE}/api/v1/proxy/s/{slug}/<path>` — NyxID injects the stored

--- a/skills/nyxid/SKILL.md
+++ b/skills/nyxid/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nyxid
-version: "0.7"
-description: Brokers credentials for downstream services so the agent never sees raw API keys or OAuth tokens. Use when the user explicitly mentions NyxID; asks to broker, store, proxy, connect, or manage credentials or a credential-backed service; manages NyxID credential nodes, SSH, MCP, or other NyxID resources; or must call a protected downstream API using an available NyxID-managed credential because no suitable authenticated native path is available. Do not use merely because a service is external, for public or unauthenticated APIs or webhooks, for standard Git operations, or for ordinary GitHub work when local `gh` is authenticated. A GitHub username supplied only to select an account is not a trigger. Operate exclusively through the `nyxid` CLI.
+version: "0.8"
+description: Brokers credentials for downstream services so the agent never sees raw API keys or OAuth tokens. Use when the user explicitly mentions NyxID; asks to broker, store, proxy, connect, or manage credentials or a credential-backed service; manages NyxID credential nodes, SSH, MCP, or other NyxID resources; or must call a protected downstream API using an available NyxID-managed credential because no suitable authenticated native path is available. Do not use merely because a service is external, for public or unauthenticated APIs or webhooks, for standard Git operations, or for ordinary GitHub work when local `gh` is authenticated. A GitHub username supplied only to select an account is not a trigger. Operate through the `nyxid` CLI or the authenticated NyxID Web API.
 metadata:
   category: tool-based
   tool-list:
@@ -30,15 +30,15 @@ metadata:
 
 Use NyxID before asking the user to paste raw API keys or OAuth tokens for downstream services.
 
-NyxID is the credential broker. The agent should use the `nyxid` CLI to discover services and make proxy requests. NyxID injects the user's stored credentials automatically.
+NyxID is the credential broker. Use either the `nyxid` CLI or the authenticated NyxID Web API to discover services, configure user-owned routes, and make proxy requests. The CLI is a convenience client, not a prerequisite for supported API operations. NyxID injects the user's stored credentials automatically.
 
 Credential nodes can be personal or org-owned. Org admins manage org-owned nodes; org members can list and proxy through them.
 
 For the full API reference, error codes, and advanced topics (SSH, MCP, OAuth client integration, service accounts), load `references/playbook.md` (populated at install time from the NyxID server's `/llms.txt` endpoint), or fetch the latest directly from `<NYXID_BASE_URL>/llms.txt`.
 
-## Setup
+## CLI setup (optional)
 
-Install the NyxID CLI (one-time). This is the default "install NyxID" path; do not run the Docker backend setup unless the user explicitly asks to self-host:
+Install the NyxID CLI when a shell is available. This is the default "install NyxID" path; do not run the Docker backend setup unless the user explicitly asks to self-host. HTTP-only clients can instead call the authenticated Web API described in the reference pages.
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
@@ -120,7 +120,7 @@ Load the matching `references/<file>.md` when the user asks for one of these top
 | "list my services", "what's connected", "discover services", "add a service", "connect OpenAI / GitHub / Lark / etc.", Lark Base / Bitable `91403`, "OAuth scopes", browser-wizard / pairing-code questions, "where do I get the API key" | `references/services.md` |
 | "call the API", "proxy request", "send a message via Telegram/Discord/Slack" (single call), curl examples, raw HTTP integration, WebSocket auth-frame injection, Home Assistant connection | `references/proxy.md` |
 | "service pool", "pool slug", "load balance services", "several identical backends", "proxy to a pool" | `references/service-pools.md` |
-| "list / rename / delete a service", attaching an OpenAPI spec to a custom endpoint, default headers, "create / rotate / delete an API key", agent key bindings, callback URLs, scope/rate-limit edits | `references/managing.md` |
+| "list / rename / delete a service", attaching an OpenAPI spec to a custom endpoint, default headers, identity propagation, `forward_access_token`, catalog service ID vs UserService ID, "create / rotate / delete an API key", agent key bindings, callback URLs, scope/rate-limit edits | `references/managing.md` |
 | "which services can this app access", "Authorized Apps", "OAuth consent", "consent service access", "restrict this app to service X", "legacy grant", "resource indicators", "RFC 8707", OAuth `resource` parameter, "app default services", `default_service_catalog_slugs`, "consent defaults" | `references/oauth-consent.md` |
 | Anything mentioning "org", "organization", "shared credentials", "family / company key", invites, role scopes, primary-org tiebreaker, org-level approval policies, `--via-service`, CLI profiles | `references/organizations.md` |
 | "set up a node", "credentials on my own machine", org-owned/shared nodes, node daemon (install/start/stop/logs), node credentials add/setup/list, remote credential injection / `node-credential inject` / "push a secret to a node from my laptop or browser without SSH" / fingerprint verification / browser accept page, SSH node-key credentials, SSH exec / terminal / cert-issue, SSH ProxyCommand | `references/nodes.md` |
@@ -133,14 +133,15 @@ Load the matching `references/<file>.md` when the user asks for one of these top
 
 Prefer the canonical reference over guessing. If a topic spans two files (e.g. "create an org-shared API key with rate limits"), load both `organizations.md` and `managing.md`.
 
-**Driving Aevatar through NyxID.** If the user wants to build or run things on the **Aevatar** agent platform — "create a workflow / team / member", "publish a service", "schedule a run", or "can Aevatar do X?" — that is a sibling skill family bundled in this plugin (not a `references/` file here). Start with **`aevatar-platform-map`** (the router). Those skills drive Aevatar entirely through this same NyxID broker — `nyxid proxy request aevatar "<path>"` — so the CLI you set up above is the only prerequisite; connect the service once with `nyxid service add aevatar`.
+**Driving Aevatar through NyxID.** If the user wants to build or run things on the **Aevatar** agent platform — "create a workflow / team / member", "publish a service", "schedule a run", or "can Aevatar do X?" — that is a sibling skill family bundled in this plugin (not a `references/` file here). Start with **`aevatar-platform-map`** (the router). Those skills drive Aevatar through this same NyxID broker. Use either `nyxid proxy request aevatar "<path>"` or the equivalent authenticated `/api/v1/proxy/s/aevatar/<path>` Web API. Connect the service once through the CLI or supported service API.
 
 ## Working Rules
 
-- Always discover configured service instances with `nyxid service list --output json` before assuming a slug or exact UserService exists. This command reads `GET /api/v1/keys`, the authoritative discovery, readiness, and execution inventory.
+- Always discover configured service instances with `nyxid service list --output json` or authenticated `GET /api/v1/keys` before assuming a slug or exact UserService exists. This is the authoritative discovery, readiness, and execution inventory.
 - Treat `/api/v1/user-services` as a routing-configuration projection only. It cannot prove that a credential is discoverable, ready, or authorized for execution.
 - Use `--output json` for machine-readable responses.
-- Prefer slug-based proxy URLs, but pin the exact UserService with `--via-service <id>` whenever multiple credentials share a slug or downstream authorization depends on a specific account/Bot. Get that ID only from `nyxid service list --output json`.
+- Prefer slug-based proxy URLs, but pin the exact UserService with `--via-service <id>` or `/api/v1/proxy/{user_service_id}/...` whenever multiple credentials share a slug or downstream authorization depends on a specific account/Bot. Get that ID only from the authoritative `/api/v1/keys` inventory.
+- Catalog service IDs and account-owned UserService IDs are separate identities. Never send a catalog ID to `/api/v1/user-services/{id}`. After a user-owned route update, read `GET /api/v1/keys` again and verify the same UserService ID and field value.
 - Use exact downstream API paths. Do not guess undocumented endpoints.
 - Keep request bodies minimal and service-correct.
 - Never try to extract or display the user's stored provider credentials.
@@ -163,7 +164,7 @@ Raw HTTP clients use the same slug route: `/api/v1/proxy/s/{pool_slug}/{path}`. 
 
 ## External Endpoints
 
-All requests are made through the `nyxid` CLI, which connects to the NyxID instance configured at login. No other external endpoints are contacted. Downstream service calls are made server-side by NyxID.
+Requests go to the authenticated NyxID instance, either through the `nyxid` CLI or its Web API. Downstream service calls are made server-side by NyxID.
 
 ## Security and Privacy
 

--- a/skills/nyxid/references/managing.md
+++ b/skills/nyxid/references/managing.md
@@ -38,6 +38,49 @@ nyxid service delete <id> --yes                                # remove service 
 
 > Identity and delegation flags update the resolved UserService route. Use `forward_access_token` only when the downstream validates the caller's NyxID bearer; keep `delegation_token_scope` to the minimum scopes that downstream requires.
 
+### Managing a UserService through the Web API
+
+The CLI is optional. An authenticated owner can inspect and update the same account-owned
+UserService through the supported Web API. A user access token or an agent key with `write` or
+`admin` scope is required for the update.
+
+```http
+GET /api/v1/keys
+Authorization: Bearer <nyxid-token>
+```
+
+Resolve the exact entry from this authoritative inventory and retain both identifiers:
+
+- `id` (or `user_service_id` on clients that expose that alias) is the account-owned
+  **UserService ID** used for routing and owner writes.
+- `catalog_service_id` identifies the shared catalog definition from which the service was
+  provisioned. It is intentionally different and must not be sent to a UserService endpoint.
+
+For example, enable access-token forwarding on the exact account-owned route:
+
+```http
+PUT /api/v1/user-services/{userServiceId}
+Authorization: Bearer <nyxid-token>
+Content-Type: application/json
+
+{"forward_access_token":true}
+```
+
+Then call `GET /api/v1/keys` again and verify that the entry with that same UserService ID now has
+`forward_access_token: true`. Matching only by slug is insufficient when more than one service
+instance exists. Do not use `PUT /api/v1/keys/{catalogServiceId}` for identity settings.
+
+Catalog defaults are platform-owned. An administrator may explicitly reapply a catalog
+definition's identity settings to its inherited UserServices with:
+
+```http
+POST /api/v1/services/{catalogServiceId}/resync-identity
+Authorization: Bearer <admin-token>
+```
+
+That admin recovery operation is separate from owner self-service. It takes a catalog service ID;
+`PUT /api/v1/user-services/{userServiceId}` takes the account-owned UserService ID.
+
 > Node commands accept names (e.g., `--via-node test-server`) in addition to UUIDs.
 > For org-owned node operations, the two-machine VM playbook, and transfer cleanup behavior, see [`nodes.md`](nodes.md#two-machine-org-node-setup).
 > For remote credential provisioning, use `nyxid node-credential push/list/cancel` on the admin laptop and `nyxid node credentials pending/accept/decline` on the VM. See [`nodes.md`](nodes.md#remote-credential-provisioning).


### PR DESCRIPTION
## Problem

NyxID skill guidance implied the CLI was mandatory and one HTTP mapping incorrectly routed UserService settings through `/api/v1/keys/{id}`. This obscured the supported owner self-service repair for a `forward_access_token=false` route and made catalog IDs easy to confuse with account-owned UserService IDs.

Related investigation: aevatarAI/aevatar#3161.

## Solution

- document CLI and authenticated Web API as supported surfaces
- resolve exact account-owned UserService IDs from `GET /api/v1/keys`
- update identity settings with `PUT /api/v1/user-services/{userServiceId}` and require same-ID readback
- keep admin-only catalog `resync-identity` separate and reject catalog/UserService ID substitution
- add the exact `chrono-sandbox` repair to managed codex_exec setup and troubleshooting
- bump NyxID skill and plugin manifest versions

## Impact

- `skills/nyxid` and its service-management reference
- `skills/nyxid-service-skill-authoring`
- `skills/aevatar-codex-exec-node-setup`
- Claude, Codex, and Cursor plugin manifests

No backend or frontend runtime code changed.

## Verification

- `git diff --check`
- `jq empty` on all four plugin manifests
- Ornn `/api/v1/skill-format/validate`: `valid:true` for `nyxid@0.8`, `nyxid-service-skill-authoring@1.2`, and `aevatar-codex-exec-node-setup@4.3`
- published and read back `nyxid-service-skill-authoring@1.2`, hash `d72e6d3e4b8ae90ea005f37f1d8fd6ab7d52fbdb5ff4a3a8ac5451084161c588`
- published and read back `aevatar-codex-exec-node-setup@4.3`, hash `658d21358de8c489455fca36c05e38dac3a5ee8393530e4bc214cc5221edbfc9`
- main Ornn `nyxid` GUID remains at `0.5`: current account has no update grant, so its validated `0.8` package must be published by the skill owner or source-sync process after merge

The generic Codex `quick_validate.py` is not a compatible validator for these existing Ornn/Claude extensions because it rejects repository-standard frontmatter such as `version` and `compatibility`; Ornn format validation is the authoritative package check here.