### PR TITLE
Publish authoritative API key rotation lineage

### DIFF
--- a/backend/src/services/developer_webhook_service.rs
+++ b/backend/src/services/developer_webhook_service.rs
@@ -79,10 +79,10 @@ impl DeveloperWebhookDispatcher {
         event_type: &str,
         data: Value,
     ) -> Result<(), DeliveryFailure> {
-        if !data
+        if data
             .get("user_id")
             .and_then(serde_json::Value::as_str)
-            .is_some_and(|value| !value.is_empty())
+            .is_none_or(|value| value.is_empty())
         {
             return Err(DeliveryFailure {
                 attempts: 0,

--- a/frontend/src/components/assistant/assistant-key-rotate-dialog.test.tsx
+++ b/frontend/src/components/assistant/assistant-key-rotate-dialog.test.tsx
@@ -143,6 +143,7 @@ describe("AssistantKeyRotateDialog", () => {
       replacementSnapshot({ updated_at: "2026-08-11T07:59:59Z" }),
       replacementSnapshot({ full_key: "nyxid_ag_must_not_escape" }),
       replacementSnapshot({ ignored: { Authorization: "Bearer hidden" } }),
+      replacementSnapshot({ note: "nyxid_ag_must_not_escape_value" }),
     ];
 
     for (const snapshot of invalidSnapshots) {

--- a/frontend/src/components/assistant/assistant-key-rotate-dialog.tsx
+++ b/frontend/src/components/assistant/assistant-key-rotate-dialog.tsx
@@ -61,17 +61,26 @@ type ApiKeySnapshot = z.infer<typeof apiKeySnapshotSchema>;
 
 const FORBIDDEN_READ_BACK_FIELDS = new Set([
   "accesstoken",
+  "apikey",
   "authorization",
   "cookie",
+  "credential",
   "fullkey",
   "keyhash",
+  "password",
   "rawbody",
   "rawupstreambody",
   "refreshtoken",
   "secret",
+  "token",
 ]);
+const SECRET_READ_BACK_VALUE =
+  /(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})/i;
 
 function assertSecretFreeReadBack(value: unknown): void {
+  if (typeof value === "string" && SECRET_READ_BACK_VALUE.test(value)) {
+    throw new Error("NyxID returned secret-bearing verification data.");
+  }
   if (Array.isArray(value)) {
     for (const entry of value) assertSecretFreeReadBack(entry);
     return;


### PR DESCRIPTION
Relates to aevatarAI/aevatar#3388
Closes ChronoAIProject/NyxID#1406

## Problem and solution

API key rotation did not expose authoritative predecessor/version evidence and could race with binding mutations. This PR makes lineage an immutable database fact, centralizes authority-field writes, makes rotation plus binding cloning transactional, and publishes the complete NyxID-owned assistant key.rotate journey in registry v7.

## Security contract

- Exact-key reads expose created_at, rotation_predecessor_id, positive state_version, and updated_at without key hashes or secret material.
- A reserved successor ID must be a UUID; same action and predecessor replay the same successor ID without replaying the secret, while parameter drift conflicts.
- Cross-owner reserved successor IDs return NotFound to avoid existence leakage.
- Rotation and replay revalidate current actor ownership, organization role, service scope, and node scope inside the transaction.
- Historical committed lineage remains replayable after successor deactivation.
- The assistant action receipt preserves the original requestedAt so browser verification rejects stale successors even after later ordinary updates.
- The browser requires exact successor/predecessor identities, positive authority version, created_at and updated_at at or after requestedAt, and secret-free read-back before reporting only { key: { keyId } }.

## Impacted paths

- API key model, handlers, mutation/scope/key services, MongoDB indexes and CI topology
- Assistant registry v7 and durable key rotation action endpoint
- Assistant frontend schema, action registry/card, rotation dialog and transport fingerprinting

## Verification

- cargo fmt --all -- --check
- cargo check -p nyxid --all-features
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p nyxid --tests --no-run
- 288 focused frontend tests passed after rebasing current main
- npm run build
- npm run lint (0 errors; existing warnings only)
- Transaction route test is intentionally replica-set-only and runs in CI via NYXID_TEST_DATABASE_URL.