### PR TITLE
Implement typed assistant decision facade

### DIFF
--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -8994,9 +8994,10 @@ mod proxy_resolution_integration_tests {
         for body in [
             r#"{"type":"text","prompt":"connect api-github","clientRequestId":"00000000-0000-4000-8000-000000000001"}"#,
             r#"{"type":"text","prompt":"continue","clientRequestId":"00000000-0000-4000-8000-000000000002","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae"}"#,
+            r#"{"type":"input.resolve","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000010","requestId":"input-1","answer":{"selectedOptionIds":["option-a","option-b"]},"expectedStateVersion":19}"#,
             r#"{"type":"action.continue","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000003","originTurnId":"turn-action-1","actions":[{"actionRequestId":"act-1","originTurnId":"turn-action-1","disposition":"completed","resource":{"userService":{"userServiceId":"00000000-0000-4000-8000-000000000123"}}}]}"#,
             r#"{"type":"action.continue","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000009","originTurnId":"turn-action-2","actions":[{"actionRequestId":"act-2","originTurnId":"turn-action-2","disposition":"failed"}]}"#,
-            r#"{"type":"approval.resolve","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000004","requestId":"approval-1","approved":true,"reason":"Approved by user"}"#,
+            r#"{"type":"approval.resolve","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000004","requestId":"approval-1","approved":true,"reason":"Approved by user","expectedStateVersion":21}"#,
             r#"{"type":"task.stop","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","turnId":"turn-1","stopRequestId":"stop-1","clientRequestId":"00000000-0000-4000-8000-000000000005","expectedStateVersion":0}"#,
             r#"{"type":"task.steer","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","turnId":"turn-1","steeringId":"steer-1","clientRequestId":"00000000-0000-4000-8000-000000000006","instruction":"Try again","expectedStateVersion":2}"#,
             r#"{"type":"step.retry","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","turnId":"turn-1","taskId":"task-1","stepId":"step-1","retryRequestId":"retry-1","clientRequestId":"00000000-0000-4000-8000-000000000007","expectedOperationGeneration":2,"expectedStateVersion":3}"#,
@@ -9271,6 +9272,16 @@ mod proxy_resolution_integration_tests {
                 "conversationId": "nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae",
             }),
             serde_json::json!({
+                "type": "input.resolve",
+                "conversationId": "nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae",
+                "clientRequestId": "00000000-0000-4000-8000-000000000010",
+                "requestId": "input-1",
+                "answer": {
+                    "selectedOptionIds": ["option-a", "option-b"]
+                },
+                "expectedStateVersion": 19,
+            }),
+            serde_json::json!({
                 "type": "action.continue",
                 "conversationId": "nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae",
                 "clientRequestId": "00000000-0000-4000-8000-000000000003",
@@ -9304,6 +9315,7 @@ mod proxy_resolution_integration_tests {
                 "requestId": "approval-1",
                 "approved": true,
                 "reason": "Approved by user",
+                "expectedStateVersion": 21,
             }),
             serde_json::json!({
                 "type": "task.stop",
@@ -9348,9 +9360,10 @@ mod proxy_resolution_integration_tests {
         let expected_accepts = [
             "text/event-stream",
             "text/event-stream",
+            "application/json",
             "text/event-stream",
             "text/event-stream",
-            "text/event-stream",
+            "application/json",
             "application/json",
             "application/json",
             "application/json",

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -217,6 +217,8 @@ pub fn typed_chat_path() -> String {
 const TYPED_CHAT_PROMPT_MAX_CHARS: usize = 32_768;
 const ACTION_CONTINUATION_MAX_REPORTS: usize = 64;
 const APPROVAL_REASON_MAX_CHARS: usize = 2_048;
+const INPUT_ANSWER_MAX_CHARS: usize = 32_768;
+const INPUT_SELECTION_MAX_OPTIONS: usize = 6;
 
 static FORBIDDEN_COMMAND_KEY: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
@@ -254,6 +256,7 @@ pub struct PreparedAssistantChatCommand {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AssistantChatCommand {
     Text(TextChatCommand),
+    InputResolve(InputResolveCommand),
     ActionContinue(ActionContinueCommand),
     ApprovalResolve(ApprovalResolveCommand),
     TaskStop(TaskStopCommand),
@@ -267,6 +270,36 @@ pub struct TextChatCommand {
     pub prompt: String,
     pub client_request_id: String,
     pub conversation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputResolveCommand {
+    pub conversation_id: String,
+    pub client_request_id: String,
+    pub request_id: String,
+    pub answer: InputAnswer,
+    pub expected_state_version: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputAnswer {
+    FreeText { free_text: String },
+    SelectedOptions { selected_option_ids: Vec<String> },
+}
+
+impl InputAnswer {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            Self::FreeText { free_text } => serde_json::json!({
+                "freeText": free_text
+            }),
+            Self::SelectedOptions {
+                selected_option_ids,
+            } => serde_json::json!({
+                "selectedOptionIds": selected_option_ids
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -284,6 +317,7 @@ pub struct ApprovalResolveCommand {
     pub request_id: String,
     pub approved: bool,
     pub reason: Option<String>,
+    pub expected_state_version: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -404,10 +438,6 @@ impl ActionResource {
             }),
         }
     }
-
-    fn is_user_service(&self) -> bool {
-        matches!(self, Self::UserService { .. })
-    }
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -419,6 +449,27 @@ struct RawTextChatCommand {
     client_request_id: String,
     #[serde(default)]
     conversation_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RawInputResolveCommand {
+    #[serde(rename = "type")]
+    _command_type: String,
+    conversation_id: String,
+    client_request_id: String,
+    request_id: String,
+    answer: RawInputAnswer,
+    expected_state_version: i64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RawInputAnswer {
+    #[serde(default)]
+    free_text: Option<String>,
+    #[serde(default)]
+    selected_option_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -454,6 +505,7 @@ struct RawApprovalResolveCommand {
     approved: bool,
     #[serde(default)]
     reason: Option<String>,
+    expected_state_version: i64,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -560,6 +612,41 @@ fn normalize_reason(reason: Option<String>) -> AppResult<Option<String>> {
     Ok(Some(trimmed.to_string()))
 }
 
+fn parse_input_answer(raw: RawInputAnswer) -> AppResult<InputAnswer> {
+    match (raw.free_text, raw.selected_option_ids) {
+        (Some(free_text), None) => {
+            let trimmed = free_text.trim();
+            if trimmed.is_empty() || free_text.chars().count() > INPUT_ANSWER_MAX_CHARS {
+                return Err(AppError::BadRequest("Invalid input answer.".to_string()));
+            }
+            Ok(InputAnswer::FreeText {
+                free_text: trimmed.to_string(),
+            })
+        }
+        (None, Some(selected_option_ids)) => {
+            if selected_option_ids.is_empty()
+                || selected_option_ids.len() > INPUT_SELECTION_MAX_OPTIONS
+            {
+                return Err(AppError::BadRequest("Invalid input answer.".to_string()));
+            }
+            let mut seen = HashSet::new();
+            let mut normalized = Vec::with_capacity(selected_option_ids.len());
+            for option_id in selected_option_ids {
+                let option_id = option_id.trim();
+                validate_control_identity(option_id, "selectedOptionId")?;
+                if !seen.insert(option_id.to_string()) {
+                    return Err(AppError::BadRequest("Invalid input answer.".to_string()));
+                }
+                normalized.push(option_id.to_string());
+            }
+            Ok(InputAnswer::SelectedOptions {
+                selected_option_ids: normalized,
+            })
+        }
+        _ => Err(AppError::BadRequest("Invalid input answer.".to_string())),
+    }
+}
+
 fn reject_secret_shaped_command(value: &serde_json::Value) -> AppResult<()> {
     if contains_secret_shaped_value(value) {
         return Err(AppError::BadRequest(
@@ -658,6 +745,23 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
                 conversation_id: raw.conversation_id,
             }))
         }
+        "input.resolve" => {
+            let raw: RawInputResolveCommand = serde_json::from_value(value).map_err(|e| {
+                AppError::BadRequest(format!("Invalid input resolution request: {e}"))
+            })?;
+            validate_conversation_id(&raw.conversation_id)?;
+            validate_control_identity(&raw.client_request_id, "clientRequestId")?;
+            validate_control_identity(&raw.request_id, "requestId")?;
+            validate_positive(raw.expected_state_version, "expectedStateVersion")?;
+            let answer = parse_input_answer(raw.answer)?;
+            Ok(AssistantChatCommand::InputResolve(InputResolveCommand {
+                conversation_id: raw.conversation_id,
+                client_request_id: raw.client_request_id,
+                request_id: raw.request_id,
+                answer,
+                expected_state_version: raw.expected_state_version,
+            }))
+        }
         "action.continue" => {
             let raw: RawActionContinueCommand = serde_json::from_value(value).map_err(|e| {
                 AppError::BadRequest(format!("Invalid action continuation request: {e}"))
@@ -695,14 +799,9 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
                 }
                 let disposition = ActionDisposition::parse(&report.disposition)?;
                 let resource = parse_action_resource(report.resource)?;
-                if disposition == ActionDisposition::Completed
-                    && !resource
-                        .as_ref()
-                        .is_some_and(ActionResource::is_user_service)
-                {
+                if disposition == ActionDisposition::Completed && resource.is_none() {
                     return Err(AppError::BadRequest(
-                        "Completed action reports require resource.userService.userServiceId."
-                            .to_string(),
+                        "Completed action reports require a resource reference.".to_string(),
                     ));
                 }
                 actions.push(ActionReport {
@@ -728,6 +827,7 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
             validate_conversation_id(&raw.conversation_id)?;
             validate_control_identity(&raw.client_request_id, "clientRequestId")?;
             validate_control_identity(&raw.request_id, "requestId")?;
+            validate_positive(raw.expected_state_version, "expectedStateVersion")?;
             let reason = normalize_reason(raw.reason)?;
             Ok(AssistantChatCommand::ApprovalResolve(
                 ApprovalResolveCommand {
@@ -736,6 +836,7 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
                     request_id: raw.request_id,
                     approved: raw.approved,
                     reason,
+                    expected_state_version: raw.expected_state_version,
                 },
             ))
         }
@@ -889,6 +990,18 @@ pub fn prepare_assistant_chat_command(
                 response_kind: AssistantChatResponseKind::Stream,
             })
         }
+        AssistantChatCommand::InputResolve(command) => Ok(PreparedAssistantChatCommand {
+            body: serde_json::json!({
+                "type": "input.resolve",
+                "conversationId": command.conversation_id,
+                "clientRequestId": command.client_request_id,
+                "requestId": command.request_id,
+                "answer": command.answer.to_json(),
+                "expectedStateVersion": command.expected_state_version,
+            }),
+            client_request_id: command.client_request_id.clone(),
+            response_kind: AssistantChatResponseKind::Json,
+        }),
         AssistantChatCommand::ActionContinue(command) => {
             let mut actions = Vec::with_capacity(command.actions.len());
             for report in &command.actions {
@@ -964,10 +1077,14 @@ pub fn prepare_assistant_chat_command(
                     serde_json::Value::String(reason.clone()),
                 );
             }
+            body.insert(
+                "expectedStateVersion".to_string(),
+                serde_json::Value::Number(command.expected_state_version.into()),
+            );
             Ok(PreparedAssistantChatCommand {
                 body: serde_json::Value::Object(body),
                 client_request_id: command.client_request_id.clone(),
-                response_kind: AssistantChatResponseKind::Stream,
+                response_kind: AssistantChatResponseKind::Json,
             })
         }
         AssistantChatCommand::TaskStop(command) => Ok(PreparedAssistantChatCommand {
@@ -1483,6 +1600,129 @@ mod tests {
     }
 
     #[test]
+    fn parses_and_rebuilds_both_closed_input_answer_variants() {
+        let selected = prepare_assistant_chat_command(&parse_command(json!({
+            "type": "input.resolve",
+            "conversationId": CONV,
+            "clientRequestId": "client-input-1",
+            "requestId": "input-1",
+            "answer": {
+                "selectedOptionIds": [" option-a ", "option-b"]
+            },
+            "expectedStateVersion": 19
+        })))
+        .unwrap();
+        let free_text = prepare_assistant_chat_command(&parse_command(json!({
+            "type": "input.resolve",
+            "conversationId": CONV,
+            "clientRequestId": "client-input-2",
+            "requestId": "input-2",
+            "answer": {
+                "freeText": "  Singapore  "
+            },
+            "expectedStateVersion": 20
+        })))
+        .unwrap();
+
+        assert_eq!(
+            selected,
+            PreparedAssistantChatCommand {
+                body: json!({
+                    "type": "input.resolve",
+                    "conversationId": CONV,
+                    "clientRequestId": "client-input-1",
+                    "requestId": "input-1",
+                    "answer": {
+                        "selectedOptionIds": ["option-a", "option-b"]
+                    },
+                    "expectedStateVersion": 19
+                }),
+                client_request_id: "client-input-1".to_string(),
+                response_kind: AssistantChatResponseKind::Json,
+            }
+        );
+        assert_eq!(
+            free_text.body,
+            json!({
+                "type": "input.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "client-input-2",
+                "requestId": "input-2",
+                "answer": {
+                    "freeText": "Singapore"
+                },
+                "expectedStateVersion": 20
+            })
+        );
+        assert_eq!(
+            free_text.response_kind.accept_header_value(),
+            "application/json"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_input_resolutions_fail_closed() {
+        let command = |answer: serde_json::Value, expected_state_version: i64| {
+            json!({
+                "type": "input.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "client-input-1",
+                "requestId": "input-1",
+                "answer": answer,
+                "expectedStateVersion": expected_state_version
+            })
+        };
+        let mut unknown_root = command(json!({ "freeText": "answer" }), 19);
+        unknown_root
+            .as_object_mut()
+            .unwrap()
+            .insert("scopeId".to_string(), json!("someone-else"));
+        let values = vec![
+            json!({
+                "type": "input.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "client-input-1",
+                "requestId": "input-1",
+                "answer": { "freeText": "answer" }
+            }),
+            command(json!({ "freeText": "answer" }), 0),
+            command(json!({}), 19),
+            command(
+                json!({
+                    "freeText": "answer",
+                    "selectedOptionIds": ["option-a"]
+                }),
+                19,
+            ),
+            command(json!({ "freeText": "   " }), 19),
+            command(
+                json!({ "freeText": "x".repeat(INPUT_ANSWER_MAX_CHARS + 1) }),
+                19,
+            ),
+            command(json!({ "selectedOptionIds": [] }), 19),
+            command(
+                json!({
+                    "selectedOptionIds": [
+                        "option-a", "option-b", "option-c", "option-d",
+                        "option-e", "option-f", "option-g"
+                    ]
+                }),
+                19,
+            ),
+            command(
+                json!({ "selectedOptionIds": ["option-a", " option-a "] }),
+                19,
+            ),
+            command(json!({ "selectedOptionIds": ["bad/id"] }), 19),
+            command(json!({ "freeText": "answer", "label": "extra" }), 19),
+            unknown_root,
+        ];
+        for value in values {
+            assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());
+        }
+    }
+
+    #[test]
     fn parses_action_continue_for_reports_and_resource_free_wakes() {
         let continuation = parse_command(json!({
             "type": "action.continue",
@@ -1546,6 +1786,40 @@ mod tests {
                 .accept_header_value(),
             "text/event-stream"
         );
+    }
+
+    #[test]
+    fn completed_action_reports_round_trip_each_safe_resource_variant() {
+        for (index, resource) in [
+            json!({ "userService": { "userServiceId": "service-1" } }),
+            json!({ "key": { "keyId": "key-1" } }),
+            json!({ "node": { "nodeId": "node-1" } }),
+            json!({ "serviceAccount": { "serviceAccountId": "sa-1" } }),
+            json!({ "developerApp": { "clientId": "app-1" } }),
+            json!({ "device": { "deviceId": "device-1" } }),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let action_request_id = format!("act-{index}");
+            let command = parse_command(json!({
+                "type": "action.continue",
+                "conversationId": CONV,
+                "clientRequestId": format!("client-{index}"),
+                "originTurnId": "turn-1",
+                "actions": [{
+                    "actionRequestId": action_request_id,
+                    "originTurnId": "turn-1",
+                    "disposition": "completed",
+                    "resource": resource.clone()
+                }]
+            }));
+
+            assert_eq!(
+                prepare_assistant_chat_command(&command).unwrap().body["actions"][0]["resource"],
+                resource
+            );
+        }
     }
 
     #[test]
@@ -1625,6 +1899,63 @@ mod tests {
                     }
                 ]
             }),
+            json!({
+                "type": "action.continue",
+                "conversationId": CONV,
+                "clientRequestId": "request-1",
+                "originTurnId": "turn-1",
+                "actions": [{
+                    "actionRequestId": "act-1",
+                    "originTurnId": "turn-1",
+                    "disposition": "completed",
+                    "resource": {
+                        "key": { "keyId": "key-1" },
+                        "node": { "nodeId": "node-1" }
+                    }
+                }]
+            }),
+            json!({
+                "type": "action.continue",
+                "conversationId": CONV,
+                "clientRequestId": "request-1",
+                "originTurnId": "turn-1",
+                "actions": [{
+                    "actionRequestId": "act-1",
+                    "originTurnId": "turn-1",
+                    "disposition": "completed",
+                    "resource": {
+                        "key": { "keyId": "key-1", "label": "extra" }
+                    }
+                }]
+            }),
+            json!({
+                "type": "action.continue",
+                "conversationId": CONV,
+                "clientRequestId": "request-1",
+                "originTurnId": "turn-1",
+                "actions": [{
+                    "actionRequestId": "act-1",
+                    "originTurnId": "turn-1",
+                    "disposition": "completed",
+                    "resource": {
+                        "workspace": { "workspaceId": "workspace-1" }
+                    }
+                }]
+            }),
+            json!({
+                "type": "action.continue",
+                "conversationId": CONV,
+                "clientRequestId": "request-1",
+                "originTurnId": "turn-1",
+                "actions": [{
+                    "actionRequestId": "act-1",
+                    "originTurnId": "turn-1",
+                    "disposition": "completed",
+                    "resource": {
+                        "key": { "nodeId": "node-1" }
+                    }
+                }]
+            }),
         ] {
             assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());
         }
@@ -1638,10 +1969,43 @@ mod tests {
             "clientRequestId": "request-approval-1",
             "requestId": "approval-1",
             "approved": true,
-            "reason": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+            "reason": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "expectedStateVersion": 21
         });
 
         assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());
+    }
+
+    #[test]
+    fn approval_resolution_requires_a_positive_observed_state_version() {
+        for value in [
+            json!({
+                "type": "approval.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "request-approval-1",
+                "requestId": "approval-1",
+                "approved": true
+            }),
+            json!({
+                "type": "approval.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "request-approval-1",
+                "requestId": "approval-1",
+                "approved": true,
+                "expectedStateVersion": 0
+            }),
+            json!({
+                "type": "approval.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "request-approval-1",
+                "requestId": "approval-1",
+                "approved": true,
+                "expectedStateVersion": 21,
+                "stateVersion": 21
+            }),
+        ] {
+            assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());
+        }
     }
 
     #[test]
@@ -1666,6 +2030,14 @@ mod tests {
                 "type": "text",
                 "prompt": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
                 "clientRequestId": "request-text-1"
+            }),
+            json!({
+                "type": "input.resolve",
+                "conversationId": CONV,
+                "clientRequestId": "client-input-1",
+                "requestId": "input-1",
+                "answer": { "freeText": "nyxid_secret_abcdefgh" },
+                "expectedStateVersion": 19
             }),
             json!({
                 "type": "action.continue",
@@ -1728,7 +2100,8 @@ mod tests {
             "clientRequestId": "request-approval-1",
             "requestId": "approval-1",
             "approved": true,
-            "reason": "Approved by user"
+            "reason": "Approved by user",
+            "expectedStateVersion": 21
         })))
         .unwrap();
         let stop = prepare_assistant_chat_command(&parse_command(json!({
@@ -1753,10 +2126,10 @@ mod tests {
         })))
         .unwrap();
 
-        assert_eq!(approval.response_kind, AssistantChatResponseKind::Stream);
+        assert_eq!(approval.response_kind, AssistantChatResponseKind::Json);
         assert_eq!(
             approval.response_kind.accept_header_value(),
-            "text/event-stream"
+            "application/json"
         );
         assert_eq!(
             approval.body,
@@ -1766,7 +2139,8 @@ mod tests {
                 "clientRequestId": "request-approval-1",
                 "requestId": "approval-1",
                 "approved": true,
-                "reason": "Approved by user"
+                "reason": "Approved by user",
+                "expectedStateVersion": 21
             })
         );
         assert_eq!(stop.response_kind, AssistantChatResponseKind::Json);

--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -122,7 +122,7 @@ The body matches Aevatar's own console client: create carries a create-only comm
 
 `POST /chat` accepts a discriminated command allowlist. NyxID parses each command with unknown-field denial, rejects secret-shaped keys and values, validates control identities, and rebuilds the exact upstream object. It never spreads an arbitrary caller object into the Aevatar body.
 
-Every typed command includes `clientRequestId`. NyxID copies that value into the outbound `Idempotency-Key` header. Text, action continuation, and approval resolution request `Accept: text/event-stream`. Stop, steer, retry, and skip request `Accept: application/json`.
+Every typed command includes `clientRequestId`. NyxID copies that value into the outbound `Idempotency-Key` header. Text and action continuation request `Accept: text/event-stream`. Input resolution, approval resolution, stop, steer, retry, and skip request `Accept: application/json`.
 
 ### `text`
 
@@ -149,6 +149,23 @@ Typed continuation:
 
 The prompt must be nonblank after trimming. Its 32,768-character maximum is measured on the original untrimmed string, and the submitted string is preserved in the rebuilt body. The Studio builder instead trims before both length validation and serialization. The current browser starts new conversations through Studio; typed create remains part of the backend contract and upstream actor protocol.
 
+### `input.resolve`
+
+```json
+{
+  "type": "input.resolve",
+  "conversationId": "nyxid-chat-f8369965a444433f92ec50e67ad8ee52",
+  "clientRequestId": "request-identity",
+  "requestId": "input-identity",
+  "answer": {
+    "selectedOptionIds": ["option-a", "option-b"]
+  },
+  "expectedStateVersion": 22
+}
+```
+
+`answer` is a closed union with exactly one of `freeText` or `selectedOptionIds`. Free text is trimmed, must remain nonblank, and is limited to 32,768 characters. A selection contains 1-6 distinct control identities. `expectedStateVersion` is required and must be positive. The browser reads it from the authoritative typed current-state envelope, verifies the exact pending input identity, and never derives it from AG-UI `sequence` (which is `progressSequence`). The command returns JSON transport acceptance; the matching `nyxid.input.changed` or current-state `latestInputResolution` proves commit.
+
 ### `action.continue`
 
 ```json
@@ -172,7 +189,7 @@ The prompt must be nonblank after trimming. Its 32,768-character maximum is meas
 }
 ```
 
-The report batch contains at most 64 entries. Action request IDs must be unique in the batch. When reports are present, the outer `originTurnId` is required and every report must match it. Allowed dispositions are `completed`, `declined`, `failed`, `cancelled`, and `expired`. The resource grammar is described in [Action cards](04-action-cards.md); the current backend requires a completed report to carry a `userService` resource.
+The report batch contains at most 64 entries. Action request IDs must be unique in the batch. When reports are present, the outer `originTurnId` is required and every report must match it. Allowed dispositions are `completed`, `declined`, `failed`, `cancelled`, and `expired`. The resource grammar is described in [Action cards](04-action-cards.md); every completed report requires exactly one allowlisted safe resource reference.
 
 An empty `actions` array is a typed actor wake and may omit `originTurnId`.
 
@@ -185,11 +202,12 @@ An empty `actions` array is a typed actor wake and may omit `originTurnId`.
   "clientRequestId": "request-identity",
   "requestId": "approval-identity",
   "approved": true,
-  "reason": "optional trimmed reason"
+  "reason": "optional trimmed reason",
+  "expectedStateVersion": 22
 }
 ```
 
-An empty reason is omitted. A nonempty reason is trimmed and limited to 2,048 characters.
+An empty reason is omitted. A nonempty reason is trimmed and limited to 2,048 characters. `expectedStateVersion` is required and must be positive. The browser reads it from the authoritative typed current-state envelope and verifies the exact pending approval identity. This command returns JSON transport acceptance; the matching `nyxid.approval.changed` or current-state `latestApprovalResolution` proves commit.
 
 ### `task.stop`
 

--- a/docs/chat/04-action-cards.md
+++ b/docs/chat/04-action-cards.md
@@ -251,7 +251,7 @@ The schema recognizes these strict one-variant resource references:
 
 Each object has exactly one variant and each payload has exactly one valid control identity. The builder copies only the allowlisted variant and ID into the wire body.
 
-The generic schema anticipates other registry actions, but the current backend requires every `completed` report to contain `resource.userService.userServiceId`. A completed report with no resource or any other resource variant is rejected by `backend/src/services/assistant_service.rs:parse_assistant_chat_command`. This is stricter than the generic frontend union and is the effective shipped contract.
+Every `completed` report must carry exactly one of these allowlisted resource variants. A completed report with no resource, multiple variants, an unknown variant, an extra payload member, an invalid control identity, or secret-shaped material is rejected by `backend/src/services/assistant_service.rs:parse_assistant_chat_command`.
 
 Declined, failed, cancelled, and expired reports may omit the resource.
 

--- a/frontend/src/components/assistant/blocks/approval-card.tsx
+++ b/frontend/src/components/assistant/blocks/approval-card.tsx
@@ -150,6 +150,28 @@ function DecidedCard({ block }: { readonly block: ApprovalCardContentBlock }) {
   );
 }
 
+function SubmittedCard({
+  block,
+}: {
+  readonly block: ApprovalCardContentBlock;
+}) {
+  if (!block.decision_submission) return null;
+  return (
+    <section className="rounded-xl border border-warning/30 bg-warning/[0.06] p-4">
+      <div className="flex items-center gap-2 text-[12px] font-semibold text-foreground">
+        <Loader2 className="h-4 w-4 animate-spin text-warning" />
+        Decision sent
+      </div>
+      <p className="mt-2 text-[12px] leading-relaxed text-muted-foreground">
+        {block.body}
+      </p>
+      <p className="mt-1.5 text-[11px] text-text-tertiary">
+        Waiting for the committed {block.decision_submission} decision.
+      </p>
+    </section>
+  );
+}
+
 export function ApprovalCard({
   block,
   onDecide,
@@ -157,9 +179,9 @@ export function ApprovalCard({
   readonly block: ApprovalCardContentBlock;
   readonly onDecide: (approved: boolean) => Promise<void> | void;
 }) {
-  const [pendingAction, setPendingAction] = useState<
-    "approve" | "deny" | null
-  >(null);
+  const [pendingAction, setPendingAction] = useState<"approve" | "deny" | null>(
+    null,
+  );
   const [now, setNow] = useState(Date.now());
   const lastClick = useRef(Number.NEGATIVE_INFINITY);
 
@@ -172,6 +194,7 @@ export function ApprovalCard({
     const clickedAt = Date.now();
     if (
       block.decision !== null ||
+      block.decision_submission != null ||
       pendingAction !== null ||
       clickedAt - lastClick.current < CLICK_THROTTLE_MS
     ) {
@@ -193,6 +216,9 @@ export function ApprovalCard({
 
   if (block.decision !== null) {
     return <DecidedCard block={block} />;
+  }
+  if (block.decision_submission) {
+    return <SubmittedCard block={block} />;
   }
 
   const remainingMs = new Date(block.expires_at).getTime() - now;
@@ -238,8 +264,9 @@ export function ApprovalCard({
 
         {block.approval_mode === "grant" && (
           <p className="mt-2.5 text-[11px] leading-relaxed text-muted-foreground">
-            Approving also allows repeat {block.service_slug} writes for the next{" "}
-            {grantDurationLabel(block.grant_duration_sec)} without asking again.
+            Approving also allows repeat {block.service_slug} writes for the
+            next {grantDurationLabel(block.grant_duration_sec)} without asking
+            again.
           </p>
         )}
       </div>

--- a/frontend/src/components/assistant/blocks/input-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/input-card.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { InputCardContentBlock } from "@/types/assistant";
+import { InputCard } from "./input-card";
+
+function inputCard(
+  overrides: Partial<InputCardContentBlock> = {},
+): InputCardContentBlock {
+  return {
+    type: "input_card",
+    block_id: "input-card-1",
+    request_id: "input-1",
+    prompt: "Choose deployment regions",
+    options: [
+      { option_id: "option-sg", label: "Singapore" },
+      { option_id: "option-fra", label: "Frankfurt" },
+    ],
+    allow_free_text: true,
+    multi_select: true,
+    state_version: 23,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("InputCard", () => {
+  it("submits opaque option ids without labels or free text", async () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(<InputCard block={inputCard()} onResolve={onResolve} />);
+
+    fireEvent.click(screen.getByLabelText("Singapore"));
+    fireEvent.click(screen.getByLabelText("Frankfurt"));
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() =>
+      expect(onResolve).toHaveBeenCalledWith({
+        selectedOptionIds: ["option-sg", "option-fra"],
+      }),
+    );
+  });
+
+  it("submits trimmed free text as the other union branch", async () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InputCard block={inputCard({ options: [] })} onResolve={onResolve} />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Answer" }), {
+      target: { value: "  Singapore north  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit answer" }));
+
+    await waitFor(() =>
+      expect(onResolve).toHaveBeenCalledWith({ freeText: "Singapore north" }),
+    );
+  });
+});

--- a/frontend/src/components/assistant/blocks/input-card.tsx
+++ b/frontend/src/components/assistant/blocks/input-card.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import { Check, Loader2, MessageSquareText, Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { InputAnswer } from "@/schemas/assistant-input";
+import type { InputCardContentBlock } from "@/types/assistant";
+
+export function InputCard({
+  block,
+  onResolve,
+}: {
+  readonly block: InputCardContentBlock;
+  readonly onResolve: (answer: InputAnswer) => Promise<void> | void;
+}) {
+  const [selectedOptionIds, setSelectedOptionIds] = useState<string[]>([]);
+  const [freeText, setFreeText] = useState("");
+  const [pending, setPending] = useState<"selection" | "text" | null>(null);
+
+  useEffect(() => {
+    setSelectedOptionIds([]);
+    setFreeText("");
+    setPending(null);
+  }, [block.request_id]);
+
+  async function submit(answer: InputAnswer, mode: "selection" | "text") {
+    if (block.status !== "pending" || pending !== null) return;
+    setPending(mode);
+    try {
+      await onResolve(answer);
+    } catch {
+      // The mutation owns delivery errors and re-enables this card on failure.
+    } finally {
+      setPending(null);
+    }
+  }
+
+  if (block.status !== "pending") {
+    const resolved = block.status === "resolved";
+    const submitted = block.status === "submitted";
+    return (
+      <section
+        className={`rounded-lg border p-4 ${
+          resolved
+            ? "border-success/30 bg-success/[0.06]"
+            : submitted
+              ? "border-warning/30 bg-warning/[0.06]"
+              : "border-border bg-overlay"
+        }`}
+      >
+        <div className="flex items-center gap-2 text-[12px] font-semibold text-foreground">
+          {submitted ? (
+            <Loader2 className="h-4 w-4 animate-spin text-warning" />
+          ) : (
+            <Check
+              className={`h-4 w-4 ${resolved ? "text-success" : "text-muted-foreground"}`}
+            />
+          )}
+          {resolved
+            ? "Answer recorded"
+            : submitted
+              ? "Answer sent"
+              : "Input cancelled"}
+        </div>
+        <p className="mt-2 text-[12px] leading-relaxed text-muted-foreground">
+          {block.prompt}
+        </p>
+        {submitted ? (
+          <p className="mt-1.5 text-[11px] text-text-tertiary">
+            Waiting for committed confirmation.
+          </p>
+        ) : null}
+      </section>
+    );
+  }
+
+  const busy = pending !== null;
+  const normalizedText = freeText.trim();
+  return (
+    <section className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
+      <div className="flex items-start gap-3 border-b border-border px-4 py-3.5">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-nyx-secondary-400/30 bg-nyx-secondary-400/10">
+          <MessageSquareText className="h-4 w-4 text-nyx-secondary-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[13px] font-semibold text-foreground">
+            Input required
+          </h3>
+          <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+            {block.prompt}
+          </p>
+        </div>
+      </div>
+
+      {block.options.length > 0 ? (
+        <div className="grid gap-2 px-4 py-3.5">
+          {block.options.map((option) => {
+            const checked = selectedOptionIds.includes(option.option_id);
+            return (
+              <label
+                key={option.option_id}
+                className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border px-3 py-2.5 text-[12px] hover:bg-muted"
+              >
+                <input
+                  checked={checked}
+                  disabled={busy}
+                  name={`assistant-input-${block.request_id}`}
+                  onChange={(event) => {
+                    setSelectedOptionIds((current) =>
+                      block.multi_select
+                        ? event.target.checked
+                          ? [...new Set([...current, option.option_id])]
+                          : current.filter((id) => id !== option.option_id)
+                        : event.target.checked
+                          ? [option.option_id]
+                          : [],
+                    );
+                  }}
+                  type={block.multi_select ? "checkbox" : "radio"}
+                  value={option.option_id}
+                />
+                <span className="min-w-0">
+                  <span className="block font-medium text-foreground">
+                    {option.label}
+                  </span>
+                  {option.description ? (
+                    <span className="mt-0.5 block text-[11px] text-muted-foreground">
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
+              </label>
+            );
+          })}
+          <Button
+            type="button"
+            size="sm"
+            className="mt-1 w-fit"
+            disabled={busy || selectedOptionIds.length === 0}
+            onClick={() => void submit({ selectedOptionIds }, "selection")}
+          >
+            {pending === "selection" ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <Send />
+            )}
+            Submit
+          </Button>
+        </div>
+      ) : null}
+
+      {block.allow_free_text ? (
+        <form
+          className="flex gap-2 border-t border-border px-4 py-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (normalizedText)
+              void submit({ freeText: normalizedText }, "text");
+          }}
+        >
+          <Input
+            aria-label="Answer"
+            disabled={busy}
+            maxLength={32_768}
+            onChange={(event) => setFreeText(event.target.value)}
+            value={freeText}
+          />
+          <Button
+            type="submit"
+            size="icon"
+            disabled={busy || !normalizedText}
+            title="Submit answer"
+          >
+            {pending === "text" ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <Send />
+            )}
+            <span className="sr-only">Submit answer</span>
+          </Button>
+        </form>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/assistant/chat-thread.tsx
+++ b/frontend/src/components/assistant/chat-thread.tsx
@@ -12,12 +12,14 @@ import { ActionCard } from "@/components/assistant/blocks/action-card";
 import { ApprovalCard } from "@/components/assistant/blocks/approval-card";
 import { ArtifactBlock } from "@/components/assistant/blocks/artifact-block";
 import { ConnectCard } from "@/components/assistant/blocks/connect-card";
+import { InputCard } from "@/components/assistant/blocks/input-card";
 import { RunCard } from "@/components/assistant/blocks/run-card";
 import { TextBlock } from "@/components/assistant/blocks/text-block";
 import { useFadingPresence } from "@/hooks/use-fading-presence";
 import haloSheet from "@/assets/halo-sheet.webp";
 import { formatClockTime } from "@/lib/utils";
 import type { ActionReport } from "@/schemas/assistant-actions";
+import type { InputAnswer } from "@/schemas/assistant-input";
 import type { AssistantMessage, ContentBlock } from "@/types/assistant";
 
 function UnsupportedContent() {
@@ -70,6 +72,7 @@ function isTextBlock(block: unknown): boolean {
 function renderBlock(
   block: unknown,
   onDecideApproval: (blockId: string, approved: boolean) => Promise<void>,
+  onResolveInput: (blockId: string, answer: InputAnswer) => Promise<void>,
   onActionProgress: (blockId: string, inProgress: boolean) => void,
   onBlockAction: (blockId: string, note: string) => void,
   onResolveAction: (report: ActionReport) => Promise<void>,
@@ -91,6 +94,13 @@ function renderBlock(
         <ApprovalCard
           block={typed}
           onDecide={(approved) => onDecideApproval(typed.block_id, approved)}
+        />
+      );
+    case "input_card":
+      return (
+        <InputCard
+          block={typed}
+          onResolve={(answer) => onResolveInput(typed.block_id, answer)}
         />
       );
     case "action_card":
@@ -355,7 +365,11 @@ function ThinkingRow({
       aria-label={active ? "Assistant is thinking" : undefined}
       aria-hidden={active ? undefined : true}
     >
-      {overlay ? <span aria-hidden /> : <AssistantIdentity time="" loading={loading} />}
+      {overlay ? (
+        <span aria-hidden />
+      ) : (
+        <AssistantIdentity time="" loading={loading} />
+      )}
       <div className="min-h-[18px] min-w-0 flex-1">
         <StreamingDots visible={active} />
       </div>
@@ -382,6 +396,7 @@ export function ChatThread({
   transcriptSettling = false,
   bottomInset = 0,
   onDecideApproval,
+  onResolveInput = async () => undefined,
   onActionProgress = () => undefined,
   onBlockAction = () => undefined,
   onResolveAction = async () => undefined,
@@ -419,6 +434,10 @@ export function ChatThread({
   readonly onDecideApproval: (
     blockId: string,
     approved: boolean,
+  ) => Promise<void>;
+  readonly onResolveInput?: (
+    blockId: string,
+    answer: InputAnswer,
   ) => Promise<void>;
   readonly onActionProgress?: (blockId: string, inProgress: boolean) => void;
   readonly onBlockAction?: (blockId: string, note: string) => void;
@@ -637,6 +656,7 @@ export function ChatThread({
                               {renderBlock(
                                 block,
                                 onDecideApproval,
+                                onResolveInput,
                                 onActionProgress,
                                 onBlockAction,
                                 onResolveAction,
@@ -692,6 +712,7 @@ export function ChatThread({
                               {renderBlock(
                                 block,
                                 onDecideApproval,
+                                onResolveInput,
                                 onActionProgress,
                                 onBlockAction,
                                 onResolveAction,

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -23,6 +23,7 @@ import {
 import { assistantMockStore } from "@/lib/assistant/mock-data";
 import { assistantTransport } from "@/lib/assistant/transport";
 import type { ActionReport } from "@/schemas/assistant-actions";
+import type { InputAnswer } from "@/schemas/assistant-input";
 import type {
   ActiveTurn,
   Conversation,
@@ -822,9 +823,8 @@ export function useDecideApproval(conversationId: string | undefined) {
       readonly approved: boolean;
     }): Promise<void> => {
       if (!conversationId) throw new Error("Select a conversation first.");
-      // On the live contract the approve endpoint streams an SSE
-      // continuation of the run; the pump projects its events and the
-      // handle makes the stop button work during it.
+      // Approval returns JSON acceptance. The transport keeps the conversation
+      // reserved while it observes the matching committed resolution.
       const pump = createTurnEventPump(queryClient, conversationId);
       try {
         const handle = await assistantTransport.decideApproval(
@@ -857,6 +857,48 @@ export function useDecideApproval(conversationId: string | undefined) {
         description:
           error instanceof AssistantTurnActiveError
             ? "Wait for the current reply to finish, then decide again."
+            : error instanceof Error && error.message
+              ? error.message
+              : "The assistant backend did not respond. Try again.",
+      });
+    },
+  });
+}
+
+export function useResolveInput(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      blockId,
+      answer,
+    }: {
+      readonly blockId: string;
+      readonly answer: InputAnswer;
+    }): Promise<void> => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      const pump = createTurnEventPump(queryClient, conversationId);
+      try {
+        const handle = await assistantTransport.resolveInput(
+          conversationId,
+          blockId,
+          answer,
+          pump.onEvent,
+        );
+        if (handle) activeHandles.set(conversationId, handle);
+        else if (!pump.receivedEvent()) pump.disown();
+        await projectTransportState(queryClient, conversationId);
+      } catch (error) {
+        if (!pump.receivedEvent() && !pump.expired()) pump.restorePrevious();
+        throw error;
+      }
+    },
+    onError: (error) => {
+      if (error instanceof AssistantTurnCancelledError) return;
+      toast.error("Input was not delivered", {
+        id: "assistant-input-failed",
+        description:
+          error instanceof AssistantTurnActiveError
+            ? "Wait for the current reply to finish, then try again."
             : error instanceof Error && error.message
               ? error.message
               : "The assistant backend did not respond. Try again.",

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -3931,10 +3931,7 @@ describe("live AG-UI frame taxonomy", () => {
     ).toHaveLength(1);
   });
 
-  it("settles the parked run ledger when the approval is decided", async () => {
-    // The prior turn's ledger froze in awaiting_approval with a waiting
-    // step; deciding must flip it (approved → done/completed) so the
-    // transient activity line doesn't show a stale approval clock forever.
+  it("does not treat a committed approval as tool-step completion", async () => {
     stubFetch(
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
@@ -3978,24 +3975,23 @@ describe("live AG-UI frame taxonomy", () => {
       (event) => events.push(event),
     );
 
-    const ledgerFlip = events.find(
+    const ledgerPatch = events.find(
       (event): event is Extract<TurnEvent, { event: "block.updated" }> =>
         event.event === "block.updated" &&
-        (event.patch as { state?: string }).state === "completed",
+        (Array.isArray((event.patch as { steps?: unknown }).steps) ||
+          "state" in event.patch),
     );
-    expect(ledgerFlip).toBeDefined();
-    const steps = (
-      ledgerFlip?.patch as {
-        steps?: Array<{ status: string }>;
-      }
-    ).steps;
-    expect(steps?.[0]?.status).toBe("done");
+    expect(ledgerPatch).toBeUndefined();
+    expect(
+      events.some(
+        (event) =>
+          event.event === "block.updated" &&
+          (event.patch as { decision?: string }).decision === "approved",
+      ),
+    ).toBe(true);
   });
 
-  it("settles only the decided approval's step; other gates stay parked", async () => {
-    // Second-pass codex P2: ledger settlement is correlated by
-    // approval_request_id — deciding one card must not settle a step gated
-    // on a different pending approval, and the ledger stays parked.
+  it("leaves every multi-gate step parked until actor state advances", async () => {
     stubFetch(
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
@@ -4051,24 +4047,22 @@ describe("live AG-UI frame taxonomy", () => {
       (event) => events.push(event),
     );
 
-    const ledgerPatch = events.find(
-      (event): event is Extract<TurnEvent, { event: "block.updated" }> =>
-        event.event === "block.updated" &&
-        Array.isArray((event.patch as { steps?: unknown }).steps),
-    );
-    const patch = ledgerPatch?.patch as {
-      state?: string;
-      steps?: Array<{ status: string; approval_request_id: string | null }>;
-    };
-    expect(patch.state).toBe("awaiting_approval");
-    const stepA = patch.steps?.find(
-      (step) => step.approval_request_id === "req-A",
-    );
-    const stepB = patch.steps?.find(
-      (step) => step.approval_request_id === "req-B",
-    );
-    expect(stepA?.status).toBe("waiting");
-    expect(stepB?.status).toBe("done");
+    expect(
+      events.some(
+        (event) =>
+          event.event === "block.updated" &&
+          Array.isArray((event.patch as { steps?: unknown }).steps),
+      ),
+    ).toBe(false);
+
+    const after = await transport.getHistory(CONVERSATION_ID);
+    const run = after.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "run");
+    expect(run?.type === "run" && run.state).toBe("awaiting_approval");
+    expect(
+      run?.type === "run" && run.steps.map((step) => step.status),
+    ).toEqual(["waiting", "waiting"]);
   });
 
   it("terminalizes waiting steps when the run dies at an approval gate", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1727,6 +1727,7 @@ describe("AevatarAssistantTransport", () => {
     });
     let releaseStop: (() => void) | undefined;
     let approveCalls = 0;
+    let stateReads = 0;
     let streamCalls = 0;
     const mock = vi.fn(
       (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -1745,9 +1746,41 @@ describe("AevatarAssistantTransport", () => {
               resolve(jsonResponse({ status: "accepted" }, 202));
           });
         }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          stateReads += 1;
+          return Promise.resolve(
+            jsonResponse(
+              stateReads === 1
+                ? {
+                    status: "current",
+                    stateVersion: 70,
+                    snapshot: {
+                      actorId: CONVERSATION_ID,
+                      stateVersion: 70,
+                      attentionKind: "approval",
+                      pendingApproval: { approvalRequestId: "req-fence" },
+                    },
+                  }
+                : {
+                    status: "current",
+                    stateVersion: 71,
+                    snapshot: {
+                      actorId: CONVERSATION_ID,
+                      stateVersion: 71,
+                      attentionKind: "none",
+                      latestApprovalResolution: {
+                        requestId: "req-fence",
+                        outcome: "accepted",
+                        approved: true,
+                      },
+                    },
+                  },
+            ),
+          );
+        }
         if (url.endsWith("/approve") && init?.method === "POST") {
           approveCalls += 1;
-          return Promise.resolve(sseResponse(OBSERVED_FRAMES));
+          return Promise.resolve(jsonResponse({ status: "accepted" }, 202));
         }
         if (url.endsWith("/stream") && init?.method === "POST") {
           streamCalls += 1;
@@ -2509,12 +2542,51 @@ describe("live AG-UI frame taxonomy", () => {
       .map((event) => event.block);
   }
 
-  function routeApprove(response: () => Response): FetchRoute {
+  function decisionStateEnvelope(
+    kind: "approval" | "input",
+    requestId: string,
+    stateVersion: number,
+    snapshot: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      status: "current",
+      stateVersion,
+      snapshot: {
+        actorId: CONVERSATION_ID,
+        stateVersion,
+        progressSequence: 9_999,
+        attentionKind: kind,
+        ...(kind === "input"
+          ? { pendingInput: { requestId } }
+          : { pendingApproval: { approvalRequestId: requestId } }),
+        ...snapshot,
+      },
+    };
+  }
+
+  function routeDecisionStates(
+    ...states: readonly Record<string, unknown>[]
+  ): FetchRoute {
+    let readIndex = 0;
+    return (url, init) => {
+      if (
+        url !== `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/state` ||
+        (init?.method ?? "GET") !== "GET"
+      ) {
+        return undefined;
+      }
+      const state = states[Math.min(readIndex, states.length - 1)];
+      readIndex += 1;
+      return state ? jsonResponse(state) : undefined;
+    };
+  }
+
+  function routeJsonResolve(
+    type: "approval.resolve" | "input.resolve",
+    response: () => Response = () => jsonResponse({ status: "accepted" }, 202),
+  ): FetchRoute {
     return (url, init) =>
-      url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/approve` &&
-      init?.method === "POST"
-        ? response()
-        : undefined;
+      isTypedCommandRequest(url, init, type) ? response() : undefined;
   }
 
   it("maps TOOL_CALL_START/END onto a run step ledger", async () => {
@@ -2867,7 +2939,17 @@ describe("live AG-UI frame taxonomy", () => {
     );
   });
 
-  it("streams the approve endpoint's SSE continuation as a follow-on turn", async () => {
+  it("resolves approval through current-state GET, JSON POST, then committed observation", async () => {
+    const pendingState = decisionStateEnvelope("approval", "req-1", 23);
+    const committedState = decisionStateEnvelope("approval", "req-1", 24, {
+      attentionKind: "none",
+      pendingApproval: null,
+      latestApprovalResolution: {
+        requestId: "req-1",
+        outcome: "accepted",
+        approved: true,
+      },
+    });
     const fetchMock = stubFetch(
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
@@ -2876,27 +2958,13 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-1", toolName: "lark_post" },
         },
       ]),
-      routeApprove(() =>
-        sseResponse([
-          { type: "RUN_STARTED", turnId: TURN_ID },
-          {
-            type: "TEXT_MESSAGE_START",
-            textMessageStart: { messageId: "m-2", role: "assistant" },
-          },
-          {
-            type: "TEXT_MESSAGE_CONTENT",
-            textMessageContent: { delta: "Posted to #eng-updates." },
-          },
-          { type: "TEXT_MESSAGE_END", textMessageEnd: { messageId: "m-2" } },
-          { type: "RUN_FINISHED" },
-        ]),
-      ),
+      routeDecisionStates(pendingState, committedState),
+      routeJsonResolve("approval.resolve"),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
     await seedActorConversation(transport);
-    const firstTurn = await collectTurn(transport, "Post the digest");
-    const lastFirstCursor = firstTurn[firstTurn.length - 1]?.cursor ?? 0;
+    await collectTurn(transport, "Post the digest");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
       .flatMap((message) => message.blocks)
@@ -2904,22 +2972,14 @@ describe("live AG-UI frame taxonomy", () => {
     expect(card).toBeDefined();
 
     const events: TurnEvent[] = [];
-    const done = new Promise<void>((resolve) => {
-      void transport
-        .decideApproval(
-          CONVERSATION_ID,
-          card?.block_id ?? "",
-          true,
-          (event) => {
-            events.push(event);
-            if (event.event === "turn.completed") resolve();
-          },
-        )
-        .then((handle) => {
-          expect(handle).not.toBeNull();
-        });
-    });
-    await done;
+    await expect(
+      transport.decideApproval(
+        CONVERSATION_ID,
+        card?.block_id ?? "",
+        true,
+        (event) => events.push(event),
+      ),
+    ).resolves.toBeNull();
 
     const approveCall = fetchMock.mock.calls.find(([input, init]) =>
       isTypedCommandRequest(
@@ -2936,89 +2996,680 @@ describe("live AG-UI frame taxonomy", () => {
       clientRequestId: string;
       requestId: string;
       approved: boolean;
+      expectedStateVersion: number;
       sessionId?: string;
     };
-    expect(approveBody.type).toBe("approval.resolve");
-    expect(approveBody.conversationId).toBe(CONVERSATION_ID);
-    expect(approveBody.clientRequestId).toMatch(/^[0-9a-f-]{36}$/);
-    expect(approveBody.requestId).toBe("req-1");
-    expect(approveBody.approved).toBe(true);
-    expect(approveBody.sessionId).toBeUndefined();
-
-    // Continuation cursors continue past the prior turn's, so a
-    // still-subscribed at-least-once consumer never drops them.
-    expect(events[0]?.cursor).toBeGreaterThan(lastFirstCursor);
-    const cursors = events.map((event) => event.cursor);
-    expect(cursors).toEqual([...cursors].sort((a, b) => a - b));
-    const flip = events.find(
-      (event): event is Extract<TurnEvent, { event: "block.updated" }> =>
-        event.event === "block.updated",
-    );
-    expect(flip?.patch).toMatchObject({
-      decision: "approved",
-      decision_channel: "web",
+    expect(approveBody).toEqual({
+      type: "approval.resolve",
+      conversationId: CONVERSATION_ID,
+      clientRequestId: approveBody.clientRequestId,
+      requestId: "req-1",
+      approved: true,
+      expectedStateVersion: 23,
     });
-    const text = blockCompletions(events).find(
-      (block) => block.type === "text",
+    expect(approveBody.clientRequestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(approveBody.sessionId).toBeUndefined();
+    const stateCallIndexes = fetchMock.mock.calls.flatMap(([input], index) =>
+      String(input).endsWith("/state") ? [index] : [],
     );
-    expect(text?.type === "text" && text.text).toBe("Posted to #eng-updates.");
-    const terminal = events[events.length - 1];
-    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
-      "completed",
+    const postIndex = fetchMock.mock.calls.findIndex(([input, init]) =>
+      isTypedCommandRequest(
+        String(input),
+        init as RequestInit | undefined,
+        "approval.resolve",
+      ),
     );
+    expect(stateCallIndexes).toHaveLength(2);
+    expect(stateCallIndexes[0]).toBeLessThan(postIndex);
+    expect(postIndex).toBeLessThan(stateCallIndexes[1] ?? -1);
+    expect(events.map((event) => event.event)).toEqual([
+      "block.updated",
+      "block.updated",
+    ]);
+    expect(events[0]).toMatchObject({
+      patch: {
+        decision_submission: "approved",
+        state_version: 23,
+      },
+    });
+    expect(events[1]).toMatchObject({
+      patch: {
+        decision: "approved",
+        decision_channel: "web",
+        decision_submission: null,
+      },
+    });
   });
 
-  it("fails closed when an approval continuation ends without a terminal frame", async () => {
-    stubFetch(
+  it("requires the exact latest approval resolution and a version advance", async () => {
+    const fetchMock = stubFetch(
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
           type: "TOOL_APPROVAL_REQUEST",
-          toolApprovalRequest: { requestId: "req-truncated" },
+          toolApprovalRequest: { requestId: "req-exact" },
         },
       ]),
-      routeApprove(() =>
-        sseResponse([
-          { type: "RUN_STARTED", turnId: TURN_ID },
-          {
-            type: "TEXT_MESSAGE_START",
-            textMessageStart: { messageId: "m-truncated", role: "assistant" },
+      routeDecisionStates(
+        decisionStateEnvelope("approval", "req-exact", 30),
+        decisionStateEnvelope("approval", "req-exact", 31, {
+          latestApprovalResolution: {
+            requestId: "req-other",
+            outcome: "accepted",
+            approved: false,
           },
-          {
-            type: "TEXT_MESSAGE_CONTENT",
-            textMessageContent: { delta: "Partial continuation" },
+        }),
+        decisionStateEnvelope("approval", "req-exact", 30, {
+          latestApprovalResolution: {
+            requestId: "req-exact",
+            outcome: "accepted",
+            approved: false,
           },
-        ]),
+        }),
+        decisionStateEnvelope("approval", "req-exact", 31, {
+          attentionKind: "none",
+          pendingApproval: null,
+          latestApprovalResolution: {
+            requestId: "req-exact",
+            outcome: "accepted",
+            approved: false,
+          },
+        }),
       ),
+      routeJsonResolve("approval.resolve"),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
     await seedActorConversation(transport);
-    await collectTurn(transport, "Run an approved action");
+    await collectTurn(transport, "Run an action");
     const history = await transport.getHistory(CONVERSATION_ID);
     const card = history.messages
       .flatMap((message) => message.blocks)
       .find((block) => block.type === "approval_card");
 
     const events: TurnEvent[] = [];
-    await new Promise<void>((resolve) => {
-      void transport.decideApproval(
+    await transport.decideApproval(
+      CONVERSATION_ID,
+      card?.block_id ?? "",
+      false,
+      (event) => events.push(event),
+    );
+
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).endsWith("/state"),
+      ),
+    ).toHaveLength(4);
+    expect(events.at(-1)).toMatchObject({
+      event: "block.updated",
+      patch: {
+        decision: "denied",
+        decision_channel: "web",
+      },
+    });
+  });
+
+  it("renders committed input, ignores AG-UI sequence as a version, and resolves selected options", async () => {
+    let releaseObservation: ((response: Response) => void) | undefined;
+    let stateReads = 0;
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID, sequence: 8_888 },
+        {
+          type: "CUSTOM",
+          sequence: 8_889,
+          custom: {
+            name: "nyxid.input.request",
+            payload: {
+              requestId: "input-1",
+              prompt: "Choose regions",
+              options: [
+                { optionId: "region-sg", label: "Singapore" },
+                { optionId: "region-jp", label: "Japan" },
+              ],
+              allowFreeText: false,
+              multiSelect: true,
+            },
+          },
+        },
+      ]),
+      (url, init) => {
+        if (
+          url !== `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/state` ||
+          (init?.method ?? "GET") !== "GET"
+        ) {
+          return undefined;
+        }
+        stateReads += 1;
+        if (stateReads === 1) {
+          return jsonResponse(decisionStateEnvelope("input", "input-1", 41));
+        }
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              releaseObservation = (response) => {
+                void response.json().then((body) => {
+                  controller.enqueue(
+                    new TextEncoder().encode(JSON.stringify(body)),
+                  );
+                  controller.close();
+                });
+              };
+            },
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      },
+      routeJsonResolve("input.resolve"),
+      routeHistory([]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Ask me");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const card = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+    expect(card).toMatchObject({
+      type: "input_card",
+      request_id: "input-1",
+      status: "pending",
+      multi_select: true,
+      options: [
+        { option_id: "region-sg", label: "Singapore" },
+        { option_id: "region-jp", label: "Japan" },
+      ],
+    });
+    expect(card?.type === "input_card" && card.state_version).toBeUndefined();
+
+    const events: TurnEvent[] = [];
+    const resolving = transport.resolveInput(
+      CONVERSATION_ID,
+      card?.block_id ?? "",
+      { selectedOptionIds: ["region-sg", "region-jp"] },
+      (event) => events.push(event),
+    );
+    while (!releaseObservation) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    const submitted = await transport.getHistory(CONVERSATION_ID);
+    const submittedCard = submitted.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+    expect(submittedCard).toMatchObject({
+      status: "submitted",
+      state_version: 41,
+    });
+    const resolveCall = fetchMock.mock.calls.find(([input, init]) =>
+      isTypedCommandRequest(
+        String(input),
+        init as RequestInit | undefined,
+        "input.resolve",
+      ),
+    );
+    const resolveBody = jsonRequestBody(
+      resolveCall?.[1] as RequestInit | undefined,
+    );
+    expect(resolveBody).toEqual({
+      type: "input.resolve",
+      conversationId: CONVERSATION_ID,
+      clientRequestId: resolveBody["clientRequestId"],
+      requestId: "input-1",
+      answer: { selectedOptionIds: ["region-sg", "region-jp"] },
+      expectedStateVersion: 41,
+    });
+    releaseObservation?.(
+      jsonResponse(
+        decisionStateEnvelope("input", "input-1", 42, {
+          attentionKind: "none",
+          pendingInput: null,
+          latestInputResolution: {
+            requestId: "input-1",
+            outcome: "accepted",
+          },
+        }),
+      ),
+    );
+    await resolving;
+    expect(events.at(-1)).toMatchObject({
+      event: "block.updated",
+      patch: { status: "resolved" },
+    });
+  });
+
+  it("sends the exact free-text input body and rejects mixed answers before POST", async () => {
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        {
+          type: "CUSTOM",
+          custom: {
+            name: "nyxid.input.request",
+            payload: {
+              requestId: "input-text",
+              prompt: "Name the region",
+              options: [],
+              allowFreeText: true,
+              multiSelect: false,
+            },
+          },
+        },
+      ]),
+      routeDecisionStates(
+        decisionStateEnvelope("input", "input-text", 51),
+        decisionStateEnvelope("input", "input-text", 52, {
+          attentionKind: "none",
+          pendingInput: null,
+          latestInputResolution: {
+            requestId: "input-text",
+            outcome: "accepted",
+          },
+        }),
+      ),
+      routeJsonResolve("input.resolve"),
+      routeHistory([]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Ask me");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const card = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+
+    await expect(
+      transport.resolveInput(CONVERSATION_ID, card?.block_id ?? "", {
+        freeText: "Singapore",
+        selectedOptionIds: ["region-sg"],
+      }),
+    ).rejects.toThrow();
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(
+          String(input),
+          init as RequestInit | undefined,
+          "input.resolve",
+        ),
+      ),
+    ).toHaveLength(0);
+
+    await transport.resolveInput(CONVERSATION_ID, card?.block_id ?? "", {
+      freeText: "  Singapore  ",
+    });
+    const resolveCall = fetchMock.mock.calls.find(([input, init]) =>
+      isTypedCommandRequest(
+        String(input),
+        init as RequestInit | undefined,
+        "input.resolve",
+      ),
+    );
+    expect(
+      jsonRequestBody(resolveCall?.[1] as RequestInit | undefined),
+    ).toEqual({
+      type: "input.resolve",
+      conversationId: CONVERSATION_ID,
+      clientRequestId: expect.any(String),
+      requestId: "input-text",
+      answer: { freeText: "Singapore" },
+      expectedStateVersion: 51,
+    });
+  });
+
+  it.each([
+    [
+      "non-current status",
+      {
+        status: "stale",
+        stateVersion: 61,
+        snapshot: {
+          actorId: CONVERSATION_ID,
+          stateVersion: 61,
+          attentionKind: "input",
+          pendingInput: { requestId: "input-fence" },
+        },
+      },
+    ],
+    [
+      "missing authoritative version",
+      {
+        status: "current",
+        snapshot: {
+          actorId: CONVERSATION_ID,
+          stateVersion: 61,
+          attentionKind: "input",
+          pendingInput: { requestId: "input-fence" },
+        },
+      },
+    ],
+    [
+      "zero authoritative version",
+      {
+        status: "current",
+        stateVersion: 0,
+        snapshot: {
+          actorId: CONVERSATION_ID,
+          stateVersion: 0,
+          attentionKind: "input",
+          pendingInput: { requestId: "input-fence" },
+        },
+      },
+    ],
+    [
+      "envelope and snapshot version mismatch",
+      {
+        status: "current",
+        stateVersion: 61,
+        snapshot: {
+          actorId: CONVERSATION_ID,
+          stateVersion: 60,
+          attentionKind: "input",
+          pendingInput: { requestId: "input-fence" },
+        },
+      },
+    ],
+    [
+      "snapshot actor mismatch",
+      {
+        status: "current",
+        stateVersion: 61,
+        snapshot: {
+          actorId: "nyxid-chat-other",
+          stateVersion: 61,
+          attentionKind: "input",
+          pendingInput: { requestId: "input-fence" },
+        },
+      },
+    ],
+    [
+      "attention kind mismatch",
+      {
+        status: "current",
+        stateVersion: 61,
+        snapshot: {
+          actorId: CONVERSATION_ID,
+          stateVersion: 61,
+          attentionKind: "approval",
+          pendingInput: { requestId: "input-fence" },
+        },
+      },
+    ],
+    [
+      "pending request mismatch",
+      {
+        status: "current",
+        stateVersion: 61,
+        snapshot: {
+          actorId: CONVERSATION_ID,
+          stateVersion: 61,
+          attentionKind: "input",
+          pendingInput: { requestId: "input-other" },
+        },
+      },
+    ],
+  ])("blocks input POST on %s", async (_caseName, currentState) => {
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        {
+          type: "CUSTOM",
+          custom: {
+            name: "nyxid.input.request",
+            payload: {
+              requestId: "input-fence",
+              prompt: "Choose one",
+              options: [
+                { optionId: "option-a", label: "A" },
+                { optionId: "option-b", label: "B" },
+              ],
+              allowFreeText: false,
+              multiSelect: false,
+            },
+          },
+        },
+      ]),
+      routeDecisionStates(currentState),
+      routeJsonResolve("input.resolve"),
+      routeHistory([]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Ask me");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const card = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+
+    await expect(
+      transport.resolveInput(CONVERSATION_ID, card?.block_id ?? "", {
+        selectedOptionIds: ["option-a"],
+      }),
+    ).rejects.toThrow();
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(
+          String(input),
+          init as RequestInit | undefined,
+          "input.resolve",
+        ),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("restores input to pending when committed observation times out", async () => {
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        {
+          type: "CUSTOM",
+          custom: {
+            name: "nyxid.input.request",
+            payload: {
+              requestId: "input-timeout",
+              prompt: "Choose one",
+              options: [
+                { optionId: "option-a", label: "A" },
+                { optionId: "option-b", label: "B" },
+              ],
+              allowFreeText: false,
+              multiSelect: false,
+            },
+          },
+        },
+      ]),
+      routeDecisionStates(decisionStateEnvelope("input", "input-timeout", 62)),
+      routeJsonResolve("input.resolve"),
+      routeHistory([]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Ask me");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const card = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+
+    await expect(
+      transport.resolveInput(CONVERSATION_ID, card?.block_id ?? "", {
+        selectedOptionIds: ["option-a"],
+      }),
+    ).rejects.toThrow("its committed result was not observed");
+
+    const after = await transport.getHistory(CONVERSATION_ID);
+    const cardAfter = after.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+    expect(cardAfter).toMatchObject({
+      status: "pending",
+      state_version: 62,
+    });
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).endsWith("/state"),
+      ),
+    ).toHaveLength(5);
+  });
+
+  it("absorbs a late committed input before retrying without a second POST", async () => {
+    const pendingState = decisionStateEnvelope("input", "input-late", 63);
+    const committedState = decisionStateEnvelope("input", "input-late", 64, {
+      attentionKind: "none",
+      pendingInput: null,
+      latestInputResolution: {
+        requestId: "input-late",
+        outcome: "accepted",
+      },
+    });
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        {
+          type: "CUSTOM",
+          custom: {
+            name: "nyxid.input.request",
+            payload: {
+              requestId: "input-late",
+              prompt: "Choose one",
+              options: [
+                { optionId: "option-a", label: "A" },
+                { optionId: "option-b", label: "B" },
+              ],
+              allowFreeText: false,
+              multiSelect: false,
+            },
+          },
+        },
+      ]),
+      routeDecisionStates(
+        pendingState,
+        pendingState,
+        pendingState,
+        pendingState,
+        pendingState,
+        committedState,
+      ),
+      routeJsonResolve("input.resolve"),
+      routeHistory([]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Ask me");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const card = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+    const answer = { selectedOptionIds: ["option-a"] };
+
+    await expect(
+      transport.resolveInput(CONVERSATION_ID, card?.block_id ?? "", answer),
+    ).rejects.toThrow("its committed result was not observed");
+    await expect(
+      transport.resolveInput(CONVERSATION_ID, card?.block_id ?? "", answer),
+    ).resolves.toBeNull();
+
+    const after = await transport.getHistory(CONVERSATION_ID);
+    const cardAfter = after.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+    expect(cardAfter).toMatchObject({ status: "resolved", state_version: 64 });
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(
+          String(input),
+          init as RequestInit | undefined,
+          "input.resolve",
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("does not let an old input card pause a broad signal wait", async () => {
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        {
+          type: "CUSTOM",
+          custom: {
+            name: "nyxid.input.request",
+            payload: {
+              requestId: "input-old",
+              prompt: "Old question",
+              options: [
+                { optionId: "old-a", label: "Old A" },
+                { optionId: "old-b", label: "Old B" },
+              ],
+              allowFreeText: false,
+              multiSelect: false,
+            },
+          },
+        },
+      ]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Create old card");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const oldCard = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "input_card");
+
+    vi.spyOn(chatStreamClient, "start").mockImplementation(
+      (request): ChatStreamRequestHandle => {
+        void Promise.resolve().then(() => {
+          request.onFrames([
+            {
+              type: "RUN_STARTED",
+              turnId: "turn-broad-signal",
+            },
+            {
+              type: "CUSTOM",
+              custom: {
+                name: "aevatar.workflow.waiting_signal",
+                payload: { signalName: "unrelated", stepId: "wait-new" },
+              },
+            },
+          ] as ChatStreamFrame[]);
+        });
+        return {
+          headers: Promise.resolve({
+            kind: "response",
+            status: 200,
+            contentType: "text/event-stream",
+          }),
+          completion: new Promise<ChatStreamCompletionResult>(() => undefined),
+          cancel: vi.fn(),
+        };
+      },
+    );
+    const waiting = new Promise<void>((resolve) => {
+      transport.sendMessage(
         CONVERSATION_ID,
-        card?.block_id ?? "",
-        true,
+        "Start unrelated wait",
         (event) => {
-          events.push(event);
-          if (event.event === "turn.completed") resolve();
+          if (event.event === "turn.status" && event.status === "waiting")
+            resolve();
         },
       );
     });
+    await waiting;
 
-    expect(events.at(-1)).toMatchObject({
-      event: "turn.completed",
-      turn_id: TURN_ID,
-      status: "failed",
-      error: { code: "stream_closed" },
-    });
+    await expect(
+      transport.resolveInput(CONVERSATION_ID, oldCard?.block_id ?? "", {
+        selectedOptionIds: ["old-a"],
+      }),
+    ).rejects.toBeInstanceOf(AssistantTurnActiveError);
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(
+          String(input),
+          init as RequestInit | undefined,
+          "input.resolve",
+        ),
+      ),
+    ).toHaveLength(0);
+    expect(() =>
+      transport.sendMessage(CONVERSATION_ID, "Still active", () => {}),
+    ).toThrow(AssistantTurnActiveError);
+    transport.cancelActiveTurn(CONVERSATION_ID);
   });
 
   it("reserves the conversation for the whole approve exchange", async () => {
@@ -3034,6 +3685,18 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-slow" },
         },
       ]),
+      routeDecisionStates(
+        decisionStateEnvelope("approval", "req-slow", 60),
+        decisionStateEnvelope("approval", "req-slow", 61, {
+          attentionKind: "none",
+          pendingApproval: null,
+          latestApprovalResolution: {
+            requestId: "req-slow",
+            outcome: "accepted",
+            approved: true,
+          },
+        }),
+      ),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
@@ -3054,7 +3717,7 @@ describe("live AG-UI frame taxonomy", () => {
           approveSignal = init?.signal;
           return new Promise<Response>((resolve) => {
             releaseApprove = () => {
-              resolve(jsonResponse({ accepted: true }));
+              resolve(jsonResponse({ status: "accepted" }, 202));
             };
           });
         }
@@ -3072,6 +3735,9 @@ describe("live AG-UI frame taxonomy", () => {
     expect(() => {
       transport.sendMessage(CONVERSATION_ID, "concurrent send", () => {});
     }).toThrow(AssistantTurnActiveError);
+    await expect(
+      transport.decideApproval(CONVERSATION_ID, card?.block_id ?? "", false),
+    ).rejects.toBeInstanceOf(AssistantTurnActiveError);
     // Stop must be able to abort the in-flight approve request.
     expect(approveSignal).toBeDefined();
     releaseApprove();
@@ -3143,8 +3809,8 @@ describe("live AG-UI frame taxonomy", () => {
     expect(list).toHaveLength(0);
   });
 
-  it("settles immediately when the approve endpoint acks with JSON", async () => {
-    stubFetch(
+  it("restores approval to retryable when committed observation times out", async () => {
+    const fetchMock = stubFetch(
       routeStream([
         { type: "RUN_STARTED", turnId: TURN_ID },
         {
@@ -3152,7 +3818,8 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-2" },
         },
       ]),
-      routeApprove(() => jsonResponse({ accepted: true })),
+      routeDecisionStates(decisionStateEnvelope("approval", "req-2", 80)),
+      routeJsonResolve("approval.resolve"),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
@@ -3164,25 +3831,104 @@ describe("live AG-UI frame taxonomy", () => {
       .find((block) => block.type === "approval_card");
 
     const events: TurnEvent[] = [];
-    const handle = await transport.decideApproval(
-      CONVERSATION_ID,
-      card?.block_id ?? "",
-      false,
-      (event) => events.push(event),
-    );
+    await expect(
+      transport.decideApproval(
+        CONVERSATION_ID,
+        card?.block_id ?? "",
+        false,
+        (event) => events.push(event),
+      ),
+    ).rejects.toThrow("its committed result was not observed");
 
-    // No live continuation — no handle to register (a stale entry would
-    // linger in the caller's registry after the turn completed).
-    expect(handle).toBeNull();
-    const flip = events.find(
-      (event): event is Extract<TurnEvent, { event: "block.updated" }> =>
-        event.event === "block.updated",
+    expect(events[0]).toMatchObject({
+      event: "block.updated",
+      patch: {
+        decision_submission: "denied",
+        state_version: 80,
+      },
+    });
+    expect(events.at(-1)).toMatchObject({
+      event: "block.updated",
+      patch: { decision_submission: null },
+    });
+    const after = await transport.getHistory(CONVERSATION_ID);
+    const cardAfter = after.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "approval_card");
+    expect(cardAfter).toMatchObject({
+      decision: null,
+      decision_submission: null,
+    });
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        String(input).endsWith("/state"),
+      ),
+    ).toHaveLength(5);
+  });
+
+  it("absorbs a late committed approval before retrying without a second POST", async () => {
+    const pendingState = decisionStateEnvelope("approval", "req-late", 81);
+    const committedState = decisionStateEnvelope("approval", "req-late", 82, {
+      attentionKind: "none",
+      pendingApproval: null,
+      latestApprovalResolution: {
+        requestId: "req-late",
+        outcome: "accepted",
+        approved: true,
+      },
+    });
+    const fetchMock = stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        {
+          type: "TOOL_APPROVAL_REQUEST",
+          toolApprovalRequest: { requestId: "req-late" },
+        },
+      ]),
+      routeDecisionStates(
+        pendingState,
+        pendingState,
+        pendingState,
+        pendingState,
+        pendingState,
+        committedState,
+      ),
+      routeJsonResolve("approval.resolve"),
+      routeHistory([]),
     );
-    expect(flip?.patch).toMatchObject({ decision: "denied" });
-    const terminal = events[events.length - 1];
-    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
-      "completed",
-    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Do the thing");
+    const history = await transport.getHistory(CONVERSATION_ID);
+    const card = history.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "approval_card");
+
+    await expect(
+      transport.decideApproval(CONVERSATION_ID, card?.block_id ?? "", true),
+    ).rejects.toThrow("its committed result was not observed");
+    await expect(
+      transport.decideApproval(CONVERSATION_ID, card?.block_id ?? "", false),
+    ).resolves.toBeNull();
+
+    const after = await transport.getHistory(CONVERSATION_ID);
+    const cardAfter = after.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "approval_card");
+    expect(cardAfter).toMatchObject({
+      decision: "approved",
+      decision_submission: null,
+      state_version: 82,
+    });
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(
+          String(input),
+          init as RequestInit | undefined,
+          "approval.resolve",
+        ),
+      ),
+    ).toHaveLength(1);
   });
 
   it("settles the parked run ledger when the approval is decided", async () => {
@@ -3201,10 +3947,19 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-ledger" },
         },
       ]),
-      (url, init) =>
-        url.endsWith("/approve") && init?.method === "POST"
-          ? jsonResponse({ accepted: true })
-          : undefined,
+      routeDecisionStates(
+        decisionStateEnvelope("approval", "req-ledger", 90),
+        decisionStateEnvelope("approval", "req-ledger", 91, {
+          attentionKind: "none",
+          pendingApproval: null,
+          latestApprovalResolution: {
+            requestId: "req-ledger",
+            outcome: "accepted",
+            approved: true,
+          },
+        }),
+      ),
+      routeJsonResolve("approval.resolve"),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
@@ -3261,10 +4016,19 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-B", toolCallId: "c2" },
         },
       ]),
-      (url, init) =>
-        url.endsWith("/approve") && init?.method === "POST"
-          ? jsonResponse({ accepted: true })
-          : undefined,
+      routeDecisionStates(
+        decisionStateEnvelope("approval", "req-B", 100),
+        decisionStateEnvelope("approval", "req-B", 101, {
+          attentionKind: "approval",
+          pendingApproval: { approvalRequestId: "req-A" },
+          latestApprovalResolution: {
+            requestId: "req-B",
+            outcome: "accepted",
+            approved: true,
+          },
+        }),
+      ),
+      routeJsonResolve("approval.resolve"),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
@@ -3490,6 +4254,7 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-hung" },
         },
       ]),
+      routeDecisionStates(decisionStateEnvelope("approval", "req-hung", 110)),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
@@ -3527,10 +4292,12 @@ describe("live AG-UI frame taxonomy", () => {
     transport.cancelActiveTurn(CONVERSATION_ID);
 
     await expect(pending).rejects.toThrow("The approval request was stopped.");
-    const terminal = events[events.length - 1];
-    expect(terminal?.event === "turn.completed" && terminal.status).toBe(
-      "cancelled",
-    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: "turn.completed",
+      status: "cancelled",
+      error: null,
+    });
   });
 
   it("fails an approve rejection with a single messaging surface", async () => {
@@ -3545,10 +4312,10 @@ describe("live AG-UI frame taxonomy", () => {
           toolApprovalRequest: { requestId: "req-502" },
         },
       ]),
-      (url, init) =>
-        url.endsWith("/approve") && init?.method === "POST"
-          ? jsonResponse({ code: "UPSTREAM_DOWN", message: "bad gateway" }, 502)
-          : undefined,
+      routeDecisionStates(decisionStateEnvelope("approval", "req-502", 120)),
+      routeJsonResolve("approval.resolve", () =>
+        jsonResponse({ code: "UPSTREAM_DOWN", message: "bad gateway" }, 502),
+      ),
       routeHistory([]),
     );
     const transport = new AevatarAssistantTransport();
@@ -3569,13 +4336,7 @@ describe("live AG-UI frame taxonomy", () => {
       ),
     ).rejects.toThrow("bad gateway");
 
-    const terminal = events[events.length - 1];
-    expect(
-      terminal?.event === "turn.completed" && {
-        status: terminal.status,
-        error: terminal.error,
-      },
-    ).toEqual({ status: "failed", error: null });
+    expect(events).toHaveLength(0);
     // The card was never flipped — the decision stays retryable.
     const after = await transport.getHistory(CONVERSATION_ID);
     const cardAfter = after.messages
@@ -3584,6 +4345,9 @@ describe("live AG-UI frame taxonomy", () => {
     expect(cardAfter?.type === "approval_card" && cardAfter.decision).toBe(
       null,
     );
+    await expect(
+      transport.decideApproval(CONVERSATION_ID, card?.block_id ?? "", true),
+    ).rejects.toThrow("bad gateway");
   });
 
   it("mines a raw.observed completion for steps and fallback text, never reasoning", async () => {
@@ -6934,9 +7698,9 @@ describe("studio new chats and typed actor compatibility", () => {
       status: "completed",
     });
     // The turn is delivered, not swallowed: the run's answer reaches the UI.
-    expect(
-      created.some((event) => event.event === "message.completed"),
-    ).toBe(true);
+    expect(created.some((event) => event.event === "message.completed")).toBe(
+      true,
+    );
 
     // The elided watermark leaves no stored fence, so the next turn recovers
     // one from history rather than continuing at a fabricated version.
@@ -6975,50 +7739,50 @@ describe("studio new chats and typed actor compatibility", () => {
     ["a boolean", true],
     ["an array", []],
     ["a negative version", "-1"],
-  ])("fails closed on a present but non-int64 stateVersion: %s", async (
-    _label,
-    stateVersion,
-  ) => {
-    mockChatStreams((request) =>
-      request.url === WORKFLOW_URL
-        ? {
-            frames: [
-              {
-                timestamp: "1785297207163",
-                custom: {
-                  name: "aevatar.chat.context",
-                  payload: {
-                    "@type":
-                      "type.googleapis.com/aevatar.workflow.runs.WorkflowChatContextPayload",
-                    scopeId: USER_ID,
-                    conversationId: WORKFLOW_CONVERSATION,
-                    turnId: WORKFLOW_TURN,
-                    stateVersion,
+  ])(
+    "fails closed on a present but non-int64 stateVersion: %s",
+    async (_label, stateVersion) => {
+      mockChatStreams((request) =>
+        request.url === WORKFLOW_URL
+          ? {
+              frames: [
+                {
+                  timestamp: "1785297207163",
+                  custom: {
+                    name: "aevatar.chat.context",
+                    payload: {
+                      "@type":
+                        "type.googleapis.com/aevatar.workflow.runs.WorkflowChatContextPayload",
+                      scopeId: USER_ID,
+                      conversationId: WORKFLOW_CONVERSATION,
+                      turnId: WORKFLOW_TURN,
+                      stateVersion,
+                    },
                   },
                 },
-              },
-              { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
-              ...WORKFLOW_TAIL,
-            ],
-          }
-        : undefined,
-    );
-    stubFetch();
-    const transport = new AevatarAssistantTransport();
-    const conversation = await transport.createConversation();
+                { runStarted: { threadId: RUN_ACTOR, runId: RUN_ACTOR } },
+                ...WORKFLOW_TAIL,
+              ],
+            }
+          : undefined,
+      );
+      stubFetch();
+      const transport = new AevatarAssistantTransport();
+      const conversation = await transport.createConversation();
 
-    const events = await collectWorkflowTurn(
-      transport,
-      conversation.id,
-      "create",
-    );
+      const events = await collectWorkflowTurn(
+        transport,
+        conversation.id,
+        "create",
+      );
 
-    expect(events.at(-1)).toMatchObject({
-      event: "turn.completed",
-      status: "failed",
-      error: { code: "stream_protocol_error" },
-    });
-  });
+      expect(events.at(-1)).toMatchObject({
+        event: "turn.completed",
+        status: "failed",
+        error: { code: "stream_protocol_error" },
+      });
+    },
+  );
 
   function customFrame(name: string, payload: unknown): ChatStreamFrame {
     return { custom: { name, payload } } as ChatStreamFrame;

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -39,6 +39,13 @@ import {
   type AssistantActionRequest,
 } from "@/schemas/assistant-actions";
 import {
+  assistantInputRequestSchema,
+  buildInputResolveBody,
+  inputAnswerSchema,
+  type AssistantInputRequest,
+  type InputAnswer,
+} from "@/schemas/assistant-input";
+import {
   applyTurnEvent,
   EMPTY_TURN_STATE,
   toTerminalBlock,
@@ -53,6 +60,7 @@ import type {
   ContentBlock,
   Conversation,
   ConversationHistory,
+  InputCardContentBlock,
   RunContentBlock,
   TurnEvent,
   TurnHandle,
@@ -205,11 +213,12 @@ const assistantApi = {
       onResponse: wireLog.onResponse,
     });
   },
-  post<T>(endpoint: string, body?: unknown): Promise<T> {
+  post<T>(endpoint: string, body?: unknown, signal?: AbortSignal): Promise<T> {
     return apiClient<T>(endpoint, {
       method: "POST",
       body,
       preserveSessionOn401: true,
+      signal,
       ...assistantWireLogOptions(),
     });
   },
@@ -293,6 +302,7 @@ const PRE_START_STOP_WINDOW_MS = 5_000;
 // accepts the connection but never answers would pin the `pendingStops`
 // entry forever and tax every later send/delete with the full fence wait.
 const STOP_REQUEST_DEADLINE_MS = 10_000;
+const DECISION_OBSERVATION_DELAYS_MS = [0, 250, 750, 1_500] as const;
 
 // Hard deadline on the composite DELETE. The deletion reservation rejects
 // sends and approvals while it holds, so an unanswered DELETE without a
@@ -341,6 +351,13 @@ interface ToolApprovalPayload {
   readonly expires_at?: string;
   readonly commandId?: string;
   readonly stepId?: string;
+  readonly presentation?: {
+    readonly action?: string;
+    readonly target?: string;
+    readonly actorLabel?: string;
+    readonly reversibility?: string;
+    readonly grantBoundary?: string;
+  };
 }
 
 type AuthorizationReasonCode =
@@ -383,6 +400,8 @@ interface CustomEnvelope {
 
 interface AgUiFrame {
   readonly type?: string;
+  /** Actor-owned progress sequence. This is not the committed state version. */
+  readonly sequence?: string | number;
   readonly actorId?: string;
   readonly turnId?: string;
   readonly textMessageStart?: {
@@ -718,7 +737,7 @@ interface RunningTurn {
   /** tool `toolCallId` / workflow `stepId` → index into `runSteps`. */
   stepKeys: Map<string, number>;
   /** Open cards: block_id → kind, completed at turn finalization. */
-  openCards: Map<string, "approval" | "connect">;
+  openCards: Map<string, "approval" | "connect" | "input">;
   /** Dedupe guards, per reference client behavior. */
   promptedApprovalIds: Set<string>;
   /** Service dedupe key → connect card block_id (for in-place upgrades). */
@@ -726,6 +745,10 @@ interface RunningTurn {
   /** Action request id → action card block id. */
   promptedActionIds: Map<string, string>;
   waitingForApproval: boolean;
+  /** Exact approval request currently owning the human gate. */
+  pendingApprovalRequestId: string | null;
+  /** Exact typed input request currently owning the human gate. */
+  pendingInputRequestId: string | null;
   /**
    * Suspended on `aevatar.workflow.waiting_signal`. Distinct from
    * `waitingForApproval`: it silences the progress watchdog, but there is no
@@ -2693,14 +2716,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
   }
 
-  /**
-   * Send an approval decision. On the live contract the approve endpoint
-   * answers with an SSE continuation of the run (reference client behavior);
-   * the frames stream through the same adapter as the original turn, with
-   * cursors continuing past the previous turn's so at-least-once consumers
-   * never regress. Resolves once the continuation has started; the returned
-   * handle cancels it.
-   */
+  /** Submit a version-fenced approval decision and project JSON acceptance. */
   async decideApproval(
     conversationId: string,
     blockId: string,
@@ -2735,159 +2751,230 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (card.decision !== null) {
       throw new Error("This approval was already decided.");
     }
-    const active = this.running.get(conversationId);
-    if (active) {
-      if (!active.waitingForApproval) {
-        throw new AssistantTurnActiveError();
-      }
-      // The original stream is idle at the human gate; settle it quietly so
-      // the continuation below becomes the one live turn.
-      this.pauseForApproval(conversationId, active);
-    }
-
-    // Reserve the conversation BEFORE the network call: the whole approve
-    // exchange must read as one active turn, or the idle gap while awaiting
-    // response headers lets a concurrent send/approve/delete slip past the
-    // active-turn guards and interleave two streams into one reducer. The
-    // reservation's controller doubles as the fetch signal so Stop can
-    // abort an approve request hung before headers.
-    const run = this.newRun(
-      onEvent ?? noopEvent,
-      active?.turnId ?? stored.turnState.activeTurn?.turnId ?? null,
-    );
-    // Continuation cursors continue past the previous turn's: the reducer
-    // and any still-subscribed pump dedup by strictly-increasing cursor.
-    // (Read lastCursor only after pauseForApproval settled the prior turn.)
-    run.cursor = stored.turnState.lastCursor;
-    this.running.set(conversationId, run);
-
-    // Reservation first, THEN the fence: the approve must not overtake a
-    // prior turn's still-pending stop upstream, and the reservation keeps
-    // concurrent sends out while this waits. A cancel landing during the
-    // wait settles the run before anything was dispatched — bail with no
-    // continuation rather than posting a decision for a cancelled flow.
-    await this.awaitPendingStop(conversationId);
-    if (run.finished || run.controller.signal.aborted) {
-      return null;
-    }
-
-    const stream = this.startChatStream(
+    const run = this.reserveHumanDecision(
       conversationId,
-      run,
-      TYPED_CHAT_URL,
-      JSON.stringify({
-        type: "approval.resolve",
-        conversationId,
-        clientRequestId: crypto.randomUUID(),
-        requestId: card.approval_request_id,
-        approved,
-      }),
+      "approval",
+      blockId,
+      card.approval_request_id,
+      onEvent ?? noopEvent,
     );
-    const response = await stream.headers;
-    if (response.kind === "cancelled") {
-      // cancelTurn already emitted the terminal events when the user stopped
-      // this request before response headers arrived.
-      this.finishTurn(conversationId, run, "cancelled", null);
-      throw new AssistantTurnCancelledError();
-    }
-    if (response.kind === "network_error") {
-      const aborted = run.controller.signal.aborted;
-      // cancelTurn may already have settled the run; finishTurn is a no-op
-      // then. The card was never flipped, so the decision stays retryable.
-      // Pre-stream failures settle the turn with a NULL error: the thrown
-      // rejection is what surfaces (the mutation's onError toast) — a turn
-      // error here would double-toast the same failure.
-      this.finishTurn(
+    try {
+      await this.awaitPendingStop(conversationId);
+      this.throwIfControlCancelled(run);
+      const preflight = await this.readDecisionPreflight(
         conversationId,
-        run,
-        aborted ? "cancelled" : "failed",
-        null,
+        "approval",
+        card.approval_request_id,
+        run.controller.signal,
       );
-      throw aborted
-        ? new AssistantTurnCancelledError()
-        : new Error(response.message);
-    }
-    if (response.kind === "http_error") {
-      const failure = streamStartError(response.status, response.body);
-      // Null turn error for the same single-toast reason as above.
-      this.finishTurn(conversationId, run, "failed", null);
-      throw new Error(failure.message);
-    }
-
-    this.emit(conversationId, run, {
-      cursor: this.nextCursor(run),
-      event: "block.updated",
-      block_id: blockId,
-      patch: {
-        decision: approved ? "approved" : "denied",
-        decision_channel: "web",
-      },
-    });
-    // The prior turn's ledger parked with a step waiting on THIS approval;
-    // settle that step so the transient activity line doesn't show a stale
-    // approval clock (approved → the step proceeds; denied → skipped).
-    // Correlated by approval_request_id: deciding one card must not settle
-    // steps gated on a different pending approval, and a ledger with other
-    // approvals still waiting stays parked.
-    const parkedLedger = [...stored.turnState.messages]
-      .flatMap((message) => message.blocks)
-      .reverse()
-      .find(
-        (candidate): candidate is RunContentBlock =>
-          candidate.type === "run" &&
-          candidate.state === "awaiting_approval" &&
-          candidate.steps.some(
-            (step) =>
-              step.status === "waiting" &&
-              step.approval_request_id === card.approval_request_id,
-          ),
-      );
-    if (parkedLedger) {
-      const steps = parkedLedger.steps.map((step) =>
-        step.status === "waiting" &&
-        step.approval_request_id === card.approval_request_id
-          ? {
-              ...step,
-              status: approved ? ("done" as const) : ("skipped" as const),
-            }
-          : step,
-      );
-      const stillWaiting = steps.some((step) => step.status === "waiting");
-      this.emit(conversationId, run, {
-        cursor: this.nextCursor(run),
-        event: "block.updated",
-        block_id: parkedLedger.block_id,
-        patch: {
-          state: stillWaiting
-            ? "awaiting_approval"
-            : approved
-              ? "completed"
-              : "cancelled",
-          steps,
-          steps_complete: steps.filter((step) => step.status === "done").length,
+      if (preflight.committed) {
+        this.applyCommittedApproval(
+          conversationId,
+          stored,
+          card,
+          blockId,
+          preflight.approved!,
+          preflight.stateVersion,
+          onEvent ?? noopEvent,
+        );
+        return null;
+      }
+      const expectedStateVersion = preflight.stateVersion;
+      this.throwIfControlCancelled(run);
+      await assistantApi.post<{ readonly status: string }>(
+        `${ASSISTANT_PREFIX}/chat`,
+        {
+          type: "approval.resolve",
+          conversationId,
+          clientRequestId: crypto.randomUUID(),
+          requestId: card.approval_request_id,
+          approved,
+          expectedStateVersion,
         },
-      });
-    }
+        run.controller.signal,
+      );
+      this.throwIfControlCancelled(run);
 
-    if (response.contentType.includes("text/event-stream")) {
-      void this.consumeApprovalContinuation(conversationId, run, stream);
-    } else {
-      // Older backend acknowledging with JSON: nothing further will stream,
-      // and there is no live continuation for the caller to hold a handle
-      // to — returning one would let a stale entry linger in the caller's
-      // handle registry after this turn already completed.
-      stream.cancel();
-      this.finishTurn(conversationId, run, "completed", null);
+      this.emitLocalBlockPatch(
+        conversationId,
+        blockId,
+        {
+          decision_submission: approved ? "approved" : "denied",
+          state_version: expectedStateVersion,
+        },
+        onEvent ?? noopEvent,
+      );
+      const committedStateVersion = await this.observeDecisionCommit(
+        conversationId,
+        "approval",
+        card.approval_request_id,
+        expectedStateVersion,
+        approved,
+        run.controller.signal,
+      );
+      if (committedStateVersion === null) {
+        this.emitLocalBlockPatch(
+          conversationId,
+          blockId,
+          { decision_submission: null },
+          onEvent ?? noopEvent,
+        );
+        throw new AssistantProtocolError(
+          "The approval decision was accepted for dispatch, but its committed result was not observed. The card is retryable and current state will be checked before another submission.",
+        );
+      }
+      this.applyCommittedApproval(
+        conversationId,
+        stored,
+        card,
+        blockId,
+        approved,
+        committedStateVersion,
+        onEvent ?? noopEvent,
+      );
       return null;
+    } catch (error) {
+      if (run.controller.signal.aborted) {
+        throw new AssistantTurnCancelledError();
+      }
+      throw error;
+    } finally {
+      this.releaseHumanDecision(conversationId, run);
     }
-    return {
-      get turnId() {
-        return run.turnId;
-      },
-      cancel: () => {
-        this.cancelTurn(conversationId, run);
-      },
-    };
+  }
+
+  /** Submit a strict input answer against the exact committed request version. */
+  async resolveInput(
+    conversationId: string,
+    blockId: string,
+    answer: InputAnswer,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<TurnHandle | null> {
+    this.ensureScope();
+    conversationId = this.canonicalConversationId(conversationId);
+    if (this.deletingConversations.has(conversationId)) {
+      throw new Error("This conversation is being deleted.");
+    }
+    if (!TYPED_SERVER_CONVERSATION_ID_PATTERN.test(conversationId)) {
+      throw new AssistantProtocolError(
+        "Input answers require a typed assistant conversation.",
+      );
+    }
+    const stored = this.conversations.get(conversationId);
+    const card = stored?.turnState.messages
+      .flatMap((message) => message.blocks)
+      .find(
+        (block): block is InputCardContentBlock =>
+          block.type === "input_card" && block.block_id === blockId,
+      );
+    if (!stored || !card) throw new Error("Input request was not found.");
+    if (card.status !== "pending") {
+      throw new Error("This input request was already resolved.");
+    }
+    const parsedAnswer = inputAnswerSchema.parse(answer);
+    if ("freeText" in parsedAnswer && !card.allow_free_text) {
+      throw new AssistantProtocolError(
+        "This input request does not allow a free-text answer.",
+      );
+    }
+    if ("selectedOptionIds" in parsedAnswer) {
+      const optionIds = new Set(card.options.map((option) => option.option_id));
+      if (
+        parsedAnswer.selectedOptionIds.some(
+          (optionId) => !optionIds.has(optionId),
+        )
+      ) {
+        throw new AssistantProtocolError(
+          "The answer selected an option that is not part of this request.",
+        );
+      }
+      if (!card.multi_select && parsedAnswer.selectedOptionIds.length !== 1) {
+        throw new AssistantProtocolError(
+          "This input request accepts exactly one selected option.",
+        );
+      }
+    }
+    const run = this.reserveHumanDecision(
+      conversationId,
+      "input",
+      blockId,
+      card.request_id,
+      onEvent ?? noopEvent,
+    );
+    try {
+      await this.awaitPendingStop(conversationId);
+      this.throwIfControlCancelled(run);
+      const preflight = await this.readDecisionPreflight(
+        conversationId,
+        "input",
+        card.request_id,
+        run.controller.signal,
+      );
+      if (preflight.committed) {
+        this.emitLocalBlockPatch(
+          conversationId,
+          blockId,
+          { status: "resolved", state_version: preflight.stateVersion },
+          onEvent ?? noopEvent,
+        );
+        return null;
+      }
+      const expectedStateVersion = preflight.stateVersion;
+      const body = buildInputResolveBody(
+        conversationId,
+        crypto.randomUUID(),
+        card.request_id,
+        parsedAnswer,
+        expectedStateVersion,
+      );
+      this.throwIfControlCancelled(run);
+      await assistantApi.post<{ readonly status: string }>(
+        `${ASSISTANT_PREFIX}/chat`,
+        body,
+        run.controller.signal,
+      );
+      this.throwIfControlCancelled(run);
+      this.emitLocalBlockPatch(
+        conversationId,
+        blockId,
+        { status: "submitted", state_version: expectedStateVersion },
+        onEvent ?? noopEvent,
+      );
+      const committedStateVersion = await this.observeDecisionCommit(
+        conversationId,
+        "input",
+        card.request_id,
+        expectedStateVersion,
+        undefined,
+        run.controller.signal,
+      );
+      if (committedStateVersion !== null) {
+        this.emitLocalBlockPatch(
+          conversationId,
+          blockId,
+          { status: "resolved", state_version: committedStateVersion },
+          onEvent ?? noopEvent,
+        );
+      } else {
+        this.emitLocalBlockPatch(
+          conversationId,
+          blockId,
+          { status: "pending" },
+          onEvent ?? noopEvent,
+        );
+        throw new AssistantProtocolError(
+          "The input answer was accepted for dispatch, but its committed result was not observed. The card is retryable and current state will be checked before another submission.",
+        );
+      }
+      return null;
+    } catch (error) {
+      if (run.controller.signal.aborted) {
+        throw new AssistantTurnCancelledError();
+      }
+      throw error;
+    } finally {
+      this.releaseHumanDecision(conversationId, run);
+    }
   }
 
   setActionCardInProgress(
@@ -3177,7 +3264,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
   private emitLocalBlockPatch(
     conversationId: string,
     blockId: string,
-    patch: Partial<ActionCardContentBlock>,
+    patch: Partial<ContentBlock>,
     onEvent: (event: TurnEvent) => void,
   ): void {
     const stored = this.conversations.get(conversationId);
@@ -3637,6 +3724,8 @@ export class AevatarAssistantTransport implements AssistantTransport {
       promptedConnectSlugs: new Map(),
       promptedActionIds: new Map(),
       waitingForApproval: false,
+      pendingApprovalRequestId: null,
+      pendingInputRequestId: null,
       awaitingSignal: false,
       watchdog: null,
       deliveryStarted: false,
@@ -4458,18 +4547,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
   }
 
-  private async consumeApprovalContinuation(
-    conversationId: string,
-    run: RunningTurn,
-    stream: ChatStreamRequestHandle,
-  ): Promise<void> {
-    const result = await this.consumeTurnStream(conversationId, run, stream);
-    if (result.kind === "settled" || run.finished) return;
-    this.closeOpenMessage(conversationId, run);
-    this.finalizeActivity(conversationId, run, "failed");
-    this.finishTurn(conversationId, run, "failed", result.error);
-  }
-
   private startChatStream(
     conversationId: string,
     run: RunningTurn,
@@ -5053,6 +5130,29 @@ export class AevatarAssistantTransport implements AssistantTransport {
         }
         return;
       }
+      case "nyxid.input.request": {
+        const request = assistantInputRequestSchema.safeParse(payload);
+        if (request.success) {
+          this.addInputCard(conversationId, run, request.data);
+        }
+        return;
+      }
+      case "nyxid.input.changed":
+        this.applyInputChanged(conversationId, run, payload);
+        return;
+      case "nyxid.approval.request": {
+        if (payload && typeof payload === "object") {
+          this.addApprovalCard(
+            conversationId,
+            run,
+            payload as ToolApprovalPayload,
+          );
+        }
+        return;
+      }
+      case "nyxid.approval.changed":
+        this.applyApprovalChanged(conversationId, run, payload);
+        return;
       case "aevatar.tool_approval.pending":
         this.addApprovalCard(
           conversationId,
@@ -5679,12 +5779,20 @@ export class AevatarAssistantTransport implements AssistantTransport {
     if (!requestId || run.promptedApprovalIds.has(requestId)) return;
     run.promptedApprovalIds.add(requestId);
     run.waitingForApproval = true;
+    run.pendingApprovalRequestId = requestId;
     // A human gate has no client-imposed deadline; stop the watchdog.
     this.clearWatchdog(run);
 
+    const presentation = payload.presentation;
+    const presentationBody = [
+      presentation?.actorLabel,
+      presentation?.action,
+      presentation?.target ? `on ${presentation.target}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
     const body =
-      payload.message ??
-      payload.body ??
+      (payload.message ?? payload.body ?? presentationBody) ||
       (payload.toolName
         ? `The assistant wants to run ${redactDisplayText(payload.toolName)}.`
         : "The assistant is requesting your approval to continue.");
@@ -5705,6 +5813,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       expires_at: payload.expiresAt ?? payload.expires_at ?? "",
       decision: null,
       decision_channel: null,
+      decision_submission: null,
     };
     this.appendActivityBlock(conversationId, run, block);
     run.openCards.set(block.block_id, "approval");
@@ -5722,6 +5831,117 @@ export class AevatarAssistantTransport implements AssistantTransport {
         turn_id: run.turnId,
         status: "waiting",
       });
+    }
+  }
+
+  private addInputCard(
+    conversationId: string,
+    run: RunningTurn,
+    request: AssistantInputRequest,
+  ): void {
+    const dedupeKey = `input:${request.requestId}`;
+    if (run.promptedApprovalIds.has(dedupeKey)) return;
+    run.promptedApprovalIds.add(dedupeKey);
+    run.awaitingSignal = true;
+    run.pendingInputRequestId = request.requestId;
+    this.clearWatchdog(run);
+
+    const block: InputCardContentBlock = {
+      type: "input_card",
+      block_id: newId("input-card"),
+      request_id: request.requestId,
+      prompt: redactDisplayText(request.prompt),
+      options: request.options.map((option) => ({
+        option_id: option.optionId,
+        label: redactDisplayText(option.label),
+        ...(option.description
+          ? { description: redactDisplayText(option.description) }
+          : {}),
+      })),
+      allow_free_text: request.allowFreeText,
+      multi_select: request.multiSelect,
+      status: "pending",
+    };
+    this.appendActivityBlock(conversationId, run, block);
+    run.openCards.set(block.block_id, "input");
+    this.markStepWaiting(
+      conversationId,
+      run,
+      protoString(request["stepId"]),
+      request.requestId,
+    );
+    if (run.runBlockId) this.patchRunBlock(conversationId, run);
+    if (run.turnId) {
+      this.emit(conversationId, run, {
+        cursor: this.nextCursor(run),
+        event: "turn.status",
+        turn_id: run.turnId,
+        status: "waiting",
+      });
+    }
+  }
+
+  private applyInputChanged(
+    conversationId: string,
+    run: RunningTurn,
+    payload: unknown,
+  ): void {
+    if (!payload || typeof payload !== "object") return;
+    const requestId = protoString(
+      (payload as Record<string, unknown>)["requestId"],
+    );
+    if (!requestId) return;
+    const card = this.conversations
+      .get(conversationId)
+      ?.turnState.messages.flatMap((message) => message.blocks)
+      .find(
+        (block): block is InputCardContentBlock =>
+          block.type === "input_card" && block.request_id === requestId,
+      );
+    if (!card) return;
+    this.emitLocalBlockPatch(
+      conversationId,
+      card.block_id,
+      { status: "resolved" },
+      run.onEvent,
+    );
+    if (run.pendingInputRequestId === requestId) {
+      run.pendingInputRequestId = null;
+      run.awaitingSignal = false;
+    }
+  }
+
+  private applyApprovalChanged(
+    conversationId: string,
+    run: RunningTurn,
+    payload: unknown,
+  ): void {
+    if (!payload || typeof payload !== "object") return;
+    const record = payload as Record<string, unknown>;
+    const requestId = protoString(record["requestId"]);
+    if (!requestId || typeof record["approved"] !== "boolean") return;
+    const card = this.conversations
+      .get(conversationId)
+      ?.turnState.messages.flatMap((message) => message.blocks)
+      .find(
+        (block): block is ApprovalCardContentBlock =>
+          block.type === "approval_card" &&
+          block.approval_request_id === requestId,
+      );
+    if (!card) return;
+    this.emitLocalBlockPatch(
+      conversationId,
+      card.block_id,
+      {
+        decision: record["approved"] ? "approved" : "denied",
+        decision_channel: "web",
+        decision_submission: null,
+      },
+      run.onEvent,
+    );
+    if (run.pendingApprovalRequestId === requestId) {
+      run.pendingApprovalRequestId = null;
+      run.waitingForApproval = false;
     }
   }
 
@@ -6182,12 +6402,277 @@ export class AevatarAssistantTransport implements AssistantTransport {
     });
   }
 
-  /**
-   * Quietly settle a turn idling at a human gate so an approval decision can
-   * become the live turn: no card is terminal-ized (the decision flow patches
-   * it), the ledger parks as awaiting-approval, and the fetch aborts.
-   */
-  private pauseForApproval(conversationId: string, run: RunningTurn): void {
+  private reserveHumanDecision(
+    conversationId: string,
+    expectedKind: "approval" | "input",
+    blockId: string,
+    requestId: string,
+    onEvent: (event: TurnEvent) => void,
+  ): RunningTurn {
+    this.pauseAtHumanGate(conversationId, expectedKind, blockId, requestId);
+    if (this.running.has(conversationId)) {
+      throw new AssistantTurnActiveError();
+    }
+    const stored = this.conversations.get(conversationId);
+    if (!stored) throw new AssistantConversationNotFoundError();
+    const run = this.newRun(onEvent, null, "actor");
+    run.cursor = stored.turnState.lastCursor;
+    this.running.set(conversationId, run);
+    return run;
+  }
+
+  private releaseHumanDecision(conversationId: string, run: RunningTurn): void {
+    if (this.running.get(conversationId) !== run) return;
+    run.finished = true;
+    this.clearWatchdog(run);
+    this.running.delete(conversationId);
+  }
+
+  private throwIfControlCancelled(run: RunningTurn): void {
+    if (run.finished || run.controller.signal.aborted) {
+      throw new AssistantTurnCancelledError();
+    }
+  }
+
+  private async readDecisionPreflight(
+    conversationId: string,
+    kind: "approval" | "input",
+    requestId: string,
+    signal: AbortSignal,
+  ): Promise<{
+    readonly stateVersion: number;
+    readonly committed: boolean;
+    readonly approved?: boolean;
+  }> {
+    const current = await this.readCurrentDecisionState(conversationId, signal);
+    const latest =
+      current.snapshot[
+        kind === "input" ? "latestInputResolution" : "latestApprovalResolution"
+      ];
+    if (latest && typeof latest === "object" && !Array.isArray(latest)) {
+      const latestRecord = latest as Record<string, unknown>;
+      if (
+        protoString(latestRecord["requestId"]) === requestId &&
+        latestRecord["outcome"] === "accepted"
+      ) {
+        if (kind === "input") {
+          return { stateVersion: current.stateVersion, committed: true };
+        }
+        if (typeof latestRecord["approved"] === "boolean") {
+          return {
+            stateVersion: current.stateVersion,
+            committed: true,
+            approved: latestRecord["approved"],
+          };
+        }
+      }
+    }
+    if (current.snapshot["attentionKind"] !== kind) {
+      throw new AssistantProtocolError(
+        `The assistant is no longer waiting for ${kind}.`,
+      );
+    }
+    const pending =
+      current.snapshot[kind === "input" ? "pendingInput" : "pendingApproval"];
+    if (!pending || typeof pending !== "object" || Array.isArray(pending)) {
+      throw new AssistantProtocolError(
+        `The pending ${kind} request is no longer current.`,
+      );
+    }
+    const pendingRecord = pending as Record<string, unknown>;
+    const observedRequestId = protoString(
+      kind === "input"
+        ? pendingRecord["requestId"]
+        : (pendingRecord["approvalRequestId"] ?? pendingRecord["requestId"]),
+    );
+    if (observedRequestId !== requestId) {
+      throw new AssistantProtocolError(
+        `The pending ${kind} request changed before it could be resolved.`,
+      );
+    }
+    return { stateVersion: current.stateVersion, committed: false };
+  }
+
+  private applyCommittedApproval(
+    conversationId: string,
+    stored: StoredConversation,
+    card: ApprovalCardContentBlock,
+    blockId: string,
+    approved: boolean,
+    stateVersion: number,
+    onEvent: (event: TurnEvent) => void,
+  ): void {
+    this.emitLocalBlockPatch(
+      conversationId,
+      blockId,
+      {
+        decision: approved ? "approved" : "denied",
+        decision_channel: "web",
+        decision_submission: null,
+        state_version: stateVersion,
+      },
+      onEvent,
+    );
+
+    // Settle only the ledger step fenced by this exact approval request.
+    const parkedLedger = [...stored.turnState.messages]
+      .flatMap((message) => message.blocks)
+      .reverse()
+      .find(
+        (candidate): candidate is RunContentBlock =>
+          candidate.type === "run" &&
+          candidate.state === "awaiting_approval" &&
+          candidate.steps.some(
+            (step) =>
+              step.status === "waiting" &&
+              step.approval_request_id === card.approval_request_id,
+          ),
+      );
+    if (!parkedLedger) return;
+
+    const steps = parkedLedger.steps.map((step) =>
+      step.status === "waiting" &&
+      step.approval_request_id === card.approval_request_id
+        ? {
+            ...step,
+            status: approved ? ("done" as const) : ("skipped" as const),
+          }
+        : step,
+    );
+    const stillWaiting = steps.some((step) => step.status === "waiting");
+    this.emitLocalBlockPatch(
+      conversationId,
+      parkedLedger.block_id,
+      {
+        state: stillWaiting
+          ? "awaiting_approval"
+          : approved
+            ? "completed"
+            : "cancelled",
+        steps,
+        steps_complete: steps.filter((step) => step.status === "done").length,
+      },
+      onEvent,
+    );
+  }
+
+  private async readCurrentDecisionState(
+    conversationId: string,
+    signal: AbortSignal,
+  ): Promise<{
+    readonly stateVersion: number;
+    readonly snapshot: Record<string, unknown>;
+  }> {
+    const response = await assistantApi.get<unknown>(
+      `${ASSISTANT_PREFIX}/conversations/${encodeURIComponent(conversationId)}/state`,
+      signal,
+    );
+    if (!response || typeof response !== "object" || Array.isArray(response)) {
+      throw new AssistantProtocolError(
+        "The assistant state response was not a valid current-state envelope.",
+      );
+    }
+    const envelope = response as Record<string, unknown>;
+    if (envelope["status"] !== "current") {
+      throw new AssistantProtocolError(
+        "The assistant state is not current. Refresh the conversation and try again.",
+      );
+    }
+    const stateVersion = positiveStateVersion(envelope["stateVersion"]);
+    const snapshot = envelope["snapshot"];
+    if (
+      stateVersion === undefined ||
+      !snapshot ||
+      typeof snapshot !== "object" ||
+      Array.isArray(snapshot)
+    ) {
+      throw new AssistantProtocolError(
+        "The assistant state did not include an authoritative positive version.",
+      );
+    }
+    const snapshotRecord = snapshot as Record<string, unknown>;
+    if (protoString(snapshotRecord["actorId"]) !== conversationId) {
+      throw new AssistantProtocolError(
+        "The assistant state snapshot belongs to a different conversation.",
+      );
+    }
+    if (positiveStateVersion(snapshotRecord["stateVersion"]) !== stateVersion) {
+      throw new AssistantProtocolError(
+        "The assistant state envelope and snapshot versions did not match.",
+      );
+    }
+    return { stateVersion, snapshot: snapshotRecord };
+  }
+
+  private async observeDecisionCommit(
+    conversationId: string,
+    kind: "approval" | "input",
+    requestId: string,
+    expectedStateVersion: number,
+    approved: boolean | undefined,
+    signal: AbortSignal,
+  ): Promise<number | null> {
+    for (const delayMs of DECISION_OBSERVATION_DELAYS_MS) {
+      await abortableDelay(delayMs, signal);
+      const current = await this.readCurrentDecisionState(
+        conversationId,
+        signal,
+      );
+      const latest =
+        current.snapshot[
+          kind === "input"
+            ? "latestInputResolution"
+            : "latestApprovalResolution"
+        ];
+      if (latest && typeof latest === "object" && !Array.isArray(latest)) {
+        const latestRecord = latest as Record<string, unknown>;
+        const matchesDecision =
+          protoString(latestRecord["requestId"]) === requestId &&
+          latestRecord["outcome"] === "accepted" &&
+          (kind === "input" || latestRecord["approved"] === approved);
+        if (matchesDecision && current.stateVersion > expectedStateVersion) {
+          return current.stateVersion;
+        }
+      }
+      const pending =
+        current.snapshot[kind === "input" ? "pendingInput" : "pendingApproval"];
+      if (pending && typeof pending === "object" && !Array.isArray(pending)) {
+        const pendingRecord = pending as Record<string, unknown>;
+        const pendingRequestId = protoString(
+          kind === "input"
+            ? pendingRecord["requestId"]
+            : (pendingRecord["approvalRequestId"] ??
+                pendingRecord["requestId"]),
+        );
+        if (pendingRequestId !== requestId) {
+          throw new AssistantProtocolError(
+            `A different pending ${kind} request replaced the submitted request.`,
+          );
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Quietly settle a stream that is already parked at a human gate. */
+  private pauseAtHumanGate(
+    conversationId: string,
+    expectedKind: "approval" | "input",
+    blockId: string,
+    requestId: string,
+  ): void {
+    const run = this.running.get(conversationId);
+    if (!run) return;
+    const exactRequestId =
+      expectedKind === "approval"
+        ? run.pendingApprovalRequestId
+        : run.pendingInputRequestId;
+    if (
+      exactRequestId !== requestId ||
+      run.openCards.get(blockId) !== expectedKind
+    ) {
+      throw new AssistantTurnActiveError();
+    }
     if (run.finished) return;
     this.acceptActionBatch(conversationId, run);
     this.closeOpenMessage(conversationId, run);

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -2770,8 +2770,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
       if (preflight.committed) {
         this.applyCommittedApproval(
           conversationId,
-          stored,
-          card,
           blockId,
           preflight.approved!,
           preflight.stateVersion,
@@ -2825,8 +2823,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
       }
       this.applyCommittedApproval(
         conversationId,
-        stored,
-        card,
         blockId,
         approved,
         committedStateVersion,
@@ -6495,8 +6491,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
 
   private applyCommittedApproval(
     conversationId: string,
-    stored: StoredConversation,
-    card: ApprovalCardContentBlock,
     blockId: string,
     approved: boolean,
     stateVersion: number,
@@ -6510,47 +6504,6 @@ export class AevatarAssistantTransport implements AssistantTransport {
         decision_channel: "web",
         decision_submission: null,
         state_version: stateVersion,
-      },
-      onEvent,
-    );
-
-    // Settle only the ledger step fenced by this exact approval request.
-    const parkedLedger = [...stored.turnState.messages]
-      .flatMap((message) => message.blocks)
-      .reverse()
-      .find(
-        (candidate): candidate is RunContentBlock =>
-          candidate.type === "run" &&
-          candidate.state === "awaiting_approval" &&
-          candidate.steps.some(
-            (step) =>
-              step.status === "waiting" &&
-              step.approval_request_id === card.approval_request_id,
-          ),
-      );
-    if (!parkedLedger) return;
-
-    const steps = parkedLedger.steps.map((step) =>
-      step.status === "waiting" &&
-      step.approval_request_id === card.approval_request_id
-        ? {
-            ...step,
-            status: approved ? ("done" as const) : ("skipped" as const),
-          }
-        : step,
-    );
-    const stillWaiting = steps.some((step) => step.status === "waiting");
-    this.emitLocalBlockPatch(
-      conversationId,
-      parkedLedger.block_id,
-      {
-        state: stillWaiting
-          ? "awaiting_approval"
-          : approved
-            ? "completed"
-            : "cancelled",
-        steps,
-        steps_complete: steps.filter((step) => step.status === "done").length,
       },
       onEvent,
     );

--- a/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
@@ -80,6 +80,7 @@ class StubTransport implements AssistantTransport {
   sendCalls = 0;
   cancelCalls = 0;
   approvalCalls = 0;
+  inputCalls = 0;
   progressCalls = 0;
   blockCalls = 0;
   continueCalls = 0;
@@ -208,6 +209,11 @@ class StubTransport implements AssistantTransport {
 
   async decideApproval(): Promise<TurnHandle | null> {
     this.approvalCalls += 1;
+    return null;
+  }
+
+  async resolveInput(): Promise<TurnHandle | null> {
+    this.inputCalls += 1;
     return null;
   }
 

--- a/frontend/src/lib/assistant/scenario-intercept-transport.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.ts
@@ -18,6 +18,7 @@ import { applyTurnEvent, EMPTY_TURN_STATE } from "@/lib/assistant/stream";
 import { useAssistantMockScenariosStore } from "@/stores/assistant-mock-scenarios-store";
 import { useAuthStore } from "@/stores/auth-store";
 import type { ActionReport } from "@/schemas/assistant-actions";
+import type { InputAnswer } from "@/schemas/assistant-input";
 import type {
   AssistantMessage,
   AssistantTransport,
@@ -412,6 +413,15 @@ export class ScenarioInterceptTransport implements AssistantTransport {
       this.restoreOwnership(conversationId, priorOwnership);
       throw error;
     }
+  }
+
+  resolveInput(
+    conversationId: string,
+    blockId: string,
+    answer: InputAnswer,
+    onEvent: (event: TurnEvent) => void = () => undefined,
+  ): Promise<TurnHandle | null> {
+    return this.delegate.resolveInput(conversationId, blockId, answer, onEvent);
   }
 
   setActionCardInProgress(

--- a/frontend/src/lib/assistant/stream.ts
+++ b/frontend/src/lib/assistant/stream.ts
@@ -43,6 +43,10 @@ export function toTerminalBlock(block: ContentBlock): ContentBlock {
       return block.decision === null
         ? { ...block, decision: "cancelled" }
         : block;
+    case "input_card":
+      return block.status === "pending"
+        ? { ...block, status: "cancelled" }
+        : block;
     case "connect_card":
       if (
         block.state === "connected" ||

--- a/frontend/src/lib/assistant/transport-shell.test.ts
+++ b/frontend/src/lib/assistant/transport-shell.test.ts
@@ -76,6 +76,11 @@ class RecordingTransport implements AssistantTransport {
     return null;
   }
 
+  async resolveInput(): Promise<TurnHandle | null> {
+    this.calls.push("input");
+    return null;
+  }
+
   setActionCardInProgress(): void {
     this.calls.push("progress");
   }

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -14,6 +14,7 @@ import {
   buildActionWakeBody,
   type ActionReport,
 } from "@/schemas/assistant-actions";
+import { inputAnswerSchema, type InputAnswer } from "@/schemas/assistant-input";
 import type {
   AssistantTransport,
   Conversation,
@@ -177,6 +178,29 @@ class MockAssistantTransport implements AssistantTransport {
     return null;
   }
 
+  async resolveInput(
+    conversationId: string,
+    blockId: string,
+    answer: InputAnswer,
+    onEvent: (event: TurnEvent) => void = () => undefined,
+  ): Promise<TurnHandle | null> {
+    inputAnswerSchema.parse(answer);
+    const block = assistantMockStore.findBlock(conversationId, blockId);
+    if (block?.type !== "input_card") {
+      throw new Error("Input request was not found.");
+    }
+    if (block.status !== "pending") {
+      throw new Error("This input request was already resolved.");
+    }
+    this.emitLocalActionPatch(
+      conversationId,
+      blockId,
+      { status: "resolved" },
+      onEvent,
+    );
+    return null;
+  }
+
   setActionCardInProgress(
     conversationId: string,
     blockId: string,
@@ -251,13 +275,13 @@ class MockAssistantTransport implements AssistantTransport {
             block.type === "action_card" &&
             block.action_request_id === report.actionRequestId,
         );
-      if (card?.type === "action_card") {
-        actionLookup.set(report.actionRequestId, card.action);
-      }
       const refusedByCardState =
         card?.type === "action_card" &&
         (card.status === "conflicted" ||
           (card.status === "blocked" && report.disposition === "completed"));
+      if (card?.type === "action_card") {
+        actionLookup.set(report.actionRequestId, card.action);
+      }
       if (refusedByCardState) {
         if (
           card?.type === "action_card" &&
@@ -635,6 +659,20 @@ export class DelegatingAssistantTransport implements AssistantTransport {
       conversationId,
       blockId,
       approved,
+      onEvent,
+    );
+  }
+
+  resolveInput(
+    conversationId: string,
+    blockId: string,
+    answer: InputAnswer,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<TurnHandle | null> {
+    return this.transport.resolveInput(
+      conversationId,
+      blockId,
+      answer,
       onEvent,
     );
   }

--- a/frontend/src/lib/assistant/wire-replay.ts
+++ b/frontend/src/lib/assistant/wire-replay.ts
@@ -88,7 +88,9 @@ function safeErrorCode(value: unknown, fallback: string): string {
  * `aevatar.media.chunk` (`MediaContentEvent`) flattened to the fields `addMedia`
  * reads. `ChatContentPart` names the location `uri`, not `url`.
  */
-function mediaPartFields(body: Record<string, unknown>): Record<string, unknown> {
+function mediaPartFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
   const part = unpackAny(body["part"]);
   return {
     mediaType: part["mediaType"],
@@ -636,6 +638,7 @@ class ReplayProjector {
         stringValue(body, "expiresAt") || stringValue(body, "expires_at"),
       decision: null,
       decision_channel: null,
+      decision_submission: null,
     };
     this.appendActivityBlock(block, frame);
     this.openCards.set(block.block_id, "approval");

--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -18,6 +18,7 @@ const {
   mockCreateMutateAsync,
   mockCancelMutateAsync,
   mockDecideMutateAsync,
+  mockResolveInputMutateAsync,
   mockContinueAction,
   mockDeleteMutateAsync,
   mockSendMutateAsync,
@@ -28,6 +29,7 @@ const {
   mockCreateMutateAsync: vi.fn(),
   mockCancelMutateAsync: vi.fn(),
   mockDecideMutateAsync: vi.fn(),
+  mockResolveInputMutateAsync: vi.fn(),
   mockContinueAction: vi.fn(),
   mockDeleteMutateAsync: vi.fn(),
   mockSendMutateAsync: vi.fn(),
@@ -129,19 +131,19 @@ vi.mock("@/hooks/use-assistant", () => ({
     data:
       conversationId && !state.historyLoading
         ? {
-          conversation: {
-            ...(state.conversations?.find(
-              (conversation) => conversation.id === conversationId,
-            ) ?? {
-              id: conversationId,
-              title: "Loading",
-              created_at: "2026-07-29T00:00:00.000Z",
-              last_message_at: "2026-07-29T00:00:00.000Z",
-            }),
-            id: state.historyCanonicalId ?? conversationId,
-          },
-          messages: state.historyMessages,
-          has_more: false,
+            conversation: {
+              ...(state.conversations?.find(
+                (conversation) => conversation.id === conversationId,
+              ) ?? {
+                id: conversationId,
+                title: "Loading",
+                created_at: "2026-07-29T00:00:00.000Z",
+                last_message_at: "2026-07-29T00:00:00.000Z",
+              }),
+              id: state.historyCanonicalId ?? conversationId,
+            },
+            messages: state.historyMessages,
+            has_more: false,
             awaitingProjection: state.historyAwaitingProjection,
             projectionStalled: state.historyProjectionStalled,
           }
@@ -174,6 +176,10 @@ vi.mock("@/hooks/use-assistant", () => ({
   useDecideApproval: () => ({
     mutateAsync: mockDecideMutateAsync,
     isPending: state.decisionPending,
+  }),
+  useResolveInput: () => ({
+    mutateAsync: mockResolveInputMutateAsync,
+    isPending: false,
   }),
   useActionCardActions: () => ({
     setInProgress: vi.fn(),
@@ -591,9 +597,7 @@ describe("AssistantPage new chat", () => {
     expect(
       screen.queryByText(/no saved transcript yet/i),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/You can keep chatting/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/You can keep chatting/)).not.toBeInTheDocument();
     expect(screen.getByText("still here")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toBeEnabled();
   });

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -30,6 +30,7 @@ import {
   useDecideApproval,
   useDeleteConversation,
   useSendMessage,
+  useResolveInput,
   useTurnEpisode,
 } from "@/hooks/use-assistant";
 import { ApiError } from "@/lib/api-client";
@@ -41,6 +42,7 @@ import {
 import { markChatActivity } from "@/lib/assistant/connect-watch";
 import { parseAssistantSearch } from "@/lib/assistant/search";
 import type { ActionReport } from "@/schemas/assistant-actions";
+import type { InputAnswer } from "@/schemas/assistant-input";
 import { useAssistantContextStore } from "@/stores/assistant-context-store";
 import { useAssistantDraftStore } from "@/stores/assistant-draft-store";
 import { useAuthStore } from "@/stores/auth-store";
@@ -189,6 +191,7 @@ export function AssistantPage({
   const sendMessage = useSendMessage(selectedId);
   const cancelTurn = useCancelTurn(selectedId);
   const decideApproval = useDecideApproval(selectedId);
+  const resolveInput = useResolveInput(selectedId);
   const actionCards = useActionCardActions(selectedId);
   const deleteConversation = useDeleteConversation();
   const turnStatus = turn.data?.status;
@@ -199,6 +202,7 @@ export function AssistantPage({
     sendMessage.isPending ||
     cancelTurn.isPending ||
     decideApproval.isPending ||
+    resolveInput.isPending ||
     episodeState?.open === true;
 
   // Effects queued by an earlier quiet render must observe a continuation
@@ -424,6 +428,15 @@ export function AssistantPage({
     }
   }
 
+  async function handleResolveInput(blockId: string, answer: InputAnswer) {
+    beginContinuation();
+    try {
+      await resolveInput.mutateAsync({ blockId, answer });
+    } finally {
+      endContinuation();
+    }
+  }
+
   async function handleResolveAction(report: ActionReport) {
     beginContinuation();
     try {
@@ -598,6 +611,7 @@ export function AssistantPage({
               episodeState?.projecting === true || sendMessage.isPending
             }
             onDecideApproval={handleDecideApproval}
+            onResolveInput={handleResolveInput}
             onActionProgress={actionCards.setInProgress}
             onBlockAction={actionCards.blockAction}
             onResolveAction={handleResolveAction}

--- a/frontend/src/schemas/assistant-actions.test.ts
+++ b/frontend/src/schemas/assistant-actions.test.ts
@@ -132,7 +132,13 @@ describe("assistant action request schema", () => {
       },
     });
 
-    for (const request of [badSlug, httpUrl, queryUrl, fragmentUrl, badAuthKeyName]) {
+    for (const request of [
+      badSlug,
+      httpUrl,
+      queryUrl,
+      fragmentUrl,
+      badAuthKeyName,
+    ]) {
       expect(resolveAssistantAction(request)).toMatchObject({
         supported: false,
         params: { variant: "unknown" },
@@ -421,7 +427,7 @@ describe("action continuation schema", () => {
     ).toBe(false);
   });
 
-  it("rejects completed service.connect reports without a userService resource", () => {
+  it("requires the resource variant owned by service and key actions", () => {
     expect(() =>
       buildActionContinueBody(
         "nyxid-chat-actor-1",
@@ -436,9 +442,7 @@ describe("action continuation schema", () => {
         ],
         new Map([["act-1", "service.connect"]]),
       ),
-    ).toThrow(
-      "service.connect completed reports must include resource.userService.userServiceId",
-    );
+    ).toThrow("Completed action reports must include a resource reference");
     expect(() =>
       buildActionContinueBody(
         "nyxid-chat-actor-1",
@@ -452,14 +456,62 @@ describe("action continuation schema", () => {
             resource: { key: { keyId: "key-1" } },
           },
         ],
-        new Map([["act-1", "service.connect"]]),
+        new Map([["act-1", "service.reauthorize"]]),
       ),
     ).toThrow(
-      "service.connect completed reports must include resource.userService.userServiceId",
+      "service.reauthorize completed reports must include resource.userService.userServiceId",
     );
+    expect(() =>
+      buildActionContinueBody(
+        "nyxid-chat-actor-1",
+        "request-1",
+        "turn-origin-1",
+        [
+          {
+            actionRequestId: "act-1",
+            originTurnId: "turn-origin-1",
+            disposition: "completed",
+            resource: {
+              userService: { userServiceId: "service-1" },
+            },
+          },
+        ],
+        new Map([["act-1", "key.rotate"]]),
+      ),
+    ).toThrow("key.rotate completed reports must include resource.key.keyId");
   });
 
-  it("fails closed for completed reports without resources when the action lookup is missing", () => {
+  it("round-trips all six safe resource variants when the action is neutral", () => {
+    const resources = [
+      { userService: { userServiceId: "service-1" } },
+      { key: { keyId: "key-1" } },
+      { node: { nodeId: "node-1" } },
+      { serviceAccount: { serviceAccountId: "sa-1" } },
+      { developerApp: { clientId: "app-1" } },
+      { device: { deviceId: "device-1" } },
+    ] as const;
+
+    for (const [index, resource] of resources.entries()) {
+      const actionRequestId = `act-${String(index)}`;
+      const body = buildActionContinueBody(
+        "nyxid-chat-actor-1",
+        `request-${String(index)}`,
+        "turn-origin-1",
+        [
+          {
+            actionRequestId,
+            originTurnId: "turn-origin-1",
+            disposition: "completed",
+            resource,
+          },
+        ],
+        new Map([[actionRequestId, "node.inspect"]]),
+      );
+      expect(body.actions[0]?.resource).toEqual(resource);
+    }
+  });
+
+  it("fails closed for completed reports without resources", () => {
     expect(() =>
       buildActionContinueBody(
         "nyxid-chat-actor-1",

--- a/frontend/src/schemas/assistant-actions.ts
+++ b/frontend/src/schemas/assistant-actions.ts
@@ -24,7 +24,8 @@ const requiredWireStringSchema = z
   .transform((value) => value.trim())
   .pipe(z.string().min(1));
 
-const SECRET_VALUE = /(Bearer\s+)[A-Za-z0-9._~+/-]+|nyx(?:id)?_[A-Za-z0-9_-]{8,}/gi;
+const SECRET_VALUE =
+  /(Bearer\s+)[A-Za-z0-9._~+/-]+|nyx(?:id)?_[A-Za-z0-9_-]{8,}/gi;
 const FORBIDDEN_ACTION_KEY =
   /(?:^|[_-])(authorization|api[-_]?key|token|secret|password|credential|cookie|user[-_]?code|device[-_]?code)(?:$|[_-])/i;
 
@@ -269,7 +270,6 @@ export type ActionWakeBody = z.infer<typeof actionWakeBodySchema>;
 export type ActionReportActionLookup =
   | ReadonlyMap<string, string>
   | Readonly<Record<string, string | undefined>>;
-
 function matchesSecretValue(value: string): boolean {
   SECRET_VALUE.lastIndex = 0;
   return SECRET_VALUE.test(value);
@@ -319,16 +319,20 @@ function assertReportMatchesAction(
   action: string | undefined,
 ): void {
   if (report.disposition !== "completed") return;
-  if (
-    action === "service.connect" &&
-    (!report.resource || !("userService" in report.resource))
-  ) {
+  if (!report.resource) {
     throw new Error(
-      "service.connect completed reports must include resource.userService.userServiceId",
+      "Completed action reports must include a resource reference",
     );
   }
-  if (!report.resource) {
-    throw new Error("Completed action reports must include a resource reference");
+  if (action?.startsWith("service.") && !("userService" in report.resource)) {
+    throw new Error(
+      `${action} completed reports must include resource.userService.userServiceId`,
+    );
+  }
+  if (action?.startsWith("key.") && !("key" in report.resource)) {
+    throw new Error(
+      `${action} completed reports must include resource.key.keyId`,
+    );
   }
 }
 

--- a/frontend/src/schemas/assistant-input.test.ts
+++ b/frontend/src/schemas/assistant-input.test.ts
@@ -74,7 +74,11 @@ describe("assistant input schemas", () => {
         requestId: "input-1",
         prompt: "Choose a region",
         options: [
-          { optionId: "option-sg", label: "Singapore" },
+          {
+            optionId: "option-sg",
+            label: "Singapore",
+            additiveHint: "future-field",
+          },
           { optionId: "option-fra", label: "Frankfurt" },
         ],
         allowFreeText: false,
@@ -87,6 +91,28 @@ describe("assistant input schemas", () => {
         requestId: "input-1",
         prompt: "Choose a region",
         options: [],
+        allowFreeText: false,
+        multiSelect: false,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts the plan gate's single proceed option with free-text revision", () => {
+    expect(
+      assistantInputRequestSchema.safeParse({
+        requestId: "plan-gate-1",
+        prompt: "Proceed with this plan or describe a revision",
+        options: [{ optionId: "proceed", label: "Proceed" }],
+        allowFreeText: true,
+        multiSelect: false,
+      }).success,
+    ).toBe(true);
+
+    expect(
+      assistantInputRequestSchema.safeParse({
+        requestId: "invalid-single-choice-1",
+        prompt: "Choose an option",
+        options: [{ optionId: "only", label: "Only option" }],
         allowFreeText: false,
         multiSelect: false,
       }).success,

--- a/frontend/src/schemas/assistant-input.test.ts
+++ b/frontend/src/schemas/assistant-input.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  assistantInputRequestSchema,
+  buildInputResolveBody,
+  inputAnswerSchema,
+  inputResolveBodySchema,
+} from "./assistant-input";
+
+describe("assistant input schemas", () => {
+  it("builds each closed answer variant with a positive observed version", () => {
+    expect(
+      buildInputResolveBody(
+        "nyxid-chat-1",
+        "client-1",
+        "input-1",
+        { freeText: "  Singapore  " },
+        23,
+      ),
+    ).toEqual({
+      type: "input.resolve",
+      conversationId: "nyxid-chat-1",
+      clientRequestId: "client-1",
+      requestId: "input-1",
+      answer: { freeText: "Singapore" },
+      expectedStateVersion: 23,
+    });
+    expect(
+      buildInputResolveBody(
+        "nyxid-chat-1",
+        "client-2",
+        "input-2",
+        { selectedOptionIds: ["option-a", "option-b"] },
+        24,
+      ).answer,
+    ).toEqual({ selectedOptionIds: ["option-a", "option-b"] });
+  });
+
+  it("rejects mixed, empty, duplicate and over-broad answers", () => {
+    for (const answer of [
+      {},
+      { freeText: "" },
+      { freeText: "answer", selectedOptionIds: ["option-a"] },
+      { selectedOptionIds: [] },
+      { selectedOptionIds: ["option-a", "option-a"] },
+      {
+        selectedOptionIds: [
+          "option-a",
+          "option-b",
+          "option-c",
+          "option-d",
+          "option-e",
+          "option-f",
+          "option-g",
+        ],
+      },
+    ]) {
+      expect(inputAnswerSchema.safeParse(answer).success).toBe(false);
+    }
+    expect(
+      inputResolveBodySchema.safeParse({
+        type: "input.resolve",
+        conversationId: "nyxid-chat-1",
+        clientRequestId: "client-1",
+        requestId: "input-1",
+        answer: { freeText: "answer" },
+        expectedStateVersion: 0,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts only an actionable safe input request", () => {
+    expect(
+      assistantInputRequestSchema.safeParse({
+        requestId: "input-1",
+        prompt: "Choose a region",
+        options: [
+          { optionId: "option-sg", label: "Singapore" },
+          { optionId: "option-fra", label: "Frankfurt" },
+        ],
+        allowFreeText: false,
+        multiSelect: true,
+        turnId: "turn-1",
+      }).success,
+    ).toBe(true);
+    expect(
+      assistantInputRequestSchema.safeParse({
+        requestId: "input-1",
+        prompt: "Choose a region",
+        options: [],
+        allowFreeText: false,
+        multiSelect: false,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/frontend/src/schemas/assistant-input.ts
+++ b/frontend/src/schemas/assistant-input.ts
@@ -52,7 +52,7 @@ const inputOptionSchema = z
     label: z.string().max(4_096),
     description: z.string().max(4_096).optional(),
   })
-  .strict();
+  .passthrough();
 
 export const assistantInputRequestSchema = z
   .object({
@@ -79,11 +79,12 @@ export const assistantInputRequestSchema = z
         message: "Input request has no answer mode",
       });
     }
-    if (request.options.length === 1) {
+    if (request.options.length === 1 && !request.allowFreeText) {
       context.addIssue({
         code: "custom",
         path: ["options"],
-        message: "Choice input requires at least two options",
+        message:
+          "Choice input requires at least two options or a free-text alternative",
       });
     }
     if (request.options.length === 0 && request.multiSelect) {

--- a/frontend/src/schemas/assistant-input.ts
+++ b/frontend/src/schemas/assistant-input.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import { actionControlIdentitySchema } from "@/schemas/assistant-actions";
+
+const INPUT_MAX_CHARS = 32_768;
+const INPUT_MAX_OPTIONS = 6;
+
+export const inputAnswerSchema = z.union([
+  z
+    .object({
+      freeText: z
+        .string()
+        .max(INPUT_MAX_CHARS)
+        .transform((value) => value.trim())
+        .pipe(z.string().min(1)),
+    })
+    .strict(),
+  z
+    .object({
+      selectedOptionIds: z
+        .array(actionControlIdentitySchema)
+        .min(1)
+        .max(INPUT_MAX_OPTIONS)
+        .transform((ids, context) => {
+          const normalized = ids.map((id) => id.trim());
+          if (new Set(normalized).size !== normalized.length) {
+            context.addIssue({
+              code: "custom",
+              message: "Selected option ids must be distinct",
+            });
+            return z.NEVER;
+          }
+          return normalized;
+        }),
+    })
+    .strict(),
+]);
+
+export const inputResolveBodySchema = z
+  .object({
+    type: z.literal("input.resolve"),
+    conversationId: actionControlIdentitySchema,
+    clientRequestId: actionControlIdentitySchema,
+    requestId: actionControlIdentitySchema,
+    answer: inputAnswerSchema,
+    expectedStateVersion: z.number().int().safe().positive(),
+  })
+  .strict();
+
+const inputOptionSchema = z
+  .object({
+    optionId: actionControlIdentitySchema,
+    label: z.string().max(4_096),
+    description: z.string().max(4_096).optional(),
+  })
+  .strict();
+
+export const assistantInputRequestSchema = z
+  .object({
+    requestId: actionControlIdentitySchema,
+    prompt: z.string().min(1).max(INPUT_MAX_CHARS),
+    options: z.array(inputOptionSchema).max(INPUT_MAX_OPTIONS).default([]),
+    allowFreeText: z.boolean().default(false),
+    multiSelect: z.boolean().default(false),
+  })
+  .passthrough()
+  .superRefine((request, context) => {
+    const optionIds = request.options.map((option) => option.optionId);
+    if (new Set(optionIds).size !== optionIds.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Input option ids must be distinct",
+      });
+    }
+    if (!request.allowFreeText && request.options.length === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Input request has no answer mode",
+      });
+    }
+    if (request.options.length === 1) {
+      context.addIssue({
+        code: "custom",
+        path: ["options"],
+        message: "Choice input requires at least two options",
+      });
+    }
+    if (request.options.length === 0 && request.multiSelect) {
+      context.addIssue({
+        code: "custom",
+        path: ["multiSelect"],
+        message: "Free-text-only input cannot be multi-select",
+      });
+    }
+  });
+
+export type InputAnswer = z.infer<typeof inputAnswerSchema>;
+export type InputResolveBody = z.infer<typeof inputResolveBodySchema>;
+export type AssistantInputRequest = z.infer<typeof assistantInputRequestSchema>;
+
+export function buildInputResolveBody(
+  conversationId: string,
+  clientRequestId: string,
+  requestId: string,
+  answer: InputAnswer,
+  expectedStateVersion: number,
+): InputResolveBody {
+  return inputResolveBodySchema.parse({
+    type: "input.resolve",
+    conversationId,
+    clientRequestId,
+    requestId,
+    answer,
+    expectedStateVersion,
+  });
+}

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -2,6 +2,7 @@ import type {
   ActionCardParams,
   ActionReport,
 } from "@/schemas/assistant-actions";
+import type { InputAnswer } from "@/schemas/assistant-input";
 
 export type ConnectCardState =
   | "needs_connection"
@@ -91,6 +92,32 @@ export interface ApprovalCardContentBlock {
   readonly expires_at: string;
   readonly decision: ApprovalDecision | null;
   readonly decision_channel: ApprovalDecisionChannel | null;
+  /** 202 accepted, awaiting the matching committed resolution fact. */
+  readonly decision_submission?: "approved" | "denied" | null;
+  /** Authoritative current-state version, when rehydrated from `/state`. */
+  readonly state_version?: number;
+}
+
+export type InputCardStatus =
+  | "pending"
+  | "submitted"
+  | "resolved"
+  | "cancelled";
+
+export interface InputCardContentBlock {
+  readonly type: "input_card";
+  readonly block_id: string;
+  readonly request_id: string;
+  readonly prompt: string;
+  readonly options: readonly {
+    readonly option_id: string;
+    readonly label: string;
+    readonly description?: string;
+  }[];
+  readonly allow_free_text: boolean;
+  readonly multi_select: boolean;
+  readonly state_version?: number;
+  readonly status: InputCardStatus;
 }
 
 export interface ArtifactContentBlock {
@@ -134,6 +161,7 @@ export type ContentBlock =
   | ConnectCardContentBlock
   | RunContentBlock
   | ApprovalCardContentBlock
+  | InputCardContentBlock
   | ArtifactContentBlock
   | ActionCardContentBlock;
 
@@ -300,16 +328,19 @@ export interface AssistantTransport {
    */
   cancelActiveTurn(conversationId: string): void;
   /**
-   * Send an approval decision. On the live Aevatar contract the approve
-   * endpoint responds with an SSE continuation of the run; implementations
-   * that stream it return a cancellable handle for the continuation turn and
-   * deliver its events to `onEvent`. Implementations with no continuation
-   * (mock) return null.
+   * Send a version-fenced approval decision. The command returns JSON
+   * acceptance; later committed projection frames carry business progress.
    */
   decideApproval(
     conversationId: string,
     blockId: string,
     approved: boolean,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<TurnHandle | null>;
+  resolveInput(
+    conversationId: string,
+    blockId: string,
+    answer: InputAnswer,
     onEvent?: (event: TurnEvent) => void,
   ): Promise<TurnHandle | null>;
   setActionCardInProgress(


### PR DESCRIPTION
## Problem

The NyxID assistant facade could not submit v4 `input.resolve`, did not fence `approval.resolve` with the authoritative state version, rejected safe non-service action resources, and treated 202 acceptance as completion.

## Solution

- add strict `input.resolve` and version-fenced `approval.resolve` JSON commands;
- accept the six typed safe resource variants for completed action reports;
- render and submit typed input cards;
- preflight current actor state, observe committed resolution, and make uncertain submissions retryable without duplicate POST after late visibility;
- pause only the exact active request/card/kind;
- keep approval truth separate from tool-step/effect completion;
- tolerate additive input descriptor fields and support the single proceed + free-text plan gate.

This is the bounded G6 facade batch for #1400. It does not close aevatarAI/aevatar#3366: full `/state` snapshot rehydration remains a follow-up before frontend parity can be claimed.

## Verification

- frontend full suite: 2,832 passed
- transport/schema focused after review fixes: 237 passed
- TypeScript build: passed
- production build: passed
- lint: 0 errors (23 pre-existing warnings)
- Rust assistant service: 27 passed
- Rust proxy integration: 16 passed
- cargo fmt and git diff checks: passed

`test:producer-contract` was not run because this local environment does not provide `NYXID_URL`.
