### PR TITLE
Complete Assistant task-plan frontend parity

### DIFF
--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -259,6 +259,7 @@ pub enum AssistantChatCommand {
     InputResolve(InputResolveCommand),
     ActionContinue(ActionContinueCommand),
     ApprovalResolve(ApprovalResolveCommand),
+    PlanResolve(PlanResolveCommand),
     TaskStop(TaskStopCommand),
     TaskSteer(TaskSteerCommand),
     StepRetry(StepRetryCommand),
@@ -317,6 +318,18 @@ pub struct ApprovalResolveCommand {
     pub request_id: String,
     pub approved: bool,
     pub reason: Option<String>,
+    pub expected_state_version: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanResolveCommand {
+    pub conversation_id: String,
+    pub task_id: String,
+    pub plan_id: String,
+    pub request_id: String,
+    pub client_request_id: String,
+    pub plan_revision: i64,
+    pub confirmed: bool,
     pub expected_state_version: i64,
 }
 
@@ -505,6 +518,21 @@ struct RawApprovalResolveCommand {
     approved: bool,
     #[serde(default)]
     reason: Option<String>,
+    expected_state_version: i64,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RawPlanResolveCommand {
+    #[serde(rename = "type")]
+    _command_type: String,
+    conversation_id: String,
+    task_id: String,
+    plan_id: String,
+    request_id: String,
+    client_request_id: String,
+    plan_revision: i64,
+    confirmed: bool,
     expected_state_version: i64,
 }
 
@@ -840,6 +868,28 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
                 },
             ))
         }
+        "plan.resolve" => {
+            let raw: RawPlanResolveCommand = serde_json::from_value(value).map_err(|e| {
+                AppError::BadRequest(format!("Invalid plan resolution request: {e}"))
+            })?;
+            validate_conversation_id(&raw.conversation_id)?;
+            validate_control_identity(&raw.task_id, "taskId")?;
+            validate_control_identity(&raw.plan_id, "planId")?;
+            validate_control_identity(&raw.request_id, "requestId")?;
+            validate_control_identity(&raw.client_request_id, "clientRequestId")?;
+            validate_positive(raw.plan_revision, "planRevision")?;
+            validate_positive(raw.expected_state_version, "expectedStateVersion")?;
+            Ok(AssistantChatCommand::PlanResolve(PlanResolveCommand {
+                conversation_id: raw.conversation_id,
+                task_id: raw.task_id,
+                plan_id: raw.plan_id,
+                request_id: raw.request_id,
+                client_request_id: raw.client_request_id,
+                plan_revision: raw.plan_revision,
+                confirmed: raw.confirmed,
+                expected_state_version: raw.expected_state_version,
+            }))
+        }
         "task.stop" => {
             let raw: RawTaskStopCommand = serde_json::from_value(value)
                 .map_err(|e| AppError::BadRequest(format!("Invalid stop request: {e}")))?;
@@ -1087,6 +1137,21 @@ pub fn prepare_assistant_chat_command(
                 response_kind: AssistantChatResponseKind::Json,
             })
         }
+        AssistantChatCommand::PlanResolve(command) => Ok(PreparedAssistantChatCommand {
+            body: serde_json::json!({
+                "type": "plan.resolve",
+                "conversationId": command.conversation_id,
+                "taskId": command.task_id,
+                "planId": command.plan_id,
+                "requestId": command.request_id,
+                "clientRequestId": command.client_request_id,
+                "planRevision": command.plan_revision,
+                "confirmed": command.confirmed,
+                "expectedStateVersion": command.expected_state_version,
+            }),
+            client_request_id: command.client_request_id.clone(),
+            response_kind: AssistantChatResponseKind::Json,
+        }),
         AssistantChatCommand::TaskStop(command) => Ok(PreparedAssistantChatCommand {
             body: serde_json::json!({
                 "type": "task.stop",
@@ -2002,6 +2067,92 @@ mod tests {
                 "approved": true,
                 "expectedStateVersion": 21,
                 "stateVersion": 21
+            }),
+        ] {
+            assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());
+        }
+    }
+
+    #[test]
+    fn parses_and_rebuilds_exact_plan_resolution() {
+        let prepared = prepare_assistant_chat_command(&parse_command(json!({
+            "type": "plan.resolve",
+            "conversationId": CONV,
+            "taskId": "task-alpha",
+            "planId": "plan-alpha",
+            "requestId": "plan-gate-alpha",
+            "clientRequestId": "client-plan-alpha",
+            "planRevision": 3,
+            "confirmed": true,
+            "expectedStateVersion": 23
+        })))
+        .unwrap();
+
+        assert_eq!(prepared.response_kind, AssistantChatResponseKind::Json);
+        assert_eq!(prepared.client_request_id, "client-plan-alpha");
+        assert_eq!(
+            prepared.body,
+            json!({
+                "type": "plan.resolve",
+                "conversationId": CONV,
+                "taskId": "task-alpha",
+                "planId": "plan-alpha",
+                "requestId": "plan-gate-alpha",
+                "clientRequestId": "client-plan-alpha",
+                "planRevision": 3,
+                "confirmed": true,
+                "expectedStateVersion": 23
+            })
+        );
+    }
+
+    #[test]
+    fn plan_resolution_requires_exact_positive_identities_and_versions() {
+        for value in [
+            json!({
+                "type": "plan.resolve",
+                "conversationId": CONV,
+                "taskId": "task-alpha",
+                "planId": "plan-alpha",
+                "requestId": "plan-gate-alpha",
+                "clientRequestId": "client-plan-alpha",
+                "planRevision": 0,
+                "confirmed": true,
+                "expectedStateVersion": 23
+            }),
+            json!({
+                "type": "plan.resolve",
+                "conversationId": CONV,
+                "taskId": "task-alpha",
+                "planId": "bad/plan",
+                "requestId": "plan-gate-alpha",
+                "clientRequestId": "client-plan-alpha",
+                "planRevision": 3,
+                "confirmed": false,
+                "expectedStateVersion": 23
+            }),
+            json!({
+                "type": "plan.resolve",
+                "conversationId": CONV,
+                "taskId": "task-alpha",
+                "planId": "plan-alpha",
+                "requestId": "plan-gate-alpha",
+                "clientRequestId": "client-plan-alpha",
+                "planRevision": 3,
+                "confirmed": true,
+                "expectedStateVersion": 0
+            }),
+            json!({
+                "type": "plan.resolve",
+                "conversationId": CONV,
+                "taskId": "task-alpha",
+                "planId": "plan-alpha",
+                "requestId": "plan-gate-alpha",
+                "clientRequestId": "client-plan-alpha",
+                "planRevision": 3,
+                "confirmed": true,
+                "expectedStateVersion": 23,
+                "stateVersion": 23
             }),
         ] {
             assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());

--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -1,6 +1,6 @@
 # Assistant Chat Wire Contract
 
-Last verified against `fix-new-chat-timing` (2026-08-04).
+Last verified against support-contract revision `f45febb057a7182dab2495d4c739d2bb8d7026f5` (2026-08-11).
 
 This document specifies the browser-to-NyxID contract and the Aevatar request NyxID produces. It is the canonical API reference for the assistant chat surface.
 
@@ -222,7 +222,7 @@ An empty reason is omitted. A nonempty reason is trimmed and limited to 2,048 ch
 }
 ```
 
-`expectedStateVersion` must be nonnegative. This command returns JSON. The typed transport waits for any pending stop ordering fence before later turn or action delivery.
+The backend accepts a nonnegative `expectedStateVersion`, but the browser never submits zero. It first reads authoritative current state, requires a positive exact version and the matching active turn, and verifies that at least one current TaskPlan step offers `availableActions.stop`. This command returns JSON. The typed transport waits for any pending stop ordering fence before later turn or action delivery.
 
 ### `task.steer`
 
@@ -238,7 +238,7 @@ An empty reason is omitted. A nonempty reason is trimmed and limited to 2,048 ch
 }
 ```
 
-The instruction must be nonblank after trimming. The preserved wire value is not normalized. `expectedStateVersion` must be nonnegative. This command returns JSON.
+The instruction must be nonblank after trimming. The preserved wire value is not normalized. The browser reads the current active turn and requires a positive exact `expectedStateVersion`; it never opens a competing text turn to steer active work. This command returns JSON.
 
 ### `step.retry` and `step.skip`
 
@@ -256,7 +256,7 @@ The instruction must be nonblank after trimming. The preserved wire value is not
 }
 ```
 
-`step.skip` has the same fields except `type` is `step.skip` and `skipRequestId` replaces `retryRequestId`. `expectedOperationGeneration` must be positive; `expectedStateVersion` must be nonnegative. Both return JSON.
+`step.skip` has the same fields except `type` is `step.skip` and `skipRequestId` replaces `retryRequestId`. The browser submits either command only when that exact step offers the corresponding `availableActions.retry` or `availableActions.skip`. It copies the positive `expectedOperationGeneration` from the step's current operation and a positive exact `expectedStateVersion` from the same current-state read. Both return JSON.
 
 Typed command parsing and reconstruction are implemented by `backend/src/services/assistant_service.rs:parse_assistant_chat_command` and `prepare_assistant_chat_command`. Header enforcement is in `backend/src/handlers/assistant.rs:typed_chat`.
 
@@ -403,6 +403,14 @@ GET /api/chat/conversations/{id}/state
 ```
 
 The upstream response uses the typed reconnect envelope with `current`, `not_modified`, `reload_required`, or `not_found` outcomes. A `chatc-...` state request returns a not-found-shaped error without calling the typed state resource. Workflow state is learned from Chat History and `aevatar.chat.context`.
+
+After loading a `nyxid-chat-...` transcript, the browser also reads this state resource and hydrates the current TaskPlan, input, approval, and action cards. It does not proactively hydrate `chatc-...` conversations. A state-resource `404` after a valid typed transcript preserves the richer local/history mirror for mixed deployments instead of erasing cards.
+
+`activeTask` carries the full published TaskPlan shape. Live `nyxid.task.snapshot`, live `nyxid.task.step.changed`, and `snapshot.activeTask` all enter the same task reducer. The reducer enforces actor identity, plan revision, monotonically increasing `progressSequence` and `stateVersion`, and exact task/step relationships. Unknown additive fields are ignored. `availableActions` is a closed object containing only `retry`, `skip`, and `stop`; an unknown action verb fails closed.
+
+The hydrated cards live in one stable synthetic current-state message. Each hydration removes the prior managed TaskPlan/input/approval/action projections and rebuilds one copy of each current card, so repeated reloads cannot accumulate duplicates. A partial pending-input or pending-approval snapshot may retain the matching richer live card by request identity. Matching committed input and approval resolutions retain the local terminal card while advancing its state version.
+
+`reload_required`, actor mismatch, invalid versions, unavailable controls, and stale operation generations fail before a control POST. Stop, steer, retry, and skip always preflight this resource; the browser never fabricates `expectedStateVersion: 0`.
 
 Implementation: `backend/src/handlers/assistant.rs:get_state`.
 

--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -122,7 +122,7 @@ The body matches Aevatar's own console client: create carries a create-only comm
 
 `POST /chat` accepts a discriminated command allowlist. NyxID parses each command with unknown-field denial, rejects secret-shaped keys and values, validates control identities, and rebuilds the exact upstream object. It never spreads an arbitrary caller object into the Aevatar body.
 
-Every typed command includes `clientRequestId`. NyxID copies that value into the outbound `Idempotency-Key` header. Text and action continuation request `Accept: text/event-stream`. Input resolution, approval resolution, stop, steer, retry, and skip request `Accept: application/json`.
+Every typed command includes `clientRequestId`. NyxID copies that value into the outbound `Idempotency-Key` header. Text and action continuation request `Accept: text/event-stream`. Input, approval, and plan resolution plus stop, steer, retry, and skip request `Accept: application/json`.
 
 ### `text`
 
@@ -208,6 +208,24 @@ An empty `actions` array is a typed actor wake and may omit `originTurnId`.
 ```
 
 An empty reason is omitted. A nonempty reason is trimmed and limited to 2,048 characters. `expectedStateVersion` is required and must be positive. The browser reads it from the authoritative typed current-state envelope and verifies the exact pending approval identity. This command returns JSON transport acceptance; the matching `nyxid.approval.changed` or current-state `latestApprovalResolution` proves commit.
+
+### `plan.resolve`
+
+```json
+{
+  "type": "plan.resolve",
+  "conversationId": "nyxid-chat-f8369965a444433f92ec50e67ad8ee52",
+  "taskId": "task-identity",
+  "planId": "plan-identity",
+  "requestId": "plan-gate-identity",
+  "clientRequestId": "request-identity",
+  "planRevision": 3,
+  "confirmed": true,
+  "expectedStateVersion": 23
+}
+```
+
+All four plan and gate identities are required and `planRevision` plus `expectedStateVersion` must be positive. At click time the browser re-reads authoritative current state, requires an exact `confirm` + `pending` gate match, and submits the state version from that same read. A pending Stop fence is observed before this preflight. JSON 202 is dispatch acceptance only; the browser refreshes current state once and changes the card only when the actor-owned TaskPlan gate changes.
 
 ### `task.stop`
 
@@ -407,6 +425,8 @@ The upstream response uses the typed reconnect envelope with `current`, `not_mod
 After loading a `nyxid-chat-...` transcript, the browser also reads this state resource and hydrates the current TaskPlan, input, approval, and action cards. It does not proactively hydrate `chatc-...` conversations. A state-resource `404` after a valid typed transcript preserves the richer local/history mirror for mixed deployments instead of erasing cards.
 
 `activeTask` carries the full published TaskPlan shape. Live `nyxid.task.snapshot`, live `nyxid.task.step.changed`, and `snapshot.activeTask` all enter the same task reducer. The reducer enforces actor identity, plan revision, monotonically increasing `progressSequence` and `stateVersion`, and exact task/step relationships. Unknown additive fields are ignored. `availableActions` is a closed object containing only `retry`, `skip`, and `stop`; an unknown action verb fails closed.
+
+Task-step approval observations retain the public decision mode, `approval_required` / `denied` receipt status, observation time, optional `rejected` / `expired` / `timed_out` terminal outcome, and optional non-sensitive `subjectKind`. The public read model deliberately reserves and omits `subjectId`; the browser does not recreate or display it.
 
 The hydrated cards live in one stable synthetic current-state message. Each hydration removes the prior managed TaskPlan/input/approval/action projections and rebuilds one copy of each current card, so repeated reloads cannot accumulate duplicates. A partial pending-input or pending-approval snapshot may retain the matching richer live card by request identity. Matching committed input and approval resolutions retain the local terminal card while advancing its state version.
 

