### PR TITLE
Implement least-scope assistant key creation

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -243,6 +243,19 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
         .create_index(IndexModel::builder().keys(doc! { "user_id": 1 }).build())
         .await?;
 
+    // ── assistant_action_receipts ──
+    // A user/action/request identity admits exactly one durable reservation.
+    // The receipt is secret-free and reserves the eventual resource UUID.
+    let action_receipts = db.collection::<mongodb::bson::Document>("assistant_action_receipts");
+    action_receipts
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "user_id": 1, "action": 1, "action_request_id": 1 })
+                .options(IndexOptions::builder().unique(true).build())
+                .build(),
+        )
+        .await?;
+
     // ── mfa_factors ──
     let mfa = db.collection::<mongodb::bson::Document>("mfa_factors");
     mfa.create_index(IndexModel::builder().keys(doc! { "user_id": 1 }).build())

--- a/backend/src/handlers/assistant_action_effects.rs
+++ b/backend/src/handlers/assistant_action_effects.rs
@@ -1,0 +1,362 @@
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::AppState;
+use crate::errors::AppResult;
+use crate::mw::auth::AuthUser;
+use crate::services::assistant_action_execution_service::{
+    self, KeyCreateActionRequest, KeyCreateActionResult,
+};
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateAssistantKeyRequest {
+    pub action_request_id: String,
+    pub name: String,
+    pub platform: String,
+    pub allowed_service_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AssistantKeyResource {
+    pub key_id: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateAssistantKeyResponse {
+    pub resource: AssistantKeyResource,
+    pub replayed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_key: Option<String>,
+}
+
+/// Create the exact least-scope agent key requested by a browser action.
+/// Replays return only the durable safe resource identity.
+pub async fn create_key(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(body): Json<CreateAssistantKeyRequest>,
+) -> AppResult<Json<CreateAssistantKeyResponse>> {
+    auth_user.ensure_write_scope()?;
+    let result = assistant_action_execution_service::create_key(
+        &state.db,
+        &auth_user.user_id.to_string(),
+        KeyCreateActionRequest {
+            action_request_id: body.action_request_id,
+            name: body.name,
+            platform: body.platform,
+            allowed_service_ids: body.allowed_service_ids,
+        },
+    )
+    .await?;
+
+    Ok(Json(match result {
+        KeyCreateActionResult::Created(created) => CreateAssistantKeyResponse {
+            resource: AssistantKeyResource { key_id: created.id },
+            replayed: false,
+            full_key: Some(created.full_key),
+        },
+        KeyCreateActionResult::Replayed { key_id } => CreateAssistantKeyResponse {
+            resource: AssistantKeyResource { key_id },
+            replayed: true,
+            full_key: None,
+        },
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+        routing::{get, post},
+    };
+    use mongodb::{IndexModel, bson::doc, options::IndexOptions};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::handlers::api_keys;
+    use crate::models::api_key::{ApiKey, COLLECTION_NAME as API_KEYS};
+    use crate::models::assistant_action_receipt::COLLECTION_NAME as ASSISTANT_ACTION_RECEIPTS;
+    use crate::models::user::{COLLECTION_NAME as USERS, User, UserType};
+    use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
+    use crate::test_utils::{connect_test_database, test_app_state, test_user, test_user_service};
+
+    fn access_token(state: &AppState, user_id: &str) -> String {
+        crate::crypto::jwt::generate_access_token(
+            &state.jwt_keys,
+            &state.config,
+            &Uuid::parse_str(user_id).expect("valid user id"),
+            "",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("sign test access token")
+    }
+
+    fn app(state: AppState) -> Router {
+        Router::new()
+            .route("/assistant/actions/key-create", post(create_key))
+            .route("/api-keys/{key_id}", get(api_keys::get_key))
+            .with_state(state)
+    }
+
+    async fn request(
+        app: Router,
+        token: &str,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("authorization", format!("Bearer {token}"));
+        let body = match body {
+            Some(value) => {
+                builder = builder.header("content-type", "application/json");
+                Body::from(value.to_string())
+            }
+            None => Body::empty(),
+        };
+        let response = app
+            .oneshot(builder.body(body).expect("build request"))
+            .await
+            .expect("route response");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response");
+        let value = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes).into_owned() }));
+        (status, value)
+    }
+
+    async fn prepare_database(
+        prefix: &str,
+    ) -> Option<(mongodb::Database, String, UserService, UserService)> {
+        let db = connect_test_database(prefix).await?;
+        db.collection::<mongodb::bson::Document>(ASSISTANT_ACTION_RECEIPTS)
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "user_id": 1, "action": 1, "action_request_id": 1 })
+                    .options(IndexOptions::builder().unique(true).build())
+                    .build(),
+            )
+            .await
+            .expect("create receipt uniqueness index");
+
+        let actor_id = Uuid::new_v4().to_string();
+        let other_id = Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_many([
+                test_user(&actor_id, UserType::Person),
+                test_user(&other_id, UserType::Person),
+            ])
+            .await
+            .expect("insert users");
+
+        let own_service = test_user_service(
+            &Uuid::new_v4().to_string(),
+            &actor_id,
+            "own-service",
+            &Uuid::new_v4().to_string(),
+            None,
+            None,
+        );
+        let other_service = test_user_service(
+            &Uuid::new_v4().to_string(),
+            &other_id,
+            "other-service",
+            &Uuid::new_v4().to_string(),
+            None,
+            None,
+        );
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_many([own_service.clone(), other_service.clone()])
+            .await
+            .expect("insert services");
+
+        Some((db, actor_id, own_service, other_service))
+    }
+
+    fn create_body(action_request_id: &str, service_ids: Value) -> Value {
+        json!({
+            "actionRequestId": action_request_id,
+            "name": "coding-agent",
+            "platform": "codex",
+            "allowedServiceIds": service_ids,
+        })
+    }
+
+    #[tokio::test]
+    async fn key_create_fails_closed_for_adversarial_service_sets() {
+        let Some((db, actor_id, own_service, other_service)) =
+            prepare_database("assistant_key_create_adversarial").await
+        else {
+            return;
+        };
+        let state = test_app_state(db.clone());
+        let token = access_token(&state, &actor_id);
+        let unknown_id = Uuid::new_v4().to_string();
+        let fixtures = [
+            (
+                "missing",
+                json!({
+                    "actionRequestId": "missing",
+                    "name": "coding-agent",
+                    "platform": "codex",
+                }),
+                StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                "empty",
+                create_body("empty", json!([])),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "duplicate",
+                create_body(
+                    "duplicate",
+                    json!([own_service.id.clone(), own_service.id.clone()]),
+                ),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "malformed",
+                create_body("malformed", json!(["not/a/service-id"])),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "unknown",
+                create_body("unknown", json!([unknown_id])),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "cross-owner",
+                create_body("cross-owner", json!([other_service.id])),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                "unknown-field",
+                json!({
+                    "actionRequestId": "unknown-field",
+                    "name": "coding-agent",
+                    "platform": "codex",
+                    "allowedServiceIds": [own_service.id],
+                    "allowAllServices": true,
+                }),
+                StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+        ];
+
+        for (label, body, expected_status) in fixtures {
+            let (status, response) = request(
+                app(state.clone()),
+                &token,
+                "POST",
+                "/assistant/actions/key-create",
+                Some(body),
+            )
+            .await;
+            assert_eq!(status, expected_status, "{label}: {response}");
+        }
+
+        assert_eq!(
+            db.collection::<ApiKey>(API_KEYS)
+                .count_documents(doc! { "user_id": &actor_id })
+                .await
+                .expect("count keys"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_read_back_proves_least_scope_without_secret_material() {
+        let Some((db, actor_id, own_service, _)) =
+            prepare_database("assistant_key_create_read_back").await
+        else {
+            return;
+        };
+        let state = test_app_state(db);
+        let token = access_token(&state, &actor_id);
+        let body = create_body("read-back", json!([own_service.id.clone()]));
+
+        let (status, created) = request(
+            app(state.clone()),
+            &token,
+            "POST",
+            "/assistant/actions/key-create",
+            Some(body),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        assert_eq!(created["replayed"], false);
+        let key_id = created["resource"]["keyId"]
+            .as_str()
+            .expect("safe key identity");
+        assert!(created["fullKey"].as_str().is_some());
+
+        let (status, read_back) = request(
+            app(state.clone()),
+            &token,
+            "GET",
+            &format!("/api-keys/{key_id}"),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{read_back}");
+        assert_eq!(read_back["id"], key_id);
+        assert_eq!(read_back["scopes"], "proxy");
+        assert_eq!(read_back["allowed_service_ids"], json!([own_service.id]));
+        assert_eq!(read_back["allow_all_services"], false);
+        assert_eq!(read_back["allowed_node_ids"], json!([]));
+        assert_eq!(read_back["allow_all_nodes"], false);
+        for forbidden in ["fullKey", "full_key", "keyHash", "key_hash", "secret"] {
+            assert!(
+                read_back.get(forbidden).is_none(),
+                "leaked field: {forbidden}"
+            );
+        }
+
+        let (status, replayed) = request(
+            app(state),
+            &token,
+            "POST",
+            "/assistant/actions/key-create",
+            Some(create_body("read-back", json!([own_service.id]))),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{replayed}");
+        assert_eq!(replayed["resource"]["keyId"], key_id);
+        assert_eq!(replayed["replayed"], true);
+        assert!(replayed.get("fullKey").is_none());
+    }
+
+    #[test]
+    fn replay_response_is_secret_free() {
+        let response = CreateAssistantKeyResponse {
+            resource: AssistantKeyResource {
+                key_id: "key-alpha".to_string(),
+            },
+            replayed: true,
+            full_key: None,
+        };
+        assert_eq!(
+            serde_json::to_value(response).expect("serialize response"),
+            json!({
+                "resource": { "keyId": "key-alpha" },
+                "replayed": true,
+            })
+        );
+    }
+}

--- a/backend/src/handlers/assistant_actions.rs
+++ b/backend/src/handlers/assistant_actions.rs
@@ -6,9 +6,10 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 pub const ASSISTANT_ACTIONS_SCHEMA_VERSION: u32 = 4;
-pub const ASSISTANT_ACTIONS_REVISION: &str = "nyxid-assistant-actions.v4";
+pub const ASSISTANT_ACTIONS_REVISION: &str = "nyxid-assistant-actions.v6";
 
 const SERVICE_CONNECT_DESCRIPTION: &str = "Ask the user's browser to connect a service through NyxID. Use when a task needs a catalog service (by slug) or a custom HTTPS endpoint that the user has not connected yet. NyxID owns the entire journey - auth modality, consent copy, and credential storage - and reports back only completion or decline with a safe resource reference. Never ask the user for keys, tokens, or passwords in chat.";
+const KEY_CREATE_DESCRIPTION: &str = "Ask the user's browser to create a scoped NyxID API key for the named platform and allowed services. Use when the user wants a new agent identity bounded to specific user-service IDs. NyxID owns key creation and one-time key display, and reports only a safe key reference. Never request, expose, or repeat key material in chat.";
 
 #[derive(Serialize)]
 struct AssistantActionsManifest {
@@ -32,58 +33,83 @@ static MANIFEST_BODY: LazyLock<String> = LazyLock::new(|| {
     let manifest = AssistantActionsManifest {
         schema_version: ASSISTANT_ACTIONS_SCHEMA_VERSION,
         revision: ASSISTANT_ACTIONS_REVISION,
-        actions: vec![AssistantActionDescriptor {
-            action: "service.connect",
-            description: SERVICE_CONNECT_DESCRIPTION,
-            params_schema: json!({
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": ["catalogService"],
-                        "properties": {
-                            "catalogService": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": ["serviceSlug"],
-                                "properties": {
-                                    "serviceSlug": { "type": "string" },
-                                    "requestedScopes": {
-                                        "type": "array",
-                                        "items": { "type": "string" }
-                                    },
-                                    "viaNodeId": { "type": "string" },
-                                    "targetOrgId": { "type": "string" }
+        actions: vec![
+            AssistantActionDescriptor {
+                action: "service.connect",
+                description: SERVICE_CONNECT_DESCRIPTION,
+                params_schema: json!({
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["catalogService"],
+                            "properties": {
+                                "catalogService": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": ["serviceSlug"],
+                                    "properties": {
+                                        "serviceSlug": { "type": "string" },
+                                        "requestedScopes": {
+                                            "type": "array",
+                                            "items": { "type": "string" }
+                                        },
+                                        "viaNodeId": { "type": "string" },
+                                        "targetOrgId": { "type": "string" }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["customService"],
+                            "properties": {
+                                "customService": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": ["name", "endpointUrl", "authMethod"],
+                                    "properties": {
+                                        "name": { "type": "string" },
+                                        "endpointUrl": { "type": "string" },
+                                        "authMethod": { "type": "string" },
+                                        "authKeyName": { "type": "string" },
+                                        "viaNodeId": { "type": "string" },
+                                        "targetOrgId": { "type": "string" }
+                                    }
                                 }
                             }
                         }
-                    },
-                    {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": ["customService"],
-                        "properties": {
-                            "customService": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": ["name", "endpointUrl", "authMethod"],
-                                "properties": {
-                                    "name": { "type": "string" },
-                                    "endpointUrl": { "type": "string" },
-                                    "authMethod": { "type": "string" },
-                                    "authKeyName": { "type": "string" },
-                                    "viaNodeId": { "type": "string" },
-                                    "targetOrgId": { "type": "string" }
-                                }
-                            }
+                    ]
+                }),
+                risk: "grant",
+                tier: "v1",
+                remember_eligible: true,
+            },
+            AssistantActionDescriptor {
+                action: "key.create",
+                description: KEY_CREATE_DESCRIPTION,
+                params_schema: json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name", "platform", "allowedServiceIds"],
+                    "properties": {
+                        "name": { "type": "string" },
+                        "platform": { "type": "string" },
+                        "allowedServiceIds": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 64,
+                            "uniqueItems": true,
+                            "items": { "type": "string" }
                         }
                     }
-                ]
-            }),
-            risk: "grant",
-            tier: "v1",
-            remember_eligible: true,
-        }],
+                }),
+                risk: "grant",
+                tier: "v1",
+                remember_eligible: false,
+            },
+        ],
     };
 
     serde_json::to_string(&manifest).expect("assistant actions manifest must serialize")
@@ -153,7 +179,7 @@ mod tests {
         "credentials",
     ];
 
-    fn golden_params_schema() -> Value {
+    fn service_connect_params_schema() -> Value {
         json!({
             "oneOf": [
                 {
@@ -201,18 +227,45 @@ mod tests {
         })
     }
 
+    fn key_create_params_schema() -> Value {
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "platform", "allowedServiceIds"],
+            "properties": {
+                "name": { "type": "string" },
+                "platform": { "type": "string" },
+                "allowedServiceIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 64,
+                    "uniqueItems": true,
+                    "items": { "type": "string" }
+                }
+            }
+        })
+    }
+
     fn golden_manifest() -> Value {
         json!({
             "schema_version": 4,
-            "revision": "nyxid-assistant-actions.v4",
+            "revision": "nyxid-assistant-actions.v6",
             "actions": [
                 {
                     "action": "service.connect",
                     "description": super::SERVICE_CONNECT_DESCRIPTION,
-                    "params_schema": golden_params_schema(),
+                    "params_schema": service_connect_params_schema(),
                     "risk": "grant",
                     "tier": "v1",
                     "remember_eligible": true
+                },
+                {
+                    "action": "key.create",
+                    "description": super::KEY_CREATE_DESCRIPTION,
+                    "params_schema": key_create_params_schema(),
+                    "risk": "grant",
+                    "tier": "v1",
+                    "remember_eligible": false
                 }
             ]
         })
@@ -254,6 +307,15 @@ mod tests {
                     .get("properties")
                     .and_then(Value::as_object)
                     .expect("object schemas must have a properties object");
+                if let Some(required) = object.get("required") {
+                    for name in required.as_array().expect("required must be an array") {
+                        let name = name.as_str().expect("required names must be strings");
+                        assert!(
+                            properties.contains_key(name),
+                            "required property is not declared: {name}"
+                        );
+                    }
+                }
                 for (name, property_schema) in properties {
                     let normalized = normalize_secret_name(name);
                     assert!(
@@ -263,11 +325,25 @@ mod tests {
                     validate_schema_node(property_schema);
                 }
             }
-            "array" => validate_schema_node(
-                object
-                    .get("items")
-                    .expect("array schemas must have an items schema"),
-            ),
+            "array" => {
+                if let Some(min_items) = object.get("minItems") {
+                    assert!(min_items.as_u64().is_some(), "minItems must be an integer");
+                }
+                if let Some(max_items) = object.get("maxItems") {
+                    assert!(max_items.as_u64().is_some(), "maxItems must be an integer");
+                }
+                if let Some(unique_items) = object.get("uniqueItems") {
+                    assert!(
+                        unique_items.as_bool().is_some(),
+                        "uniqueItems must be a boolean"
+                    );
+                }
+                validate_schema_node(
+                    object
+                        .get("items")
+                        .expect("array schemas must have an items schema"),
+                );
+            }
             "string" => {}
             other => panic!("unsupported schema type: {other}"),
         }
@@ -341,6 +417,7 @@ mod tests {
         }
 
         assert!(seen_actions.contains("service.connect"));
+        assert!(seen_actions.contains("key.create"));
     }
 
     #[test]
@@ -349,13 +426,26 @@ mod tests {
         let actions = manifest["actions"].as_array().unwrap();
 
         assert_eq!(manifest["schema_version"], 4);
-        assert_eq!(manifest["revision"], "nyxid-assistant-actions.v4");
-        assert_eq!(actions.len(), 1);
+        assert_eq!(manifest["revision"], "nyxid-assistant-actions.v6");
+        assert_eq!(actions.len(), 2);
         assert_eq!(actions[0]["action"], "service.connect");
         assert_eq!(actions[0]["risk"], "grant");
         assert_eq!(actions[0]["tier"], "v1");
         assert_eq!(actions[0]["remember_eligible"], true);
-        assert_eq!(actions[0]["params_schema"], golden_params_schema());
+        assert_eq!(actions[0]["params_schema"], service_connect_params_schema());
+        assert_eq!(actions[1]["action"], "key.create");
+        assert_eq!(actions[1]["risk"], "grant");
+        assert_eq!(actions[1]["tier"], "v1");
+        assert_eq!(actions[1]["remember_eligible"], false);
+        assert_eq!(actions[1]["params_schema"], key_create_params_schema());
+        assert_eq!(
+            actions[1]["params_schema"]["properties"]["allowedServiceIds"]["minItems"],
+            1
+        );
+        assert_eq!(
+            actions[1]["params_schema"]["properties"]["allowedServiceIds"]["uniqueItems"],
+            true
+        );
         assert_eq!(manifest, golden_manifest());
     }
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -12,6 +12,7 @@ pub mod agent_bindings;
 pub mod api_keys;
 pub mod approvals;
 pub mod assistant;
+pub mod assistant_action_effects;
 pub mod assistant_actions;
 pub mod assistant_readiness;
 pub mod auth;

--- a/backend/src/models/assistant_action_receipt.rs
+++ b/backend/src/models/assistant_action_receipt.rs
@@ -1,0 +1,64 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::bson_datetime;
+
+pub const COLLECTION_NAME: &str = "assistant_action_receipts";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantActionReceiptStatus {
+    Pending,
+    Completed,
+}
+
+/// Durable, secret-free evidence for a NyxID-owned browser action.
+///
+/// `resource_id` is reserved before the effect is attempted. A retry can
+/// therefore distinguish "not applied yet" from "applied but the response was
+/// lost" without persisting or replaying one-time credentials.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssistantActionReceipt {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub user_id: String,
+    pub action: String,
+    pub action_request_id: String,
+    pub request_fingerprint: String,
+    pub resource_id: String,
+    pub status: AssistantActionReceiptStatus,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default, with = "bson_datetime::optional")]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bson_roundtrip_never_contains_secret_material() {
+        let receipt = AssistantActionReceipt {
+            id: "receipt-alpha".to_string(),
+            user_id: "user-alpha".to_string(),
+            action: "key.create".to_string(),
+            action_request_id: "action-alpha".to_string(),
+            request_fingerprint: "abc123".to_string(),
+            resource_id: "key-alpha".to_string(),
+            status: AssistantActionReceiptStatus::Completed,
+            created_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+        };
+
+        let document = bson::to_document(&receipt).expect("serialize receipt");
+        let serialized = document.to_string().to_ascii_lowercase();
+        for forbidden in ["full_key", "key_hash", "secret", "credential"] {
+            assert!(!serialized.contains(forbidden));
+        }
+        let restored: AssistantActionReceipt =
+            bson::from_document(document).expect("deserialize receipt");
+        assert_eq!(restored.resource_id, "key-alpha");
+        assert_eq!(restored.status, AssistantActionReceiptStatus::Completed);
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -3,6 +3,7 @@ pub mod anonymous_endpoint_usage;
 pub mod api_key;
 pub mod approval_grant;
 pub mod approval_request;
+pub mod assistant_action_receipt;
 pub mod audit_log;
 pub mod auth_device_code;
 pub mod authorization_code;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1417,6 +1417,10 @@ pub fn build_router(
             "/readiness",
             get(handlers::assistant_readiness::get_readiness),
         )
+        .route(
+            "/actions/key-create",
+            post(handlers::assistant_action_effects::create_key),
+        )
         .merge(assistant_proxy_routes);
 
     let ssh_billing_routes = ssh_billing_routes!(register_billing_routes, Router::new());

--- a/backend/src/services/assistant_action_execution_service.rs
+++ b/backend/src/services/assistant_action_execution_service.rs
@@ -9,6 +9,7 @@ use crate::models::assistant_action_receipt::{
     AssistantActionReceipt, AssistantActionReceiptStatus,
     COLLECTION_NAME as ASSISTANT_ACTION_RECEIPTS,
 };
+use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
 use crate::services::key_service::{self, CreatedApiKey};
 
 const KEY_CREATE_ACTION: &str = "key.create";
@@ -25,7 +26,7 @@ pub struct KeyCreateActionRequest {
 
 #[derive(Debug)]
 pub enum KeyCreateActionResult {
-    Created(CreatedApiKey),
+    Created(Box<CreatedApiKey>),
     Replayed { key_id: String },
 }
 
@@ -98,6 +99,27 @@ fn request_fingerprint(request: &KeyCreateActionRequest) -> AppResult<String> {
     })
     .map_err(|error| AppError::Internal(format!("failed to fingerprint action: {error}")))?;
     Ok(hex::encode(Sha256::digest(canonical)))
+}
+
+async fn validate_personal_service_ids(
+    db: &mongodb::Database,
+    user_id: &str,
+    allowed_service_ids: &[String],
+) -> AppResult<()> {
+    let matching = db
+        .collection::<UserService>(USER_SERVICES)
+        .count_documents(doc! {
+            "_id": { "$in": allowed_service_ids },
+            "user_id": user_id,
+            "is_active": true,
+        })
+        .await?;
+    if matching != allowed_service_ids.len() as u64 {
+        return Err(AppError::ValidationError(
+            "allowedServiceIds must identify active services owned by this account".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn duplicate_key(error: &mongodb::error::Error) -> bool {
@@ -194,31 +216,17 @@ async fn mark_completed(db: &mongodb::Database, receipt: &AssistantActionReceipt
     Ok(())
 }
 
-pub async fn create_key(
+async fn create_reserved_key(
     db: &mongodb::Database,
     user_id: &str,
-    request: KeyCreateActionRequest,
+    request: &KeyCreateActionRequest,
+    receipt: &AssistantActionReceipt,
 ) -> AppResult<KeyCreateActionResult> {
-    let request = normalize_request(request)?;
-    let fingerprint = request_fingerprint(&request)?;
-    let receipt = reserve_receipt(db, user_id, &request, &fingerprint).await?;
-    if receipt.request_fingerprint != fingerprint {
-        return Err(AppError::Conflict(
-            "actionRequestId was already used with different key parameters".to_string(),
-        ));
-    }
-    if let Some(key_id) = recover_reserved_key(db, user_id, &receipt).await? {
-        if receipt.status != AssistantActionReceiptStatus::Completed {
-            mark_completed(db, &receipt).await?;
-        }
-        return Ok(KeyCreateActionResult::Replayed { key_id });
-    }
-
     let no_nodes: Vec<String> = Vec::new();
     let created = key_service::create_api_key_with_scope_authorization_and_id(
         db,
         user_id,
-        Some(user_id),
+        None,
         &receipt.resource_id,
         &request.name,
         "proxy",
@@ -238,22 +246,42 @@ pub async fn create_key(
 
     match created {
         Ok(created) => {
-            mark_completed(db, &receipt).await?;
-            Ok(KeyCreateActionResult::Created(created))
+            mark_completed(db, receipt).await?;
+            Ok(KeyCreateActionResult::Created(Box::new(created)))
         }
         Err(AppError::DatabaseError(error)) if duplicate_key(&error) => {
-            let key_id = recover_reserved_key(db, user_id, &receipt)
-                .await?
-                .ok_or_else(|| {
-                    AppError::Conflict(
-                        "reserved key id collided without a recoverable effect".to_string(),
-                    )
-                })?;
-            mark_completed(db, &receipt).await?;
+            let Some(key_id) = recover_reserved_key(db, user_id, receipt).await? else {
+                return Err(AppError::DatabaseError(error));
+            };
+            mark_completed(db, receipt).await?;
             Ok(KeyCreateActionResult::Replayed { key_id })
         }
         Err(error) => Err(error),
     }
+}
+
+pub async fn create_key(
+    db: &mongodb::Database,
+    user_id: &str,
+    request: KeyCreateActionRequest,
+) -> AppResult<KeyCreateActionResult> {
+    let request = normalize_request(request)?;
+    validate_personal_service_ids(db, user_id, &request.allowed_service_ids).await?;
+    let fingerprint = request_fingerprint(&request)?;
+    let receipt = reserve_receipt(db, user_id, &request, &fingerprint).await?;
+    if receipt.request_fingerprint != fingerprint {
+        return Err(AppError::Conflict(
+            "actionRequestId was already used with different key parameters".to_string(),
+        ));
+    }
+    if let Some(key_id) = recover_reserved_key(db, user_id, &receipt).await? {
+        if receipt.status != AssistantActionReceiptStatus::Completed {
+            mark_completed(db, &receipt).await?;
+        }
+        return Ok(KeyCreateActionResult::Replayed { key_id });
+    }
+
+    create_reserved_key(db, user_id, &request, &receipt).await
 }
 
 #[cfg(test)]
@@ -262,8 +290,11 @@ mod tests {
     use futures::TryStreamExt;
     use mongodb::{IndexModel, options::IndexOptions};
 
-    use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
-    use crate::test_utils::{connect_test_database, test_user_service};
+    use crate::models::org_membership::{
+        COLLECTION_NAME as ORG_MEMBERSHIPS, OrgMembership, OrgRole,
+    };
+    use crate::models::user::{COLLECTION_NAME as USERS, User, UserType};
+    use crate::test_utils::{connect_test_database, test_membership, test_user, test_user_service};
 
     fn request(ids: &[&str]) -> KeyCreateActionRequest {
         KeyCreateActionRequest {
@@ -309,6 +340,10 @@ mod tests {
             .await
             .expect("create receipt uniqueness index");
         let user_id = Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .expect("insert key owner");
         let service_id = Uuid::new_v4().to_string();
         let service = test_user_service(
             &service_id,
@@ -325,6 +360,65 @@ mod tests {
         Some((db, user_id, service_id))
     }
 
+    #[tokio::test]
+    async fn org_visible_services_are_rejected_before_receipt_reservation() {
+        let Some((db, user_id, _)) = prepare_database("assistant_key_create_org_owner").await
+        else {
+            return;
+        };
+
+        for (index, role) in [OrgRole::Member, OrgRole::Admin].into_iter().enumerate() {
+            let org_id = Uuid::new_v4().to_string();
+            let org_service_id = Uuid::new_v4().to_string();
+            db.collection::<User>(USERS)
+                .insert_one(test_user(&org_id, UserType::Org))
+                .await
+                .expect("insert org owner");
+            db.collection::<UserService>(USER_SERVICES)
+                .insert_one(test_user_service(
+                    &org_service_id,
+                    &org_id,
+                    &format!("org-service-{index}"),
+                    &Uuid::new_v4().to_string(),
+                    None,
+                    None,
+                ))
+                .await
+                .expect("insert org service");
+            db.collection::<OrgMembership>(ORG_MEMBERSHIPS)
+                .insert_one(test_membership(
+                    &org_id,
+                    &user_id,
+                    role,
+                    Some(vec![org_service_id.clone()]),
+                ))
+                .await
+                .expect("insert visible org membership");
+
+            let mut org_request = exact_request(&org_service_id);
+            org_request.action_request_id = format!("action-org-{index}");
+            assert!(matches!(
+                create_key(&db, &user_id, org_request).await,
+                Err(AppError::ValidationError(_))
+            ));
+        }
+
+        assert_eq!(
+            db.collection::<ApiKey>(API_KEYS)
+                .count_documents(doc! { "user_id": &user_id })
+                .await
+                .expect("count keys"),
+            0
+        );
+        assert_eq!(
+            db.collection::<AssistantActionReceipt>(ASSISTANT_ACTION_RECEIPTS)
+                .count_documents(doc! { "user_id": &user_id })
+                .await
+                .expect("count receipts"),
+            0
+        );
+    }
+
     fn exact_request(service_id: &str) -> KeyCreateActionRequest {
         KeyCreateActionRequest {
             action_request_id: "action-exactly-once".to_string(),
@@ -335,14 +429,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_replay_creates_exactly_one_least_scope_key() {
+    async fn concurrent_reserved_effect_creates_once_and_recovers_duplicate_insert() {
         let Some((db, user_id, service_id)) = prepare_database("assistant_key_create_once").await
         else {
             return;
         };
 
-        let first = create_key(&db, &user_id, exact_request(&service_id));
-        let second = create_key(&db, &user_id, exact_request(&service_id));
+        let request = normalize_request(exact_request(&service_id)).expect("normalize request");
+        let fingerprint = request_fingerprint(&request).expect("fingerprint request");
+        let receipt = reserve_receipt(&db, &user_id, &request, &fingerprint)
+            .await
+            .expect("reserve action receipt");
+
+        // Both executions deliberately skip recovery and attempt the same reserved UUID.
+        // The unique key insert selects the one caller allowed to receive key material.
+        let first = create_reserved_key(&db, &user_id, &request, &receipt);
+        let second = create_reserved_key(&db, &user_id, &request, &receipt);
         let (first, second) = tokio::join!(first, second);
         let first = first.expect("first execution");
         let second = second.expect("second execution");

--- a/backend/src/services/assistant_action_execution_service.rs
+++ b/backend/src/services/assistant_action_execution_service.rs
@@ -266,8 +266,25 @@ pub async fn create_key(
     request: KeyCreateActionRequest,
 ) -> AppResult<KeyCreateActionResult> {
     let request = normalize_request(request)?;
-    validate_personal_service_ids(db, user_id, &request.allowed_service_ids).await?;
     let fingerprint = request_fingerprint(&request)?;
+    if let Some(receipt) = find_receipt(db, user_id, &request.action_request_id).await? {
+        if receipt.request_fingerprint != fingerprint {
+            return Err(AppError::Conflict(
+                "actionRequestId was already used with different key parameters".to_string(),
+            ));
+        }
+        if let Some(key_id) = recover_reserved_key(db, user_id, &receipt).await? {
+            if receipt.status != AssistantActionReceiptStatus::Completed {
+                mark_completed(db, &receipt).await?;
+            }
+            return Ok(KeyCreateActionResult::Replayed { key_id });
+        }
+
+        validate_personal_service_ids(db, user_id, &request.allowed_service_ids).await?;
+        return create_reserved_key(db, user_id, &request, &receipt).await;
+    }
+
+    validate_personal_service_ids(db, user_id, &request.allowed_service_ids).await?;
     let receipt = reserve_receipt(db, user_id, &request, &fingerprint).await?;
     if receipt.request_fingerprint != fingerprint {
         return Err(AppError::Conflict(
@@ -505,6 +522,44 @@ mod tests {
         assert!(matches!(
             create_key(&db, &user_id, changed).await,
             Err(AppError::Conflict(_))
+        ));
+        assert_eq!(
+            db.collection::<ApiKey>(API_KEYS)
+                .count_documents(doc! { "user_id": &user_id })
+                .await
+                .expect("count keys"),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_replay_survives_service_deactivation() {
+        let Some((db, user_id, service_id)) =
+            prepare_database("assistant_key_create_deactivated_replay").await
+        else {
+            return;
+        };
+        let created = create_key(&db, &user_id, exact_request(&service_id))
+            .await
+            .expect("initial execution");
+        let KeyCreateActionResult::Created(created) = created else {
+            panic!("initial execution must create the key");
+        };
+
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id, "user_id": &user_id },
+                doc! { "$set": { "is_active": false } },
+            )
+            .await
+            .expect("deactivate service");
+
+        let replayed = create_key(&db, &user_id, exact_request(&service_id))
+            .await
+            .expect("durable exact replay");
+        assert!(matches!(
+            replayed,
+            KeyCreateActionResult::Replayed { key_id } if key_id == created.id
         ));
         assert_eq!(
             db.collection::<ApiKey>(API_KEYS)

--- a/backend/src/services/assistant_action_execution_service.rs
+++ b/backend/src/services/assistant_action_execution_service.rs
@@ -1,0 +1,415 @@
+use chrono::Utc;
+use mongodb::bson::{doc, to_bson};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::errors::{AppError, AppResult};
+use crate::models::api_key::{ApiKey, COLLECTION_NAME as API_KEYS};
+use crate::models::assistant_action_receipt::{
+    AssistantActionReceipt, AssistantActionReceiptStatus,
+    COLLECTION_NAME as ASSISTANT_ACTION_RECEIPTS,
+};
+use crate::services::key_service::{self, CreatedApiKey};
+
+const KEY_CREATE_ACTION: &str = "key.create";
+const MAX_ACTION_REQUEST_ID_LEN: usize = 256;
+const MAX_SERVICE_IDS: usize = 64;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeyCreateActionRequest {
+    pub action_request_id: String,
+    pub name: String,
+    pub platform: String,
+    pub allowed_service_ids: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum KeyCreateActionResult {
+    Created(CreatedApiKey),
+    Replayed { key_id: String },
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct KeyCreateFingerprint<'a> {
+    action: &'static str,
+    name: &'a str,
+    platform: &'a str,
+    allowed_service_ids: &'a [String],
+    scopes: &'static str,
+    allow_all_services: bool,
+    allow_all_nodes: bool,
+}
+
+fn normalize_request(request: KeyCreateActionRequest) -> AppResult<KeyCreateActionRequest> {
+    let action_request_id = request.action_request_id.trim().to_string();
+    if action_request_id.is_empty() || action_request_id.len() > MAX_ACTION_REQUEST_ID_LEN {
+        return Err(AppError::ValidationError(
+            "actionRequestId must be between 1 and 256 characters".to_string(),
+        ));
+    }
+
+    let name = request.name.trim().to_string();
+    let platform = request.platform.trim().to_string();
+    let mut allowed_service_ids = request
+        .allowed_service_ids
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .collect::<Vec<_>>();
+    if allowed_service_ids.is_empty() {
+        return Err(AppError::ValidationError(
+            "key.create requires at least one exact allowed service id".to_string(),
+        ));
+    }
+    if allowed_service_ids.len() > MAX_SERVICE_IDS
+        || allowed_service_ids.iter().any(String::is_empty)
+    {
+        return Err(AppError::ValidationError(
+            "allowedServiceIds must contain 1 to 64 non-empty ids".to_string(),
+        ));
+    }
+    allowed_service_ids.sort();
+    if allowed_service_ids
+        .windows(2)
+        .any(|pair| pair[0] == pair[1])
+    {
+        return Err(AppError::ValidationError(
+            "allowedServiceIds must not contain duplicates".to_string(),
+        ));
+    }
+
+    Ok(KeyCreateActionRequest {
+        action_request_id,
+        name,
+        platform,
+        allowed_service_ids,
+    })
+}
+
+fn request_fingerprint(request: &KeyCreateActionRequest) -> AppResult<String> {
+    let canonical = serde_json::to_vec(&KeyCreateFingerprint {
+        action: KEY_CREATE_ACTION,
+        name: &request.name,
+        platform: &request.platform,
+        allowed_service_ids: &request.allowed_service_ids,
+        scopes: "proxy",
+        allow_all_services: false,
+        allow_all_nodes: false,
+    })
+    .map_err(|error| AppError::Internal(format!("failed to fingerprint action: {error}")))?;
+    Ok(hex::encode(Sha256::digest(canonical)))
+}
+
+fn duplicate_key(error: &mongodb::error::Error) -> bool {
+    matches!(
+        error.kind.as_ref(),
+        mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(write_error))
+            if write_error.code == 11000
+    )
+}
+
+async fn find_receipt(
+    db: &mongodb::Database,
+    user_id: &str,
+    action_request_id: &str,
+) -> AppResult<Option<AssistantActionReceipt>> {
+    Ok(db
+        .collection::<AssistantActionReceipt>(ASSISTANT_ACTION_RECEIPTS)
+        .find_one(doc! {
+            "user_id": user_id,
+            "action": KEY_CREATE_ACTION,
+            "action_request_id": action_request_id,
+        })
+        .await?)
+}
+
+async fn reserve_receipt(
+    db: &mongodb::Database,
+    user_id: &str,
+    request: &KeyCreateActionRequest,
+    fingerprint: &str,
+) -> AppResult<AssistantActionReceipt> {
+    if let Some(existing) = find_receipt(db, user_id, &request.action_request_id).await? {
+        return Ok(existing);
+    }
+
+    let now = Utc::now();
+    let receipt = AssistantActionReceipt {
+        id: Uuid::new_v4().to_string(),
+        user_id: user_id.to_string(),
+        action: KEY_CREATE_ACTION.to_string(),
+        action_request_id: request.action_request_id.clone(),
+        request_fingerprint: fingerprint.to_string(),
+        resource_id: Uuid::new_v4().to_string(),
+        status: AssistantActionReceiptStatus::Pending,
+        created_at: now,
+        completed_at: None,
+    };
+    match db
+        .collection::<AssistantActionReceipt>(ASSISTANT_ACTION_RECEIPTS)
+        .insert_one(&receipt)
+        .await
+    {
+        Ok(_) => Ok(receipt),
+        Err(error) if duplicate_key(&error) => {
+            find_receipt(db, user_id, &request.action_request_id)
+                .await?
+                .ok_or_else(|| {
+                    AppError::Conflict("assistant action receipt reservation raced".to_string())
+                })
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn recover_reserved_key(
+    db: &mongodb::Database,
+    user_id: &str,
+    receipt: &AssistantActionReceipt,
+) -> AppResult<Option<String>> {
+    let key = db
+        .collection::<ApiKey>(API_KEYS)
+        .find_one(doc! { "_id": &receipt.resource_id, "user_id": user_id })
+        .await?;
+    match key {
+        Some(key) if key.is_active => Ok(Some(key.id)),
+        Some(_) => Err(AppError::Conflict(
+            "the key created for this action is no longer active".to_string(),
+        )),
+        None => Ok(None),
+    }
+}
+
+async fn mark_completed(db: &mongodb::Database, receipt: &AssistantActionReceipt) -> AppResult<()> {
+    db.collection::<AssistantActionReceipt>(ASSISTANT_ACTION_RECEIPTS)
+        .update_one(
+            doc! { "_id": &receipt.id },
+            doc! { "$set": {
+                "status": to_bson(&AssistantActionReceiptStatus::Completed)
+                    .map_err(|error| AppError::Internal(error.to_string()))?,
+                "completed_at": mongodb::bson::DateTime::from_chrono(Utc::now()),
+            } },
+        )
+        .await?;
+    Ok(())
+}
+
+pub async fn create_key(
+    db: &mongodb::Database,
+    user_id: &str,
+    request: KeyCreateActionRequest,
+) -> AppResult<KeyCreateActionResult> {
+    let request = normalize_request(request)?;
+    let fingerprint = request_fingerprint(&request)?;
+    let receipt = reserve_receipt(db, user_id, &request, &fingerprint).await?;
+    if receipt.request_fingerprint != fingerprint {
+        return Err(AppError::Conflict(
+            "actionRequestId was already used with different key parameters".to_string(),
+        ));
+    }
+    if let Some(key_id) = recover_reserved_key(db, user_id, &receipt).await? {
+        if receipt.status != AssistantActionReceiptStatus::Completed {
+            mark_completed(db, &receipt).await?;
+        }
+        return Ok(KeyCreateActionResult::Replayed { key_id });
+    }
+
+    let no_nodes: Vec<String> = Vec::new();
+    let created = key_service::create_api_key_with_scope_authorization_and_id(
+        db,
+        user_id,
+        Some(user_id),
+        &receipt.resource_id,
+        &request.name,
+        "proxy",
+        None,
+        Some("Created from a NyxID assistant action"),
+        Some(&request.allowed_service_ids),
+        Some(&no_nodes),
+        Some(false),
+        Some(false),
+        None,
+        None,
+        Some(&request.platform),
+        None,
+        None,
+    )
+    .await;
+
+    match created {
+        Ok(created) => {
+            mark_completed(db, &receipt).await?;
+            Ok(KeyCreateActionResult::Created(created))
+        }
+        Err(AppError::DatabaseError(error)) if duplicate_key(&error) => {
+            let key_id = recover_reserved_key(db, user_id, &receipt)
+                .await?
+                .ok_or_else(|| {
+                    AppError::Conflict(
+                        "reserved key id collided without a recoverable effect".to_string(),
+                    )
+                })?;
+            mark_completed(db, &receipt).await?;
+            Ok(KeyCreateActionResult::Replayed { key_id })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::TryStreamExt;
+    use mongodb::{IndexModel, options::IndexOptions};
+
+    use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
+    use crate::test_utils::{connect_test_database, test_user_service};
+
+    fn request(ids: &[&str]) -> KeyCreateActionRequest {
+        KeyCreateActionRequest {
+            action_request_id: "action-alpha".to_string(),
+            name: "  coding agent  ".to_string(),
+            platform: "codex".to_string(),
+            allowed_service_ids: ids.iter().map(|value| (*value).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_set_order_independent_and_pins_least_scope() {
+        let left = normalize_request(request(&["svc-b", "svc-a"])).expect("normalize");
+        let right = normalize_request(request(&["svc-a", "svc-b"])).expect("normalize");
+        assert_eq!(
+            request_fingerprint(&left).unwrap(),
+            request_fingerprint(&right).unwrap()
+        );
+        assert_eq!(left.name, "coding agent");
+    }
+
+    #[test]
+    fn rejects_empty_and_duplicate_service_sets() {
+        assert!(matches!(
+            normalize_request(request(&[])),
+            Err(AppError::ValidationError(_))
+        ));
+        assert!(matches!(
+            normalize_request(request(&["svc-a", "svc-a"])),
+            Err(AppError::ValidationError(_))
+        ));
+    }
+
+    async fn prepare_database(prefix: &str) -> Option<(mongodb::Database, String, String)> {
+        let db = connect_test_database(prefix).await?;
+        db.collection::<AssistantActionReceipt>(ASSISTANT_ACTION_RECEIPTS)
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "user_id": 1, "action": 1, "action_request_id": 1 })
+                    .options(IndexOptions::builder().unique(true).build())
+                    .build(),
+            )
+            .await
+            .expect("create receipt uniqueness index");
+        let user_id = Uuid::new_v4().to_string();
+        let service_id = Uuid::new_v4().to_string();
+        let service = test_user_service(
+            &service_id,
+            &user_id,
+            "api-github",
+            &Uuid::new_v4().to_string(),
+            None,
+            None,
+        );
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(service)
+            .await
+            .expect("insert scoped user service");
+        Some((db, user_id, service_id))
+    }
+
+    fn exact_request(service_id: &str) -> KeyCreateActionRequest {
+        KeyCreateActionRequest {
+            action_request_id: "action-exactly-once".to_string(),
+            name: "coding-agent".to_string(),
+            platform: "codex".to_string(),
+            allowed_service_ids: vec![service_id.to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_replay_creates_exactly_one_least_scope_key() {
+        let Some((db, user_id, service_id)) = prepare_database("assistant_key_create_once").await
+        else {
+            return;
+        };
+
+        let first = create_key(&db, &user_id, exact_request(&service_id));
+        let second = create_key(&db, &user_id, exact_request(&service_id));
+        let (first, second) = tokio::join!(first, second);
+        let first = first.expect("first execution");
+        let second = second.expect("second execution");
+
+        let created_count = [&first, &second]
+            .into_iter()
+            .filter(|result| matches!(result, KeyCreateActionResult::Created(_)))
+            .count();
+        let replayed_count = [&first, &second]
+            .into_iter()
+            .filter(|result| matches!(result, KeyCreateActionResult::Replayed { .. }))
+            .count();
+        assert_eq!(created_count, 1);
+        assert_eq!(replayed_count, 1);
+
+        let keys = db
+            .collection::<ApiKey>(API_KEYS)
+            .find(doc! { "user_id": &user_id })
+            .await
+            .expect("list created keys")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("collect created keys");
+        assert_eq!(keys.len(), 1);
+        let key = &keys[0];
+        assert_eq!(key.scopes, "proxy");
+        assert_eq!(key.allowed_service_ids, vec![service_id]);
+        assert!(key.allowed_node_ids.is_empty());
+        assert!(!key.allow_all_services);
+        assert!(!key.allow_all_nodes);
+
+        let receipts = db
+            .collection::<AssistantActionReceipt>(ASSISTANT_ACTION_RECEIPTS)
+            .find(doc! { "user_id": &user_id })
+            .await
+            .expect("list receipts")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("collect receipts");
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].resource_id, key.id);
+        assert_eq!(receipts[0].status, AssistantActionReceiptStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn action_identity_reuse_with_different_parameters_fails_closed() {
+        let Some((db, user_id, service_id)) =
+            prepare_database("assistant_key_create_conflict").await
+        else {
+            return;
+        };
+        create_key(&db, &user_id, exact_request(&service_id))
+            .await
+            .expect("initial execution");
+
+        let mut changed = exact_request(&service_id);
+        changed.name = "different-agent".to_string();
+        assert!(matches!(
+            create_key(&db, &user_id, changed).await,
+            Err(AppError::Conflict(_))
+        ));
+        assert_eq!(
+            db.collection::<ApiKey>(API_KEYS)
+                .count_documents(doc! { "user_id": &user_id })
+                .await
+                .expect("count keys"),
+            1
+        );
+    }
+}

--- a/backend/src/services/key_service.rs
+++ b/backend/src/services/key_service.rs
@@ -200,10 +200,59 @@ pub async fn create_api_key_with_scope_authorization(
     callback_url: Option<&str>,
     scope_plan_digest: Option<&str>,
 ) -> AppResult<CreatedApiKey> {
-    create_api_key_with_security_class(
+    create_api_key_with_security_class_and_id(
         db,
         user_id,
         scope_actor_user_id,
+        None,
+        name,
+        scopes,
+        expires_at,
+        description,
+        allowed_service_ids,
+        allowed_node_ids,
+        allow_all_services,
+        allow_all_nodes,
+        rate_limit_per_second,
+        rate_limit_burst,
+        platform,
+        callback_url,
+        scope_plan_digest,
+        ApiKeyPurpose::General,
+        false,
+    )
+    .await
+}
+
+/// Create an API key at a caller-reserved UUID.
+///
+/// The assistant action receipt owns this identifier before the effect starts,
+/// so a retry can recover an already-created key without minting another one.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_api_key_with_scope_authorization_and_id(
+    db: &mongodb::Database,
+    user_id: &str,
+    scope_actor_user_id: Option<&str>,
+    resource_id: &str,
+    name: &str,
+    scopes: &str,
+    expires_at: Option<chrono::DateTime<Utc>>,
+    description: Option<&str>,
+    allowed_service_ids: Option<&[String]>,
+    allowed_node_ids: Option<&[String]>,
+    allow_all_services: Option<bool>,
+    allow_all_nodes: Option<bool>,
+    rate_limit_per_second: Option<u32>,
+    rate_limit_burst: Option<u32>,
+    platform: Option<&str>,
+    callback_url: Option<&str>,
+    scope_plan_digest: Option<&str>,
+) -> AppResult<CreatedApiKey> {
+    create_api_key_with_security_class_and_id(
+        db,
+        user_id,
+        scope_actor_user_id,
+        Some(resource_id),
         name,
         scopes,
         expires_at,
@@ -228,6 +277,52 @@ pub async fn create_api_key_with_security_class(
     db: &mongodb::Database,
     user_id: &str,
     scope_actor_user_id: Option<&str>,
+    name: &str,
+    scopes: &str,
+    expires_at: Option<chrono::DateTime<Utc>>,
+    description: Option<&str>,
+    allowed_service_ids: Option<&[String]>,
+    allowed_node_ids: Option<&[String]>,
+    allow_all_services: Option<bool>,
+    allow_all_nodes: Option<bool>,
+    rate_limit_per_second: Option<u32>,
+    rate_limit_burst: Option<u32>,
+    platform: Option<&str>,
+    callback_url: Option<&str>,
+    scope_plan_digest: Option<&str>,
+    purpose: ApiKeyPurpose,
+    scheduled_write_enabled: bool,
+) -> AppResult<CreatedApiKey> {
+    create_api_key_with_security_class_and_id(
+        db,
+        user_id,
+        scope_actor_user_id,
+        None,
+        name,
+        scopes,
+        expires_at,
+        description,
+        allowed_service_ids,
+        allowed_node_ids,
+        allow_all_services,
+        allow_all_nodes,
+        rate_limit_per_second,
+        rate_limit_burst,
+        platform,
+        callback_url,
+        scope_plan_digest,
+        purpose,
+        scheduled_write_enabled,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_api_key_with_security_class_and_id(
+    db: &mongodb::Database,
+    user_id: &str,
+    scope_actor_user_id: Option<&str>,
+    resource_id: Option<&str>,
     name: &str,
     scopes: &str,
     expires_at: Option<chrono::DateTime<Utc>>,
@@ -312,7 +407,14 @@ pub async fn create_api_key_with_security_class(
         generate_api_key()
     };
 
-    let id = Uuid::new_v4().to_string();
+    let id = match resource_id {
+        Some(value) => Uuid::parse_str(value)
+            .map_err(|_| {
+                AppError::ValidationError("reserved API key id must be a UUID".to_string())
+            })?
+            .to_string(),
+        None => Uuid::new_v4().to_string(),
+    };
     let now = Utc::now();
 
     let new_key = ApiKey {

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod api_docs_service;
 pub mod api_key_scope_service;
 pub mod approval_policy;
 pub mod approval_service;
+pub mod assistant_action_execution_service;
 pub mod assistant_readiness_service;
 pub mod assistant_service;
 pub mod audit_chain_service;

--- a/frontend/src/components/assistant/assistant-key-create-dialog.test.tsx
+++ b/frontend/src/components/assistant/assistant-key-create-dialog.test.tsx
@@ -1,0 +1,275 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api-client";
+import {
+  AssistantKeyCreateDialog,
+  type AssistantKeyCreateParams,
+} from "./assistant-key-create-dialog";
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  api: { get: mockGet, post: mockPost },
+  ApiError: class ApiError extends Error {
+    readonly status: number;
+    constructor(status: number) {
+      super(`HTTP ${String(status)}`);
+      this.status = status;
+    }
+  },
+}));
+
+const PARAMS = {
+  name: "coding-agent",
+  platform: "codex",
+  allowedServiceIds: ["service-alpha"],
+} as const;
+
+function keySnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "key-created",
+    name: "coding-agent",
+    platform: "codex",
+    scopes: "proxy",
+    is_active: true,
+    allowed_service_ids: ["service-alpha"],
+    allowed_node_ids: [],
+    allow_all_services: false,
+    allow_all_nodes: false,
+    key_prefix: "nyxid_ag_safe_prefix",
+    ...overrides,
+  };
+}
+
+function installSuccessfulReads(overrides: Record<string, unknown> = {}) {
+  mockGet.mockImplementation((path: string) => {
+    if (path === "/keys/service-alpha") {
+      return Promise.resolve({
+        id: "service-alpha",
+        is_active: true,
+        credential_source: { type: "personal" },
+      });
+    }
+    if (path === "/api-keys/key-created") {
+      return Promise.resolve(keySnapshot(overrides));
+    }
+    return Promise.reject(new Error(`unexpected GET ${path}`));
+  });
+}
+
+function renderDialog(
+  params: AssistantKeyCreateParams = PARAMS,
+  onComplete = vi.fn(),
+) {
+  const onOpenChange = vi.fn();
+  const rendered = render(
+    <AssistantKeyCreateDialog
+      open
+      onOpenChange={onOpenChange}
+      actionRequestId="action-alpha"
+      params={params}
+      onComplete={onComplete}
+    />,
+  );
+  return { ...rendered, onComplete, onOpenChange };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+});
+
+describe("AssistantKeyCreateDialog", () => {
+  it("fences double submission and reports only after exact read-back and secret acknowledgement", async () => {
+    installSuccessfulReads();
+    mockPost.mockResolvedValue({
+      resource: { keyId: "key-created" },
+      replayed: false,
+      fullKey: "nyxid_ag_one_time_secret",
+    });
+    const { onComplete } = renderDialog();
+
+    const create = screen.getByRole("button", { name: "Create key" });
+    fireEvent.click(create);
+    fireEvent.click(create);
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockGet).toHaveBeenNthCalledWith(1, "/keys/service-alpha");
+    expect(mockPost).toHaveBeenCalledWith("/assistant/actions/key-create", {
+      actionRequestId: "action-alpha",
+      name: "coding-agent",
+      platform: "codex",
+      allowedServiceIds: ["service-alpha"],
+    });
+    expect(mockGet).toHaveBeenNthCalledWith(2, "/api-keys/key-created");
+
+    expect(
+      await screen.findByText("nyxid_ag_one_time_secret"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Exact least-scope access verified."),
+    ).toBeInTheDocument();
+    const finish = screen.getByRole("button", {
+      name: "I have saved it",
+    });
+    expect(finish).toBeDisabled();
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "I saved this key in a secure location.",
+      }),
+    );
+    expect(finish).toBeEnabled();
+    await userEvent.click(finish);
+    expect(onComplete).toHaveBeenCalledWith("key-created");
+    expect(onComplete).not.toHaveBeenCalledWith(
+      expect.stringContaining("one_time_secret"),
+    );
+  });
+
+  it("rejects empty and duplicate service sets before any provider read", async () => {
+    for (const allowedServiceIds of [[], ["service-alpha", "service-alpha"]]) {
+      const { unmount } = renderDialog({ ...PARAMS, allowedServiceIds });
+      await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+      expect(await screen.findByRole("alert")).toBeInTheDocument();
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(mockPost).not.toHaveBeenCalled();
+      unmount();
+      mockGet.mockClear();
+      mockPost.mockClear();
+    }
+  });
+
+  it("rejects unknown and cross-owner service reads before mutation", async () => {
+    const failures = [
+      () =>
+        Promise.resolve({
+          id: "different-service",
+          is_active: true,
+          credential_source: { type: "personal" },
+        }),
+      () =>
+        Promise.resolve({
+          id: "service-alpha",
+          is_active: true,
+          credential_source: {
+            type: "org",
+            org_id: "org-alpha",
+            role: "member",
+            allowed: true,
+          },
+        }),
+      () =>
+        Promise.reject(
+          new ApiError(404, {
+            error: "not_found",
+            error_code: 404,
+            message: "Service not found",
+          }),
+        ),
+    ];
+    for (const failure of failures) {
+      mockGet.mockImplementationOnce(failure);
+      const { unmount } = renderDialog();
+      await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+      expect(await screen.findByRole("alert")).toBeInTheDocument();
+      expect(mockPost).not.toHaveBeenCalled();
+      unmount();
+      mockGet.mockReset();
+      mockPost.mockReset();
+    }
+  });
+
+  it("keeps the safe report blocked when authoritative read-back is widened", async () => {
+    installSuccessfulReads({ allow_all_services: true });
+    mockPost.mockResolvedValue({
+      resource: { keyId: "key-created" },
+      replayed: false,
+      fullKey: "nyxid_ag_one_time_secret",
+    });
+    const { onComplete } = renderDialog();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+    expect(
+      await screen.findByText("nyxid_ag_one_time_secret"),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "I saved this key in a secure location.",
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: "I have saved it" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Retry verification" }),
+    ).toBeEnabled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("rejects secret-bearing exact read-back evidence", async () => {
+    installSuccessfulReads({ full_key: "nyxid_ag_should_not_be_here" });
+    mockPost.mockResolvedValue({
+      resource: { keyId: "key-created" },
+      replayed: false,
+      fullKey: "nyxid_ag_one_time_secret",
+    });
+    renderDialog();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "secret-bearing verification data",
+    );
+    expect(
+      screen.getByRole("button", { name: "I have saved it" }),
+    ).toBeDisabled();
+  });
+
+  it("replays a verified safe key receipt without pretending the secret is recoverable", async () => {
+    installSuccessfulReads();
+    mockPost.mockResolvedValue({
+      resource: { keyId: "key-created" },
+      replayed: true,
+    });
+    const { onComplete } = renderDialog();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+    expect(
+      await screen.findByText(/one-time secret is no longer available/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Exact least-scope access verified."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Report existing key" }),
+    );
+    expect(onComplete).toHaveBeenCalledWith("key-created");
+  });
+
+  it("rejects a replay response that includes secret material", async () => {
+    mockGet.mockResolvedValue({
+      id: "service-alpha",
+      is_active: true,
+      credential_source: { type: "personal" },
+    });
+    mockPost.mockResolvedValue({
+      resource: { keyId: "key-created" },
+      replayed: true,
+      fullKey: "nyxid_ag_should_not_exist",
+    });
+    renderDialog();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.queryByText("nyxid_ag_should_not_exist"),
+    ).not.toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/assistant/assistant-key-create-dialog.test.tsx
+++ b/frontend/src/components/assistant/assistant-key-create-dialog.test.tsx
@@ -252,6 +252,37 @@ describe("AssistantKeyCreateDialog", () => {
     expect(onComplete).toHaveBeenCalledWith("key-created");
   });
 
+  it("recovers a durable replay after an allowed service is deactivated", async () => {
+    installSuccessfulReads();
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/keys/service-alpha") {
+        return Promise.resolve({
+          id: "service-alpha",
+          is_active: false,
+          credential_source: { type: "personal" },
+        });
+      }
+      if (path === "/api-keys/key-created") {
+        return Promise.resolve(keySnapshot());
+      }
+      return Promise.reject(new Error(`unexpected GET ${path}`));
+    });
+    mockPost.mockResolvedValue({
+      resource: { keyId: "key-created" },
+      replayed: true,
+    });
+    const { onComplete } = renderDialog();
+
+    await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+    expect(
+      await screen.findByText("Exact least-scope access verified."),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Report existing key" }),
+    );
+    expect(onComplete).toHaveBeenCalledWith("key-created");
+  });
+
   it("rejects a replay response that includes secret material", async () => {
     mockGet.mockResolvedValue({
       id: "service-alpha",

--- a/frontend/src/components/assistant/assistant-key-create-dialog.tsx
+++ b/frontend/src/components/assistant/assistant-key-create-dialog.tsx
@@ -43,7 +43,7 @@ const assistantKeyCreateResponseSchema = z.discriminatedUnion("replayed", [
 const serviceSnapshotSchema = z
   .object({
     id: actionControlIdentitySchema,
-    is_active: z.literal(true),
+    is_active: z.boolean(),
     credential_source: z.object({ type: z.literal("personal") }).passthrough(),
   })
   .passthrough();

--- a/frontend/src/components/assistant/assistant-key-create-dialog.tsx
+++ b/frontend/src/components/assistant/assistant-key-create-dialog.tsx
@@ -1,0 +1,440 @@
+import { useRef, useState } from "react";
+import { Check, Copy, KeyRound, RefreshCw } from "lucide-react";
+import { z } from "zod";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ApiError, api } from "@/lib/api-client";
+import {
+  actionControlIdentitySchema,
+  keyCreateActionParamsSchema,
+} from "@/schemas/assistant-actions";
+import { copyToClipboard } from "@/lib/utils";
+
+const keyResourceSchema = z
+  .object({ keyId: actionControlIdentitySchema })
+  .strict();
+const createdKeyResponseSchema = z
+  .object({
+    resource: keyResourceSchema,
+    replayed: z.literal(false),
+    fullKey: z.string().min(1).max(4_096),
+  })
+  .strict();
+const replayedKeyResponseSchema = z
+  .object({
+    resource: keyResourceSchema,
+    replayed: z.literal(true),
+  })
+  .strict();
+const assistantKeyCreateResponseSchema = z.discriminatedUnion("replayed", [
+  createdKeyResponseSchema,
+  replayedKeyResponseSchema,
+]);
+
+const serviceSnapshotSchema = z
+  .object({
+    id: actionControlIdentitySchema,
+    is_active: z.literal(true),
+    credential_source: z.object({ type: z.literal("personal") }).passthrough(),
+  })
+  .passthrough();
+const apiKeySnapshotSchema = z
+  .object({
+    id: actionControlIdentitySchema,
+    name: z.string().min(1).max(200),
+    platform: z.string().min(1).max(100),
+    scopes: z.literal("proxy"),
+    is_active: z.literal(true),
+    allowed_service_ids: z.array(actionControlIdentitySchema).min(1).max(64),
+    allowed_node_ids: z.array(actionControlIdentitySchema).length(0),
+    allow_all_services: z.literal(false),
+    allow_all_nodes: z.literal(false),
+  })
+  .passthrough();
+
+type AssistantKeyEffectResponse = z.infer<
+  typeof assistantKeyCreateResponseSchema
+>;
+
+const FORBIDDEN_READ_BACK_FIELDS = new Set([
+  "accesstoken",
+  "authorization",
+  "cookie",
+  "fullkey",
+  "keyhash",
+  "rawbody",
+  "rawupstreambody",
+  "refreshtoken",
+  "secret",
+]);
+
+function assertSecretFreeReadBack(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) assertSecretFreeReadBack(entry);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, entry] of Object.entries(value)) {
+    const normalized = key
+      .replace(/[^A-Za-z0-9]/g, "")
+      .toLocaleLowerCase("en-US");
+    if (FORBIDDEN_READ_BACK_FIELDS.has(normalized)) {
+      throw new Error("NyxID returned secret-bearing verification data.");
+    }
+    assertSecretFreeReadBack(entry);
+  }
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]) {
+  if (left.length !== right.length) return false;
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+function errorMessage(caught: unknown, fallback: string): string {
+  if (caught instanceof ApiError) return caught.message;
+  if (caught instanceof Error && caught.message.trim()) return caught.message;
+  return fallback;
+}
+
+function KeyEffectResult({
+  result,
+  verified,
+  verifying,
+  onError,
+  onRetryVerification,
+  onFinish,
+}: {
+  readonly result: AssistantKeyEffectResponse;
+  readonly verified: boolean;
+  readonly verifying: boolean;
+  readonly onError: (message: string) => void;
+  readonly onRetryVerification: () => void;
+  readonly onFinish: (keyId: string) => void;
+}) {
+  const [saved, setSaved] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function copySecret() {
+    if (result.replayed) return;
+    try {
+      await copyToClipboard(result.fullKey);
+      setCopied(true);
+    } catch {
+      onError(
+        "The browser could not copy the key. Select and copy it manually.",
+      );
+    }
+  }
+
+  return (
+    <>
+      {result.replayed ? (
+        <div className="flex items-start gap-3 border-y border-border py-4">
+          <KeyRound className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 space-y-1">
+            <p className="text-[13px] font-medium">Existing key</p>
+            <p className="break-all font-mono text-[12px] text-muted-foreground">
+              {result.resource.keyId}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4 border-y border-border py-4">
+          <div className="flex items-center gap-2">
+            <code className="min-w-0 flex-1 select-all break-all rounded-lg border border-border bg-muted px-3 py-2 font-mono text-[12px]">
+              {result.fullKey}
+            </code>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              title="Copy API key"
+              aria-label="Copy API key"
+              onClick={() => void copySecret()}
+            >
+              {copied ? <Check className="text-success" /> : <Copy />}
+            </Button>
+          </div>
+          <label className="flex cursor-pointer items-start gap-2 text-[12px]">
+            <Checkbox
+              checked={saved}
+              onCheckedChange={(value) => setSaved(value === true)}
+            />
+            <span>I saved this key in a secure location.</span>
+          </label>
+        </div>
+      )}
+      {verified ? (
+        <p className="text-[11px] text-success">
+          Exact least-scope access verified.
+        </p>
+      ) : null}
+      <DialogFooter>
+        {!verified ? (
+          <Button
+            type="button"
+            variant="outline"
+            isLoading={verifying}
+            onClick={onRetryVerification}
+          >
+            <RefreshCw />
+            Retry verification
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          variant="primary"
+          disabled={!verified || (!result.replayed && !saved)}
+          onClick={() => onFinish(result.resource.keyId)}
+        >
+          {result.replayed ? "Report existing key" : "I have saved it"}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+export interface AssistantKeyCreateParams {
+  readonly name: string;
+  readonly platform: string;
+  readonly allowedServiceIds: readonly string[];
+}
+
+export function AssistantKeyCreateDialog({
+  open,
+  onOpenChange,
+  actionRequestId,
+  params,
+  onComplete,
+}: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly actionRequestId: string;
+  readonly params: AssistantKeyCreateParams;
+  readonly onComplete: (keyId: string) => void;
+}) {
+  const submittingRef = useRef(false);
+  const verificationRef = useRef(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [verified, setVerified] = useState(false);
+  const [result, setResult] = useState<AssistantKeyEffectResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const oneTimeSecret = result && !result.replayed ? result.fullKey : null;
+
+  function close() {
+    setResult(null);
+    setError(null);
+    setVerified(false);
+    submittingRef.current = false;
+    verificationRef.current = false;
+    setSubmitting(false);
+    setVerifying(false);
+    onOpenChange(false);
+  }
+
+  async function verifyAllowedServices(
+    allowedServiceIds: readonly string[],
+  ): Promise<void> {
+    const snapshots = await Promise.all(
+      allowedServiceIds.map(async (serviceId) => {
+        const value = await api.get<unknown>(
+          `/keys/${encodeURIComponent(serviceId)}`,
+        );
+        assertSecretFreeReadBack(value);
+        return serviceSnapshotSchema.parse(value);
+      }),
+    );
+    for (const [index, snapshot] of snapshots.entries()) {
+      if (snapshot.id !== allowedServiceIds[index]) {
+        throw new Error("NyxID returned a different service identity.");
+      }
+    }
+  }
+
+  async function verifyCreatedKey(
+    effect: AssistantKeyEffectResponse,
+    expected: z.infer<typeof keyCreateActionParamsSchema>,
+  ): Promise<void> {
+    if (verificationRef.current) return;
+    verificationRef.current = true;
+    setVerifying(true);
+    setVerified(false);
+    try {
+      const value = await api.get<unknown>(
+        `/api-keys/${encodeURIComponent(effect.resource.keyId)}`,
+      );
+      assertSecretFreeReadBack(value);
+      const snapshot = apiKeySnapshotSchema.parse(value);
+      if (
+        snapshot.id !== effect.resource.keyId ||
+        snapshot.name !== expected.name ||
+        snapshot.platform !== expected.platform ||
+        !sameStringSet(snapshot.allowed_service_ids, expected.allowedServiceIds)
+      ) {
+        throw new Error("NyxID key verification did not match this action.");
+      }
+      setVerified(true);
+      setError(null);
+    } catch (caught) {
+      setError(
+        errorMessage(caught, "NyxID could not verify the created API key."),
+      );
+    } finally {
+      verificationRef.current = false;
+      setVerifying(false);
+    }
+  }
+
+  async function createKey() {
+    if (submittingRef.current || result) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const expected = keyCreateActionParamsSchema.parse(params);
+      await verifyAllowedServices(expected.allowedServiceIds);
+      const response = assistantKeyCreateResponseSchema.parse(
+        await api.post<unknown>("/assistant/actions/key-create", {
+          actionRequestId,
+          name: expected.name,
+          platform: expected.platform,
+          allowedServiceIds: [...expected.allowedServiceIds],
+        }),
+      );
+      setResult(response);
+      await verifyCreatedKey(response, expected);
+    } catch (caught) {
+      setError(errorMessage(caught, "NyxID could not create this key."));
+    } finally {
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
+  }
+
+  async function retryVerification() {
+    if (!result) return;
+    try {
+      const expected = keyCreateActionParamsSchema.parse(params);
+      await verifyCreatedKey(result, expected);
+    } catch (caught) {
+      setError(
+        errorMessage(caught, "NyxID could not verify the created API key."),
+      );
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !oneTimeSecret) close();
+      }}
+    >
+      <DialogContent
+        onEscapeKeyDown={(event) => {
+          if (oneTimeSecret) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (oneTimeSecret) event.preventDefault();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {result?.replayed ? "API key already created" : "Create API key"}
+          </DialogTitle>
+          <DialogDescription>
+            {result
+              ? result.replayed
+                ? "The original one-time secret is no longer available."
+                : "This key is shown only once. Copy and store it securely now."
+              : "Confirm the exact key identity and service boundary."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!result ? (
+          <div className="space-y-3 border-y border-border py-4 text-[12px]">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Name</span>
+              <span className="min-w-0 truncate font-medium">
+                {params.name}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">Platform</span>
+              <Badge variant="secondary" className="max-w-[70%] truncate">
+                {params.platform}
+              </Badge>
+            </div>
+            <div className="space-y-2">
+              <span className="text-muted-foreground">Allowed services</span>
+              <div className="flex flex-wrap gap-1.5">
+                {params.allowedServiceIds.map((serviceId) => (
+                  <Badge
+                    key={serviceId}
+                    variant="secondary"
+                    className="max-w-full truncate font-mono"
+                  >
+                    {serviceId}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Proxy access only. All services outside this list and every node
+              are denied.
+            </p>
+          </div>
+        ) : null}
+
+        {error ? (
+          <p role="alert" className="text-[11px] text-destructive">
+            {error}
+          </p>
+        ) : null}
+
+        {!result ? (
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={close}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              isLoading={submitting}
+              disabled={submitting}
+              onClick={() => void createKey()}
+            >
+              Create key
+            </Button>
+          </DialogFooter>
+        ) : null}
+        {result ? (
+          <KeyEffectResult
+            result={result}
+            verified={verified}
+            verifying={verifying}
+            onError={setError}
+            onRetryVerification={() => void retryVerification()}
+            onFinish={(keyId) => {
+              onComplete(keyId);
+              close();
+            }}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/assistant/blocks/action-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactElement, ReactNode } from "react";
@@ -133,6 +139,37 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     ) : null,
 }));
 
+vi.mock("@/components/assistant/assistant-key-create-dialog", () => ({
+  AssistantKeyCreateDialog: ({
+    open,
+    actionRequestId,
+    params,
+    onComplete,
+  }: {
+    readonly open: boolean;
+    readonly actionRequestId: string;
+    readonly params: {
+      readonly name: string;
+      readonly platform: string;
+      readonly allowedServiceIds: readonly string[];
+    };
+    readonly onComplete: (keyId: string) => void;
+  }) =>
+    open ? (
+      <div
+        role="dialog"
+        data-action-request-id={actionRequestId}
+        data-name={params.name}
+        data-platform={params.platform}
+        data-service-ids={params.allowedServiceIds.join(",")}
+      >
+        <button type="button" onClick={() => onComplete("key-created")}>
+          Finish mock key creation
+        </button>
+      </div>
+    ) : null,
+}));
+
 function catalogBlock(
   overrides: Partial<ActionCardContentBlock> = {},
 ): ActionCardContentBlock {
@@ -157,6 +194,29 @@ function catalogBlock(
   };
 }
 
+function keyCreateBlock(
+  overrides: Partial<ActionCardContentBlock> = {},
+): ActionCardContentBlock {
+  return {
+    type: "action_card",
+    block_id: "action-card-key-create",
+    action: "key.create",
+    action_request_id: "act-key-create",
+    origin_turn_id: "turn-origin-1",
+    task_id: "task-1",
+    step_id: "step-1",
+    params: {
+      variant: "key_create",
+      name: "coding-agent",
+      platform: "codex",
+      allowed_service_ids: ["service-alpha"],
+    },
+    status: "pending",
+    outcome_note: "",
+    ...overrides,
+  };
+}
+
 function expectNoBlueAccent(card: HTMLElement | null) {
   const classNames = [card, ...(card?.querySelectorAll("[class]") ?? [])]
     .map((element) => element?.getAttribute("class") ?? "")
@@ -167,6 +227,40 @@ function expectNoBlueAccent(card: HTMLElement | null) {
 }
 
 describe("ActionCard", () => {
+  it("opens the key.create journey and reports only the safe key identity", async () => {
+    const onProgress = vi.fn();
+    const onResolve = vi.fn();
+    renderCard(
+      <ActionCard
+        block={keyCreateBlock()}
+        onProgress={onProgress}
+        onBlock={vi.fn()}
+        onResolve={onResolve}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Create API key" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("service-alpha")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Create key" }));
+    expect(onProgress).toHaveBeenCalledWith("action-card-key-create", true);
+    expect(screen.getByRole("dialog")).toHaveAttribute(
+      "data-action-request-id",
+      "act-key-create",
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Finish mock key creation" }),
+    );
+    expect(onResolve).toHaveBeenCalledWith({
+      actionRequestId: "act-key-create",
+      originTurnId: "turn-origin-1",
+      disposition: "completed",
+      resource: { key: { keyId: "key-created" } },
+    });
+  });
+
   it("renders owned consent copy and opens the prefilled connect journey", async () => {
     const user = userEvent.setup();
     const onProgress = vi.fn();
@@ -364,7 +458,8 @@ describe("ActionCard", () => {
     );
 
     function expectPurpleAndNeutralPalette(status: "pending" | "in_progress") {
-      const statusLabel = status === "pending" ? "Action required" : "In progress";
+      const statusLabel =
+        status === "pending" ? "Action required" : "In progress";
       const card = screen.getByRole("heading").closest("section");
       expectNoBlueAccent(card);
       expect(screen.getByText(statusLabel).closest("div")).toHaveClass(
@@ -523,7 +618,9 @@ describe("ActionCard", () => {
     );
 
     expect(screen.queryByText(new RegExp(injected))).not.toBeInTheDocument();
-    expect(screen.queryByText(/personal access token/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/personal access token/i),
+    ).not.toBeInTheDocument();
     const heading = screen.getByRole("heading");
     expect(heading.textContent ?? "").toMatch(/^Connect GitHub \(official\)/);
     expect((heading.textContent ?? "").length).toBeLessThanOrEqual(40);
@@ -593,9 +690,13 @@ describe("ActionCard", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Connect GitHub" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Connect GitHub" }),
+    ).toBeDisabled();
     expect(screen.getByRole("button", { name: "Decline" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Report failure" })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Report failure" }),
+    ).toBeEnabled();
 
     await user.click(screen.getByRole("button", { name: "Decline" }));
     expect(onResolve).toHaveBeenCalledWith({
@@ -621,14 +722,13 @@ describe("ActionCard", () => {
       onBlock,
       onResolve: vi.fn(),
     };
-    const { rerender } = renderCard(<ActionCard block={catalogBlock()} {...props} />);
+    const { rerender } = renderCard(
+      <ActionCard block={catalogBlock()} {...props} />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     rerender(
-      <ActionCard
-        block={catalogBlock({ status: "in_progress" })}
-        {...props}
-      />,
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
     );
     await user.click(
       screen.getByRole("button", { name: "Finish without service id" }),
@@ -652,10 +752,7 @@ describe("ActionCard", () => {
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     expect(onProgress).toHaveBeenCalledWith("action-card-1", true);
     rerender(
-      <ActionCard
-        block={catalogBlock({ status: "in_progress" })}
-        {...props}
-      />,
+      <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
     );
     await user.click(
       screen.getByRole("button", { name: "Dismiss mock connection" }),
@@ -680,7 +777,9 @@ describe("ActionCard", () => {
 
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     await expect(
-      user.click(screen.getByRole("button", { name: "Finish without service id" })),
+      user.click(
+        screen.getByRole("button", { name: "Finish without service id" }),
+      ),
     ).resolves.toBeUndefined();
     expect(onBlock).toHaveBeenCalledTimes(1);
   });
@@ -829,7 +928,9 @@ describe("ActionCard background authorization watch", () => {
     rerender(
       <ActionCard block={catalogBlock({ status: "in_progress" })} {...props} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Hand off to provider" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hand off to provider" }),
+    );
     fireEvent.click(
       screen.getByRole("button", { name: "Dismiss mock connection" }),
     );

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -2,11 +2,13 @@ import { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Globe,
+  KeyRound,
   Loader2,
   Server,
   ShieldCheck,
   X,
 } from "lucide-react";
+import { AssistantKeyCreateDialog } from "@/components/assistant/assistant-key-create-dialog";
 import { AddKeyDialog } from "@/components/dashboard/add-key-dialog";
 import { ServiceIcon } from "@/components/service-icon";
 import { Badge } from "@/components/ui/badge";
@@ -18,7 +20,7 @@ import {
   descriptorForAction,
 } from "@/lib/assistant/action-registry";
 import { connectWatchDeadline } from "@/lib/assistant/connect-watch";
-import type { ActionReport } from "@/schemas/assistant-actions";
+import type { ActionReport, ActionResource } from "@/schemas/assistant-actions";
 import { usePendingConnectStore } from "@/stores/pending-connect-store";
 import type { ActionCardContentBlock } from "@/types/assistant";
 
@@ -49,6 +51,37 @@ function ParameterSummary({
 }) {
   const params = block.params;
   if (params.variant === "unknown") return null;
+  if (params.variant === "key_create") {
+    return (
+      <div className="space-y-2.5 border-y border-border bg-muted px-4 py-3">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[1px] text-muted-foreground">
+            Key
+          </span>
+          <Badge variant="secondary" className="max-w-full truncate">
+            {params.name}
+          </Badge>
+          <Badge variant="secondary" className="max-w-full truncate">
+            {params.platform}
+          </Badge>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[1px] text-muted-foreground">
+            Allowed services
+          </span>
+          {params.allowed_service_ids.map((serviceId) => (
+            <Badge
+              key={serviceId}
+              variant="secondary"
+              className="max-w-full truncate font-mono"
+            >
+              {serviceId}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    );
+  }
   const scopes =
     params.variant === "catalog" ? params.requested_scopes.filter(Boolean) : [];
   let endpointHost = "";
@@ -101,7 +134,10 @@ function ParameterSummary({
           {/* Ids are wire-supplied and only length-capped at 256 chars, so they
               stay inside the card instead of widening the chat column. */}
           {params.via_node_id ? (
-            <Badge variant="secondary" className="max-w-full truncate font-mono">
+            <Badge
+              variant="secondary"
+              className="max-w-full truncate font-mono"
+            >
               <Server className="mr-1 h-3 w-3" />
               <span className="min-w-0 truncate">
                 Node {params.via_node_id}
@@ -109,7 +145,10 @@ function ParameterSummary({
             </Badge>
           ) : null}
           {params.target_org_id ? (
-            <Badge variant="secondary" className="max-w-full truncate font-mono">
+            <Badge
+              variant="secondary"
+              className="max-w-full truncate font-mono"
+            >
               <span className="min-w-0 truncate">
                 Org {params.target_org_id}
               </span>
@@ -310,7 +349,16 @@ export function ActionCard({
     block.status !== "unsupported",
   );
 
-  const verdict = settled ? SETTLED[block.status as SettledStatus] : null;
+  const baseVerdict = settled ? SETTLED[block.status as SettledStatus] : null;
+  const verdict =
+    baseVerdict && block.status === "completed" && block.action === "key.create"
+      ? {
+          ...baseVerdict,
+          badge: "Created",
+          footer:
+            "The assistant received only the verified key reference. Key material stayed in NyxID.",
+        }
+      : baseVerdict;
   const VerdictIcon = verdict?.icon;
 
   // Trust the descriptor too: a card whose verb has no journey behind it must
@@ -349,14 +397,14 @@ export function ActionCard({
 
   function report(
     disposition: "completed" | "declined" | "failed",
-    userServiceId?: string,
+    resource?: ActionResource,
   ) {
     // A manual outcome supersedes any watch still running for this card.
     if (pendingAuth) {
       watchSettledRef.current = authorizationAttemptId;
       endPendingAuth(block.block_id);
     }
-    if (disposition === "completed" && !userServiceId?.trim()) {
+    if (disposition === "completed" && !resource) {
       resolvingRef.current = true;
       void Promise.resolve()
         .then(() => onBlock(block.block_id, VERIFICATION_BLOCKED_NOTE))
@@ -375,11 +423,8 @@ export function ActionCard({
     void Promise.resolve()
       .then(() =>
         onResolve(
-          disposition === "completed" && userServiceId
-            ? {
-                ...base,
-                resource: { userService: { userServiceId } },
-              }
+          disposition === "completed" && resource
+            ? { ...base, resource }
             : base,
         ),
       )
@@ -410,6 +455,8 @@ export function ActionCard({
             <ServiceIcon slug={params.service_slug} size="sm" />
           ) : params.variant === "custom" ? (
             <Globe className="h-4 w-4 text-muted-foreground" />
+          ) : params.variant === "key_create" ? (
+            <KeyRound className="h-4 w-4 text-muted-foreground" />
           ) : (
             <AlertTriangle className="h-4 w-4 text-destructive" />
           )}
@@ -471,8 +518,9 @@ export function ActionCard({
         <div className="flex items-start gap-2 px-4 py-3">
           <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0 text-nyx-secondary-400" />
           <p className="text-[11px] leading-relaxed text-muted-foreground">
-            You choose the account, routing, and credential. The assistant
-            receives only brokered access after you finish.
+            {params.variant === "key_create"
+              ? "NyxID creates and verifies the key here. The assistant receives only the safe key reference after you finish."
+              : "You choose the account, routing, and credential. The assistant receives only brokered access after you finish."}
           </p>
         </div>
       ) : null}
@@ -494,7 +542,9 @@ export function ActionCard({
               {awaitingAuthorization
                 ? "Waiting for authorization"
                 : busy
-                  ? "Connecting"
+                  ? params.variant === "key_create"
+                    ? "Working"
+                    : "Connecting"
                   : descriptor.cta(params)}
             </Button>
           ) : null}
@@ -528,7 +578,9 @@ export function ActionCard({
 
       {/* A settled card unmounts the dialog: its journey is over, and leaving
           it mounted would let a stale flow write onto a reported outcome. */}
-      {!verdict && !unsupported ? (
+      {!verdict &&
+      !unsupported &&
+      (params.variant === "catalog" || params.variant === "custom") ? (
         <AddKeyDialog
           open={dialogOpen}
           onOpenChange={setOpen}
@@ -536,16 +588,8 @@ export function ActionCard({
             params.variant === "catalog" ? params.service_slug : undefined
           }
           prefillIncludeAllCatalog={params.variant === "catalog"}
-          prefillNodeId={
-            params.variant === "unknown"
-              ? undefined
-              : (params.via_node_id ?? undefined)
-          }
-          prefillTargetOrgId={
-            params.variant === "unknown"
-              ? undefined
-              : (params.target_org_id ?? undefined)
-          }
+          prefillNodeId={params.via_node_id ?? undefined}
+          prefillTargetOrgId={params.target_org_id ?? undefined}
           prefillCustom={
             params.variant === "custom"
               ? {
@@ -571,7 +615,13 @@ export function ActionCard({
             setOpen(false);
             return true;
           }}
-          onSuccess={({ userServiceId }) => report("completed", userServiceId)}
+          onSuccess={({ userServiceId }) => {
+            if (!userServiceId.trim()) {
+              report("completed");
+              return;
+            }
+            report("completed", { userService: { userServiceId } });
+          }}
           // Deliberately no onAuthorizationAborted: closing this short-lived
           // dialog is not abandonment. The store-backed watch must survive
           // dismissal/remount and settle the busy card (#1384).
@@ -582,6 +632,19 @@ export function ActionCard({
               startedAt: Date.now(),
             });
           }}
+        />
+      ) : null}
+      {!verdict && !unsupported && params.variant === "key_create" ? (
+        <AssistantKeyCreateDialog
+          open={dialogOpen}
+          onOpenChange={setOpen}
+          actionRequestId={block.action_request_id}
+          params={{
+            name: params.name,
+            platform: params.platform,
+            allowedServiceIds: params.allowed_service_ids,
+          }}
+          onComplete={(keyId) => report("completed", { key: { keyId } })}
         />
       ) : null}
     </section>

--- a/frontend/src/lib/assistant/action-registry.ts
+++ b/frontend/src/lib/assistant/action-registry.ts
@@ -1,12 +1,18 @@
 import {
   ACTION_SCHEMA_VERSION,
   ACTION_SERVICE_SLUG_PATTERN,
+  keyCreateActionParamsSchema,
+  serviceConnectActionParamsSchema,
   type ActionCardParams,
   type AssistantActionRequest,
 } from "@/schemas/assistant-actions";
 
 export type ActionRisk = "credential_access" | "unsupported";
-export type ActionJourney = "catalog_service" | "custom_service" | null;
+export type ActionJourney =
+  | "catalog_service"
+  | "custom_service"
+  | "key_create"
+  | null;
 
 export interface ActionDescriptor {
   readonly title: (params: ActionCardParams) => string;
@@ -79,6 +85,17 @@ const serviceConnectDescriptor: ActionDescriptor = {
   },
 };
 
+const keyCreateDescriptor: ActionDescriptor = {
+  title: () => "Create API key",
+  body: (params) =>
+    params.variant === "key_create"
+      ? `NyxID will create ${clampServiceLabel(params.name) || "an API key"} with proxy access limited to the listed services.`
+      : "NyxID will create a least-scope API key.",
+  cta: () => "Create key",
+  risk: "credential_access",
+  journey: (params) => (params.variant === "key_create" ? "key_create" : null),
+};
+
 const unsupportedDescriptor: ActionDescriptor = {
   title: () => "Unsupported action request",
   body: () =>
@@ -90,6 +107,7 @@ const unsupportedDescriptor: ActionDescriptor = {
 
 export const ACTION_REGISTRY: Readonly<Record<string, ActionDescriptor>> = {
   "service.connect": serviceConnectDescriptor,
+  "key.create": keyCreateDescriptor,
 };
 
 export interface ResolvedAction {
@@ -131,8 +149,21 @@ function safeAuthKeyName(value: string): string | null {
 }
 
 function normalizeParams(request: AssistantActionRequest): ActionCardParams {
-  const catalog = request.params.catalogService;
-  const custom = request.params.customService;
+  if (request.action === "key.create") {
+    const parsed = keyCreateActionParamsSchema.safeParse(request.params);
+    if (!parsed.success) return { variant: "unknown" };
+    return {
+      variant: "key_create",
+      name: parsed.data.name,
+      platform: parsed.data.platform,
+      allowed_service_ids: parsed.data.allowedServiceIds,
+    };
+  }
+
+  const connected = serviceConnectActionParamsSchema.safeParse(request.params);
+  if (!connected.success) return { variant: "unknown" };
+  const catalog = connected.data.catalogService;
+  const custom = connected.data.customService;
   if (catalog && !custom) {
     const serviceSlug = safeCatalogServiceSlug(catalog.serviceSlug);
     if (!serviceSlug) return { variant: "unknown" };

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -4060,9 +4060,9 @@ describe("live AG-UI frame taxonomy", () => {
       .flatMap((message) => message.blocks)
       .find((block) => block.type === "run");
     expect(run?.type === "run" && run.state).toBe("awaiting_approval");
-    expect(
-      run?.type === "run" && run.steps.map((step) => step.status),
-    ).toEqual(["waiting", "waiting"]);
+    expect(run?.type === "run" && run.steps.map((step) => step.status)).toEqual(
+      ["waiting", "waiting"],
+    );
   });
 
   it("terminalizes waiting steps when the run dies at an approval gate", async () => {
@@ -4932,6 +4932,45 @@ describe("chat action cards", () => {
         return body.type === "action.continue";
       }),
     ).toBe(false);
+  });
+
+  it("treats a reordered key.create service set as the same request", async () => {
+    stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID },
+        actionRequestFrame({
+          action: "key.create",
+          params: {
+            name: "coding-agent",
+            platform: "codex",
+            allowedServiceIds: ["service-alpha", "service-beta"],
+          },
+        }),
+        actionRequestFrame({
+          action: "key.create",
+          params: {
+            name: "coding-agent",
+            platform: "codex",
+            allowedServiceIds: ["service-beta", "service-alpha"],
+          },
+        }),
+        { type: "RUN_FINISHED", runFinished: { status: "blocked" } },
+      ]),
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await collectTurn(transport, "Create a scoped key");
+
+    const cards = await actionCardsOf(transport);
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      action: "key.create",
+      status: "pending",
+      params: {
+        variant: "key_create",
+        allowed_service_ids: ["service-alpha", "service-beta"],
+      },
+    });
   });
 
   it("patches conflicted cards when a connected service could not be reported", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -1110,6 +1110,18 @@ function fingerprintStableRequestInput(
   return fnv1aHex(stableJsonText(value));
 }
 
+function fingerprintActionRequest(request: AssistantActionRequest): string {
+  const params = resolveAssistantAction(request).params;
+  if (params.variant !== "key_create") {
+    return fingerprintStableRequestInput(request.params);
+  }
+  return fingerprintStableRequestInput({
+    name: params.name,
+    platform: params.platform,
+    allowedServiceIds: [...params.allowed_service_ids].sort(),
+  });
+}
+
 function sameStringArray(
   left: readonly string[],
   right: readonly string[],
@@ -1118,6 +1130,16 @@ function sameStringArray(
     left.length === right.length &&
     left.every((value, index) => value === right[index])
   );
+}
+
+function sameStringSet(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
 }
 
 function sameActionCardParams(
@@ -1143,6 +1165,13 @@ function sameActionCardParams(
         left.auth_key_name === right.auth_key_name &&
         left.via_node_id === right.via_node_id &&
         left.target_org_id === right.target_org_id
+      );
+    case "key_create":
+      return (
+        right.variant === "key_create" &&
+        left.name === right.name &&
+        left.platform === right.platform &&
+        sameStringSet(left.allowed_service_ids, right.allowed_service_ids)
       );
     case "unknown":
       return right.variant === "unknown";
@@ -5111,7 +5140,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
             conversationId,
             run,
             request.data,
-            fingerprintStableRequestInput(request.data.params),
+            fingerprintActionRequest(request.data),
           );
         } else {
           const unsupported = recoverUnsupportedAssistantActionRequest(payload);

--- a/frontend/src/schemas/assistant-actions.test.ts
+++ b/frontend/src/schemas/assistant-actions.test.ts
@@ -26,11 +26,13 @@ describe("assistant action request schema", () => {
       params: { catalogService: { serviceSlug: "api-github" } },
     });
 
-    expect(request.params.catalogService).toEqual({
-      serviceSlug: "api-github",
-      requestedScopes: [],
-      viaNodeId: "",
-      targetOrgId: "",
+    expect(request.params).toMatchObject({
+      catalogService: {
+        serviceSlug: "api-github",
+        requestedScopes: [],
+        viaNodeId: "",
+        targetOrgId: "",
+      },
     });
     expect(resolveAssistantAction(request)).toMatchObject({
       supported: true,
@@ -81,6 +83,63 @@ describe("assistant action request schema", () => {
         auth_key_name: "X-Build-Key",
       },
     });
+  });
+
+  it("parses an exact nonempty key.create service set", () => {
+    const request = assistantActionRequestSchema.parse({
+      ...BASE_REQUEST,
+      action: "key.create",
+      params: {
+        name: " coding-agent ",
+        platform: " codex ",
+        allowedServiceIds: ["service-alpha", "service-beta"],
+      },
+    });
+
+    expect(resolveAssistantAction(request)).toMatchObject({
+      supported: true,
+      journey: "key_create",
+      params: {
+        variant: "key_create",
+        name: "coding-agent",
+        platform: "codex",
+        allowed_service_ids: ["service-alpha", "service-beta"],
+      },
+    });
+  });
+
+  it("rejects missing, empty, duplicate, malformed, and widened key.create params", () => {
+    const invalidParams = [
+      { name: "agent", platform: "codex" },
+      { name: "agent", platform: "codex", allowedServiceIds: [] },
+      {
+        name: "agent",
+        platform: "codex",
+        allowedServiceIds: ["service-alpha", "service-alpha"],
+      },
+      {
+        name: "agent",
+        platform: "codex",
+        allowedServiceIds: ["invalid/service"],
+      },
+      {
+        name: "agent",
+        platform: "codex",
+        allowedServiceIds: ["service-alpha"],
+        allowAllServices: true,
+      },
+    ];
+
+    for (const [index, params] of invalidParams.entries()) {
+      expect(
+        assistantActionRequestSchema.safeParse({
+          ...BASE_REQUEST,
+          actionRequestId: `invalid-key-create-${String(index)}`,
+          action: "key.create",
+          params,
+        }).success,
+      ).toBe(false);
+    }
   });
 
   it("resolves bad catalog slugs and insecure custom urls as unsupported", () => {

--- a/frontend/src/schemas/assistant-actions.ts
+++ b/frontend/src/schemas/assistant-actions.ts
@@ -23,6 +23,28 @@ const requiredWireStringSchema = z
   .max(4_096)
   .transform((value) => value.trim())
   .pipe(z.string().min(1));
+const requiredActionIdentitySchema = z
+  .string()
+  .transform((value) => value.trim())
+  .pipe(actionControlIdentitySchema);
+
+const allowedServiceIdsSchema = z
+  .array(requiredActionIdentitySchema)
+  .min(1)
+  .max(64)
+  .superRefine((values, context) => {
+    const seen = new Set<string>();
+    for (const [index, value] of values.entries()) {
+      if (seen.has(value)) {
+        context.addIssue({
+          code: "custom",
+          path: [index],
+          message: "Duplicate allowed service id",
+        });
+      }
+      seen.add(value);
+    }
+  });
 
 const SECRET_VALUE =
   /(Bearer\s+)[A-Za-z0-9._~+/-]+|nyx(?:id)?_[A-Za-z0-9_-]{8,}/gi;
@@ -63,12 +85,37 @@ export const customServiceActionParamsSchema = z
   })
   .strict();
 
-export const assistantActionParamsSchema = z
+export const serviceConnectActionParamsSchema = z
   .object({
     catalogService: catalogServiceActionParamsSchema.optional(),
     customService: customServiceActionParamsSchema.optional(),
   })
-  .strict()
+  .strict();
+
+export const keyCreateActionParamsSchema = z
+  .object({
+    name: z
+      .string()
+      .max(200)
+      .transform((value) => value.trim())
+      .pipe(z.string().min(1)),
+    platform: z
+      .string()
+      .max(100)
+      .transform((value) => value.trim())
+      .pipe(z.string().min(1)),
+    allowedServiceIds: allowedServiceIdsSchema,
+  })
+  .strict();
+
+const emptyActionParamsSchema = z.object({}).strict();
+
+export const assistantActionParamsSchema = z
+  .union([
+    serviceConnectActionParamsSchema,
+    keyCreateActionParamsSchema,
+    emptyActionParamsSchema,
+  ])
   .optional()
   .default({});
 
@@ -162,6 +209,12 @@ export type ActionCardParams =
       readonly auth_key_name: string;
       readonly via_node_id: string | null;
       readonly target_org_id: string | null;
+    }
+  | {
+      readonly variant: "key_create";
+      readonly name: string;
+      readonly platform: string;
+      readonly allowed_service_ids: readonly string[];
     }
   | { readonly variant: "unknown" };
 


### PR DESCRIPTION
Closes #1405
Relates to aevatarAI/aevatar#3387

## Problem and solution

Assistant-originated key creation must never interpret a missing, empty, duplicate, unknown, or cross-owner service selection as all-service authority. This change publishes immutable registry revision `nyxid-assistant-actions.v6`, implements the owner-scoped backend effect endpoint and browser journey, and makes exact replay deterministic and secret-safe.

## Security contract

- `allowedServiceIds` is required, nonempty, unique, and capped at 64.
- Every service ID is resolved from the current owner inventory; unknown and cross-owner IDs fail closed before mutation.
- Created keys always use proxy-only scope, `allow_all_services=false`, the exact requested service set, `allow_all_nodes=false`, and no node IDs.
- Owner-scoped exact read-back proves least-scope fields and authoritative version.
- The report exposes only `{ key: { keyId } }`; key material remains one-time local UI state.
- Same-request replay returns the committed safe receipt; conflicting replay cannot create another key.

## Impacted paths

- Assistant action registry and effect endpoint
- Replay-safe key service and receipt persistence
- Assistant key-create dialog, action card, schemas, and transport

## Verification

- Backend assistant-action tests: 15 passed
- Frontend focused suites: 283 passed
- `npx tsc -b`
- Frontend lint: 0 errors (23 pre-existing warnings)
- Frontend build passed (one pre-existing CSS pseudo-class warning)
- `cargo fmt --all -- --check`
- `cargo check -p nyxid`
- `cargo clippy -p nyxid --all-targets -- -D warnings -A clippy::nonminimal-bool`
- `git diff --check origin/main...HEAD`