--- a/frontend/src/components/assistant/blocks/task-plan-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/task-plan-card.test.tsx
@@ -1,0 +1,127 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { decodeTaskPlan } from "@/lib/assistant/task-plan";
+import type { TaskPlanContentBlock } from "@/types/assistant";
+import { TaskPlanCard } from "./task-plan-card";
+
+function block(
+  actions = { retry: true, skip: true, stop: true },
+): TaskPlanContentBlock {
+  return {
+    type: "task_plan",
+    block_id: "task-plan-alpha",
+    state_version: 17,
+    progress_sequence: 9,
+    plan: decodeTaskPlan({
+      schemaVersion: 4,
+      actorId: "nyxid-chat-actor-alpha",
+      taskId: "task-alpha",
+      turnId: "turn-alpha",
+      planId: "plan-alpha",
+      planRevision: 3,
+      planRevisions: [],
+      title: "Publish a weekly update",
+      status: "active",
+      gate: {
+        mode: "auto",
+        status: "satisfied",
+        reason: "Read-only steps run automatically.",
+      },
+      steps: [
+        {
+          stepId: "step-alpha",
+          order: 1,
+          kind: "tool",
+          status: "uncertain",
+          required: true,
+          description: "Read repository history",
+          source: {
+            tool: { toolName: "github_history", serviceSlug: "api-github" },
+          },
+          mayChangeExternalState: false,
+          externalEffect: "may_have_changed",
+          availableActions: actions,
+          dependsOn: [],
+          substeps: [
+            {
+              substepId: "substep-alpha",
+              title: "Inspect merged changes",
+              status: "done",
+            },
+          ],
+          operation: {
+            operationId: "operation-alpha",
+            operationGeneration: 2,
+            kind: "tool",
+            phase: "verify",
+          },
+        },
+      ],
+    }),
+  };
+}
+
+describe("TaskPlanCard", () => {
+  it("renders complete task facts and dispatches only actor-authorized controls", async () => {
+    const onStop = vi.fn().mockResolvedValue(undefined);
+    const onRetry = vi.fn().mockResolvedValue(undefined);
+    const onSkip = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TaskPlanCard
+        block={block()}
+        onStop={onStop}
+        onRetry={onRetry}
+        onSkip={onSkip}
+      />,
+    );
+
+    expect(screen.getByText("Publish a weekly update")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Revision 3 \/ state 17 \/ sequence 9/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("github_history / api-github")).toBeInTheDocument();
+    expect(screen.getByText("may have changed")).toBeInTheDocument();
+    expect(screen.getByText("Inspect merged changes")).toBeInTheDocument();
+    expect(
+      screen.getByText(/operation-alpha \/ generation 2/),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Retry Read repository history" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Skip Read repository history" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Stop task" }));
+    });
+    expect(onRetry).toHaveBeenCalledWith("step-alpha");
+    expect(onSkip).toHaveBeenCalledWith("step-alpha");
+    expect(onStop).toHaveBeenCalledOnce();
+  });
+
+  it("does not render controls the actor did not offer", () => {
+    render(
+      <TaskPlanCard
+        block={block({ retry: false, skip: false, stop: false })}
+        onStop={vi.fn()}
+        onRetry={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Retry/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Skip/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Stop task" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/assistant/blocks/task-plan-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/task-plan-card.test.tsx
@@ -6,6 +6,11 @@ import { TaskPlanCard } from "./task-plan-card";
 
 function block(
   actions = { retry: true, skip: true, stop: true },
+  gate: Record<string, unknown> = {
+    mode: "auto",
+    status: "satisfied",
+    reason: "Read-only steps run automatically.",
+  },
 ): TaskPlanContentBlock {
   return {
     type: "task_plan",
@@ -22,11 +27,7 @@ function block(
       planRevisions: [],
       title: "Publish a weekly update",
       status: "active",
-      gate: {
-        mode: "auto",
-        status: "satisfied",
-        reason: "Read-only steps run automatically.",
-      },
+      gate,
       steps: [
         {
           stepId: "step-alpha",
@@ -66,12 +67,14 @@ describe("TaskPlanCard", () => {
     const onStop = vi.fn().mockResolvedValue(undefined);
     const onRetry = vi.fn().mockResolvedValue(undefined);
     const onSkip = vi.fn().mockResolvedValue(undefined);
+    const onResolve = vi.fn().mockResolvedValue(undefined);
     render(
       <TaskPlanCard
         block={block()}
         onStop={onStop}
         onRetry={onRetry}
         onSkip={onSkip}
+        onResolve={onResolve}
       />,
     );
 
@@ -111,6 +114,7 @@ describe("TaskPlanCard", () => {
         onStop={vi.fn()}
         onRetry={vi.fn()}
         onSkip={vi.fn()}
+        onResolve={vi.fn()}
       />,
     );
 
@@ -123,5 +127,37 @@ describe("TaskPlanCard", () => {
     expect(
       screen.queryByRole("button", { name: "Stop task" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("offers only the exact pending confirm gate and dispatches both decisions", async () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TaskPlanCard
+        block={block(
+          { retry: false, skip: false, stop: false },
+          {
+            mode: "confirm",
+            status: "pending",
+            requestId: "plan-gate-alpha",
+            taskId: "task-alpha",
+            planId: "plan-alpha",
+            planRevision: 3,
+          },
+        )}
+        onStop={vi.fn()}
+        onRetry={vi.fn()}
+        onSkip={vi.fn()}
+        onResolve={onResolve}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Confirm plan" }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Reject plan" }));
+    });
+    expect(onResolve).toHaveBeenNthCalledWith(1, true);
+    expect(onResolve).toHaveBeenNthCalledWith(2, false);
   });
 });

--- a/frontend/src/components/assistant/blocks/task-plan-card.tsx
+++ b/frontend/src/components/assistant/blocks/task-plan-card.tsx
@@ -1,0 +1,316 @@
+import { useState } from "react";
+import {
+  Check,
+  Circle,
+  CircleAlert,
+  CircleStop,
+  Clock3,
+  Loader2,
+  Minus,
+  Redo2,
+  ShieldCheck,
+  SkipForward,
+  Square,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type {
+  TaskExternalEffect,
+  TaskPlanContentBlock,
+  TaskStep,
+  TaskStepStatus,
+} from "@/types/assistant";
+
+type TaskControl = "stop" | `retry:${string}` | `skip:${string}`;
+
+const STATUS_STYLE: Record<TaskStepStatus, string> = {
+  planned: "text-text-tertiary",
+  waiting: "text-warning",
+  running: "text-nyx-secondary-400",
+  done: "text-success",
+  failed: "text-destructive",
+  skipped: "text-text-tertiary",
+  cancelled: "text-text-tertiary",
+  uncertain: "text-warning",
+};
+
+function words(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function StepIcon({ status }: { readonly status: TaskStepStatus }) {
+  const className = `h-3.5 w-3.5 shrink-0 ${STATUS_STYLE[status]}`;
+  switch (status) {
+    case "running":
+      return <Loader2 className={`${className} animate-spin`} />;
+    case "done":
+      return <Check className={className} />;
+    case "failed":
+      return <X className={className} />;
+    case "waiting":
+      return <Clock3 className={className} />;
+    case "skipped":
+      return <SkipForward className={className} />;
+    case "cancelled":
+      return <CircleStop className={className} />;
+    case "uncertain":
+      return <CircleAlert className={className} />;
+    case "planned":
+    default:
+      return <Circle className={className} />;
+  }
+}
+
+function effectStyle(effect: TaskExternalEffect): string {
+  switch (effect) {
+    case "confirmed":
+      return "border-success/25 bg-success/[0.07] text-success";
+    case "may_have_changed":
+      return "border-warning/30 bg-warning/[0.08] text-warning";
+    case "not_applied":
+      return "border-border bg-overlay text-muted-foreground";
+    case "not_started":
+    default:
+      return "border-hairline bg-transparent text-text-tertiary";
+  }
+}
+
+function StepDetails({ step }: { readonly step: TaskStep }) {
+  const sourceDetail =
+    step.source.kind === "tool" && step.source.serviceSlug
+      ? `${step.source.label} / ${step.source.serviceSlug}`
+      : step.source.label;
+  const operation = step.operation;
+  const operationDetail = operation
+    ? [
+        operation.kind,
+        operation.phase,
+        operation.operationId,
+        operation.operationGeneration
+          ? `generation ${String(operation.operationGeneration)}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" / ")
+    : "";
+
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="min-w-0 break-words text-[12px] font-medium text-foreground">
+          {step.description}
+        </span>
+        <span
+          className={`text-[10px] font-medium ${STATUS_STYLE[step.status]}`}
+        >
+          {words(step.status)}
+        </span>
+        <span
+          className={`rounded border px-1.5 py-0.5 text-[9px] font-medium ${effectStyle(step.externalEffect)}`}
+        >
+          {words(step.externalEffect)}
+        </span>
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-text-tertiary">
+        <span>{sourceDetail}</span>
+        {step.estimate ? <span>~{step.estimate.seconds}s</span> : null}
+        {step.addedInPlanRevision ? (
+          <span>revision {step.addedInPlanRevision}</span>
+        ) : null}
+      </div>
+      {operationDetail ? (
+        <div className="mt-1.5 break-words rounded bg-overlay px-2 py-1 font-mono text-[9px] text-muted-foreground">
+          {operationDetail}
+        </div>
+      ) : null}
+      {step.source.kind === "condition" ? (
+        <div className="mt-1.5 text-[10px] text-muted-foreground">
+          {step.source.condition.observedValue} gte{" "}
+          {step.source.condition.effectiveThreshold}
+          {" / "}
+          {step.source.condition.thresholdOrigin}
+          {" / "}
+          {step.source.condition.outcome}
+        </div>
+      ) : null}
+      {step.guard ? (
+        <div className="mt-1 text-[10px] text-muted-foreground">
+          Guard {step.guard.conditionStepId}: {step.guard.requiredOutcome}
+        </div>
+      ) : null}
+      {step.substeps.length > 0 ? (
+        <ul className="mt-2 space-y-1 border-l border-hairline pl-2.5">
+          {step.substeps.map((substep) => (
+            <li
+              key={substep.substepId}
+              className="flex min-w-0 items-center gap-1.5 text-[10px] text-muted-foreground"
+            >
+              {substep.status === "done" ? (
+                <Check className="h-3 w-3 shrink-0 text-success" />
+              ) : substep.status === "failed" ? (
+                <X className="h-3 w-3 shrink-0 text-destructive" />
+              ) : (
+                <Loader2 className="h-3 w-3 shrink-0 animate-spin text-nyx-secondary-400" />
+              )}
+              <span className="min-w-0 break-words">{substep.title}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {step.approvalObservation ? (
+        <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <ShieldCheck className="h-3 w-3 shrink-0" />
+          {step.approvalObservation.decisionMode} /{" "}
+          {words(step.approvalObservation.receiptStatus)}
+        </div>
+      ) : null}
+      {step.safeMessage ? (
+        <p className="mt-1.5 break-words text-[10px] text-destructive">
+          {step.safeMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function TaskPlanCard({
+  block,
+  onStop,
+  onRetry,
+  onSkip,
+}: {
+  readonly block: TaskPlanContentBlock;
+  readonly onStop: () => Promise<void>;
+  readonly onRetry: (stepId: string) => Promise<void>;
+  readonly onSkip: (stepId: string) => Promise<void>;
+}) {
+  const [pending, setPending] = useState<TaskControl | null>(null);
+  const plan = block.plan;
+  const canStop = plan.steps.some((step) => step.availableActions.stop);
+
+  async function run(control: TaskControl, action: () => Promise<void>) {
+    if (pending) return;
+    setPending(control);
+    try {
+      await action();
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <section
+      aria-label="Task plan"
+      className="overflow-hidden rounded-lg border border-border bg-card shadow-sm"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2 border-b border-border bg-overlay/50 px-3 py-2.5">
+        <div className="min-w-0 flex-1">
+          <h3 className="break-words text-[12px] font-semibold text-foreground">
+            {plan.title}
+          </h3>
+          <p className="mt-0.5 text-[10px] text-text-tertiary">
+            Revision {plan.planRevision} / state {block.state_version} /
+            sequence {block.progress_sequence}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+          <span className="rounded border border-border bg-background px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground">
+            {words(plan.status)}
+          </span>
+          {plan.gate ? (
+            <span className="rounded border border-warning/25 bg-warning/[0.07] px-1.5 py-0.5 text-[9px] font-medium text-warning">
+              {plan.gate.mode} / {plan.gate.status ?? "ready"}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      {plan.gate?.reason ? (
+        <p className="border-b border-border px-3 py-2 text-[10px] leading-relaxed text-muted-foreground">
+          {plan.gate.reason}
+        </p>
+      ) : null}
+      <ol className="divide-y divide-border">
+        {plan.steps.map((step) => (
+          <li
+            key={step.stepId}
+            className="grid grid-cols-[18px_minmax(0,1fr)] gap-2.5 px-3 py-2.5"
+          >
+            <div className="flex flex-col items-center gap-1 pt-0.5">
+              <StepIcon status={step.status} />
+              <span className="font-mono text-[9px] text-text-tertiary">
+                {step.order}
+              </span>
+            </div>
+            <div className="min-w-0">
+              <StepDetails step={step} />
+              {step.availableActions.retry || step.availableActions.skip ? (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {step.availableActions.retry ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={pending !== null}
+                      aria-label={`Retry ${step.description}`}
+                      onClick={() =>
+                        void run(`retry:${step.stepId}`, () =>
+                          onRetry(step.stepId),
+                        )
+                      }
+                    >
+                      {pending === `retry:${step.stepId}` ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <Redo2 />
+                      )}
+                      Retry
+                    </Button>
+                  ) : null}
+                  {step.availableActions.skip ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={pending !== null}
+                      aria-label={`Skip ${step.description}`}
+                      onClick={() =>
+                        void run(`skip:${step.stepId}`, () =>
+                          onSkip(step.stepId),
+                        )
+                      }
+                    >
+                      {pending === `skip:${step.stepId}` ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <Minus />
+                      )}
+                      Skip
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ol>
+      {canStop ? (
+        <div className="flex justify-end border-t border-border px-3 py-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={pending !== null}
+            onClick={() => void run("stop", onStop)}
+          >
+            {pending === "stop" ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <Square className="fill-current" />
+            )}
+            Stop task
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/assistant/blocks/task-plan-card.tsx
+++ b/frontend/src/components/assistant/blocks/task-plan-card.tsx
@@ -21,7 +21,12 @@ import type {
   TaskStepStatus,
 } from "@/types/assistant";
 
-type TaskControl = "stop" | `retry:${string}` | `skip:${string}`;
+type TaskControl =
+  | "stop"
+  | "plan:confirm"
+  | "plan:reject"
+  | `retry:${string}`
+  | `skip:${string}`;
 
 const STATUS_STYLE: Record<TaskStepStatus, string> = {
   planned: "text-text-tertiary",
@@ -178,15 +183,19 @@ export function TaskPlanCard({
   onStop,
   onRetry,
   onSkip,
+  onResolve,
 }: {
   readonly block: TaskPlanContentBlock;
   readonly onStop: () => Promise<void>;
   readonly onRetry: (stepId: string) => Promise<void>;
   readonly onSkip: (stepId: string) => Promise<void>;
+  readonly onResolve: (confirmed: boolean) => Promise<void>;
 }) {
   const [pending, setPending] = useState<TaskControl | null>(null);
   const plan = block.plan;
   const canStop = plan.steps.some((step) => step.availableActions.stop);
+  const pendingGate =
+    plan.gate?.mode === "confirm" && plan.gate.status === "pending";
 
   async function run(control: TaskControl, action: () => Promise<void>) {
     if (pending) return;
@@ -228,6 +237,40 @@ export function TaskPlanCard({
         <p className="border-b border-border px-3 py-2 text-[10px] leading-relaxed text-muted-foreground">
           {plan.gate.reason}
         </p>
+      ) : null}
+      {pendingGate ? (
+        <div className="flex flex-wrap items-center justify-end gap-1.5 border-b border-border px-3 py-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="primary"
+            disabled={pending !== null}
+            onClick={() =>
+              void run("plan:confirm", () => onResolve(true))
+            }
+          >
+            {pending === "plan:confirm" ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <Check />
+            )}
+            Confirm plan
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="destructive"
+            disabled={pending !== null}
+            onClick={() => void run("plan:reject", () => onResolve(false))}
+          >
+            {pending === "plan:reject" ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <X />
+            )}
+            Reject plan
+          </Button>
+        </div>
       ) : null}
       <ol className="divide-y divide-border">
         {plan.steps.map((step) => (

--- a/frontend/src/components/assistant/chat-composer.test.tsx
+++ b/frontend/src/components/assistant/chat-composer.test.tsx
@@ -77,13 +77,39 @@ describe("ChatComposer drafts", () => {
     expect(screen.getByRole("textbox")).toHaveValue("");
   });
 
+  it("keeps the composer writable for an active typed task and sends steering", async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ChatComposer
+        {...baseProps}
+        active
+        allowActiveInput
+        draftKey="conv:typed-task"
+        onSend={onSend}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(input).toBeEnabled();
+    expect(input).toHaveAttribute("placeholder", "Steer active task...");
+    fireEvent.change(input, {
+      target: { value: "Keep the completed search results" },
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Send steering instruction" }),
+      );
+    });
+
+    expect(onSend).toHaveBeenCalledWith("Keep the completed search results");
+    expect(baseProps.onStop).not.toHaveBeenCalled();
+  });
+
   it("restores the typed text and draft when the send rejects [guard]", async () => {
     // A dead backend must not eat the message: a rejected send puts the text
     // back in the field and re-saves the draft, so retry is one keypress.
     const onSend = vi.fn().mockRejectedValue(new Error("backend down"));
-    render(
-      <ChatComposer {...baseProps} onSend={onSend} draftKey="conv:one" />,
-    );
+    render(<ChatComposer {...baseProps} onSend={onSend} draftKey="conv:one" />);
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "Keep me" },
     });
@@ -288,7 +314,12 @@ describe("ChatComposer focus", () => {
     // one render. Reading that as "a turn just ended" would apply the
     // leave-focus-alone rule to the sidebar row the reader just clicked.
     const { rerender } = render(
-      <ChatComposer {...baseProps} active draftKey="conv:one" focusRequest={1} />,
+      <ChatComposer
+        {...baseProps}
+        active
+        draftKey="conv:one"
+        focusRequest={1}
+      />,
     );
     const sidebarRow = document.createElement("button");
     document.body.append(sidebarRow);
@@ -306,10 +337,20 @@ describe("ChatComposer focus", () => {
     // A conversation selected while its own turn is still running cannot take
     // focus yet — the request has to survive until the field comes back.
     const { rerender } = render(
-      <ChatComposer {...baseProps} active draftKey="conv:one" focusRequest={1} />,
+      <ChatComposer
+        {...baseProps}
+        active
+        draftKey="conv:one"
+        focusRequest={1}
+      />,
     );
     rerender(
-      <ChatComposer {...baseProps} active draftKey="conv:two" focusRequest={2} />,
+      <ChatComposer
+        {...baseProps}
+        active
+        draftKey="conv:two"
+        focusRequest={2}
+      />,
     );
     expect(screen.getByRole("textbox")).not.toHaveFocus();
 
@@ -332,7 +373,11 @@ describe("ChatComposer focus", () => {
     themeToggle.focus();
 
     rerender(
-      <ChatComposer {...baseProps} draftKey="conv:canonical" focusRequest={1} />,
+      <ChatComposer
+        {...baseProps}
+        draftKey="conv:canonical"
+        focusRequest={1}
+      />,
     );
 
     expect(themeToggle).toHaveFocus();
@@ -380,10 +425,20 @@ describe("ChatComposer focus", () => {
     // the field comes back; honouring it would yank focus off whatever the
     // reader picked up in the meantime.
     const { rerender } = render(
-      <ChatComposer {...baseProps} active draftKey="conv:one" focusRequest={1} />,
+      <ChatComposer
+        {...baseProps}
+        active
+        draftKey="conv:one"
+        focusRequest={1}
+      />,
     );
     rerender(
-      <ChatComposer {...baseProps} active draftKey="conv:two" focusRequest={2} />,
+      <ChatComposer
+        {...baseProps}
+        active
+        draftKey="conv:two"
+        focusRequest={2}
+      />,
     );
 
     const accountMenu = document.createElement("button");

--- a/frontend/src/components/assistant/chat-composer.tsx
+++ b/frontend/src/components/assistant/chat-composer.tsx
@@ -85,6 +85,8 @@ export function ChatComposer({
 
 interface ChatComposerProps {
   readonly active: boolean;
+  /** Keep the composer writable while a typed actor task accepts steering. */
+  readonly allowActiveInput?: boolean;
   readonly sending: boolean;
   readonly ownerUserId: string | null;
   readonly draftKey: string | null;
@@ -112,6 +114,7 @@ interface PendingDraftTransition {
 
 function DraftedChatComposer({
   active,
+  allowActiveInput = false,
   sending,
   ownerUserId,
   draftKey,
@@ -119,6 +122,7 @@ function DraftedChatComposer({
   onSend,
   onStop,
 }: ChatComposerProps) {
+  const locked = active && !allowActiveInput;
   const [content, setContent] = useState(() =>
     readOwnedDraft(ownerUserId, draftKey),
   );
@@ -337,14 +341,14 @@ function DraftedChatComposer({
    * and there is nothing new to learn.
    */
   const composerHeldFocusRef = useRef(false);
-  const renderedActiveRef = useRef(active);
-  if (renderedActiveRef.current !== active) {
-    if (active && textareaRef.current?.disabled !== true) {
+  const renderedActiveRef = useRef(locked);
+  if (renderedActiveRef.current !== locked) {
+    if (locked && textareaRef.current?.disabled !== true) {
       composerHeldFocusRef.current = Boolean(
         composerRef.current?.contains(document.activeElement),
       );
     }
-    renderedActiveRef.current = active;
+    renderedActiveRef.current = locked;
   }
 
   /**
@@ -416,7 +420,7 @@ function DraftedChatComposer({
    */
   const focusPendingRef = useRef(true);
   const seenFocusRequestRef = useRef(focusRequest);
-  const previouslyActiveRef = useRef(active);
+  const previouslyActiveRef = useRef(locked);
   const previousDraftKeyRef = useRef(draftKey);
   useEffect(() => {
     const element = textareaRef.current;
@@ -424,18 +428,17 @@ function DraftedChatComposer({
 
     const requested = seenFocusRequestRef.current !== focusRequest;
     const draftKeyMoved = previousDraftKeyRef.current !== draftKey;
-    const turnJustEnded = previouslyActiveRef.current && !active;
+    const turnJustEnded = previouslyActiveRef.current && !locked;
     seenFocusRequestRef.current = focusRequest;
     previousDraftKeyRef.current = draftKey;
-    previouslyActiveRef.current = active;
+    previouslyActiveRef.current = locked;
 
     if (requested) {
       // They just asked for this composer; nothing before it still counts.
       readerMovedOnRef.current = false;
       focusPendingRef.current = true;
     } else if (
-      (draftKeyMoved ||
-        (turnJustEnded && composerHeldFocusRef.current)) &&
+      (draftKeyMoved || (turnJustEnded && composerHeldFocusRef.current)) &&
       focusIsParked(element)
     ) {
       focusPendingRef.current = true;
@@ -461,7 +464,7 @@ function DraftedChatComposer({
     // start of what the reader was last writing.
     const caret = element.value.length;
     element.setSelectionRange(caret, caret);
-  }, [active, draftKey, focusRequest]);
+  }, [draftKey, focusRequest, locked]);
 
   function updateContent(nextContent: string) {
     contentRef.current = nextContent;
@@ -474,7 +477,7 @@ function DraftedChatComposer({
 
   async function submit() {
     const message = content.trim();
-    if (!message || active || sending) return;
+    if (!message || locked || sending) return;
     cancelScheduledSave();
     const userId = ownerUserIdRef.current;
     const key = draftKeyRef.current;
@@ -549,13 +552,15 @@ function DraftedChatComposer({
                 scheduleDraftSave();
               }}
               onScroll={handleScroll}
-              disabled={active}
+              disabled={locked}
               rows={1}
               maxLength={32_768}
               placeholder={
-                active
+                locked
                   ? "Assistant is working..."
-                  : "Message NyxID Assistant..."
+                  : allowActiveInput
+                    ? "Steer active task..."
+                    : "Message NyxID Assistant..."
               }
               className="assistant-scrollbar block min-h-8 w-full resize-none overflow-hidden bg-transparent px-0 py-1 text-[13px] leading-relaxed text-foreground outline-none transition-[height] duration-150 ease-out placeholder:text-text-tertiary disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none"
             />
@@ -576,7 +581,7 @@ function DraftedChatComposer({
             ref={controlsRef}
             className={`flex shrink-0 items-center ${multiline ? "self-end" : ""}`}
           >
-            {active ? (
+            {locked ? (
               <Button
                 type="button"
                 variant="outline"
@@ -593,7 +598,11 @@ function DraftedChatComposer({
                 size="icon"
                 disabled={!content.trim() || sending}
                 onClick={() => void submit()}
-                aria-label="Send message"
+                aria-label={
+                  allowActiveInput
+                    ? "Send steering instruction"
+                    : "Send message"
+                }
               >
                 <Send />
               </Button>

--- a/frontend/src/components/assistant/chat-thread.tsx
+++ b/frontend/src/components/assistant/chat-thread.tsx
@@ -80,6 +80,7 @@ function renderBlock(
   onStopTask: () => Promise<void>,
   onRetryStep: (stepId: string) => Promise<void>,
   onSkipStep: (stepId: string) => Promise<void>,
+  onResolvePlan: (blockId: string, confirmed: boolean) => Promise<void>,
   streaming = false,
 ) {
   if (typeof block !== "object" || block === null || !("type" in block)) {
@@ -100,6 +101,7 @@ function renderBlock(
           onStop={onStopTask}
           onRetry={onRetryStep}
           onSkip={onSkipStep}
+          onResolve={(confirmed) => onResolvePlan(typed.block_id, confirmed)}
         />
       );
     case "approval_card":
@@ -416,6 +418,7 @@ export function ChatThread({
   onStopTask = async () => undefined,
   onRetryStep = async () => undefined,
   onSkipStep = async () => undefined,
+  onResolvePlan = async () => undefined,
 }: {
   readonly messages: readonly AssistantMessage[];
   readonly thinking?: boolean;
@@ -461,6 +464,10 @@ export function ChatThread({
   readonly onStopTask?: () => Promise<void>;
   readonly onRetryStep?: (stepId: string) => Promise<void>;
   readonly onSkipStep?: (stepId: string) => Promise<void>;
+  readonly onResolvePlan?: (
+    blockId: string,
+    confirmed: boolean,
+  ) => Promise<void>;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -682,6 +689,7 @@ export function ChatThread({
                                 onStopTask,
                                 onRetryStep,
                                 onSkipStep,
+                                onResolvePlan,
                               )}
                             </div>
                           ))}
@@ -741,6 +749,7 @@ export function ChatThread({
                                 onStopTask,
                                 onRetryStep,
                                 onSkipStep,
+                                onResolvePlan,
                                 streamingGroup &&
                                   isLastBlock &&
                                   isTextBlock(block),

--- a/frontend/src/components/assistant/chat-thread.tsx
+++ b/frontend/src/components/assistant/chat-thread.tsx
@@ -14,6 +14,7 @@ import { ArtifactBlock } from "@/components/assistant/blocks/artifact-block";
 import { ConnectCard } from "@/components/assistant/blocks/connect-card";
 import { InputCard } from "@/components/assistant/blocks/input-card";
 import { RunCard } from "@/components/assistant/blocks/run-card";
+import { TaskPlanCard } from "@/components/assistant/blocks/task-plan-card";
 import { TextBlock } from "@/components/assistant/blocks/text-block";
 import { useFadingPresence } from "@/hooks/use-fading-presence";
 import haloSheet from "@/assets/halo-sheet.webp";
@@ -76,6 +77,9 @@ function renderBlock(
   onActionProgress: (blockId: string, inProgress: boolean) => void,
   onBlockAction: (blockId: string, note: string) => void,
   onResolveAction: (report: ActionReport) => Promise<void>,
+  onStopTask: () => Promise<void>,
+  onRetryStep: (stepId: string) => Promise<void>,
+  onSkipStep: (stepId: string) => Promise<void>,
   streaming = false,
 ) {
   if (typeof block !== "object" || block === null || !("type" in block)) {
@@ -89,6 +93,15 @@ function renderBlock(
       return <ConnectCard block={typed} />;
     case "run":
       return <RunCard block={typed} />;
+    case "task_plan":
+      return (
+        <TaskPlanCard
+          block={typed}
+          onStop={onStopTask}
+          onRetry={onRetryStep}
+          onSkip={onSkipStep}
+        />
+      );
     case "approval_card":
       return (
         <ApprovalCard
@@ -400,6 +413,9 @@ export function ChatThread({
   onActionProgress = () => undefined,
   onBlockAction = () => undefined,
   onResolveAction = async () => undefined,
+  onStopTask = async () => undefined,
+  onRetryStep = async () => undefined,
+  onSkipStep = async () => undefined,
 }: {
   readonly messages: readonly AssistantMessage[];
   readonly thinking?: boolean;
@@ -442,6 +458,9 @@ export function ChatThread({
   readonly onActionProgress?: (blockId: string, inProgress: boolean) => void;
   readonly onBlockAction?: (blockId: string, note: string) => void;
   readonly onResolveAction?: (report: ActionReport) => Promise<void>;
+  readonly onStopTask?: () => Promise<void>;
+  readonly onRetryStep?: (stepId: string) => Promise<void>;
+  readonly onSkipStep?: (stepId: string) => Promise<void>;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -660,6 +679,9 @@ export function ChatThread({
                                 onActionProgress,
                                 onBlockAction,
                                 onResolveAction,
+                                onStopTask,
+                                onRetryStep,
+                                onSkipStep,
                               )}
                             </div>
                           ))}
@@ -716,6 +738,9 @@ export function ChatThread({
                                 onActionProgress,
                                 onBlockAction,
                                 onResolveAction,
+                                onStopTask,
+                                onRetryStep,
+                                onSkipStep,
                                 streamingGroup &&
                                   isLastBlock &&
                                   isTextBlock(block),

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -870,6 +870,25 @@ export function useSkipStep(conversationId: string | undefined) {
   });
 }
 
+export function useResolvePlan(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      blockId,
+      confirmed,
+    }: {
+      readonly blockId: string;
+      readonly confirmed: boolean;
+    }): Promise<void> => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      await assistantTransport.resolvePlan(conversationId, blockId, confirmed);
+      await projectTransportState(queryClient, conversationId);
+    },
+    onError: (error) =>
+      taskControlError("Plan decision was not delivered", error),
+  });
+}
+
 export function useDecideApproval(conversationId: string | undefined) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -812,6 +812,64 @@ export function useCancelTurn(conversationId: string | undefined) {
   });
 }
 
+function taskControlError(title: string, error: unknown): void {
+  toast.error(title, {
+    description:
+      error instanceof Error && error.message
+        ? error.message
+        : "The actor did not accept this control. Refresh the conversation and try again.",
+  });
+}
+
+export function useStopTask(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      await assistantTransport.stopTask(conversationId);
+      activeHandles.delete(conversationId);
+      await projectTransportState(queryClient, conversationId);
+    },
+    onError: (error) => taskControlError("Task was not stopped", error),
+  });
+}
+
+export function useSteerTask(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (instruction: string): Promise<void> => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      await assistantTransport.steerTask(conversationId, instruction);
+      await projectTransportState(queryClient, conversationId);
+    },
+    onError: (error) => taskControlError("Steering was not delivered", error),
+  });
+}
+
+export function useRetryStep(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (stepId: string): Promise<void> => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      await assistantTransport.retryStep(conversationId, stepId);
+      await projectTransportState(queryClient, conversationId);
+    },
+    onError: (error) => taskControlError("Step was not retried", error),
+  });
+}
+
+export function useSkipStep(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (stepId: string): Promise<void> => {
+      if (!conversationId) throw new Error("Select a conversation first.");
+      await assistantTransport.skipStep(conversationId, stepId);
+      await projectTransportState(queryClient, conversationId);
+    },
+    onError: (error) => taskControlError("Step was not skipped", error),
+  });
+}
+
 export function useDecideApproval(conversationId: string | undefined) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -728,6 +728,128 @@ describe("AevatarAssistantTransport", () => {
     ]);
   });
 
+  it("resolves the exact fresh plan gate and refreshes committed state after acceptance", async () => {
+    const pendingTask = {
+      ...taskPlanFixture(),
+      gate: {
+        mode: "confirm",
+        status: "pending",
+        requestId: "plan-gate-current-1",
+        taskId: "task-current-1",
+        planId: "plan-current-1",
+        planRevision: 2,
+      },
+    };
+    const satisfiedTask = {
+      ...pendingTask,
+      gate: { ...pendingTask.gate, status: "satisfied" },
+    };
+    let stateReads = 0;
+    const fetchMock = stubFetch(
+      routeHistory([]),
+      (url, init) => {
+        if (!url.endsWith("/state") || (init?.method ?? "GET") !== "GET") {
+          return undefined;
+        }
+        stateReads += 1;
+        const activeTask = stateReads <= 2 ? pendingTask : satisfiedTask;
+        return jsonResponse(
+          currentTaskState(50 + stateReads, {}, { activeTask }),
+        );
+      },
+      (url, init) =>
+        isTypedCommandRequest(url, init, "plan.resolve")
+          ? jsonResponse({ status: "accepted" }, 202)
+          : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await transport.getHistory(CONVERSATION_ID);
+
+    await transport.resolvePlan(
+      CONVERSATION_ID,
+      "current-task-plan:task-current-1",
+      true,
+    );
+
+    const post = fetchMock.mock.calls.find(([input, init]) =>
+      isTypedCommandRequest(
+        String(input),
+        init as RequestInit | undefined,
+        "plan.resolve",
+      ),
+    );
+    expect(jsonRequestBody(post?.[1] as RequestInit | undefined)).toEqual({
+      type: "plan.resolve",
+      conversationId: CONVERSATION_ID,
+      taskId: "task-current-1",
+      planId: "plan-current-1",
+      requestId: "plan-gate-current-1",
+      clientRequestId: expect.any(String),
+      planRevision: 2,
+      confirmed: true,
+      expectedStateVersion: 52,
+    });
+    expect(stateReads).toBe(3);
+    const refreshed = await transport.getHistory(CONVERSATION_ID);
+    const plan = refreshed.messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "task_plan");
+    expect(plan?.type === "task_plan" && plan.plan.gate?.status).toBe(
+      "satisfied",
+    );
+  });
+
+  it("rejects a stale clicked plan gate when fresh state has another request", async () => {
+    const clickedTask = {
+      ...taskPlanFixture(),
+      gate: {
+        mode: "confirm",
+        status: "pending",
+        requestId: "plan-gate-clicked",
+        taskId: "task-current-1",
+        planId: "plan-current-1",
+        planRevision: 2,
+      },
+    };
+    const freshTask = {
+      ...clickedTask,
+      gate: { ...clickedTask.gate, requestId: "plan-gate-fresh" },
+    };
+    let stateReads = 0;
+    const fetchMock = stubFetch(routeHistory([]), (url, init) => {
+      if (!url.endsWith("/state") || (init?.method ?? "GET") !== "GET") {
+        return undefined;
+      }
+      stateReads += 1;
+      return jsonResponse(
+        currentTaskState(60 + stateReads, {}, {
+          activeTask: stateReads === 1 ? clickedTask : freshTask,
+        }),
+      );
+    });
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+    await transport.getHistory(CONVERSATION_ID);
+
+    await expect(
+      transport.resolvePlan(
+        CONVERSATION_ID,
+        "current-task-plan:task-current-1",
+        false,
+      ),
+    ).rejects.toThrow("exact plan gate");
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(
+          String(input),
+          init as RequestInit | undefined,
+          "plan.resolve",
+        ),
+      ),
+    ).toHaveLength(0);
+  });
+
   it.each([
     [
       "an unavailable Retry",

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -136,6 +136,78 @@ function actionRequestFrame(
   };
 }
 
+function taskStepFixture(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    stepId: "step-task-1",
+    order: 1,
+    kind: "tool",
+    status: "running",
+    required: true,
+    description: "Run the connected service operation",
+    source: { tool: { toolName: "connected_service_operation" } },
+    mayChangeExternalState: false,
+    externalEffect: "not_started",
+    availableActions: { retry: false, skip: false, stop: true },
+    dependsOn: [],
+    substeps: [],
+    operation: {
+      turnId: TURN_ID,
+      taskId: "task-current-1",
+      stepId: "step-task-1",
+      operationId: "operation-task-1",
+      operationGeneration: 2,
+      kind: "tool",
+      phase: "running",
+    },
+    ...overrides,
+  };
+}
+
+function taskPlanFixture(
+  stepOverrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    schemaVersion: 4,
+    actorId: CONVERSATION_ID,
+    taskId: "task-current-1",
+    turnId: TURN_ID,
+    planId: "plan-current-1",
+    planRevision: 2,
+    planRevisions: [],
+    title: "Current actor task",
+    status: "active",
+    activeStepId: "step-task-1",
+    gate: { mode: "auto", status: "satisfied" },
+    steps: [taskStepFixture(stepOverrides)],
+  };
+}
+
+function currentTaskState(
+  stateVersion: number,
+  stepOverrides: Record<string, unknown> = {},
+  snapshotOverrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    status: "current",
+    stateVersion,
+    snapshot: {
+      actorId: CONVERSATION_ID,
+      stateVersion,
+      progressSequence: 12,
+      activeTurn: { turnId: TURN_ID, status: "active" },
+      latestTurn: { turnId: TURN_ID, status: "active" },
+      activeTask: taskPlanFixture(stepOverrides),
+      pendingInput: null,
+      pendingApproval: null,
+      pendingActions: [],
+      recentActions: [],
+      ...snapshotOverrides,
+    },
+  };
+}
+
 type FetchRoute = (
   url: string,
   init: RequestInit | undefined,
@@ -344,6 +416,7 @@ function routeStream(frames: unknown[]): FetchRoute {
 function routeHistory(body: unknown): FetchRoute {
   return (url, init) =>
     url.startsWith(`${ASSISTANT_BASE}/conversations/`) &&
+    !url.endsWith("/state") &&
     (init?.method ?? "GET") === "GET"
       ? jsonResponse(body)
       : undefined;
@@ -469,6 +542,220 @@ describe("AevatarAssistantTransport", () => {
         error: terminal.error,
       },
     ).toEqual({ status: "completed", error: null });
+  });
+
+  it("hydrates one current TaskPlan, input, approval, and action card across reloads", async () => {
+    const action = {
+      schemaVersion: 4,
+      actorId: CONVERSATION_ID,
+      originTurnId: TURN_ID,
+      taskId: "task-current-1",
+      stepId: "step-task-1",
+      actionRequestId: "action-current-1",
+      action: "service.connect",
+      params: {
+        catalogService: {
+          serviceSlug: "api-github",
+          requestedScopes: ["repo"],
+        },
+      },
+    };
+    stubFetch(routeHistory([]), (url, init) =>
+      url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+        ? jsonResponse(
+            currentTaskState(
+              41,
+              {},
+              {
+                pendingInput: {
+                  requestId: "input-current-1",
+                  prompt: "Choose an environment",
+                  options: [
+                    { optionId: "staging", label: "Staging" },
+                    { optionId: "production", label: "Production" },
+                  ],
+                  allowFreeText: false,
+                  multiSelect: false,
+                },
+                pendingApproval: {
+                  approvalRequestId: "approval-current-1",
+                  toolName: "deploy_release",
+                  message: "Deploy the selected release?",
+                },
+                pendingActions: [
+                  { actionRequestId: "action-current-1", request: action },
+                ],
+                recentActions: [
+                  { actionRequestId: "action-current-1", request: action },
+                ],
+              },
+            ),
+          )
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+
+    for (let reload = 0; reload < 2; reload += 1) {
+      const history = await transport.getHistory(CONVERSATION_ID);
+      const managed = history.messages
+        .flatMap((message) => message.blocks)
+        .filter((block) =>
+          ["task_plan", "input_card", "approval_card", "action_card"].includes(
+            block.type,
+          ),
+        );
+      expect(managed.map((block) => block.type)).toEqual([
+        "task_plan",
+        "input_card",
+        "approval_card",
+        "action_card",
+      ]);
+      expect(
+        managed.every((block) => block.block_id.startsWith("current-")),
+      ).toBe(true);
+    }
+  });
+
+  it("projects the same TaskPlan from a live snapshot and a reloaded state", async () => {
+    stubFetch(
+      routeStream([
+        { type: "RUN_STARTED", turnId: TURN_ID, actorId: CONVERSATION_ID },
+        {
+          type: "CUSTOM",
+          sequence: 12,
+          custom: { name: "nyxid.task.snapshot", payload: taskPlanFixture() },
+        },
+        { type: "RUN_FINISHED" },
+      ]),
+      routeHistory([]),
+      (url, init) =>
+        url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+          ? jsonResponse(currentTaskState(42))
+          : undefined,
+    );
+    const liveTransport = new AevatarAssistantTransport();
+    await seedActorConversation(liveTransport);
+    const liveEvents = await collectTurn(liveTransport, "Run the current task");
+    const livePlan = liveEvents
+      .filter(
+        (event): event is Extract<TurnEvent, { event: "block.started" }> =>
+          event.event === "block.started",
+      )
+      .map((event) => event.block)
+      .find((block) => block.type === "task_plan");
+
+    const reloadedTransport = new AevatarAssistantTransport();
+    await seedActorConversation(reloadedTransport);
+    const reloadedPlan = (
+      await reloadedTransport.getHistory(CONVERSATION_ID)
+    ).messages
+      .flatMap((message) => message.blocks)
+      .find((block) => block.type === "task_plan");
+
+    expect(livePlan?.type === "task_plan" && livePlan.plan).toEqual(
+      reloadedPlan?.type === "task_plan" && reloadedPlan.plan,
+    );
+  });
+
+  it("sends actor controls with exact state and operation fences", async () => {
+    const fetchMock = stubFetch(
+      (url, init) =>
+        url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+          ? jsonResponse(
+              currentTaskState(47, {
+                availableActions: { retry: true, skip: true, stop: true },
+              }),
+            )
+          : undefined,
+      (url, init) =>
+        isTypedCommandRequest(url, init)
+          ? jsonResponse({ status: "accepted" }, 202)
+          : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+
+    await transport.stopTask(CONVERSATION_ID);
+    await transport.steerTask(CONVERSATION_ID, "Focus on the release branch");
+    await transport.retryStep(CONVERSATION_ID, "step-task-1");
+    await transport.skipStep(CONVERSATION_ID, "step-task-1");
+
+    const bodies = fetchMock.mock.calls
+      .filter(([input, init]) =>
+        isTypedCommandRequest(String(input), init as RequestInit | undefined),
+      )
+      .map(([, init]) => jsonRequestBody(init as RequestInit | undefined));
+    expect(bodies).toEqual([
+      {
+        type: "task.stop",
+        conversationId: CONVERSATION_ID,
+        turnId: TURN_ID,
+        stopRequestId: expect.any(String),
+        clientRequestId: expect.any(String),
+        expectedStateVersion: 47,
+      },
+      {
+        type: "task.steer",
+        conversationId: CONVERSATION_ID,
+        turnId: TURN_ID,
+        steeringId: expect.any(String),
+        clientRequestId: expect.any(String),
+        instruction: "Focus on the release branch",
+        expectedStateVersion: 47,
+      },
+      {
+        type: "step.retry",
+        conversationId: CONVERSATION_ID,
+        turnId: TURN_ID,
+        taskId: "task-current-1",
+        stepId: "step-task-1",
+        retryRequestId: expect.any(String),
+        clientRequestId: expect.any(String),
+        expectedOperationGeneration: 2,
+        expectedStateVersion: 47,
+      },
+      {
+        type: "step.skip",
+        conversationId: CONVERSATION_ID,
+        turnId: TURN_ID,
+        taskId: "task-current-1",
+        stepId: "step-task-1",
+        skipRequestId: expect.any(String),
+        clientRequestId: expect.any(String),
+        expectedOperationGeneration: 2,
+        expectedStateVersion: 47,
+      },
+    ]);
+  });
+
+  it.each([
+    [
+      "an unavailable Retry",
+      currentTaskState(49),
+      (transport: AevatarAssistantTransport) =>
+        transport.retryStep(CONVERSATION_ID, "step-task-1"),
+    ],
+    [
+      "reload_required state",
+      { status: "reload_required" },
+      (transport: AevatarAssistantTransport) =>
+        transport.stopTask(CONVERSATION_ID),
+    ],
+  ])("rejects %s without posting a command", async (_label, state, invoke) => {
+    const fetchMock = stubFetch((url, init) =>
+      url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+        ? jsonResponse(state)
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+
+    await expect(invoke(transport)).rejects.toThrow();
+    expect(
+      fetchMock.mock.calls.filter(([input, init]) =>
+        isTypedCommandRequest(String(input), init as RequestInit | undefined),
+      ),
+    ).toHaveLength(0);
   });
 
   it("serves the streamed transcript from the local mirror during and after the turn", async () => {
@@ -670,7 +957,7 @@ describe("AevatarAssistantTransport", () => {
     const getCalls = fetchMock.mock.calls.filter(
       ([, init]) => (init?.method ?? "GET") === "GET",
     );
-    expect(getCalls).toHaveLength(2);
+    expect(getCalls).toHaveLength(3);
     for (const [, init] of getCalls) {
       expect(init?.headers).toMatchObject({ Accept: "application/json" });
     }
@@ -951,6 +1238,10 @@ describe("AevatarAssistantTransport", () => {
     const stopBodies: Array<Record<string, unknown>> = [];
     let streamClientRequestId: string | undefined;
     stubFetch(
+      (url, init) =>
+        url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+          ? jsonResponse(currentTaskState(17))
+          : undefined,
       (url, init) => {
         if (
           url === `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/stop` &&
@@ -995,7 +1286,7 @@ describe("AevatarAssistantTransport", () => {
     expect(stopBodies).toHaveLength(1);
     const stop = stopBodies[0];
     expect(stop?.turnId).toBe(TURN_ID);
-    expect(stop?.expectedStateVersion).toBe(0);
+    expect(stop?.expectedStateVersion).toBe(17);
     // Fresh control identities: neither reuses the turn's clientRequestId.
     expect(stop?.stopRequestId).toMatch(/^[0-9a-f-]{36}$/);
     expect(stop?.clientRequestId).toMatch(/^[0-9a-f-]{36}$/);
@@ -1053,6 +1344,10 @@ describe("AevatarAssistantTransport", () => {
     });
     const stopBodies: Array<Record<string, unknown>> = [];
     stubFetch(
+      (url, init) =>
+        url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+          ? jsonResponse(currentTaskState(18))
+          : undefined,
       (url, init) => {
         if (url.endsWith("/stop") && init?.method === "POST") {
           stopBodies.push(
@@ -1094,7 +1389,7 @@ describe("AevatarAssistantTransport", () => {
 
     expect(stopBodies).toHaveLength(1);
     expect(stopBodies[0]?.turnId).toBe(TURN_ID);
-    expect(stopBodies[0]?.expectedStateVersion).toBe(0);
+    expect(stopBodies[0]?.expectedStateVersion).toBe(18);
   });
 
   it("fences a follow-up send behind a pre-start cancel until the deferred stop settles", async () => {
@@ -1121,6 +1416,9 @@ describe("AevatarAssistantTransport", () => {
           return Promise.resolve(
             jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
           );
+        }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          return Promise.resolve(jsonResponse(currentTaskState(19)));
         }
         if (url.endsWith("/stop") && init?.method === "POST") {
           stopCalls += 1;
@@ -1201,6 +1499,9 @@ describe("AevatarAssistantTransport", () => {
           return Promise.resolve(
             jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
           );
+        }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          return Promise.resolve(jsonResponse(currentTaskState(20)));
         }
         if (url.endsWith("/stop") && init?.method === "POST") {
           stopCalls += 1;
@@ -1289,6 +1590,9 @@ describe("AevatarAssistantTransport", () => {
           return Promise.resolve(
             jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
           );
+        }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          return Promise.resolve(jsonResponse(currentTaskState(21)));
         }
         if (url.endsWith("/stop") && init?.method === "POST") {
           stopCalls += 1;
@@ -1389,6 +1693,9 @@ describe("AevatarAssistantTransport", () => {
             jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
           );
         }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          return Promise.resolve(jsonResponse(currentTaskState(22)));
+        }
         if (url.endsWith("/stop") && init?.method === "POST") {
           return new Promise<Response>((resolve) => {
             releaseStop = () =>
@@ -1474,6 +1781,9 @@ describe("AevatarAssistantTransport", () => {
           return Promise.resolve(
             jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
           );
+        }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          return Promise.resolve(jsonResponse(currentTaskState(23)));
         }
         if (url.endsWith("/stop") && init?.method === "POST") {
           return Promise.resolve(jsonResponse({ status: "accepted" }, 202));
@@ -1750,17 +2060,17 @@ describe("AevatarAssistantTransport", () => {
           stateReads += 1;
           return Promise.resolve(
             jsonResponse(
-              stateReads === 1
-                ? {
-                    status: "current",
-                    stateVersion: 70,
-                    snapshot: {
-                      actorId: CONVERSATION_ID,
-                      stateVersion: 70,
+              stateReads <= 2
+                ? currentTaskState(
+                    70,
+                    {},
+                    {
+                      activeTurn: { turnId: "turn-2", status: "active" },
+                      latestTurn: { turnId: "turn-2", status: "active" },
                       attentionKind: "approval",
                       pendingApproval: { approvalRequestId: "req-fence" },
                     },
-                  }
+                  )
                 : {
                     status: "current",
                     stateVersion: 71,
@@ -1881,6 +2191,9 @@ describe("AevatarAssistantTransport", () => {
             jsonResponse({ status: "accepted", actorId: CONVERSATION_ID }),
           );
         }
+        if (url.endsWith("/state") && (init?.method ?? "GET") === "GET") {
+          return Promise.resolve(jsonResponse(currentTaskState(24)));
+        }
         if (url.endsWith("/stop") && init?.method === "POST") {
           return new Promise<Response>((resolve) => {
             releaseStop = () =>
@@ -1954,6 +2267,10 @@ describe("AevatarAssistantTransport", () => {
       },
     });
     stubFetch(
+      (url, init) =>
+        url.endsWith("/state") && (init?.method ?? "GET") === "GET"
+          ? jsonResponse(currentTaskState(25))
+          : undefined,
       (url, init) =>
         url.endsWith("/stop") && init?.method === "POST"
           ? jsonResponse(
@@ -2568,12 +2885,17 @@ describe("live AG-UI frame taxonomy", () => {
     ...states: readonly Record<string, unknown>[]
   ): FetchRoute {
     let readIndex = 0;
+    let hydrationPending = true;
     return (url, init) => {
       if (
         url !== `${ASSISTANT_BASE}/conversations/${CONVERSATION_ID}/state` ||
         (init?.method ?? "GET") !== "GET"
       ) {
         return undefined;
+      }
+      if (hydrationPending) {
+        hydrationPending = false;
+        return jsonResponse({ message: "not materialized" }, 404);
       }
       const state = states[Math.min(readIndex, states.length - 1)];
       readIndex += 1;
@@ -3019,9 +3341,9 @@ describe("live AG-UI frame taxonomy", () => {
         "approval.resolve",
       ),
     );
-    expect(stateCallIndexes).toHaveLength(2);
-    expect(stateCallIndexes[0]).toBeLessThan(postIndex);
-    expect(postIndex).toBeLessThan(stateCallIndexes[1] ?? -1);
+    expect(stateCallIndexes).toHaveLength(3);
+    expect(stateCallIndexes[1]).toBeLessThan(postIndex);
+    expect(postIndex).toBeLessThan(stateCallIndexes[2] ?? -1);
     expect(events.map((event) => event.event)).toEqual([
       "block.updated",
       "block.updated",
@@ -3099,7 +3421,7 @@ describe("live AG-UI frame taxonomy", () => {
       fetchMock.mock.calls.filter(([input]) =>
         String(input).endsWith("/state"),
       ),
-    ).toHaveLength(4);
+    ).toHaveLength(5);
     expect(events.at(-1)).toMatchObject({
       event: "block.updated",
       patch: {
@@ -3142,6 +3464,9 @@ describe("live AG-UI frame taxonomy", () => {
         }
         stateReads += 1;
         if (stateReads === 1) {
+          return jsonResponse({ message: "not materialized" }, 404);
+        }
+        if (stateReads === 2) {
           return jsonResponse(decisionStateEnvelope("input", "input-1", 41));
         }
         return new Response(
@@ -3506,7 +3831,7 @@ describe("live AG-UI frame taxonomy", () => {
       fetchMock.mock.calls.filter(([input]) =>
         String(input).endsWith("/state"),
       ),
-    ).toHaveLength(5);
+    ).toHaveLength(7);
   });
 
   it("absorbs a late committed input before retrying without a second POST", async () => {
@@ -3863,7 +4188,7 @@ describe("live AG-UI frame taxonomy", () => {
       fetchMock.mock.calls.filter(([input]) =>
         String(input).endsWith("/state"),
       ),
-    ).toHaveLength(5);
+    ).toHaveLength(7);
   });
 
   it("absorbs a late committed approval before retrying without a second POST", async () => {
@@ -6288,6 +6613,7 @@ describe("assistant prose fences stay inert", () => {
   it("renders wrapped history responses with fences as plain text", async () => {
     stubFetch((url, init) =>
       url.startsWith(`${ASSISTANT_BASE}/conversations/`) &&
+      !url.endsWith("/state") &&
       (init?.method ?? "GET") === "GET"
         ? jsonResponse({
             messages: [

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -50,6 +50,13 @@ import {
   EMPTY_TURN_STATE,
   toTerminalBlock,
 } from "@/lib/assistant/stream";
+import {
+  applyCurrentTaskState,
+  createTaskProjection,
+  reduceTaskFrame,
+  taskCan,
+  type AssistantTaskProjection,
+} from "@/lib/assistant/task-state";
 import type {
   ActionCardContentBlock,
   ActionCardStatus,
@@ -62,6 +69,8 @@ import type {
   ConversationHistory,
   InputCardContentBlock,
   RunContentBlock,
+  TaskPlanContentBlock,
+  TaskStep,
   TurnEvent,
   TurnHandle,
   TurnReducerState,
@@ -617,6 +626,8 @@ interface StoredConversation {
   actionRequestFingerprints: Map<string, string>;
   /** Server turn ownership for client-only activity messages. */
   activityMessageTurnIds: Map<string, string | null>;
+  /** Actor-owned task projection shared by live CUSTOM and `/state`. */
+  taskProjection?: AssistantTaskProjection;
   /** Epoch milliseconds of the latest turn.completed applied to this mirror. */
   lastLocalTurnCompletedAt?: number;
   /**
@@ -1702,6 +1713,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       turnState: EMPTY_TURN_STATE,
       actionRequestFingerprints: new Map(),
       activityMessageTurnIds: new Map(),
+      taskProjection: undefined,
     });
     this.activeConversationId = conversation.id;
     return conversation;
@@ -2099,6 +2111,15 @@ export class AevatarAssistantTransport implements AssistantTransport {
     ) {
       throw new AssistantConversationNotFoundError();
     }
+    if (TYPED_SERVER_CONVERSATION_ID_PATTERN.test(conversationId)) {
+      await this.hydrateTaskState(conversationId, stored);
+      if (
+        scopeId !== this.ensureScope() ||
+        this.deletedConversationIds.has(conversationId)
+      ) {
+        throw new AssistantConversationNotFoundError();
+      }
+    }
     this.activateConversation(conversationId, stored);
     return this.historyFromStored(stored);
   }
@@ -2153,6 +2174,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       turnState: EMPTY_TURN_STATE,
       actionRequestFingerprints: new Map(),
       activityMessageTurnIds: new Map(),
+      taskProjection: undefined,
       ...facts,
     };
   }
@@ -2743,6 +2765,90 @@ export class AevatarAssistantTransport implements AssistantTransport {
         return;
       }
     }
+  }
+
+  async stopTask(conversationId: string): Promise<void> {
+    this.ensureScope();
+    const requestedId = conversationId;
+    conversationId = this.canonicalConversationId(conversationId);
+    this.assertTypedTaskConversation(conversationId);
+    if (this.deletingConversations.has(conversationId)) {
+      throw new Error("This conversation is being deleted.");
+    }
+    const controller = this.scopeController();
+    const operation = this.dispatchTaskStop(
+      conversationId,
+      crypto.randomUUID(),
+      controller.signal,
+    );
+    this.trackFence(
+      conversationId,
+      operation.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    try {
+      await operation;
+      const run =
+        this.running.get(requestedId) ?? this.running.get(conversationId);
+      if (run) {
+        this.closeOpenMessage(conversationId, run);
+        this.finalizeActivity(conversationId, run, "cancelled");
+        this.finishTurn(conversationId, run, "cancelled", null);
+        run.controller.abort();
+      }
+    } finally {
+      controller.abort();
+      this.releaseScopeController(controller);
+    }
+  }
+
+  async steerTask(conversationId: string, instruction: string): Promise<void> {
+    this.ensureScope();
+    conversationId = this.canonicalConversationId(conversationId);
+    this.assertTypedTaskConversation(conversationId);
+    const normalized = instruction.trim();
+    if (!normalized || instruction.length > MAX_MESSAGE_CHARS) {
+      throw new Error("Steering must contain between 1 and 32768 characters.");
+    }
+    const controller = this.scopeController();
+    try {
+      const projection = await this.readTaskControlProjection(
+        conversationId,
+        controller.signal,
+      );
+      const turnId = protoString(projection.activeTurn?.["turnId"]);
+      if (!turnId) {
+        throw new AssistantProtocolError(
+          "The assistant no longer has active work to steer.",
+        );
+      }
+      await assistantApi.post(
+        `${ASSISTANT_PREFIX}/chat`,
+        {
+          type: "task.steer",
+          conversationId,
+          turnId,
+          steeringId: crypto.randomUUID(),
+          clientRequestId: crypto.randomUUID(),
+          instruction,
+          expectedStateVersion: projection.stateVersion,
+        },
+        controller.signal,
+      );
+    } finally {
+      controller.abort();
+      this.releaseScopeController(controller);
+    }
+  }
+
+  async retryStep(conversationId: string, stepId: string): Promise<void> {
+    await this.dispatchStepControl(conversationId, stepId, "retry");
+  }
+
+  async skipStep(conversationId: string, stepId: string): Promise<void> {
+    await this.dispatchStepControl(conversationId, stepId, "skip");
   }
 
   /** Submit a version-fenced approval decision and project JSON acceptance. */
@@ -3542,6 +3648,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       actionRequestFingerprints:
         existing?.actionRequestFingerprints ?? new Map(),
       activityMessageTurnIds: existing?.activityMessageTurnIds ?? new Map(),
+      taskProjection: existing?.taskProjection,
       lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion: existing?.stateVersion,
       identityPending: existing?.identityPending,
@@ -3562,6 +3669,459 @@ export class AevatarAssistantTransport implements AssistantTransport {
       `${ASSISTANT_PREFIX}/conversations/${conversationId}`,
     );
     return this.applyHistoryResponse(conversationId, body);
+  }
+
+  private async hydrateTaskState(
+    conversationId: string,
+    stored: StoredConversation,
+  ): Promise<void> {
+    let response: unknown;
+    try {
+      response = await assistantApi.get<unknown>(
+        `${ASSISTANT_PREFIX}/conversations/${encodeURIComponent(conversationId)}/state`,
+      );
+    } catch (error) {
+      if (!(error instanceof ApiError && error.status === 404)) throw error;
+      // Older typed conversations can have a valid transcript while their
+      // actor current-state projection is unavailable. Keep the richer local
+      // live/history mirror in that case; treating 404 as an authoritative
+      // empty snapshot would erase input, approval, and action cards.
+      if (stored.turnState.messages.length > 0) return;
+      response = { status: "not_found" };
+    }
+    const current = applyCurrentTaskState(
+      stored.taskProjection ?? createTaskProjection(conversationId),
+      response,
+    );
+    if (current.reload) {
+      throw new AssistantProtocolError(
+        "The assistant requested an unconditional state reload for an unconditional request.",
+      );
+    }
+    stored.taskProjection = current.projection;
+    if (current.projection.stateVersion > 0) {
+      stored.stateVersion = Math.max(
+        stored.stateVersion ?? 0,
+        current.projection.stateVersion,
+      );
+      advanceReceiptFence(conversationId, current.projection.stateVersion);
+    }
+    this.materializeCurrentStateBlocks(stored);
+  }
+
+  private assertTypedTaskConversation(conversationId: string): void {
+    if (!TYPED_SERVER_CONVERSATION_ID_PATTERN.test(conversationId)) {
+      throw new AssistantProtocolError(
+        "Task controls require a typed assistant conversation.",
+      );
+    }
+  }
+
+  private async readTaskControlProjection(
+    conversationId: string,
+    signal: AbortSignal,
+  ): Promise<AssistantTaskProjection> {
+    const stored = this.conversations.get(conversationId);
+    if (!stored) throw new AssistantConversationNotFoundError();
+    const response = await assistantApi.get<unknown>(
+      `${ASSISTANT_PREFIX}/conversations/${encodeURIComponent(conversationId)}/state`,
+      signal,
+    );
+    const current = applyCurrentTaskState(
+      stored.taskProjection ?? createTaskProjection(conversationId),
+      response,
+    );
+    if (
+      current.reload ||
+      current.projection.stateVersion <= 0 ||
+      current.projection.actorId !== conversationId
+    ) {
+      throw new AssistantProtocolError(
+        "The assistant state is not current. Refresh the conversation and try again.",
+      );
+    }
+    stored.taskProjection = current.projection;
+    stored.stateVersion = Math.max(
+      stored.stateVersion ?? 0,
+      current.projection.stateVersion,
+    );
+    this.materializeCurrentStateBlocks(stored);
+    return current.projection;
+  }
+
+  private async dispatchTaskStop(
+    conversationId: string,
+    stopRequestId: string,
+    signal: AbortSignal,
+    expectedTurnId?: string,
+  ): Promise<void> {
+    const projection = await this.readTaskControlProjection(
+      conversationId,
+      signal,
+    );
+    const turnId = protoString(projection.activeTurn?.["turnId"]);
+    if (
+      !turnId ||
+      (expectedTurnId && expectedTurnId !== turnId) ||
+      !taskCan(projection, "stop")
+    ) {
+      throw new AssistantProtocolError(
+        "The actor no longer offers Stop for this task version.",
+      );
+    }
+    await assistantApi.post(
+      `${ASSISTANT_PREFIX}/chat`,
+      {
+        type: "task.stop",
+        conversationId,
+        turnId,
+        stopRequestId,
+        clientRequestId: crypto.randomUUID(),
+        expectedStateVersion: projection.stateVersion,
+      },
+      signal,
+    );
+  }
+
+  private async dispatchStepControl(
+    conversationId: string,
+    stepId: string,
+    action: "retry" | "skip",
+  ): Promise<void> {
+    this.ensureScope();
+    conversationId = this.canonicalConversationId(conversationId);
+    this.assertTypedTaskConversation(conversationId);
+    if (this.deletingConversations.has(conversationId)) {
+      throw new Error("This conversation is being deleted.");
+    }
+    const controller = this.scopeController();
+    try {
+      const projection = await this.readTaskControlProjection(
+        conversationId,
+        controller.signal,
+      );
+      const step: TaskStep | undefined = projection.steps.get(stepId);
+      const turnId =
+        step?.operation?.turnId ??
+        protoString(projection.activeTurn?.["turnId"]);
+      const taskId = step?.operation?.taskId ?? projection.task?.taskId;
+      const operationGeneration = step?.operation?.operationGeneration;
+      if (
+        !step ||
+        !turnId ||
+        !taskId ||
+        !Number.isSafeInteger(operationGeneration) ||
+        (operationGeneration ?? 0) <= 0 ||
+        !taskCan(projection, action, stepId)
+      ) {
+        throw new AssistantProtocolError(
+          `The actor no longer offers ${action === "retry" ? "Retry" : "Skip"} for this step version.`,
+        );
+      }
+      const requestId = crypto.randomUUID();
+      await assistantApi.post(
+        `${ASSISTANT_PREFIX}/chat`,
+        action === "retry"
+          ? {
+              type: "step.retry",
+              conversationId,
+              turnId,
+              taskId,
+              stepId,
+              retryRequestId: requestId,
+              clientRequestId: crypto.randomUUID(),
+              expectedOperationGeneration: operationGeneration,
+              expectedStateVersion: projection.stateVersion,
+            }
+          : {
+              type: "step.skip",
+              conversationId,
+              turnId,
+              taskId,
+              stepId,
+              skipRequestId: requestId,
+              clientRequestId: crypto.randomUUID(),
+              expectedOperationGeneration: operationGeneration,
+              expectedStateVersion: projection.stateVersion,
+            },
+        controller.signal,
+      );
+    } finally {
+      controller.abort();
+      this.releaseScopeController(controller);
+    }
+  }
+
+  private materializeCurrentStateBlocks(stored: StoredConversation): void {
+    const projection = stored.taskProjection;
+    if (!projection) return;
+    const existingBlocks = stored.turnState.messages.flatMap(
+      (message) => message.blocks,
+    );
+    const blocks: ContentBlock[] = [];
+    if (projection.task) {
+      blocks.push({
+        type: "task_plan",
+        block_id: `current-task-plan:${projection.task.taskId}`,
+        state_version: projection.stateVersion,
+        progress_sequence: projection.progressSequence,
+        plan: projection.task,
+      });
+    }
+
+    if (projection.pendingInput) {
+      const request = assistantInputRequestSchema.safeParse(
+        projection.pendingInput,
+      );
+      if (request.success) {
+        blocks.push(
+          this.inputCardBlock(
+            request.data,
+            projection.stateVersion,
+            `current-input:${request.data.requestId}`,
+          ),
+        );
+      } else {
+        const requestId = protoString(projection.pendingInput["requestId"]);
+        const existing = existingBlocks.find(
+          (block): block is InputCardContentBlock =>
+            block.type === "input_card" && block.request_id === requestId,
+        );
+        if (existing) {
+          blocks.push({
+            ...existing,
+            state_version: projection.stateVersion,
+          });
+        }
+      }
+    } else if (projection.latestInputResolution?.["outcome"] === "accepted") {
+      const requestId = protoString(
+        projection.latestInputResolution["requestId"],
+      );
+      const existing = existingBlocks.find(
+        (block): block is InputCardContentBlock =>
+          block.type === "input_card" && block.request_id === requestId,
+      );
+      if (existing) {
+        blocks.push({
+          ...existing,
+          status: "resolved",
+          state_version: projection.stateVersion,
+        });
+      }
+    }
+    if (projection.pendingApproval) {
+      const pending = projection.pendingApproval;
+      const presentation =
+        pending["presentation"] &&
+        typeof pending["presentation"] === "object" &&
+        !Array.isArray(pending["presentation"])
+          ? (pending["presentation"] as ToolApprovalPayload["presentation"])
+          : undefined;
+      const payload = {
+        ...(pending as ToolApprovalPayload),
+        ...(presentation ?? {}),
+        presentation,
+      };
+      const requestId =
+        payload.requestId ?? payload.approvalRequestId ?? payload.commandId;
+      if (requestId) {
+        const existing = existingBlocks.find(
+          (block): block is ApprovalCardContentBlock =>
+            block.type === "approval_card" &&
+            block.approval_request_id === requestId,
+        );
+        blocks.push(
+          existing
+            ? { ...existing, state_version: projection.stateVersion }
+            : this.approvalCardBlock(
+                payload,
+                projection.stateVersion,
+                `current-approval:${requestId}`,
+              ),
+        );
+      }
+    } else if (
+      projection.latestApprovalResolution?.["outcome"] === "accepted"
+    ) {
+      const requestId = protoString(
+        projection.latestApprovalResolution["requestId"],
+      );
+      const approved = projection.latestApprovalResolution["approved"];
+      const existing = existingBlocks.find(
+        (block): block is ApprovalCardContentBlock =>
+          block.type === "approval_card" &&
+          block.approval_request_id === requestId,
+      );
+      if (existing && typeof approved === "boolean") {
+        blocks.push({
+          ...existing,
+          decision: approved ? "approved" : "denied",
+          decision_channel: "web",
+          decision_submission: null,
+          state_version: projection.stateVersion,
+        });
+      }
+    }
+    for (const summary of projection.pendingActions) {
+      const requestPayload = summary["request"];
+      const parsed = assistantActionRequestSchema.safeParse(requestPayload);
+      const request = parsed.success
+        ? parsed.data
+        : recoverUnsupportedAssistantActionRequest(requestPayload);
+      if (!request || request.actorId !== projection.actorId) continue;
+      const resolved = resolveAssistantAction(request);
+      const reports = Array.isArray(summary["reports"])
+        ? summary["reports"]
+        : [];
+      const disposition = reports
+        .slice()
+        .reverse()
+        .map((report) =>
+          report && typeof report === "object" && !Array.isArray(report)
+            ? (report as Record<string, unknown>)["disposition"]
+            : undefined,
+        )
+        .find((value): value is string => typeof value === "string");
+      const status: ActionCardStatus =
+        summary["conflicted"] === true
+          ? "conflicted"
+          : disposition === "completed"
+            ? "completed"
+            : disposition === "declined"
+              ? "declined"
+              : disposition === "failed" ||
+                  disposition === "cancelled" ||
+                  disposition === "expired"
+                ? "failed"
+                : resolved.supported
+                  ? "pending"
+                  : "unsupported";
+      blocks.push({
+        type: "action_card",
+        block_id: `current-action:${request.actionRequestId}`,
+        action: request.action,
+        action_request_id: request.actionRequestId,
+        origin_turn_id: request.originTurnId,
+        actor_id: request.actorId || undefined,
+        task_id: request.taskId,
+        step_id: request.stepId,
+        params: resolved.params,
+        status,
+        outcome_note:
+          status === "completed"
+            ? "Reported — awaiting assistant verification."
+            : "",
+      });
+      stored.actionRequestFingerprints.set(
+        request.actionRequestId,
+        fingerprintStableRequestInput(request.params),
+      );
+    }
+
+    const managedTypes = new Set<ContentBlock["type"]>([
+      "task_plan",
+      "input_card",
+      "approval_card",
+      "action_card",
+    ]);
+    const stateMessageId = `assistant-current-state:${projection.actorId ?? stored.conversation.id}`;
+    const retainedMessages = stored.turnState.messages.flatMap((message) => {
+      if (message.id === stateMessageId) return [];
+      const retainedBlocks = message.blocks.filter(
+        (block) => !managedTypes.has(block.type),
+      );
+      if (retainedBlocks.length === 0 && message.blocks.length > 0) return [];
+      return retainedBlocks.length === message.blocks.length
+        ? [message]
+        : [{ ...message, blocks: retainedBlocks }];
+    });
+    stored.turnState = {
+      ...stored.turnState,
+      messages:
+        blocks.length === 0
+          ? retainedMessages
+          : [
+              ...retainedMessages,
+              {
+                id: stateMessageId,
+                role: "assistant",
+                schema_version: 1,
+                blocks,
+                created_at:
+                  projection.task?.updatedAt ??
+                  projection.task?.createdAt ??
+                  new Date(0).toISOString(),
+                turnId:
+                  projection.task?.turnId ??
+                  protoString(projection.activeTurn?.["turnId"]),
+              },
+            ],
+    };
+  }
+
+  private inputCardBlock(
+    request: AssistantInputRequest,
+    stateVersion?: number,
+    blockId = newId("input-card"),
+  ): InputCardContentBlock {
+    return {
+      type: "input_card",
+      block_id: blockId,
+      request_id: request.requestId,
+      prompt: redactDisplayText(request.prompt),
+      options: request.options.map((option) => ({
+        option_id: option.optionId,
+        label: redactDisplayText(option.label),
+        ...(option.description
+          ? { description: redactDisplayText(option.description) }
+          : {}),
+      })),
+      allow_free_text: request.allowFreeText,
+      multi_select: request.multiSelect,
+      ...(stateVersion !== undefined ? { state_version: stateVersion } : {}),
+      status: "pending",
+    };
+  }
+
+  private approvalCardBlock(
+    payload: ToolApprovalPayload,
+    stateVersion?: number,
+    blockId = newId("approval-card"),
+  ): ApprovalCardContentBlock {
+    const requestId =
+      payload.requestId ?? payload.approvalRequestId ?? payload.commandId ?? "";
+    const presentation = payload.presentation;
+    const presentationBody = [
+      presentation?.actorLabel,
+      presentation?.action,
+      presentation?.target ? `on ${presentation.target}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const body =
+      (payload.message ?? payload.body ?? presentationBody) ||
+      (payload.toolName
+        ? `The assistant wants to run ${redactDisplayText(payload.toolName)}.`
+        : "The assistant is requesting your approval to continue.");
+    return {
+      type: "approval_card",
+      block_id: blockId,
+      approval_request_id: requestId,
+      body: redactDisplayText(body),
+      service_slug: payload.serviceSlug ?? payload.service_slug ?? "",
+      agent_key_prefix: payload.agentKeyPrefix ?? "aevatar",
+      approval_mode: payload.approvalMode === "grant" ? "grant" : "per_request",
+      grant_duration_sec:
+        typeof payload.grantDurationSec === "number"
+          ? payload.grantDurationSec
+          : null,
+      expires_at: payload.expiresAt ?? payload.expires_at ?? "",
+      decision: null,
+      decision_channel: null,
+      decision_submission: null,
+      ...(stateVersion !== undefined ? { state_version: stateVersion } : {}),
+    };
   }
 
   private applyHistoryResponse(
@@ -3662,6 +4222,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
       actionRequestFingerprints:
         existing?.actionRequestFingerprints ?? new Map(),
       activityMessageTurnIds: existing?.activityMessageTurnIds ?? new Map(),
+      taskProjection: existing?.taskProjection,
       lastLocalTurnCompletedAt: existing?.lastLocalTurnCompletedAt,
       stateVersion:
         freshStateVersion === undefined
@@ -5073,7 +5634,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
         // Workflow projection state; telemetry only, never rendered.
         return;
       case "CUSTOM": {
-        this.handleCustomFrame(conversationId, run, frame.custom ?? {});
+        this.handleCustomFrame(
+          conversationId,
+          run,
+          frame.custom ?? {},
+          frame.sequence,
+        );
         return;
       }
       default:
@@ -5117,6 +5683,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     conversationId: string,
     run: RunningTurn,
     custom: CustomEnvelope,
+    sequence?: string | number,
   ): void {
     const name = custom.name ?? "";
     const payload = unpackAny(custom.payload);
@@ -5155,6 +5722,10 @@ export class AevatarAssistantTransport implements AssistantTransport {
         }
         return;
       }
+      case "nyxid.task.snapshot":
+      case "nyxid.task.step.changed":
+        this.applyLiveTaskFrame(conversationId, run, name, payload, sequence);
+        return;
       case "nyxid.input.request": {
         const request = assistantInputRequestSchema.safeParse(payload);
         if (request.success) {
@@ -5278,6 +5849,52 @@ export class AevatarAssistantTransport implements AssistantTransport {
       default:
         return;
     }
+  }
+
+  private applyLiveTaskFrame(
+    conversationId: string,
+    run: RunningTurn,
+    name: "nyxid.task.snapshot" | "nyxid.task.step.changed",
+    payload: unknown,
+    sequence: unknown,
+  ): void {
+    const stored = this.conversations.get(conversationId);
+    if (!stored) return;
+    const projection = reduceTaskFrame(
+      stored.taskProjection ?? createTaskProjection(conversationId),
+      name,
+      payload,
+      sequence,
+    );
+    if (projection === stored.taskProjection || !projection.task) return;
+    stored.taskProjection = projection;
+    const existing = stored.turnState.messages
+      .flatMap((message) => message.blocks)
+      .find(
+        (block): block is TaskPlanContentBlock =>
+          block.type === "task_plan" &&
+          block.plan.taskId === projection.task?.taskId,
+      );
+    if (existing) {
+      this.emit(conversationId, run, {
+        cursor: this.nextCursor(run),
+        event: "block.updated",
+        block_id: existing.block_id,
+        patch: {
+          state_version: projection.stateVersion,
+          progress_sequence: projection.progressSequence,
+          plan: projection.task,
+        },
+      });
+      return;
+    }
+    this.appendActivityBlock(conversationId, run, {
+      type: "task_plan",
+      block_id: `live-task-plan:${projection.task.taskId}`,
+      state_version: projection.stateVersion,
+      progress_sequence: projection.progressSequence,
+      plan: projection.task,
+    });
   }
 
   /**
@@ -5808,38 +6425,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     // A human gate has no client-imposed deadline; stop the watchdog.
     this.clearWatchdog(run);
 
-    const presentation = payload.presentation;
-    const presentationBody = [
-      presentation?.actorLabel,
-      presentation?.action,
-      presentation?.target ? `on ${presentation.target}` : "",
-    ]
-      .filter(Boolean)
-      .join(" ");
-    const body =
-      (payload.message ?? payload.body ?? presentationBody) ||
-      (payload.toolName
-        ? `The assistant wants to run ${redactDisplayText(payload.toolName)}.`
-        : "The assistant is requesting your approval to continue.");
-    const block: ApprovalCardContentBlock = {
-      type: "approval_card",
-      block_id: newId("approval-card"),
-      approval_request_id: requestId,
-      body: redactDisplayText(body),
-      service_slug: payload.serviceSlug ?? payload.service_slug ?? "",
-      agent_key_prefix: payload.agentKeyPrefix ?? "aevatar",
-      approval_mode: payload.approvalMode === "grant" ? "grant" : "per_request",
-      grant_duration_sec:
-        typeof payload.grantDurationSec === "number"
-          ? payload.grantDurationSec
-          : null,
-      // Empty when upstream sends none: the card omits the countdown for an
-      // unparseable expiry rather than inventing a deadline.
-      expires_at: payload.expiresAt ?? payload.expires_at ?? "",
-      decision: null,
-      decision_channel: null,
-      decision_submission: null,
-    };
+    const block = this.approvalCardBlock(payload);
     this.appendActivityBlock(conversationId, run, block);
     run.openCards.set(block.block_id, "approval");
     this.markStepWaiting(
@@ -5871,22 +6457,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     run.pendingInputRequestId = request.requestId;
     this.clearWatchdog(run);
 
-    const block: InputCardContentBlock = {
-      type: "input_card",
-      block_id: newId("input-card"),
-      request_id: request.requestId,
-      prompt: redactDisplayText(request.prompt),
-      options: request.options.map((option) => ({
-        option_id: option.optionId,
-        label: redactDisplayText(option.label),
-        ...(option.description
-          ? { description: redactDisplayText(option.description) }
-          : {}),
-      })),
-      allow_free_text: request.allowFreeText,
-      multi_select: request.multiSelect,
-      status: "pending",
-    };
+    const block = this.inputCardBlock(request);
     this.appendActivityBlock(conversationId, run, block);
     run.openCards.set(block.block_id, "input");
     this.markStepWaiting(
@@ -6776,9 +7347,9 @@ export class AevatarAssistantTransport implements AssistantTransport {
   /**
    * Best-effort server-side stop (the `feature/integrate` `:stop` control
    * contract): a fresh `stopRequestId` per intent keeps the command
-   * idempotent upstream, and `expectedStateVersion: 0` skips the
-   * optimistic-concurrency fence — the transport does not track actor
-   * state versions. Requires the server-announced `turnId` (a
+   * idempotent upstream. The transport first reads actor-owned current state
+   * and sends that exact version; Stop never bypasses the stale-state fence.
+   * Requires the server-announced `turnId` (a
    * pre-RUN_STARTED cancel defers here via `stopPendingStart`). Failures
    * are swallowed — stop is an upgrade over the previous client-only
    * cancel, never a new failure mode — but the in-flight request is
@@ -6804,20 +7375,12 @@ export class AevatarAssistantTransport implements AssistantTransport {
       () => deadline.abort(),
       STOP_REQUEST_DEADLINE_MS,
     );
-    const pending = apiClient<unknown>(`${ASSISTANT_PREFIX}/chat`, {
-      method: "POST",
-      body: {
-        type: "task.stop",
-        conversationId: actorConversationId,
-        turnId: run.turnId,
-        stopRequestId: crypto.randomUUID(),
-        clientRequestId: crypto.randomUUID(),
-        expectedStateVersion: 0,
-      },
-      preserveSessionOn401: true,
-      signal: deadline.signal,
-      ...assistantWireLogOptions(),
-    }).then(
+    const pending = this.dispatchTaskStop(
+      actorConversationId,
+      crypto.randomUUID(),
+      deadline.signal,
+      run.turnId,
+    ).then(
       () => {
         clearTimeout(deadlineTimer);
         this.releaseScopeController(deadline);

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -2814,6 +2814,7 @@ export class AevatarAssistantTransport implements AssistantTransport {
     }
     const controller = this.scopeController();
     try {
+      await this.awaitPendingStop(conversationId);
       const projection = await this.readTaskControlProjection(
         conversationId,
         controller.signal,
@@ -2849,6 +2850,86 @@ export class AevatarAssistantTransport implements AssistantTransport {
 
   async skipStep(conversationId: string, stepId: string): Promise<void> {
     await this.dispatchStepControl(conversationId, stepId, "skip");
+  }
+
+  async resolvePlan(
+    conversationId: string,
+    blockId: string,
+    confirmed: boolean,
+  ): Promise<void> {
+    this.ensureScope();
+    conversationId = this.canonicalConversationId(conversationId);
+    this.assertTypedTaskConversation(conversationId);
+    if (this.deletingConversations.has(conversationId)) {
+      throw new Error("This conversation is being deleted.");
+    }
+    const stored = this.conversations.get(conversationId);
+    const card = stored?.turnState.messages
+      .flatMap((message) => message.blocks)
+      .find(
+        (block): block is TaskPlanContentBlock =>
+          block.type === "task_plan" && block.block_id === blockId,
+      );
+    const clickedGate = card?.plan.gate;
+    if (
+      !card ||
+      clickedGate?.mode !== "confirm" ||
+      clickedGate.status !== "pending" ||
+      !clickedGate.requestId ||
+      !clickedGate.taskId ||
+      !clickedGate.planId ||
+      clickedGate.planRevision === undefined
+    ) {
+      throw new AssistantProtocolError("This plan gate is no longer pending.");
+    }
+
+    const controller = this.scopeController();
+    try {
+      await this.awaitPendingStop(conversationId);
+      const projection = await this.readTaskControlProjection(
+        conversationId,
+        controller.signal,
+      );
+      const gate = projection.task?.gate;
+      if (
+        gate?.mode !== "confirm" ||
+        gate.status !== "pending" ||
+        gate.requestId !== clickedGate.requestId ||
+        gate.taskId !== clickedGate.taskId ||
+        gate.planId !== clickedGate.planId ||
+        gate.planRevision !== clickedGate.planRevision
+      ) {
+        throw new AssistantProtocolError(
+          "The actor no longer offers this exact plan gate.",
+        );
+      }
+      await assistantApi.post<{ readonly status: string }>(
+        `${ASSISTANT_PREFIX}/chat`,
+        {
+          type: "plan.resolve",
+          conversationId,
+          taskId: gate.taskId,
+          planId: gate.planId,
+          requestId: gate.requestId,
+          clientRequestId: crypto.randomUUID(),
+          planRevision: gate.planRevision,
+          confirmed,
+          expectedStateVersion: projection.stateVersion,
+        },
+        controller.signal,
+      );
+
+      // JSON 202 means accepted for actor dispatch, not committed. Refresh the
+      // same projection once and let only actor-owned state settle the gate.
+      try {
+        await this.readTaskControlProjection(conversationId, controller.signal);
+      } catch (error) {
+        if (controller.signal.aborted) throw error;
+      }
+    } finally {
+      controller.abort();
+      this.releaseScopeController(controller);
+    }
   }
 
   /** Submit a version-fenced approval decision and project JSON acceptance. */

--- a/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
@@ -207,6 +207,22 @@ class StubTransport implements AssistantTransport {
     this.cancelCalls += 1;
   }
 
+  async stopTask(): Promise<void> {
+    this.cancelCalls += 1;
+  }
+
+  async steerTask(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async retryStep(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async skipStep(): Promise<void> {
+    return Promise.resolve();
+  }
+
   async decideApproval(): Promise<TurnHandle | null> {
     this.approvalCalls += 1;
     return null;

--- a/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.test.ts
@@ -85,6 +85,7 @@ class StubTransport implements AssistantTransport {
   blockCalls = 0;
   continueCalls = 0;
   wakeCalls = 0;
+  resolvePlanCalls = 0;
   lastDelegateEvent: ((event: TurnEvent) => void) | null = null;
   private cursor = 0;
 
@@ -221,6 +222,10 @@ class StubTransport implements AssistantTransport {
 
   async skipStep(): Promise<void> {
     return Promise.resolve();
+  }
+
+  async resolvePlan(): Promise<void> {
+    this.resolvePlanCalls += 1;
   }
 
   async decideApproval(): Promise<TurnHandle | null> {

--- a/frontend/src/lib/assistant/scenario-intercept-transport.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.ts
@@ -393,6 +393,14 @@ export class ScenarioInterceptTransport implements AssistantTransport {
     return this.delegate.skipStep(conversationId, stepId);
   }
 
+  resolvePlan(
+    conversationId: string,
+    blockId: string,
+    confirmed: boolean,
+  ): Promise<void> {
+    return this.delegate.resolvePlan(conversationId, blockId, confirmed);
+  }
+
   async decideApproval(
     conversationId: string,
     blockId: string,

--- a/frontend/src/lib/assistant/scenario-intercept-transport.ts
+++ b/frontend/src/lib/assistant/scenario-intercept-transport.ts
@@ -377,6 +377,22 @@ export class ScenarioInterceptTransport implements AssistantTransport {
     this.delegate.cancelActiveTurn(conversationId);
   }
 
+  stopTask(conversationId: string): Promise<void> {
+    return this.delegate.stopTask(conversationId);
+  }
+
+  steerTask(conversationId: string, instruction: string): Promise<void> {
+    return this.delegate.steerTask(conversationId, instruction);
+  }
+
+  retryStep(conversationId: string, stepId: string): Promise<void> {
+    return this.delegate.retryStep(conversationId, stepId);
+  }
+
+  skipStep(conversationId: string, stepId: string): Promise<void> {
+    return this.delegate.skipStep(conversationId, stepId);
+  }
+
   async decideApproval(
     conversationId: string,
     blockId: string,

--- a/frontend/src/lib/assistant/task-plan.test.ts
+++ b/frontend/src/lib/assistant/task-plan.test.ts
@@ -108,6 +108,35 @@ describe("decodeTaskPlan", () => {
     ).toThrow("unknown action verb");
   });
 
+  it("preserves the public approval terminal outcome and non-sensitive subject kind", () => {
+    const decoded = decodeTaskPlan(
+      plan({
+        steps: [
+          step("step-a", 1, {
+            approvalObservation: {
+              approvalRequestId: "approval-alpha",
+              decisionMode: "per_request",
+              receiptStatus: "denied",
+              observedAt: "2026-08-11T08:00:00Z",
+              terminalOutcome: "rejected",
+              subjectKind: "nyxid.user-service",
+              futureObservationField: "ignored",
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(decoded.steps[0]?.approvalObservation).toEqual({
+      approvalRequestId: "approval-alpha",
+      decisionMode: "per_request",
+      receiptStatus: "denied",
+      observedAt: "2026-08-11T08:00:00Z",
+      terminalOutcome: "rejected",
+      subjectKind: "nyxid.user-service",
+    });
+  });
+
   it.each([
     ["unknown task status", plan({ status: "paused" })],
     [

--- a/frontend/src/lib/assistant/task-plan.test.ts
+++ b/frontend/src/lib/assistant/task-plan.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { decodeTaskPlan, TaskPlanProtocolError } from "./task-plan";
+
+function step(
+  stepId: string,
+  order: number,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    stepId,
+    order,
+    kind: "tool",
+    status: "planned",
+    required: true,
+    description: `Step ${stepId}`,
+    source: {
+      tool: {
+        toolName: "connected_service_operation",
+        serviceSlug: "api-github",
+      },
+    },
+    mayChangeExternalState: false,
+    externalEffect: "not_started",
+    availableActions: { retry: false, skip: false, stop: false },
+    dependsOn: [],
+    substeps: [],
+    ...overrides,
+  };
+}
+
+function plan(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    schemaVersion: 4,
+    actorId: "nyxid-chat-actor-alpha",
+    taskId: "task-alpha",
+    turnId: "turn-alpha",
+    planId: "plan-alpha",
+    planRevision: 2,
+    planRevisions: [],
+    title: "Publish a weekly update",
+    status: "active",
+    gate: { mode: "auto", status: "satisfied" },
+    steps: [step("step-b", 2), step("step-a", 1)],
+    ...overrides,
+  };
+}
+
+describe("decodeTaskPlan", () => {
+  it("decodes the full actor plan, sorts steps, and tolerates additive fields", () => {
+    const decoded = decodeTaskPlan({
+      ...plan(),
+      futureEnvelopeField: { enabled: true },
+      steps: [
+        step("step-b", 2, {
+          futureStepField: "ignored",
+          source: {
+            tool: {
+              toolName: "connected_service_operation",
+              serviceSlug: "api-github",
+            },
+            futureSourceArm: { label: "ignored" },
+          },
+          substeps: [
+            {
+              substepId: "substep-b",
+              title: "Search repository",
+              status: "done",
+            },
+          ],
+        }),
+        step("step-a", 1),
+      ],
+    });
+
+    expect(decoded.steps.map((candidate) => candidate.stepId)).toEqual([
+      "step-a",
+      "step-b",
+    ]);
+    expect(decoded.steps[1]?.substeps).toEqual([
+      { substepId: "substep-b", title: "Search repository", status: "done" },
+    ]);
+  });
+
+  it("fails closed on unknown action verbs while defaulting omitted known verbs", () => {
+    const decoded = decodeTaskPlan(
+      plan({
+        steps: [step("step-a", 1, { availableActions: { retry: true } })],
+      }),
+    );
+    expect(decoded.steps[0]?.availableActions).toEqual({
+      retry: true,
+      skip: false,
+      stop: false,
+    });
+
+    expect(() =>
+      decodeTaskPlan(
+        plan({
+          steps: [
+            step("step-a", 1, {
+              availableActions: { retry: false, pause: true },
+            }),
+          ],
+        }),
+      ),
+    ).toThrow("unknown action verb");
+  });
+
+  it.each([
+    ["unknown task status", plan({ status: "paused" })],
+    [
+      "source-kind mismatch",
+      plan({ steps: [step("step-a", 1, { source: { web: {} } })] }),
+    ],
+    [
+      "duplicate step identity",
+      plan({ steps: [step("step-a", 1), step("step-a", 2)] }),
+    ],
+    [
+      "operation identity mismatch",
+      plan({
+        steps: [
+          step("step-a", 1, {
+            operation: {
+              taskId: "task-other",
+              stepId: "step-a",
+              operationGeneration: 1,
+            },
+          }),
+        ],
+      }),
+    ],
+    [
+      "unbound pending gate",
+      plan({
+        gate: {
+          mode: "confirm",
+          status: "pending",
+          requestId: "input-plan",
+          taskId: "task-other",
+          planId: "plan-alpha",
+          planRevision: 2,
+        },
+      }),
+    ],
+  ])("rejects %s", (_label, input) => {
+    expect(() => decodeTaskPlan(input)).toThrow(TaskPlanProtocolError);
+  });
+});

--- a/frontend/src/lib/assistant/task-plan.ts
+++ b/frontend/src/lib/assistant/task-plan.ts
@@ -1,0 +1,622 @@
+import type {
+  TaskApprovalObservation,
+  TaskAvailableActions,
+  TaskNumericCondition,
+  TaskOperation,
+  TaskPlan,
+  TaskPlanGate,
+  TaskStep,
+  TaskStepKind,
+  TaskStepSource,
+  TaskSubstep,
+} from "@/types/assistant";
+
+export class TaskPlanProtocolError extends Error {
+  readonly code = "NYXID_TASK_PLAN_INVALID";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TaskPlanProtocolError";
+  }
+}
+
+const TASK_STATUSES = [
+  "active",
+  "succeeded",
+  "failed",
+  "stopped",
+  "blocked",
+] as const;
+const STEP_STATUSES = [
+  "planned",
+  "waiting",
+  "running",
+  "done",
+  "failed",
+  "skipped",
+  "cancelled",
+  "uncertain",
+] as const;
+const STEP_KINDS = [
+  "llm",
+  "tool",
+  "browser_action",
+  "postcondition",
+  "input",
+  "approval",
+  "web",
+  "condition",
+] as const;
+const EFFECTS = [
+  "not_started",
+  "not_applied",
+  "confirmed",
+  "may_have_changed",
+] as const;
+const ADDED_BY = [
+  "initial",
+  "scope_resolution",
+  "replan",
+  "steering",
+  "user_revision",
+] as const;
+const REVISION_CAUSES = [
+  "initial",
+  "scope_resolution",
+  "failure_recovery",
+  "steering",
+  "user_revision",
+] as const;
+
+/**
+ * Decode the actor-owned TaskPlan contract. Object members are additive, while
+ * identities, required fields, and closed enums remain fail-closed.
+ */
+export function decodeTaskPlan(input: unknown): TaskPlan {
+  const value = record(input, "task plan");
+  const taskId = identity(value.taskId, "taskId");
+  const turnId = identity(value.turnId, "turnId");
+  const actorId = identity(value.actorId, "actorId");
+  const planId = identity(value.planId, "planId");
+  const planRevision = safeInteger(value.planRevision, "planRevision", 1);
+  const steps = array(value.steps, "steps").map(decodeTaskStep);
+  const ordered = [...steps].sort(
+    (left, right) =>
+      left.order - right.order || left.stepId.localeCompare(right.stepId),
+  );
+  if (new Set(ordered.map((step) => step.stepId)).size !== ordered.length) {
+    throw invalid("TaskPlan contains duplicate step identities.");
+  }
+
+  const historyStart = optionalInteger(value.planRevisionHistoryStart, 1);
+  const activeStepId = optionalIdentity(value.activeStepId);
+  const plan: TaskPlan = {
+    schemaVersion: safeInteger(value.schemaVersion, "schemaVersion", 1),
+    actorId,
+    taskId,
+    turnId,
+    planId,
+    planRevision,
+    ...(historyStart !== undefined
+      ? { planRevisionHistoryStart: historyStart }
+      : {}),
+    planRevisions: optionalArray(value.planRevisions).map(decodeRevision),
+    title: boundedString(value.title, "title", 512),
+    status: closed(value.status, TASK_STATUSES, "status"),
+    ...(activeStepId ? { activeStepId } : {}),
+    ...optionalNamedString(value, "failureCode"),
+    ...optionalNamedString(value, "safeMessage"),
+    ...optionalNamedString(value, "createdAt"),
+    ...optionalNamedString(value, "updatedAt"),
+    ...(value.gate === undefined || value.gate === null
+      ? {}
+      : { gate: decodeGate(value.gate, taskId, planId, planRevision) }),
+    steps: ordered,
+  };
+  assertTaskPlanRelationships(plan);
+  return plan;
+}
+
+export function assertTaskPlanRelationships(plan: TaskPlan): void {
+  const steps = new Map(plan.steps.map((step) => [step.stepId, step]));
+  if (plan.activeStepId && !steps.has(plan.activeStepId)) {
+    throw invalid("TaskPlan active step does not exist.");
+  }
+  for (const step of plan.steps) {
+    if (
+      new Set(step.dependsOn).size !== step.dependsOn.length ||
+      step.dependsOn.some(
+        (dependency) => dependency === step.stepId || !steps.has(dependency),
+      )
+    ) {
+      throw invalid("Task step dependencies are invalid.");
+    }
+    if (step.guard) {
+      const condition = steps.get(step.guard.conditionStepId);
+      if (!condition || condition.kind !== "condition") {
+        throw invalid("Task step guard does not reference a condition step.");
+      }
+    }
+    const operation = step.operation;
+    if (
+      (operation?.conversationActorId &&
+        operation.conversationActorId !== plan.actorId) ||
+      (operation?.turnId && operation.turnId !== plan.turnId) ||
+      (operation?.taskId && operation.taskId !== plan.taskId) ||
+      (operation?.stepId && operation.stepId !== step.stepId)
+    ) {
+      throw invalid(
+        "Task operation identity does not match its TaskPlan step.",
+      );
+    }
+  }
+}
+
+export function decodeTaskStep(input: unknown): TaskStep {
+  const value = record(input, "task step");
+  const kind = closed(value.kind, STEP_KINDS, "step.kind");
+  const source = decodeSource(value.source, kind);
+  const operation =
+    value.operation === undefined || value.operation === null
+      ? null
+      : decodeOperation(value.operation);
+  const estimateRecord = optionalRecord(value.estimate);
+  const estimate = estimateRecord
+    ? {
+        kind: closed(
+          estimateRecord.kind,
+          ["duration"] as const,
+          "estimate.kind",
+        ),
+        seconds: safeInteger(estimateRecord.seconds, "estimate.seconds", 0),
+      }
+    : undefined;
+  const approvalObservation =
+    value.approvalObservation === undefined ||
+    value.approvalObservation === null
+      ? undefined
+      : decodeApprovalObservation(value.approvalObservation);
+  const guard =
+    value.guard === undefined || value.guard === null
+      ? undefined
+      : decodeGuard(value.guard);
+  const addedInPlanRevision = optionalInteger(value.addedInPlanRevision, 1);
+  const cancelledInPlanRevision = optionalInteger(
+    value.cancelledInPlanRevision,
+    1,
+  );
+  const actionRequestId = optionalIdentity(value.actionRequestId);
+  const approvalRequestId = optionalIdentity(value.approvalRequestId);
+
+  return {
+    stepId: identity(value.stepId, "stepId"),
+    order: safeInteger(value.order, "step.order", 0),
+    kind,
+    status: closed(value.status, STEP_STATUSES, "step.status"),
+    required: boolean(value.required, "step.required"),
+    description: boundedString(value.description, "step.description", 1_024),
+    source,
+    mayChangeExternalState: boolean(
+      value.mayChangeExternalState,
+      "step.mayChangeExternalState",
+    ),
+    externalEffect: closed(
+      value.externalEffect,
+      EFFECTS,
+      "step.externalEffect",
+    ),
+    availableActions: decodeActions(value.availableActions),
+    ...optionalNamedString(value, "updatedAt"),
+    ...(value.addedBy !== undefined
+      ? { addedBy: closed(value.addedBy, ADDED_BY, "step.addedBy") }
+      : {}),
+    ...(addedInPlanRevision !== undefined ? { addedInPlanRevision } : {}),
+    ...(cancelledInPlanRevision !== undefined
+      ? { cancelledInPlanRevision }
+      : {}),
+    dependsOn: optionalArray(value.dependsOn).map((item) =>
+      identity(item, "step.dependsOn"),
+    ),
+    ...(estimate ? { estimate } : {}),
+    substeps: optionalArray(value.substeps).map(decodeSubstep),
+    operation,
+    ...(approvalObservation ? { approvalObservation } : {}),
+    ...(guard ? { guard } : {}),
+    ...(actionRequestId ? { actionRequestId } : {}),
+    ...(approvalRequestId ? { approvalRequestId } : {}),
+    ...optionalNamedString(value, "failureCode"),
+    ...optionalNamedString(value, "safeMessage"),
+    ...(typeof value.safeToSkip === "boolean"
+      ? { safeToSkip: value.safeToSkip }
+      : {}),
+  };
+}
+
+function decodeGuard(input: unknown): NonNullable<TaskStep["guard"]> {
+  const value = record(input, "step guard");
+  return {
+    conditionStepId: identity(value.conditionStepId, "guard.conditionStepId"),
+    requiredOutcome: closed(
+      value.requiredOutcome,
+      ["true", "false"] as const,
+      "guard.requiredOutcome",
+    ),
+  };
+}
+
+function decodeApprovalObservation(input: unknown): TaskApprovalObservation {
+  const value = record(input, "step approval observation");
+  return {
+    approvalRequestId: identity(
+      value.approvalRequestId,
+      "approvalObservation.approvalRequestId",
+    ),
+    decisionMode: closed(
+      value.decisionMode,
+      ["unknown", "per_request", "grant"] as const,
+      "approvalObservation.decisionMode",
+    ),
+    receiptStatus: closed(
+      value.receiptStatus,
+      ["approval_required", "denied"] as const,
+      "approvalObservation.receiptStatus",
+    ),
+    observedAt: boundedString(
+      value.observedAt,
+      "approvalObservation.observedAt",
+      128,
+    ),
+  };
+}
+
+function decodeGate(
+  input: unknown,
+  taskId: string,
+  planId: string,
+  planRevision: number,
+): TaskPlanGate {
+  const value = record(input, "plan gate");
+  const requestId = optionalIdentity(value.requestId);
+  const gateTaskId = optionalIdentity(value.taskId);
+  const gatePlanId = optionalIdentity(value.planId);
+  const gatePlanRevision = optionalInteger(value.planRevision, 1);
+  const gate: TaskPlanGate = {
+    mode: closed(value.mode, ["auto", "confirm"] as const, "gate.mode"),
+    ...(value.status !== undefined
+      ? {
+          status: closed(
+            value.status,
+            ["pending", "satisfied", "rejected"] as const,
+            "gate.status",
+          ),
+        }
+      : {}),
+    ...(requestId ? { requestId } : {}),
+    ...(gateTaskId ? { taskId: gateTaskId } : {}),
+    ...(gatePlanId ? { planId: gatePlanId } : {}),
+    ...(gatePlanRevision !== undefined
+      ? { planRevision: gatePlanRevision }
+      : {}),
+    ...optionalNamedString(value, "reason"),
+    ...optionalNamedString(value, "decidedAt"),
+  };
+  if (
+    gate.mode === "confirm" &&
+    gate.status === "pending" &&
+    (!gate.requestId ||
+      gate.taskId !== taskId ||
+      gate.planId !== planId ||
+      gate.planRevision !== planRevision)
+  ) {
+    throw invalid(
+      "Pending plan gate does not bind the exact TaskPlan identity.",
+    );
+  }
+  return gate;
+}
+
+function decodeRevision(input: unknown): TaskPlan["planRevisions"][number] {
+  const value = record(input, "plan revision");
+  return {
+    planRevision: safeInteger(value.planRevision, "revision.planRevision", 1),
+    revisionCause: closed(
+      value.revisionCause,
+      REVISION_CAUSES,
+      "revision.revisionCause",
+    ),
+    ...optionalNamedString(value, "committedAt"),
+    addedStepIds: optionalArray(value.addedStepIds).map((item) =>
+      identity(item, "revision.addedStepIds"),
+    ),
+    cancelledStepIds: optionalArray(value.cancelledStepIds).map((item) =>
+      identity(item, "revision.cancelledStepIds"),
+    ),
+  };
+}
+
+function decodeSubstep(input: unknown): TaskSubstep {
+  const value = record(input, "substep");
+  return {
+    substepId: identity(value.substepId, "substepId"),
+    title: boundedString(value.title, "substep.title", 512),
+    status: closed(
+      value.status,
+      ["running", "done", "failed"] as const,
+      "substep.status",
+    ),
+  };
+}
+
+function decodeActions(input: unknown): TaskAvailableActions {
+  const value = input === undefined ? {} : record(input, "availableActions");
+  const supported = new Set<keyof TaskAvailableActions>([
+    "retry",
+    "skip",
+    "stop",
+  ]);
+  if (
+    Object.keys(value).some(
+      (key) => !supported.has(key as keyof TaskAvailableActions),
+    )
+  ) {
+    throw invalid("availableActions contains an unknown action verb.");
+  }
+  const action = (key: keyof TaskAvailableActions): boolean =>
+    value[key] === undefined
+      ? false
+      : boolean(value[key], `availableActions.${key}`);
+  return {
+    retry: action("retry"),
+    skip: action("skip"),
+    stop: action("stop"),
+  };
+}
+
+function decodeSource(
+  input: unknown,
+  expectedKind: TaskStepKind,
+): TaskStepSource {
+  const value = record(input, "step source");
+  const expectedKey =
+    expectedKind === "browser_action" ? "browserAction" : expectedKind;
+  const knownArms = [
+    "llm",
+    "tool",
+    "browserAction",
+    "postcondition",
+    "input",
+    "approval",
+    "web",
+    "condition",
+  ] as const;
+  const populated = knownArms.filter((key) => optionalRecord(value[key]));
+  if (populated.length !== 1 || populated[0] !== expectedKey) {
+    throw invalid("Task step source does not match its kind.");
+  }
+  const source = record(value[expectedKey], `source.${expectedKey}`);
+  switch (expectedKey) {
+    case "llm":
+      return { kind: "llm", label: optionalString(source.model) || "LLM" };
+    case "tool": {
+      const toolName = boundedString(
+        source.toolName,
+        "source.tool.toolName",
+        256,
+      );
+      const serviceSlug = optionalIdentity(source.serviceSlug);
+      const serviceId = optionalIdentity(source.serviceId);
+      return {
+        kind: "tool",
+        label: toolName,
+        ...(serviceSlug ? { serviceSlug } : {}),
+        ...(serviceId ? { serviceId } : {}),
+      };
+    }
+    case "browserAction":
+      return {
+        kind: "browserAction",
+        label: optionalString(source.action) || "Browser action",
+      };
+    case "postcondition":
+      return {
+        kind: "postcondition",
+        label: optionalString(source.check) || "Postcondition",
+      };
+    case "input":
+      return { kind: "input", label: "User input" };
+    case "approval":
+      return { kind: "approval", label: "Approval" };
+    case "condition": {
+      const condition = decodeCondition(source.condition);
+      return {
+        kind: "condition",
+        label: `${String(condition.observedValue)} >= ${String(condition.effectiveThreshold)}`,
+        condition,
+      };
+    }
+    default:
+      return { kind: "web", label: "Web" };
+  }
+}
+
+function decodeCondition(input: unknown): TaskNumericCondition {
+  const value = record(input, "source.condition.condition");
+  return {
+    conditionId: identity(value.conditionId, "condition.conditionId"),
+    sourceInputRequestId: identity(
+      value.sourceInputRequestId,
+      "condition.sourceInputRequestId",
+    ),
+    suggestedThreshold: integer(
+      value.suggestedThreshold,
+      "condition.suggestedThreshold",
+    ),
+    effectiveThreshold: integer(
+      value.effectiveThreshold,
+      "condition.effectiveThreshold",
+    ),
+    thresholdOrigin: closed(
+      value.thresholdOrigin,
+      ["suggested", "user_override"] as const,
+      "condition.thresholdOrigin",
+    ),
+    observedValue: integer(value.observedValue, "condition.observedValue"),
+    comparison: closed(
+      value.comparison,
+      ["gte"] as const,
+      "condition.comparison",
+    ),
+    outcome: closed(
+      value.outcome,
+      ["true", "false"] as const,
+      "condition.outcome",
+    ),
+    ...optionalNamedString(value, "evaluatedAt"),
+    guardedToolName: boundedString(
+      value.guardedToolName,
+      "condition.guardedToolName",
+      256,
+    ),
+  };
+}
+
+function decodeOperation(input: unknown): TaskOperation {
+  const value = record(input, "operation");
+  const operation: Record<string, string | number> = {};
+  for (const key of [
+    "conversationActorId",
+    "turnId",
+    "taskId",
+    "stepId",
+    "operationId",
+  ] as const) {
+    const identityValue = optionalIdentity(value[key]);
+    if (identityValue) operation[key] = identityValue;
+  }
+  for (const key of [
+    "operationGeneration",
+    "latestProgressSequence",
+  ] as const) {
+    const numberValue = optionalInteger(value[key], 0);
+    if (numberValue !== undefined) operation[key] = numberValue;
+  }
+  for (const key of [
+    "kind",
+    "phase",
+    "safeMessage",
+    "failureCode",
+    "progressMessage",
+    "startedAt",
+    "updatedAt",
+    "completedAt",
+    "lastProgressAt",
+    "stalledAt",
+  ] as const) {
+    const stringValue = optionalString(value[key]);
+    if (stringValue) operation[key] = stringValue;
+  }
+  return operation;
+}
+
+function record(input: unknown, label: string): Record<string, unknown> {
+  const value = optionalRecord(input);
+  if (!value) throw invalid(`${label} must be an object.`);
+  return value;
+}
+
+function optionalRecord(input: unknown): Record<string, unknown> | null {
+  return input && typeof input === "object" && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : null;
+}
+
+function array(input: unknown, label: string): unknown[] {
+  if (!Array.isArray(input)) throw invalid(`${label} must be an array.`);
+  return input;
+}
+
+function optionalArray(input: unknown): unknown[] {
+  return input === undefined || input === null
+    ? []
+    : array(input, "optional collection");
+}
+
+function identity(input: unknown, label: string): string {
+  const value = optionalIdentity(input);
+  if (!value) throw invalid(`${label} is invalid.`);
+  return value;
+}
+
+function optionalIdentity(input: unknown): string | undefined {
+  if (typeof input !== "string" || input.length < 1 || input.length > 256) {
+    return undefined;
+  }
+  return [...input].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127 || /[\s/\\?#]/u.test(character);
+  })
+    ? undefined
+    : input;
+}
+
+function boundedString(input: unknown, label: string, max: number): string {
+  if (
+    typeof input !== "string" ||
+    input.trim() !== input ||
+    input.length < 1 ||
+    input.length > max
+  ) {
+    throw invalid(`${label} is invalid.`);
+  }
+  return input;
+}
+
+function optionalString(input: unknown): string | undefined {
+  return typeof input === "string" && input.trim() ? input.trim() : undefined;
+}
+
+function optionalNamedString(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, string> {
+  const parsed = optionalString(value[key]);
+  return parsed ? { [key]: parsed } : {};
+}
+
+function safeInteger(input: unknown, label: string, minimum: number): number {
+  if (!Number.isSafeInteger(input) || (input as number) < minimum) {
+    throw invalid(`${label} is invalid.`);
+  }
+  return input as number;
+}
+
+function integer(input: unknown, label: string): number {
+  if (!Number.isSafeInteger(input)) throw invalid(`${label} is invalid.`);
+  return input as number;
+}
+
+function optionalInteger(input: unknown, minimum: number): number | undefined {
+  return input === undefined || input === null
+    ? undefined
+    : safeInteger(input, "integer", minimum);
+}
+
+function boolean(input: unknown, label: string): boolean {
+  if (typeof input !== "boolean") throw invalid(`${label} is invalid.`);
+  return input;
+}
+
+function closed<const T extends readonly string[]>(
+  input: unknown,
+  values: T,
+  label: string,
+): T[number] {
+  if (typeof input !== "string" || !values.includes(input)) {
+    throw invalid(`${label} is outside the closed contract.`);
+  }
+  return input as T[number];
+}
+
+function invalid(message: string): TaskPlanProtocolError {
+  return new TaskPlanProtocolError(message);
+}

--- a/frontend/src/lib/assistant/task-plan.ts
+++ b/frontend/src/lib/assistant/task-plan.ts
@@ -266,6 +266,16 @@ function decodeApprovalObservation(input: unknown): TaskApprovalObservation {
       "approvalObservation.observedAt",
       128,
     ),
+    ...(value.terminalOutcome !== undefined
+      ? {
+          terminalOutcome: closed(
+            value.terminalOutcome,
+            ["rejected", "expired", "timed_out"] as const,
+            "approvalObservation.terminalOutcome",
+          ),
+        }
+      : {}),
+    ...optionalNamedString(value, "subjectKind"),
   };
 }
 

--- a/frontend/src/lib/assistant/task-state.test.ts
+++ b/frontend/src/lib/assistant/task-state.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCurrentTaskState,
+  createTaskProjection,
+  reduceTaskFrame,
+  taskCan,
+  TaskStateProtocolError,
+} from "./task-state";
+
+const ACTOR_ID = "nyxid-chat-actor-alpha";
+
+function step(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    stepId: "step-alpha",
+    order: 1,
+    kind: "tool",
+    status: "running",
+    required: true,
+    description: "Read repository history",
+    source: { tool: { toolName: "github_history", serviceSlug: "api-github" } },
+    mayChangeExternalState: false,
+    externalEffect: "not_started",
+    availableActions: { retry: true, skip: true, stop: true },
+    dependsOn: [],
+    substeps: [],
+    operation: {
+      turnId: "turn-alpha",
+      taskId: "task-alpha",
+      stepId: "step-alpha",
+      operationId: "operation-alpha",
+      operationGeneration: 3,
+    },
+    ...overrides,
+  };
+}
+
+function plan(
+  stepOverrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    schemaVersion: 4,
+    actorId: ACTOR_ID,
+    taskId: "task-alpha",
+    turnId: "turn-alpha",
+    planId: "plan-alpha",
+    planRevision: 2,
+    planRevisions: [],
+    title: "Research dinner options",
+    status: "active",
+    activeStepId: "step-alpha",
+    gate: { mode: "auto", status: "satisfied" },
+    steps: [step(stepOverrides)],
+  };
+}
+
+function currentState(
+  stateVersion = 11,
+  progressSequence = 5,
+): Record<string, unknown> {
+  return {
+    status: "current",
+    stateVersion,
+    snapshot: {
+      actorId: ACTOR_ID,
+      stateVersion,
+      progressSequence,
+      activeTurn: { turnId: "turn-alpha", status: "active" },
+      latestTurn: { turnId: "turn-alpha", status: "active" },
+      activeTask: plan(),
+      pendingInput: { requestId: "input-alpha" },
+      pendingApproval: { approvalRequestId: "approval-alpha" },
+      pendingActions: [{ actionRequestId: "action-alpha" }],
+      recentActions: [{ actionRequestId: "action-alpha" }],
+    },
+  };
+}
+
+describe("assistant task projection", () => {
+  it("produces the same TaskPlan model from live snapshot and current state", () => {
+    const live = reduceTaskFrame(
+      createTaskProjection(ACTOR_ID),
+      "nyxid.task.snapshot",
+      plan(),
+      5,
+    );
+    const reloaded = applyCurrentTaskState(
+      createTaskProjection(ACTOR_ID),
+      currentState(),
+    ).projection;
+
+    expect(reloaded.task).toEqual(live.task);
+    expect([...reloaded.steps]).toEqual([...live.steps]);
+    expect(reloaded.pendingActions).toHaveLength(1);
+  });
+
+  it("applies only newer exact-plan step changes", () => {
+    const snapshot = reduceTaskFrame(
+      createTaskProjection(ACTOR_ID),
+      "nyxid.task.snapshot",
+      plan(),
+      5,
+    );
+    const changed = reduceTaskFrame(
+      snapshot,
+      "nyxid.task.step.changed",
+      {
+        taskId: "task-alpha",
+        planRevision: 2,
+        changeKind: "status",
+        step: step({ status: "done", externalEffect: "not_applied" }),
+      },
+      6,
+    );
+
+    expect(changed.steps.get("step-alpha")?.status).toBe("done");
+    expect(reduceTaskFrame(changed, "nyxid.task.snapshot", plan(), 6)).toBe(
+      changed,
+    );
+    expect(() =>
+      reduceTaskFrame(
+        changed,
+        "nyxid.task.step.changed",
+        {
+          taskId: "task-other",
+          planRevision: 2,
+          changeKind: "status",
+          step: step(),
+        },
+        7,
+      ),
+    ).toThrow(TaskStateProtocolError);
+  });
+
+  it("never rolls state or progress backward and exposes only actor actions", () => {
+    const current = applyCurrentTaskState(
+      createTaskProjection(ACTOR_ID),
+      currentState(),
+    ).projection;
+    const stale = applyCurrentTaskState(
+      current,
+      currentState(10, 4),
+    ).projection;
+
+    expect(stale).toBe(current);
+    expect(taskCan(current, "stop")).toBe(true);
+    expect(taskCan(current, "retry", "step-alpha")).toBe(true);
+    expect(taskCan(current, "skip", "missing-step")).toBe(false);
+  });
+
+  it("handles conditional current-state statuses explicitly", () => {
+    const current = applyCurrentTaskState(
+      createTaskProjection(ACTOR_ID),
+      currentState(),
+    ).projection;
+    expect(
+      applyCurrentTaskState(current, {
+        status: "not_modified",
+        stateVersion: 11,
+      }),
+    ).toEqual({ projection: current, reload: false });
+    expect(
+      applyCurrentTaskState(current, { status: "reload_required" }).reload,
+    ).toBe(true);
+    expect(
+      applyCurrentTaskState(current, { status: "not_found" }).projection.task,
+    ).toBeNull();
+    expect(() =>
+      applyCurrentTaskState(current, {
+        ...currentState(),
+        snapshot: {
+          ...(currentState().snapshot as Record<string, unknown>),
+          actorId: "nyxid-chat-other",
+        },
+      }),
+    ).toThrow("different conversation");
+  });
+
+  it("rejects a live TaskPlan for a different conversation actor", () => {
+    expect(() =>
+      reduceTaskFrame(
+        createTaskProjection("nyxid-chat-actor-other"),
+        "nyxid.task.snapshot",
+        plan(),
+        1,
+      ),
+    ).toThrow("different conversation");
+  });
+});

--- a/frontend/src/lib/assistant/task-state.ts
+++ b/frontend/src/lib/assistant/task-state.ts
@@ -1,0 +1,293 @@
+import {
+  assertTaskPlanRelationships,
+  decodeTaskPlan,
+  decodeTaskStep,
+} from "@/lib/assistant/task-plan";
+import type { TaskPlan, TaskStep } from "@/types/assistant";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface AssistantTaskProjection {
+  readonly actorId: string | null;
+  readonly stateVersion: number;
+  readonly progressSequence: number;
+  readonly activeTurn: JsonRecord | null;
+  readonly latestTurn: JsonRecord | null;
+  readonly task: TaskPlan | null;
+  readonly steps: ReadonlyMap<string, TaskStep>;
+  readonly pendingInput: JsonRecord | null;
+  readonly pendingApproval: JsonRecord | null;
+  readonly latestInputResolution: JsonRecord | null;
+  readonly latestApprovalResolution: JsonRecord | null;
+  readonly pendingActions: readonly JsonRecord[];
+}
+
+export class TaskStateProtocolError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = "NYXID_STATE_SNAPSHOT_INVALID") {
+    super(message);
+    this.name = "TaskStateProtocolError";
+    this.code = code;
+  }
+}
+
+export function createTaskProjection(
+  actorId: string | null = null,
+): AssistantTaskProjection {
+  return {
+    actorId,
+    stateVersion: 0,
+    progressSequence: 0,
+    activeTurn: null,
+    latestTurn: null,
+    task: null,
+    steps: new Map(),
+    pendingInput: null,
+    pendingApproval: null,
+    latestInputResolution: null,
+    latestApprovalResolution: null,
+    pendingActions: [],
+  };
+}
+
+export function reduceTaskFrame(
+  projection: AssistantTaskProjection,
+  name: string,
+  payload: unknown,
+  rawSequence: unknown,
+): AssistantTaskProjection {
+  if (name !== "nyxid.task.snapshot" && name !== "nyxid.task.step.changed") {
+    return projection;
+  }
+  const sequence = version(rawSequence);
+  if (sequence === null) {
+    throw new TaskStateProtocolError(
+      "Actor progress sequence is invalid.",
+      "NYXID_SEQUENCE_INVALID",
+    );
+  }
+  if (sequence <= projection.progressSequence) return projection;
+
+  if (name === "nyxid.task.snapshot") {
+    const task = decodeTaskPlan(payload);
+    if (projection.actorId && projection.actorId !== task.actorId) {
+      throw new TaskStateProtocolError(
+        "TaskPlan belongs to a different conversation.",
+        "NYXID_STATE_IDENTITY_CONFLICT",
+      );
+    }
+    return {
+      ...projection,
+      actorId: task.actorId,
+      progressSequence: sequence,
+      task,
+      steps: new Map(task.steps.map((step) => [step.stepId, step])),
+    };
+  }
+
+  const change = record(payload, "task step change");
+  const changeKind = change.changeKind;
+  if (
+    changeKind !== "status" &&
+    changeKind !== "substep" &&
+    changeKind !== "added" &&
+    changeKind !== "cancelled"
+  ) {
+    throw new TaskStateProtocolError("Task step change kind is invalid.");
+  }
+  if (!projection.task) {
+    throw new TaskStateProtocolError(
+      "Task step change arrived before its TaskPlan snapshot.",
+    );
+  }
+  if (
+    change.taskId !== projection.task.taskId ||
+    version(change.planRevision) !== projection.task.planRevision
+  ) {
+    throw new TaskStateProtocolError(
+      "Task step change does not match the active TaskPlan.",
+    );
+  }
+  const step = decodeTaskStep(change.step);
+  const steps = new Map(projection.steps);
+  steps.set(step.stepId, step);
+  const ordered = [...steps.values()].sort(
+    (left, right) =>
+      left.order - right.order || left.stepId.localeCompare(right.stepId),
+  );
+  const task = { ...projection.task, steps: ordered };
+  assertTaskPlanRelationships(task);
+  return {
+    ...projection,
+    progressSequence: sequence,
+    task,
+    steps,
+  };
+}
+
+export function applyCurrentTaskState(
+  projection: AssistantTaskProjection,
+  input: unknown,
+): { readonly projection: AssistantTaskProjection; readonly reload: boolean } {
+  const envelope = record(input, "current-state envelope");
+  if (envelope.status === "reload_required") {
+    return { projection, reload: true };
+  }
+  if (envelope.status === "not_found") {
+    return {
+      projection: createTaskProjection(projection.actorId),
+      reload: false,
+    };
+  }
+  if (envelope.status === "not_modified") {
+    const stateVersion = version(envelope.stateVersion);
+    if (stateVersion !== projection.stateVersion) {
+      throw new TaskStateProtocolError(
+        "Current-state version does not match the local projection.",
+        "NYXID_STATE_VERSION_CONFLICT",
+      );
+    }
+    return { projection, reload: false };
+  }
+  if (envelope.status !== "current") {
+    throw new TaskStateProtocolError(
+      "Current-state status is outside the supported contract.",
+      "NYXID_STATE_STATUS_INVALID",
+    );
+  }
+
+  const snapshot = record(envelope.snapshot, "current-state snapshot");
+  const stateVersion = version(envelope.stateVersion);
+  const snapshotVersion = version(snapshot.stateVersion);
+  const progressSequence = version(snapshot.progressSequence);
+  if (
+    stateVersion === null ||
+    snapshotVersion !== stateVersion ||
+    progressSequence === null
+  ) {
+    throw new TaskStateProtocolError(
+      "Current-state snapshot versions are invalid.",
+    );
+  }
+  if (
+    stateVersion < projection.stateVersion ||
+    progressSequence < projection.progressSequence
+  ) {
+    return { projection, reload: false };
+  }
+  const actorId = identity(snapshot.actorId);
+  if (!actorId || (projection.actorId && projection.actorId !== actorId)) {
+    throw new TaskStateProtocolError(
+      "Current-state snapshot belongs to a different conversation.",
+      "NYXID_STATE_IDENTITY_CONFLICT",
+    );
+  }
+
+  const activeTask = optionalRecord(snapshot.activeTask);
+  const task = activeTask ? decodeTaskPlan(activeTask) : null;
+  if (task && task.actorId !== actorId) {
+    throw new TaskStateProtocolError(
+      "Current-state TaskPlan belongs to a different conversation.",
+      "NYXID_STATE_IDENTITY_CONFLICT",
+    );
+  }
+  const pendingActions = distinctActions([
+    ...optionalArray(snapshot.pendingActions),
+    ...optionalArray(snapshot.recentActions),
+  ]);
+  return {
+    projection: {
+      actorId,
+      stateVersion,
+      progressSequence,
+      activeTurn: cloneNullableRecord(snapshot.activeTurn),
+      latestTurn: cloneNullableRecord(snapshot.latestTurn),
+      task,
+      steps: new Map(task?.steps.map((step) => [step.stepId, step]) ?? []),
+      pendingInput: cloneNullableRecord(snapshot.pendingInput),
+      pendingApproval: cloneNullableRecord(snapshot.pendingApproval),
+      latestInputResolution: cloneNullableRecord(
+        snapshot.latestInputResolution,
+      ),
+      latestApprovalResolution: cloneNullableRecord(
+        snapshot.latestApprovalResolution,
+      ),
+      pendingActions,
+    },
+    reload: false,
+  };
+}
+
+export function taskCan(
+  projection: AssistantTaskProjection | null | undefined,
+  action: "retry" | "skip" | "stop",
+  stepId?: string,
+): boolean {
+  if (!projection) return false;
+  if (action === "stop" && !stepId) {
+    return [...projection.steps.values()].some(
+      (step) => step.availableActions.stop,
+    );
+  }
+  if (!stepId) return false;
+  return projection.steps.get(stepId)?.availableActions[action] === true;
+}
+
+function distinctActions(input: unknown[]): JsonRecord[] {
+  const actions = new Map<string, JsonRecord>();
+  for (const item of input) {
+    const action = optionalRecord(item);
+    const actionRequestId = identity(action?.actionRequestId);
+    if (!action || !actionRequestId || actions.has(actionRequestId)) continue;
+    actions.set(actionRequestId, cloneRecord(action));
+  }
+  return [...actions.values()];
+}
+
+function record(input: unknown, label: string): JsonRecord {
+  const value = optionalRecord(input);
+  if (!value) throw new TaskStateProtocolError(`${label} must be an object.`);
+  return value;
+}
+
+function optionalRecord(input: unknown): JsonRecord | null {
+  return input && typeof input === "object" && !Array.isArray(input)
+    ? (input as JsonRecord)
+    : null;
+}
+
+function optionalArray(input: unknown): unknown[] {
+  return Array.isArray(input) ? input : [];
+}
+
+function version(input: unknown): number | null {
+  const parsed =
+    typeof input === "string" && /^\d+$/.test(input) ? Number(input) : input;
+  return typeof parsed === "number" &&
+    Number.isSafeInteger(parsed) &&
+    parsed >= 0
+    ? parsed
+    : null;
+}
+
+function identity(input: unknown): string | null {
+  if (typeof input !== "string" || input.length < 1 || input.length > 256) {
+    return null;
+  }
+  return [...input].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127 || /[\s/\\?#]/u.test(character);
+  })
+    ? null
+    : input;
+}
+
+function cloneRecord(value: JsonRecord): JsonRecord {
+  return JSON.parse(JSON.stringify(value)) as JsonRecord;
+}
+
+function cloneNullableRecord(value: unknown): JsonRecord | null {
+  const parsed = optionalRecord(value);
+  return parsed ? cloneRecord(parsed) : null;
+}

--- a/frontend/src/lib/assistant/transport-shell.test.ts
+++ b/frontend/src/lib/assistant/transport-shell.test.ts
@@ -87,6 +87,10 @@ class RecordingTransport implements AssistantTransport {
     this.calls.push("skip-step");
   }
 
+  async resolvePlan(): Promise<void> {
+    this.calls.push("resolve-plan");
+  }
+
   async decideApproval(): Promise<TurnHandle | null> {
     this.calls.push("approval");
     return null;

--- a/frontend/src/lib/assistant/transport-shell.test.ts
+++ b/frontend/src/lib/assistant/transport-shell.test.ts
@@ -71,6 +71,22 @@ class RecordingTransport implements AssistantTransport {
     this.calls.push("cancel");
   }
 
+  async stopTask(): Promise<void> {
+    this.calls.push("stop-task");
+  }
+
+  async steerTask(): Promise<void> {
+    this.calls.push("steer-task");
+  }
+
+  async retryStep(): Promise<void> {
+    this.calls.push("retry-step");
+  }
+
+  async skipStep(): Promise<void> {
+    this.calls.push("skip-step");
+  }
+
   async decideApproval(): Promise<TurnHandle | null> {
     this.calls.push("approval");
     return null;

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -186,6 +186,42 @@ class MockAssistantTransport implements AssistantTransport {
     if (!stepId) throw new Error("Step identity is required.");
   }
 
+  async resolvePlan(
+    conversationId: string,
+    blockId: string,
+    confirmed: boolean,
+  ): Promise<void> {
+    const block = assistantMockStore.findBlock(conversationId, blockId);
+    if (block?.type !== "task_plan") {
+      throw new Error("Task plan was not found.");
+    }
+    const gate = block.plan.gate;
+    if (
+      gate?.mode !== "confirm" ||
+      gate.status !== "pending" ||
+      !gate.requestId ||
+      !gate.taskId ||
+      !gate.planId ||
+      gate.planRevision === undefined
+    ) {
+      throw new Error("This plan gate is no longer pending.");
+    }
+    this.emitLocalActionPatch(
+      conversationId,
+      blockId,
+      {
+        plan: {
+          ...block.plan,
+          gate: {
+            ...gate,
+            status: confirmed ? "satisfied" : "rejected",
+          },
+        },
+      },
+      () => undefined,
+    );
+  }
+
   async decideApproval(
     conversationId: string,
     blockId: string,
@@ -682,6 +718,14 @@ export class DelegatingAssistantTransport implements AssistantTransport {
 
   skipStep(conversationId: string, stepId: string): Promise<void> {
     return this.transport.skipStep(conversationId, stepId);
+  }
+
+  resolvePlan(
+    conversationId: string,
+    blockId: string,
+    confirmed: boolean,
+  ): Promise<void> {
+    return this.transport.resolvePlan(conversationId, blockId, confirmed);
   }
 
   decideApproval(

--- a/frontend/src/lib/assistant/transport.ts
+++ b/frontend/src/lib/assistant/transport.ts
@@ -167,6 +167,25 @@ class MockAssistantTransport implements AssistantTransport {
     }
   }
 
+  async stopTask(conversationId: string): Promise<void> {
+    this.cancelActiveTurn(conversationId);
+  }
+
+  async steerTask(conversationId: string, instruction: string): Promise<void> {
+    void conversationId;
+    if (!instruction.trim()) throw new Error("Steering cannot be empty.");
+  }
+
+  async retryStep(conversationId: string, stepId: string): Promise<void> {
+    void conversationId;
+    if (!stepId) throw new Error("Step identity is required.");
+  }
+
+  async skipStep(conversationId: string, stepId: string): Promise<void> {
+    void conversationId;
+    if (!stepId) throw new Error("Step identity is required.");
+  }
+
   async decideApproval(
     conversationId: string,
     blockId: string,
@@ -647,6 +666,22 @@ export class DelegatingAssistantTransport implements AssistantTransport {
 
   cancelActiveTurn(conversationId: string): void {
     this.transport.cancelActiveTurn(conversationId);
+  }
+
+  stopTask(conversationId: string): Promise<void> {
+    return this.transport.stopTask(conversationId);
+  }
+
+  steerTask(conversationId: string, instruction: string): Promise<void> {
+    return this.transport.steerTask(conversationId, instruction);
+  }
+
+  retryStep(conversationId: string, stepId: string): Promise<void> {
+    return this.transport.retryStep(conversationId, stepId);
+  }
+
+  skipStep(conversationId: string, stepId: string): Promise<void> {
+    return this.transport.skipStep(conversationId, stepId);
   }
 
   decideApproval(

--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -19,6 +19,10 @@ const {
   mockCancelMutateAsync,
   mockDecideMutateAsync,
   mockResolveInputMutateAsync,
+  mockStopTaskMutateAsync,
+  mockSteerTaskMutateAsync,
+  mockRetryStepMutateAsync,
+  mockSkipStepMutateAsync,
   mockContinueAction,
   mockDeleteMutateAsync,
   mockSendMutateAsync,
@@ -30,6 +34,10 @@ const {
   mockCancelMutateAsync: vi.fn(),
   mockDecideMutateAsync: vi.fn(),
   mockResolveInputMutateAsync: vi.fn(),
+  mockStopTaskMutateAsync: vi.fn(),
+  mockSteerTaskMutateAsync: vi.fn(),
+  mockRetryStepMutateAsync: vi.fn(),
+  mockSkipStepMutateAsync: vi.fn(),
   mockContinueAction: vi.fn(),
   mockDeleteMutateAsync: vi.fn(),
   mockSendMutateAsync: vi.fn(),
@@ -179,6 +187,22 @@ vi.mock("@/hooks/use-assistant", () => ({
   }),
   useResolveInput: () => ({
     mutateAsync: mockResolveInputMutateAsync,
+    isPending: false,
+  }),
+  useStopTask: () => ({
+    mutateAsync: mockStopTaskMutateAsync,
+    isPending: false,
+  }),
+  useSteerTask: () => ({
+    mutateAsync: mockSteerTaskMutateAsync,
+    isPending: false,
+  }),
+  useRetryStep: () => ({
+    mutateAsync: mockRetryStepMutateAsync,
+    isPending: false,
+  }),
+  useSkipStep: () => ({
+    mutateAsync: mockSkipStepMutateAsync,
     isPending: false,
   }),
   useActionCardActions: () => ({
@@ -896,5 +920,87 @@ describe("AssistantPage canonical conversation resolution", () => {
     renderPage();
 
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("AssistantPage typed task controls", () => {
+  it("routes active-task input and TaskPlan actions through actor controls", async () => {
+    const event = userEvent.setup();
+    const conversationId = "nyxid-chat-f8369965a444433f92ec50e67ad8ee52";
+    state.search = { c: conversationId };
+    state.conversations = [{ ...existingConversation, id: conversationId }];
+    state.historyMessages = [
+      {
+        id: "assistant-current-state",
+        role: "assistant",
+        schema_version: 1,
+        created_at: "2026-08-11T00:00:00.000Z",
+        blocks: [
+          {
+            type: "task_plan",
+            block_id: "current-task-plan:task-alpha",
+            state_version: 47,
+            progress_sequence: 12,
+            plan: {
+              schemaVersion: 4,
+              actorId: conversationId,
+              taskId: "task-alpha",
+              turnId: "turn-alpha",
+              planId: "plan-alpha",
+              planRevision: 2,
+              planRevisions: [],
+              title: "Publish the release",
+              status: "active",
+              activeStepId: "step-alpha",
+              steps: [
+                {
+                  stepId: "step-alpha",
+                  order: 1,
+                  kind: "tool",
+                  status: "running",
+                  required: true,
+                  description: "Publish release notes",
+                  source: { kind: "tool", label: "github_release" },
+                  mayChangeExternalState: true,
+                  externalEffect: "not_started",
+                  availableActions: {
+                    retry: true,
+                    skip: true,
+                    stop: true,
+                  },
+                  dependsOn: [],
+                  substeps: [],
+                  operation: { operationGeneration: 2 },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    renderPage();
+
+    const composer = screen.getByRole("textbox");
+    expect(composer).toBeEnabled();
+    await event.type(composer, "Use the release branch");
+    await event.click(
+      screen.getByRole("button", { name: "Send steering instruction" }),
+    );
+    expect(mockSteerTaskMutateAsync).toHaveBeenCalledWith(
+      "Use the release branch",
+    );
+    expect(mockSendMutateAsync).not.toHaveBeenCalled();
+
+    await event.click(screen.getByRole("button", { name: "Stop task" }));
+    await event.click(
+      screen.getByRole("button", { name: "Retry Publish release notes" }),
+    );
+    await event.click(
+      screen.getByRole("button", { name: "Skip Publish release notes" }),
+    );
+    expect(mockStopTaskMutateAsync).toHaveBeenCalledOnce();
+    expect(mockRetryStepMutateAsync).toHaveBeenCalledWith("step-alpha");
+    expect(mockSkipStepMutateAsync).toHaveBeenCalledWith("step-alpha");
+    expect(mockCancelMutateAsync).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/assistant.test.tsx
+++ b/frontend/src/pages/assistant.test.tsx
@@ -23,6 +23,7 @@ const {
   mockSteerTaskMutateAsync,
   mockRetryStepMutateAsync,
   mockSkipStepMutateAsync,
+  mockResolvePlanMutateAsync,
   mockContinueAction,
   mockDeleteMutateAsync,
   mockSendMutateAsync,
@@ -38,6 +39,7 @@ const {
   mockSteerTaskMutateAsync: vi.fn(),
   mockRetryStepMutateAsync: vi.fn(),
   mockSkipStepMutateAsync: vi.fn(),
+  mockResolvePlanMutateAsync: vi.fn(),
   mockContinueAction: vi.fn(),
   mockDeleteMutateAsync: vi.fn(),
   mockSendMutateAsync: vi.fn(),
@@ -203,6 +205,10 @@ vi.mock("@/hooks/use-assistant", () => ({
   }),
   useSkipStep: () => ({
     mutateAsync: mockSkipStepMutateAsync,
+    isPending: false,
+  }),
+  useResolvePlan: () => ({
+    mutateAsync: mockResolvePlanMutateAsync,
     isPending: false,
   }),
   useActionCardActions: () => ({
@@ -952,6 +958,14 @@ describe("AssistantPage typed task controls", () => {
               title: "Publish the release",
               status: "active",
               activeStepId: "step-alpha",
+              gate: {
+                mode: "confirm",
+                status: "pending",
+                requestId: "plan-gate-alpha",
+                taskId: "task-alpha",
+                planId: "plan-alpha",
+                planRevision: 2,
+              },
               steps: [
                 {
                   stepId: "step-alpha",
@@ -1001,6 +1015,16 @@ describe("AssistantPage typed task controls", () => {
     expect(mockStopTaskMutateAsync).toHaveBeenCalledOnce();
     expect(mockRetryStepMutateAsync).toHaveBeenCalledWith("step-alpha");
     expect(mockSkipStepMutateAsync).toHaveBeenCalledWith("step-alpha");
+    await event.click(screen.getByRole("button", { name: "Confirm plan" }));
+    await event.click(screen.getByRole("button", { name: "Reject plan" }));
+    expect(mockResolvePlanMutateAsync).toHaveBeenNthCalledWith(1, {
+      blockId: "current-task-plan:task-alpha",
+      confirmed: true,
+    });
+    expect(mockResolvePlanMutateAsync).toHaveBeenNthCalledWith(2, {
+      blockId: "current-task-plan:task-alpha",
+      confirmed: false,
+    });
     expect(mockCancelMutateAsync).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -31,7 +31,11 @@ import {
   useDeleteConversation,
   useSendMessage,
   useResolveInput,
+  useRetryStep,
   useTurnEpisode,
+  useSkipStep,
+  useSteerTask,
+  useStopTask,
 } from "@/hooks/use-assistant";
 import { ApiError } from "@/lib/api-client";
 import {
@@ -46,7 +50,11 @@ import type { InputAnswer } from "@/schemas/assistant-input";
 import { useAssistantContextStore } from "@/stores/assistant-context-store";
 import { useAssistantDraftStore } from "@/stores/assistant-draft-store";
 import { useAuthStore } from "@/stores/auth-store";
-import { isTurnActive, type AssistantMessage } from "@/types/assistant";
+import {
+  isTurnActive,
+  type AssistantMessage,
+  type TaskPlanContentBlock,
+} from "@/types/assistant";
 
 const MockScenariosAction = import.meta.env.DEV
   ? lazy(() =>
@@ -106,6 +114,23 @@ function optimisticUserMessage(text: string): AssistantMessage {
     blocks: [{ type: "text", block_id: "optimistic-user-block", text }],
     created_at: new Date().toISOString(),
   };
+}
+
+function latestTaskPlanBlock(
+  messages: readonly AssistantMessage[],
+): TaskPlanContentBlock | undefined {
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex -= 1
+  ) {
+    const blocks = messages[messageIndex]?.blocks ?? [];
+    for (let blockIndex = blocks.length - 1; blockIndex >= 0; blockIndex -= 1) {
+      const block = blocks[blockIndex];
+      if (block?.type === "task_plan") return block;
+    }
+  }
+  return undefined;
 }
 
 interface PendingSendEcho {
@@ -193,6 +218,10 @@ export function AssistantPage({
   const decideApproval = useDecideApproval(selectedId);
   const resolveInput = useResolveInput(selectedId);
   const actionCards = useActionCardActions(selectedId);
+  const stopTask = useStopTask(selectedId);
+  const steerTask = useSteerTask(selectedId);
+  const retryStep = useRetryStep(selectedId);
+  const skipStep = useSkipStep(selectedId);
   const deleteConversation = useDeleteConversation();
   const turnStatus = turn.data?.status;
   const active = isTurnActive(turnStatus);
@@ -201,6 +230,10 @@ export function AssistantPage({
     active ||
     sendMessage.isPending ||
     cancelTurn.isPending ||
+    stopTask.isPending ||
+    steerTask.isPending ||
+    retryStep.isPending ||
+    skipStep.isPending ||
     decideApproval.isPending ||
     resolveInput.isPending ||
     episodeState?.open === true;
@@ -514,6 +547,52 @@ export function AssistantPage({
       ? transcript
       : [...transcript, optimisticUserMessage(pendingEcho.content)];
   }, [history.data?.messages, pendingEcho]);
+  const taskPlanBlock = useMemo(
+    () => latestTaskPlanBlock(messages),
+    [messages],
+  );
+  const typedTaskActive = Boolean(
+    selectedId?.startsWith("nyxid-chat-") &&
+    taskPlanBlock?.plan.actorId === selectedId &&
+    taskPlanBlock.plan.status === "active",
+  );
+
+  async function handleComposerSend(content: string) {
+    if (!typedTaskActive) return handleSend(content);
+    beginContinuation();
+    try {
+      await steerTask.mutateAsync(content);
+    } finally {
+      endContinuation();
+    }
+  }
+
+  async function handleStopTask() {
+    beginContinuation();
+    try {
+      await stopTask.mutateAsync();
+    } finally {
+      endContinuation();
+    }
+  }
+
+  async function handleRetryStep(stepId: string) {
+    beginContinuation();
+    try {
+      await retryStep.mutateAsync(stepId);
+    } finally {
+      endContinuation();
+    }
+  }
+
+  async function handleSkipStep(stepId: string) {
+    beginContinuation();
+    try {
+      await skipStep.mutateAsync(stepId);
+    } finally {
+      endContinuation();
+    }
+  }
   const awaitingFirstTurn =
     active || sendMessage.isPending || episodeState?.open === true;
 
@@ -615,17 +694,25 @@ export function AssistantPage({
             onActionProgress={actionCards.setInProgress}
             onBlockAction={actionCards.blockAction}
             onResolveAction={handleResolveAction}
+            onStopTask={handleStopTask}
+            onRetryStep={handleRetryStep}
+            onSkipStep={handleSkipStep}
           />
         )}
         <div ref={composerRef} className="absolute inset-x-0 bottom-0 z-10">
           <ChatComposer
-            active={active}
-            sending={sendMessage.isPending}
+            active={active || typedTaskActive}
+            allowActiveInput={typedTaskActive}
+            sending={sendMessage.isPending || steerTask.isPending}
             ownerUserId={user?.id ?? null}
             draftKey={draftKey}
             focusRequest={composerFocusRequest}
-            onSend={handleSend}
-            onStop={() => cancelTurn.mutateAsync()}
+            onSend={handleComposerSend}
+            onStop={() =>
+              typedTaskActive
+                ? stopTask.mutateAsync()
+                : cancelTurn.mutateAsync()
+            }
           />
         </div>
       </div>

--- a/frontend/src/pages/assistant.tsx
+++ b/frontend/src/pages/assistant.tsx
@@ -31,6 +31,7 @@ import {
   useDeleteConversation,
   useSendMessage,
   useResolveInput,
+  useResolvePlan,
   useRetryStep,
   useTurnEpisode,
   useSkipStep,
@@ -217,6 +218,7 @@ export function AssistantPage({
   const cancelTurn = useCancelTurn(selectedId);
   const decideApproval = useDecideApproval(selectedId);
   const resolveInput = useResolveInput(selectedId);
+  const resolvePlan = useResolvePlan(selectedId);
   const actionCards = useActionCardActions(selectedId);
   const stopTask = useStopTask(selectedId);
   const steerTask = useSteerTask(selectedId);
@@ -234,6 +236,7 @@ export function AssistantPage({
     steerTask.isPending ||
     retryStep.isPending ||
     skipStep.isPending ||
+    resolvePlan.isPending ||
     decideApproval.isPending ||
     resolveInput.isPending ||
     episodeState?.open === true;
@@ -593,6 +596,15 @@ export function AssistantPage({
       endContinuation();
     }
   }
+
+  async function handleResolvePlan(blockId: string, confirmed: boolean) {
+    beginContinuation();
+    try {
+      await resolvePlan.mutateAsync({ blockId, confirmed });
+    } finally {
+      endContinuation();
+    }
+  }
   const awaitingFirstTurn =
     active || sendMessage.isPending || episodeState?.open === true;
 
@@ -697,6 +709,7 @@ export function AssistantPage({
             onStopTask={handleStopTask}
             onRetryStep={handleRetryStep}
             onSkipStep={handleSkipStep}
+            onResolvePlan={handleResolvePlan}
           />
         )}
         <div ref={composerRef} className="absolute inset-x-0 bottom-0 z-10">

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -27,6 +27,188 @@ export type RunStepStatus =
   | "failed"
   | "skipped";
 
+export type TaskStatus =
+  | "active"
+  | "succeeded"
+  | "failed"
+  | "stopped"
+  | "blocked";
+
+export type TaskStepStatus =
+  | "planned"
+  | "waiting"
+  | "running"
+  | "done"
+  | "failed"
+  | "skipped"
+  | "cancelled"
+  | "uncertain";
+
+export type TaskExternalEffect =
+  | "not_started"
+  | "not_applied"
+  | "confirmed"
+  | "may_have_changed";
+
+export type TaskStepKind =
+  | "llm"
+  | "tool"
+  | "browser_action"
+  | "postcondition"
+  | "input"
+  | "approval"
+  | "web"
+  | "condition";
+
+export interface TaskAvailableActions {
+  readonly retry: boolean;
+  readonly skip: boolean;
+  readonly stop: boolean;
+}
+
+export interface TaskSubstep {
+  readonly substepId: string;
+  readonly title: string;
+  readonly status: "running" | "done" | "failed";
+}
+
+export interface TaskNumericCondition {
+  readonly conditionId: string;
+  readonly sourceInputRequestId: string;
+  readonly suggestedThreshold: number;
+  readonly effectiveThreshold: number;
+  readonly thresholdOrigin: "suggested" | "user_override";
+  readonly observedValue: number;
+  readonly comparison: "gte";
+  readonly outcome: "true" | "false";
+  readonly evaluatedAt?: string;
+  readonly guardedToolName: string;
+}
+
+export type TaskStepSource =
+  | { readonly kind: "llm"; readonly label: string }
+  | {
+      readonly kind: "tool";
+      readonly label: string;
+      readonly serviceSlug?: string;
+      readonly serviceId?: string;
+    }
+  | { readonly kind: "browserAction"; readonly label: string }
+  | { readonly kind: "postcondition"; readonly label: string }
+  | { readonly kind: "input"; readonly label: string }
+  | { readonly kind: "approval"; readonly label: string }
+  | { readonly kind: "web"; readonly label: string }
+  | {
+      readonly kind: "condition";
+      readonly label: string;
+      readonly condition: TaskNumericCondition;
+    };
+
+export interface TaskOperation {
+  readonly conversationActorId?: string;
+  readonly turnId?: string;
+  readonly taskId?: string;
+  readonly stepId?: string;
+  readonly operationId?: string;
+  readonly operationGeneration?: number;
+  readonly kind?: string;
+  readonly phase?: string;
+  readonly latestProgressSequence?: number;
+  readonly safeMessage?: string;
+  readonly failureCode?: string;
+  readonly progressMessage?: string;
+  readonly startedAt?: string;
+  readonly updatedAt?: string;
+  readonly completedAt?: string;
+  readonly lastProgressAt?: string;
+  readonly stalledAt?: string;
+}
+
+export interface TaskApprovalObservation {
+  readonly approvalRequestId: string;
+  readonly decisionMode: "unknown" | "per_request" | "grant";
+  readonly receiptStatus: "approval_required" | "denied";
+  readonly observedAt: string;
+}
+
+export interface TaskStep {
+  readonly stepId: string;
+  readonly order: number;
+  readonly kind: TaskStepKind;
+  readonly status: TaskStepStatus;
+  readonly required: boolean;
+  readonly description: string;
+  readonly source: TaskStepSource;
+  readonly mayChangeExternalState: boolean;
+  readonly externalEffect: TaskExternalEffect;
+  readonly availableActions: TaskAvailableActions;
+  readonly updatedAt?: string;
+  readonly addedBy?:
+    | "initial"
+    | "scope_resolution"
+    | "replan"
+    | "steering"
+    | "user_revision";
+  readonly addedInPlanRevision?: number;
+  readonly cancelledInPlanRevision?: number;
+  readonly dependsOn: readonly string[];
+  readonly estimate?: { readonly kind: "duration"; readonly seconds: number };
+  readonly substeps: readonly TaskSubstep[];
+  readonly operation?: TaskOperation | null;
+  readonly approvalObservation?: TaskApprovalObservation;
+  readonly guard?: {
+    readonly conditionStepId: string;
+    readonly requiredOutcome: "true" | "false";
+  };
+  readonly actionRequestId?: string;
+  readonly approvalRequestId?: string;
+  readonly failureCode?: string;
+  readonly safeMessage?: string;
+  readonly safeToSkip?: boolean;
+}
+
+export interface TaskPlanGate {
+  readonly mode: "auto" | "confirm";
+  readonly status?: "pending" | "satisfied" | "rejected";
+  readonly requestId?: string;
+  readonly taskId?: string;
+  readonly planId?: string;
+  readonly planRevision?: number;
+  readonly reason?: string;
+  readonly decidedAt?: string;
+}
+
+export interface TaskPlan {
+  readonly schemaVersion: number;
+  readonly actorId: string;
+  readonly taskId: string;
+  readonly turnId: string;
+  readonly planId: string;
+  readonly planRevision: number;
+  readonly planRevisionHistoryStart?: number;
+  readonly planRevisions: readonly {
+    readonly planRevision: number;
+    readonly revisionCause:
+      | "initial"
+      | "scope_resolution"
+      | "failure_recovery"
+      | "steering"
+      | "user_revision";
+    readonly committedAt?: string;
+    readonly addedStepIds: readonly string[];
+    readonly cancelledStepIds: readonly string[];
+  }[];
+  readonly title: string;
+  readonly status: TaskStatus;
+  readonly activeStepId?: string;
+  readonly failureCode?: string;
+  readonly safeMessage?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly gate?: TaskPlanGate | null;
+  readonly steps: readonly TaskStep[];
+}
+
 export type ApprovalDecision = "approved" | "denied" | "expired" | "cancelled";
 
 export type ApprovalDecisionChannel = "web" | "telegram" | "mobile";
@@ -78,6 +260,14 @@ export interface RunContentBlock {
     readonly artifact_id: string | null;
     readonly approval_request_id: string | null;
   }>;
+}
+
+export interface TaskPlanContentBlock {
+  readonly type: "task_plan";
+  readonly block_id: string;
+  readonly state_version: number;
+  readonly progress_sequence: number;
+  readonly plan: TaskPlan;
 }
 
 export interface ApprovalCardContentBlock {
@@ -160,6 +350,7 @@ export type ContentBlock =
   | TextContentBlock
   | ConnectCardContentBlock
   | RunContentBlock
+  | TaskPlanContentBlock
   | ApprovalCardContentBlock
   | InputCardContentBlock
   | ArtifactContentBlock
@@ -327,6 +518,12 @@ export interface AssistantTransport {
    * on response headers. No-op when nothing is running.
    */
   cancelActiveTurn(conversationId: string): void;
+  /** Stop the actor-owned task against the latest committed state version. */
+  stopTask(conversationId: string): Promise<void>;
+  /** Steer active actor work without opening a competing text turn. */
+  steerTask(conversationId: string, instruction: string): Promise<void>;
+  retryStep(conversationId: string, stepId: string): Promise<void>;
+  skipStep(conversationId: string, stepId: string): Promise<void>;
   /**
    * Send a version-fenced approval decision. The command returns JSON
    * acceptance; later committed projection frames carry business progress.

--- a/frontend/src/types/assistant.ts
+++ b/frontend/src/types/assistant.ts
@@ -129,6 +129,8 @@ export interface TaskApprovalObservation {
   readonly decisionMode: "unknown" | "per_request" | "grant";
   readonly receiptStatus: "approval_required" | "denied";
   readonly observedAt: string;
+  readonly terminalOutcome?: "rejected" | "expired" | "timed_out";
+  readonly subjectKind?: string;
 }
 
 export interface TaskStep {
@@ -524,6 +526,12 @@ export interface AssistantTransport {
   steerTask(conversationId: string, instruction: string): Promise<void>;
   retryStep(conversationId: string, stepId: string): Promise<void>;
   skipStep(conversationId: string, stepId: string): Promise<void>;
+  /** Resolve the exact pending plan gate against a fresh actor-state fence. */
+  resolvePlan(
+    conversationId: string,
+    blockId: string,
+    confirmed: boolean,
+  ): Promise<void>;
   /**
    * Send a version-fenced approval decision. The command returns JSON
    * acceptance; later committed projection frames carry business progress.


### PR DESCRIPTION
## Problem and solution

The NyxID human-session Assistant facade did not hydrate or control the complete actor-owned Aevatar task model. It could therefore diverge from Studio on plan gates, action availability, version fencing, control transitions, reload, and terminal artifacts.

This change adds the shared typed reducer/current-state decoder, TaskPlan rendering, plan confirmation, version-fenced stop/steer/retry/skip controls, reload hydration, and forward-compatible additive-field handling while unknown action verbs fail closed.

Tracks aevatarAI/aevatar#3366.

## Impact

- Assistant frontend transport, reducer, state hydration, task cards, and composer controls
- backend Assistant service response compatibility
- chat wire-contract documentation

## Verification

- frontend Vitest: 316 passed
- Rust focused/backend tests: 29 passed
- frontend lint and build passed
- Rust format and feature checks passed locally

## Documentation

Updated `docs/chat/02-wire-contract.md` for the shared actor-owned task/current-state contract.
