### PR TITLE
Add exact connected-service approvals

### DIFF
--- a/backend/src/billing_integration_tests.rs
+++ b/backend/src/billing_integration_tests.rs
@@ -23,6 +23,9 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use crate::errors::{AppError, AppResult};
+use crate::models::approval_request::{
+    ApprovalRequest, COLLECTION_NAME as APPROVAL_REQUESTS, ExactServiceApprovalBinding,
+};
 use crate::models::billing_rate_cache::{BillingRateCache, COLLECTION_NAME as BILLING_RATE_CACHE};
 use crate::models::billing_wallet::{
     BillingWallet, COLLECTION_NAME as BILLING_WALLET, CollectionState, PlanKind,
@@ -31,7 +34,11 @@ use crate::models::downstream_service::{
     COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
 };
 use crate::models::node::{COLLECTION_NAME as NODES, Node, NodeMetrics, NodeStatus};
+use crate::models::notification_channel::{
+    COLLECTION_NAME as NOTIFICATION_CHANNELS, NotificationChannel,
+};
 use crate::models::provider_config::{COLLECTION_NAME as PROVIDER_CONFIGS, ProviderConfig};
+use crate::models::service_approval_config::ApprovalMode;
 use crate::models::service_billing::{BillingMetric, PlatformUsage};
 use crate::models::ssh_auth_mode::SshAuthMode;
 use crate::models::usage_meter::{
@@ -473,6 +480,149 @@ async fn billing_route_coverage_smoke() {
     );
     assert_route_settled(&db, &mcp.slug, BillingMetric::Requests).await;
     exercised_routes.insert("/mcp (POST)");
+
+    let now = Utc::now();
+    db.collection::<NotificationChannel>(NOTIFICATION_CHANNELS)
+        .insert_one(NotificationChannel {
+            id: Uuid::new_v4().to_string(),
+            user_id: owner_id.clone(),
+            telegram_chat_id: None,
+            telegram_username: None,
+            telegram_enabled: false,
+            telegram_link_code: None,
+            telegram_link_code_expires_at: None,
+            approval_timeout_secs: 300,
+            grant_expiry_days: 30,
+            approval_required: true,
+            push_enabled: false,
+            push_devices: vec![],
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect("enable per-request approval for exact redemption smoke");
+    let exact_arguments = serde_json::json!({
+        "method": "GET",
+        "path": "/exact-billing?source=approval",
+    });
+    let exact_catalog = crate::services::mcp_service::load_operation_catalog(
+        &db,
+        state.node_ws_manager.as_ref(),
+        &owner_id,
+        crate::services::mcp_service::NodeScope::Unrestricted,
+        crate::services::mcp_service::ServiceScope::Unrestricted,
+    )
+    .await
+    .expect("load exact redemption catalog");
+    let exact_service = exact_catalog
+        .services
+        .iter()
+        .find(|service| service.service_id == mcp.id)
+        .expect("billing MCP service is present in exact catalog");
+    let exact_endpoint = exact_service
+        .endpoints
+        .iter()
+        .find(|endpoint| endpoint.endpoint_id == "nyx_generic_proxy_v1")
+        .expect("generic billing MCP request endpoint");
+    let endpoint_id = exact_endpoint.endpoint_id.clone();
+    let endpoint_contract_digest =
+        crate::services::mcp_service::endpoint_contract_digest(exact_endpoint);
+    let operation_digest = crate::services::mcp_service::exact_operation_digest(
+        &mcp.id,
+        exact_endpoint,
+        &exact_arguments,
+    );
+    let catalog_digest =
+        crate::services::mcp_service::operation_catalog_digest(&exact_catalog.services);
+    let request_id = Uuid::new_v4().to_string();
+    let operation_id = "billing-exact-operation".to_string();
+    let operation_generation = 1;
+    let effect_idempotency_key = "billing-exact-idempotency".to_string();
+    let request_key = crate::services::mcp_service::canonical_sha256(serde_json::json!({
+        "contract_version": "nyxid-exact-approval-request.v1",
+        "requester_type": "access_token",
+        "requester_id": owner_id,
+        "actor_user_id": owner_id,
+        "operation_id": operation_id,
+        "operation_generation": operation_generation,
+        "idempotency_key": effect_idempotency_key,
+    }));
+    db.collection::<ApprovalRequest>(APPROVAL_REQUESTS)
+        .insert_one(ApprovalRequest {
+            id: request_id.clone(),
+            user_id: owner_id.clone(),
+            service_id: mcp.id.clone(),
+            service_name: exact_service.service_name.clone(),
+            service_slug: exact_service.service_slug.clone(),
+            requester_type: "access_token".to_string(),
+            requester_id: owner_id.clone(),
+            requester_label: None,
+            operation_summary: "GET /exact-billing".to_string(),
+            action_description: None,
+            http_method: Some("GET".to_string()),
+            resource: Some("/exact-billing".to_string()),
+            verb: Some("read".to_string()),
+            grant_scope: None,
+            tool_name: None,
+            tool_call_id: None,
+            tool_arguments: None,
+            is_destructive: None,
+            approval_mode: ApprovalMode::PerRequest,
+            status: "approved".to_string(),
+            idempotency_key: request_key.clone(),
+            notification_channel: None,
+            telegram_message_id: None,
+            telegram_chat_id: None,
+            expires_at: now + Duration::minutes(5),
+            decided_at: Some(now),
+            decision_channel: Some("web".to_string()),
+            decision_idempotency_key: Some("billing-exact-decision".to_string()),
+            notify_user_ids: vec![owner_id.clone()],
+            from_org_policy: false,
+            exact_service: Some(ExactServiceApprovalBinding {
+                request_key,
+                actor_user_id: owner_id.clone(),
+                user_service_id: mcp.id.clone(),
+                endpoint_id,
+                catalog_digest: catalog_digest.clone(),
+                endpoint_contract_digest,
+                operation_digest: operation_digest.clone(),
+                operation_id: operation_id.clone(),
+                operation_generation,
+                effect_idempotency_key: effect_idempotency_key.clone(),
+                arguments: exact_arguments,
+                redemption: None,
+            }),
+            created_at: now,
+        })
+        .await
+        .expect("insert approved exact-service authority");
+    let redeem_body = serde_json::json!({
+        "catalog_digest": catalog_digest,
+        "operation_digest": operation_digest,
+        "operation_id": operation_id,
+        "operation_generation": operation_generation,
+        "idempotency_key": effect_idempotency_key,
+    });
+    let redeem_response = call_mounted_route(
+        &app,
+        route_request(
+            Method::POST,
+            &format!("/api/v1/approvals/exact-service/requests/{request_id}/redeem"),
+            &token,
+            Body::from(redeem_body.to_string()),
+        ),
+    )
+    .await;
+    let redeemed: serde_json::Value =
+        serde_json::from_slice(&redeem_response).expect("parse exact redemption response");
+    assert_eq!(redeemed["state"], "redeemed");
+    assert_route_settled_count(&db, &mcp.slug, BillingMetric::Requests, 2).await;
+    exercised_routes.insert("/api/v1/approvals/exact-service/requests/{request_id}/redeem");
+    db.collection::<NotificationChannel>(NOTIFICATION_CHANNELS)
+        .delete_one(doc! { "user_id": &owner_id })
+        .await
+        .expect("clear exact redemption approval policy before later route smoke cases");
 
     let node_mcp = insert_route_service(
         &db,

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -947,6 +947,22 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
                 .build(),
         )
         .await?;
+    approval_requests
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "exact_service.request_key": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("exact_service_request_key_unique".to_string())
+                        .unique(true)
+                        .partial_filter_expression(
+                            doc! { "exact_service.request_key": { "$type": "string" } },
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
 
     // ── approval_grants ──
     let approval_grants = db.collection::<mongodb::bson::Document>("approval_grants");

--- a/backend/src/handlers/approvals.rs
+++ b/backend/src/handlers/approvals.rs
@@ -1715,6 +1715,7 @@ mod tests {
             decision_idempotency_key: None,
             notify_user_ids: vec![],
             from_org_policy: false,
+            exact_service: None,
             created_at: Utc::now(),
         }
     }

--- a/backend/src/handlers/exact_service_approvals.rs
+++ b/backend/src/handlers/exact_service_approvals.rs
@@ -1,0 +1,159 @@
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+};
+
+use crate::AppState;
+use crate::errors::{AppError, AppResult};
+use crate::mw::auth::{AuthMethod, AuthUser};
+use crate::services::billing::route_inventory::{
+    BillingIngress, BillingRoutePolicy, enforce_billing_egress_classification,
+};
+use crate::services::exact_service_approval_service::{
+    self, ExactServiceApprovalCaller, ExactServiceApprovalCreate, ExactServiceApprovalFence,
+    ExactServiceApprovalResult,
+};
+
+pub async fn create_request(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(input): Json<ExactServiceApprovalCreate>,
+) -> AppResult<Json<ExactServiceApprovalResult>> {
+    auth_user.ensure_rest_proxy_access()?;
+    enforce_rate_limit(&state, &auth_user)?;
+    let caller = caller(&auth_user)?;
+    Ok(Json(
+        exact_service_approval_service::create_request(&state, &caller, input).await?,
+    ))
+}
+
+pub async fn observe_request(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(request_id): Path<String>,
+) -> AppResult<Json<ExactServiceApprovalResult>> {
+    auth_user.ensure_rest_proxy_access()?;
+    enforce_rate_limit(&state, &auth_user)?;
+    let caller = caller(&auth_user)?;
+    Ok(Json(
+        exact_service_approval_service::observe_request(&state, &caller, &request_id).await?,
+    ))
+}
+
+pub async fn redeem_request(
+    State(state): State<AppState>,
+    Extension(billing_route_policy): Extension<BillingRoutePolicy>,
+    auth_user: AuthUser,
+    Path(request_id): Path<String>,
+    Json(fence): Json<ExactServiceApprovalFence>,
+) -> AppResult<Json<ExactServiceApprovalResult>> {
+    auth_user.ensure_rest_proxy_access()?;
+    enforce_rate_limit(&state, &auth_user)?;
+    let caller = caller(&auth_user)?;
+    let permit =
+        enforce_billing_egress_classification(Some(billing_route_policy), BillingIngress::Mcp)?;
+    Ok(Json(
+        exact_service_approval_service::redeem_request(&state, &caller, &request_id, fence, permit)
+            .await?,
+    ))
+}
+
+fn caller(auth_user: &AuthUser) -> AppResult<ExactServiceApprovalCaller> {
+    let actor_user_id = auth_user.user_id.to_string();
+    let (requester_type, requester_id) =
+        match auth_user.auth_method {
+            AuthMethod::ApiKey => (
+                "api_key",
+                auth_user.api_key_id.clone().ok_or_else(|| {
+                    AppError::Unauthorized("api_key identity missing".to_string())
+                })?,
+            ),
+            AuthMethod::Relay => (
+                "relay",
+                auth_user.api_key_id.clone().ok_or_else(|| {
+                    AppError::Unauthorized("relay key identity missing".to_string())
+                })?,
+            ),
+            AuthMethod::Delegated => (
+                "delegated",
+                auth_user.acting_client_id.clone().ok_or_else(|| {
+                    AppError::Unauthorized("delegated client identity missing".to_string())
+                })?,
+            ),
+            AuthMethod::ServiceAccount => ("service_account", actor_user_id.clone()),
+            AuthMethod::AccessToken => (
+                "access_token",
+                auth_user
+                    .oauth_client_id
+                    .clone()
+                    .unwrap_or_else(|| actor_user_id.clone()),
+            ),
+            AuthMethod::Session => ("session", actor_user_id.clone()),
+        };
+    Ok(ExactServiceApprovalCaller {
+        actor_user_id,
+        proxy_resolution_user_id: auth_user.proxy_resolution_user_id(),
+        approval_owner_user_id: auth_user.effective_approval_owner_user_id(),
+        requester_type: requester_type.to_string(),
+        requester_id,
+        requester_label: auth_user.api_key_name.clone(),
+        api_key_id: auth_user.api_key_id.clone(),
+        allow_all_services: auth_user.allow_all_services,
+        allowed_service_ids: auth_user.allowed_service_ids.clone(),
+        allow_all_nodes: auth_user.allow_all_nodes,
+        allowed_node_ids: auth_user.allowed_node_ids.clone(),
+    })
+}
+
+fn enforce_rate_limit(state: &AppState, auth_user: &AuthUser) -> AppResult<()> {
+    crate::mw::rate_limit::check_agent_rate_limit_raw(
+        &state.per_agent_limiter,
+        auth_user.api_key_id.as_deref(),
+        auth_user.rate_limit_per_second,
+        auth_user.rate_limit_burst,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::api_key::ApiKeyPurpose;
+
+    fn auth(method: AuthMethod) -> AuthUser {
+        AuthUser {
+            user_id: uuid::Uuid::new_v4(),
+            session_id: None,
+            scope: "proxy".to_string(),
+            acting_client_id: (method == AuthMethod::Delegated).then(|| "client-alpha".to_string()),
+            oauth_client_id: None,
+            approval_owner_user_id: None,
+            auth_method: method,
+            allow_all_services: true,
+            allow_all_nodes: true,
+            allowed_service_ids: vec![],
+            resource_uris: None,
+            allowed_node_ids: vec![],
+            api_key_id: Some("key-alpha".to_string()),
+            api_key_name: Some("Agent".to_string()),
+            api_key_purpose: ApiKeyPurpose::General,
+            rate_limit_per_second: None,
+            rate_limit_burst: None,
+            ip_address: None,
+            user_agent: None,
+        }
+    }
+
+    #[test]
+    fn api_key_requester_is_bound_to_key_not_user() {
+        let auth = auth(AuthMethod::ApiKey);
+        let caller = caller(&auth).unwrap();
+        assert_eq!(caller.requester_id, "key-alpha");
+        assert_ne!(caller.requester_id, auth.user_id.to_string());
+    }
+
+    #[test]
+    fn delegated_requester_is_bound_to_oauth_client() {
+        let auth = auth(AuthMethod::Delegated);
+        assert_eq!(caller(&auth).unwrap().requester_id, "client-alpha");
+    }
+}

--- a/backend/src/handlers/mcp.rs
+++ b/backend/src/handlers/mcp.rs
@@ -1,6 +1,5 @@
 use axum::{Json, extract::State};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use crate::AppState;
 use crate::errors::AppResult;
@@ -76,6 +75,7 @@ pub struct McpEndpointConfig {
     pub request_body_required: bool,
     pub response_description: Option<String>,
     pub response: crate::models::service_endpoint::OperationResponseContract,
+    pub operation_digest: String,
 }
 
 // --- Handler ---
@@ -122,7 +122,7 @@ pub async fn get_mcp_config(
 
     let total_endpoints: usize = mcp_services.iter().map(|s| s.endpoints.len()).sum();
     let total_services = mcp_services.len();
-    let catalog_digest = catalog_digest(&mcp_services);
+    let catalog_digest = mcp_service::operation_catalog_digest(&catalog.services);
 
     Ok(Json(McpConfigResponse {
         contract_version: "1.0",
@@ -190,6 +190,7 @@ fn config_services(tool_services: &[mcp_service::McpToolService]) -> Vec<McpServ
                     request_body_required: ep.request_body_required,
                     response_description: ep.response_description.clone(),
                     response: ep.response.clone(),
+                    operation_digest: mcp_service::endpoint_contract_digest(ep),
                 })
                 .collect();
 
@@ -211,35 +212,6 @@ fn config_services(tool_services: &[mcp_service::McpToolService]) -> Vec<McpServ
 /// SHA-256 of canonical JSON containing only `contract_version` and the sorted
 /// normalized service descriptors. Caller identity, observation time,
 /// diagnostics, and deployment URL are deliberately excluded.
-fn catalog_digest(services: &[McpServiceConfig]) -> String {
-    let value = serde_json::json!({
-        "contract_version": "1.0",
-        "services": services,
-    });
-    let canonical = canonical_json(value);
-    let encoded = serde_json::to_vec(&canonical).expect("serializing JSON values cannot fail");
-    format!("sha256:{}", hex::encode(Sha256::digest(encoded)))
-}
-
-fn canonical_json(value: serde_json::Value) -> serde_json::Value {
-    match value {
-        serde_json::Value::Array(values) => {
-            serde_json::Value::Array(values.into_iter().map(canonical_json).collect())
-        }
-        serde_json::Value::Object(values) => {
-            let mut entries: Vec<_> = values.into_iter().collect();
-            entries.sort_by(|left, right| left.0.cmp(&right.0));
-            serde_json::Value::Object(
-                entries
-                    .into_iter()
-                    .map(|(key, value)| (key, canonical_json(value)))
-                    .collect(),
-            )
-        }
-        other => other,
-    }
-}
-
 /// Build the proxy base URL from the backend's base_url config.
 fn build_proxy_base_url(base_url: &str) -> String {
     format!("{}/api/v1/proxy", base_url.trim_end_matches('/'))
@@ -249,7 +221,7 @@ fn build_proxy_base_url(base_url: &str) -> String {
 mod tests {
     use super::{
         McpCatalogDiagnostics, McpEndpointConfig, McpServiceConfig, build_proxy_base_url,
-        catalog_digest, config_services,
+        config_services,
     };
     use crate::models::service_endpoint::OperationResponseContract;
     use crate::services::mcp_service::{self, McpToolEndpoint, McpToolService, McpToolSource};
@@ -291,6 +263,7 @@ mod tests {
                     content_types: vec!["application/json".to_string()],
                     binary_artifact: Some(false),
                 },
+                operation_digest: "sha256:endpoint".to_string(),
             }],
         }
     }
@@ -306,7 +279,10 @@ mod tests {
             "type": "object"
         }));
 
-        assert_eq!(catalog_digest(&[first]), catalog_digest(&[second]));
+        assert_eq!(
+            mcp_service::canonical_sha256(serde_json::json!(first)),
+            mcp_service::canonical_sha256(serde_json::json!(second))
+        );
     }
 
     #[test]

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -37,6 +37,7 @@ pub mod device_tokens;
 pub mod devices;
 pub mod docs;
 pub mod endpoints;
+pub mod exact_service_approvals;
 pub mod health;
 pub mod invite_codes;
 pub mod keys;

--- a/backend/src/models/approval_request.rs
+++ b/backend/src/models/approval_request.rs
@@ -6,6 +6,59 @@ use crate::models::service_approval_config::{ApprovalMode, legacy_approval_mode_
 
 pub const COLLECTION_NAME: &str = "approval_requests";
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExactServiceRedemptionStatus {
+    Executing,
+    Completed,
+    Drifted,
+    Revoked,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExactServiceApprovalReceipt {
+    pub http_status: u16,
+    pub response_body: String,
+    pub response_digest: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExactServiceApprovalRedemption {
+    pub status: ExactServiceRedemptionStatus,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub admitted_at: DateTime<Utc>,
+    #[serde(default, with = "bson_datetime::optional")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receipt: Option<ExactServiceApprovalReceipt>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<String>,
+}
+
+/// Server-authoritative binding for a connected-service approval.
+///
+/// This is deliberately absent on generic tool approvals. Redemption requires
+/// every field in this binding, so a `tool_approval` sentinel request can never
+/// authorize a connected-service effect.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExactServiceApprovalBinding {
+    /// Stable hash over requester + operation identity. Uniquely indexed.
+    pub request_key: String,
+    pub actor_user_id: String,
+    pub user_service_id: String,
+    pub endpoint_id: String,
+    pub catalog_digest: String,
+    pub endpoint_contract_digest: String,
+    pub operation_digest: String,
+    pub operation_id: String,
+    pub operation_generation: i64,
+    pub effect_idempotency_key: String,
+    pub arguments: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redemption: Option<ExactServiceApprovalRedemption>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApprovalRequest {
     /// UUID v4 string
@@ -145,6 +198,11 @@ pub struct ApprovalRequest {
     #[serde(default)]
     pub from_org_policy: bool,
 
+    /// Exact connected-service approval authority. `None` for every legacy,
+    /// proxy-blocking, and generic tool approval request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exact_service: Option<ExactServiceApprovalBinding>,
+
     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
     pub created_at: DateTime<Utc>,
 }
@@ -192,6 +250,7 @@ mod tests {
             decision_idempotency_key: None,
             notify_user_ids: vec![],
             from_org_policy: false,
+            exact_service: None,
             created_at: Utc::now(),
         }
     }

--- a/backend/src/mw/auth.rs
+++ b/backend/src/mw/auth.rs
@@ -316,6 +316,7 @@ fn api_key_management_write_requires_scope(method: &Method, path: &str) -> bool 
         "/api/v1/llm",
         "/api/v1/proxy",
         "/api/v1/ssh",
+        "/api/v1/approvals/exact-service",
     ]
     .iter()
     .any(|prefix| path_matches_prefix(path, prefix))
@@ -376,6 +377,7 @@ fn is_delegated_native_path(path: &str) -> bool {
     }
 
     matches!(segments.as_slice(), ["approvals", "requests", _, "status"])
+        || segments.starts_with(&["approvals", "exact-service"])
 }
 
 /// Return true for management GET classes that delegated account reads must

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -198,6 +198,40 @@ macro_rules! mcp_billing_routes {
     };
 }
 
+macro_rules! exact_service_approval_billing_routes {
+    ($apply:ident, $router:expr) => {
+        $apply!($router;
+            (
+                "/approvals/exact-service/requests",
+                "/api/v1/approvals/exact-service/requests",
+                "handlers::exact_service_approvals::create_request",
+                post(handlers::exact_service_approvals::create_request),
+                crate::services::billing::route_inventory::BillingRoutePolicy::Exempt(
+                    "approval control plane; no downstream request"
+                )
+            ),
+            (
+                "/approvals/exact-service/requests/{request_id}/status",
+                "/api/v1/approvals/exact-service/requests/{request_id}/status",
+                "handlers::exact_service_approvals::observe_request",
+                get(handlers::exact_service_approvals::observe_request),
+                crate::services::billing::route_inventory::BillingRoutePolicy::Exempt(
+                    "approval observation; no downstream request"
+                )
+            ),
+            (
+                "/approvals/exact-service/requests/{request_id}/redeem",
+                "/api/v1/approvals/exact-service/requests/{request_id}/redeem",
+                "handlers::exact_service_approvals::redeem_request",
+                post(handlers::exact_service_approvals::redeem_request),
+                crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
+                    crate::services::billing::BillingIngress::Mcp
+                )
+            ),
+        )
+    };
+}
+
 macro_rules! public_proxy_billing_routes {
     ($apply:ident, $router:expr) => {
         $apply!($router;
@@ -334,6 +368,10 @@ pub(crate) fn mounted_billing_route_inventory()
     routes.extend(proxy_billing_routes!(collect_billing_route_specs, ()));
     routes.extend(ssh_billing_routes!(collect_billing_route_specs, ()));
     routes.extend(mcp_billing_routes!(collect_billing_route_specs, ()));
+    routes.extend(exact_service_approval_billing_routes!(
+        collect_billing_route_specs,
+        ()
+    ));
     routes.extend(public_proxy_billing_routes!(
         collect_billing_route_specs,
         ()
@@ -1322,6 +1360,10 @@ pub fn build_router(
     let api_v1_delegated = Router::new()
         .nest("/llm", llm_routes)
         .nest("/delegation", delegation_routes)
+        .merge(exact_service_approval_billing_routes!(
+            register_billing_routes,
+            Router::new()
+        ))
         .route(
             "/approvals/requests/{request_id}/status",
             get(handlers::approvals::get_request_status),

--- a/backend/src/services/approval_service.rs
+++ b/backend/src/services/approval_service.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use crate::config::AppConfig;
 use crate::errors::{AppError, AppResult};
 use crate::models::approval_grant::{ApprovalGrant, COLLECTION_NAME as GRANTS};
-use crate::models::approval_request::{ApprovalRequest, COLLECTION_NAME as REQUESTS};
+use crate::models::approval_request::{
+    ApprovalRequest, COLLECTION_NAME as REQUESTS, ExactServiceApprovalBinding,
+};
 use crate::models::notification_channel::{COLLECTION_NAME as CHANNELS, NotificationChannel};
 use crate::models::service_approval_config::{
     ApprovalEffect, ApprovalMode, ApprovalRule, COLLECTION_NAME as SERVICE_APPROVAL_CONFIGS,
@@ -397,6 +399,7 @@ pub struct ApprovalRequestOperation {
     pub resource: Option<String>,
     pub verb: Option<String>,
     pub grant_scope: Option<String>,
+    pub exact_service: Option<ExactServiceApprovalBinding>,
 }
 
 impl ApprovalRequestOperation {
@@ -408,7 +411,13 @@ impl ApprovalRequestOperation {
             resource: descriptor.resource.clone(),
             verb: Some(descriptor.verb.as_str().to_string()),
             grant_scope,
+            exact_service: None,
         }
+    }
+
+    pub fn with_exact_service(mut self, binding: ExactServiceApprovalBinding) -> Self {
+        self.exact_service = Some(binding);
+        self
     }
 }
 
@@ -439,16 +448,41 @@ pub async fn create_approval_request(
     };
 
     let collection = db.collection::<ApprovalRequest>(REQUESTS);
-    let idempotency_key = compute_pending_request_idempotency_key(
-        &approval_mode,
-        user_id,
-        service_id,
-        requester_type,
-        requester_id,
-        from_org_policy,
-    );
+    let idempotency_key = operation
+        .exact_service
+        .as_ref()
+        .map(|binding| binding.request_key.clone())
+        .unwrap_or_else(|| {
+            compute_pending_request_idempotency_key(
+                &approval_mode,
+                user_id,
+                service_id,
+                requester_type,
+                requester_id,
+                from_org_policy,
+            )
+        });
     let mut inserted_request: Option<ApprovalRequest> = None;
     for _attempt in 0..2 {
+        if let Some(binding) = operation.exact_service.as_ref()
+            && let Some(existing) = collection
+                .find_one(doc! { "exact_service.request_key": &binding.request_key })
+                .await?
+        {
+            if existing
+                .exact_service
+                .as_ref()
+                .is_some_and(|existing| same_exact_service_authority(existing, binding))
+                && existing.requester_type == requester_type
+                && existing.requester_id == requester_id
+            {
+                return Ok(existing);
+            }
+            return Err(AppError::Conflict(
+                "exact_service_request_conflict".to_string(),
+            ));
+        }
+
         // Check for existing pending request with the same idempotency key.
         // This handles normal idempotent retries and the winner in concurrent inserts.
         if let Some(existing) = collection
@@ -495,6 +529,7 @@ pub async fn create_approval_request(
             decision_idempotency_key: None,
             notify_user_ids: notify_user_ids.clone(),
             from_org_policy,
+            exact_service: operation.exact_service.clone(),
             created_at: now,
         };
 
@@ -620,6 +655,23 @@ pub async fn create_approval_request(
     Ok(updated)
 }
 
+fn same_exact_service_authority(
+    left: &ExactServiceApprovalBinding,
+    right: &ExactServiceApprovalBinding,
+) -> bool {
+    left.request_key == right.request_key
+        && left.actor_user_id == right.actor_user_id
+        && left.user_service_id == right.user_service_id
+        && left.endpoint_id == right.endpoint_id
+        && left.catalog_digest == right.catalog_digest
+        && left.endpoint_contract_digest == right.endpoint_contract_digest
+        && left.operation_digest == right.operation_digest
+        && left.operation_id == right.operation_id
+        && left.operation_generation == right.operation_generation
+        && left.effect_idempotency_key == right.effect_idempotency_key
+        && left.arguments == right.arguments
+}
+
 /// Create a tool approval request (from an external caller such as Aevatar).
 ///
 /// Uses sentinel `service_id: "tool_approval"` and maps the tool name into
@@ -696,6 +748,7 @@ pub async fn create_tool_approval_request(
         // approve a specific tool invocation. Org cascade does not apply.
         notify_user_ids: vec![user_id.to_string()],
         from_org_policy: false,
+        exact_service: None,
         created_at: now,
     };
 
@@ -1897,6 +1950,7 @@ mod tests {
             approval_mode: ApprovalMode::PerRequest,
             notify_user_ids: vec![],
             from_org_policy: false,
+            exact_service: None,
             created_at: now,
         }
     }
@@ -2556,6 +2610,7 @@ mod tests {
             decision_idempotency_key: None,
             notify_user_ids: vec![user_id.to_string()],
             from_org_policy: false,
+            exact_service: None,
             created_at: now,
         }
     }

--- a/backend/src/services/billing/route_inventory.rs
+++ b/backend/src/services/billing/route_inventory.rs
@@ -139,6 +139,21 @@ pub const BILLING_ROUTE_INVENTORY: &[BillingRouteSpec] = &[
         policy: BillingRoutePolicy::Exempt("control-plane discovery; no downstream request"),
     },
     BillingRouteSpec {
+        handler: "handlers::exact_service_approvals::create_request",
+        route: "/api/v1/approvals/exact-service/requests",
+        policy: BillingRoutePolicy::Exempt("approval control plane; no downstream request"),
+    },
+    BillingRouteSpec {
+        handler: "handlers::exact_service_approvals::observe_request",
+        route: "/api/v1/approvals/exact-service/requests/{request_id}/status",
+        policy: BillingRoutePolicy::Exempt("approval observation; no downstream request"),
+    },
+    BillingRouteSpec {
+        handler: "handlers::exact_service_approvals::redeem_request",
+        route: "/api/v1/approvals/exact-service/requests/{request_id}/redeem",
+        policy: BillingRoutePolicy::Metered(BillingIngress::Mcp),
+    },
+    BillingRouteSpec {
         handler: "handlers::mcp_transport::mcp_post",
         route: "/mcp (POST)",
         policy: BillingRoutePolicy::Metered(BillingIngress::Mcp),

--- a/backend/src/services/exact_service_approval_service.rs
+++ b/backend/src/services/exact_service_approval_service.rs
@@ -1,0 +1,1257 @@
+use chrono::Utc;
+use mongodb::Database;
+use mongodb::bson::{self, doc};
+use mongodb::options::{FindOneAndUpdateOptions, ReturnDocument};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::AppState;
+use crate::errors::{AppError, AppResult};
+use crate::models::approval_request::{
+    ApprovalRequest, COLLECTION_NAME as REQUESTS, ExactServiceApprovalBinding,
+    ExactServiceApprovalReceipt, ExactServiceApprovalRedemption, ExactServiceRedemptionStatus,
+};
+use crate::models::service_approval_config::ApprovalMode;
+use crate::services::billing::route_inventory::BillingEgressPermit;
+use crate::services::{approval_service, mcp_service, notification_service, proxy_service};
+
+const MAX_RECEIPT_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub struct ExactServiceApprovalCaller {
+    pub actor_user_id: String,
+    pub proxy_resolution_user_id: String,
+    pub approval_owner_user_id: String,
+    pub requester_type: String,
+    pub requester_id: String,
+    pub requester_label: Option<String>,
+    pub api_key_id: Option<String>,
+    pub allow_all_services: bool,
+    pub allowed_service_ids: Vec<String>,
+    pub allow_all_nodes: bool,
+    pub allowed_node_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExactServiceApprovalCreate {
+    pub user_service_id: String,
+    pub endpoint_id: String,
+    pub catalog_digest: String,
+    pub endpoint_contract_digest: String,
+    pub operation_digest: String,
+    pub operation_id: String,
+    pub operation_generation: i64,
+    pub idempotency_key: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExactServiceApprovalFence {
+    pub catalog_digest: String,
+    pub operation_digest: String,
+    pub operation_id: String,
+    pub operation_generation: i64,
+    pub idempotency_key: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExactServiceApprovalState {
+    Pending,
+    Approved,
+    Denied,
+    Expired,
+    Revoked,
+    Drifted,
+    Redeeming,
+    Redeemed,
+    Failed,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ExactServiceApprovalResult {
+    pub request_id: String,
+    pub state: ExactServiceApprovalState,
+    pub user_service_id: String,
+    pub endpoint_id: String,
+    pub catalog_digest: String,
+    pub endpoint_contract_digest: String,
+    pub operation_digest: String,
+    pub operation_id: String,
+    pub operation_generation: i64,
+    pub idempotency_key: String,
+    pub expires_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub receipt: Option<ExactServiceApprovalReceipt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<String>,
+}
+
+struct ExactCatalogResolution<'a> {
+    catalog: mcp_service::McpOperationCatalog,
+    service_index: usize,
+    endpoint_index: usize,
+    catalog_digest: String,
+    endpoint_contract_digest: String,
+    operation_digest: String,
+    marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl ExactCatalogResolution<'_> {
+    fn service(&self) -> &mcp_service::McpToolService {
+        &self.catalog.services[self.service_index]
+    }
+
+    fn endpoint(&self) -> &mcp_service::McpToolEndpoint {
+        &self.service().endpoints[self.endpoint_index]
+    }
+}
+
+pub async fn create_request(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    input: ExactServiceApprovalCreate,
+) -> AppResult<ExactServiceApprovalResult> {
+    validate_create(&input)?;
+    let resolution = resolve_exact_catalog(
+        state,
+        caller,
+        &input.user_service_id,
+        &input.endpoint_id,
+        &input.arguments,
+    )
+    .await?;
+    ensure_digest(
+        "catalog_digest",
+        &input.catalog_digest,
+        &resolution.catalog_digest,
+    )?;
+    ensure_digest(
+        "endpoint_contract_digest",
+        &input.endpoint_contract_digest,
+        &resolution.endpoint_contract_digest,
+    )?;
+    ensure_digest(
+        "operation_digest",
+        &input.operation_digest,
+        &resolution.operation_digest,
+    )?;
+
+    let service = resolution.service();
+    let endpoint = resolution.endpoint();
+    let descriptor =
+        mcp_service::build_mcp_operation_descriptor(service, endpoint, &input.arguments)?;
+    let approval_target = approval_target(state, caller, service).await?;
+    let pending = match approval_service::evaluate_and_check(
+        &state.db,
+        &caller.approval_owner_user_id,
+        &approval_target.service_owner_user_id,
+        &approval_target.service_id,
+        &descriptor,
+        Some(&caller.requester_type),
+        &caller.requester_id,
+        false,
+    )
+    .await?
+    {
+        approval_service::ApprovalOutcome::NeedsApproval(pending)
+            if pending.resolution.mode == ApprovalMode::PerRequest =>
+        {
+            pending
+        }
+        approval_service::ApprovalOutcome::NeedsApproval(_) => {
+            return Err(AppError::Conflict(
+                "exact_service_requires_per_request_mode".to_string(),
+            ));
+        }
+        approval_service::ApprovalOutcome::Denied => {
+            return Err(AppError::Forbidden(
+                "exact_service_operation_denied".to_string(),
+            ));
+        }
+        approval_service::ApprovalOutcome::Allowed { .. } => {
+            return Err(AppError::Conflict(
+                "exact_service_approval_not_required".to_string(),
+            ));
+        }
+    };
+
+    let notify_user_ids = approval_service::approval_notification_recipients(
+        &state.db,
+        &caller.approval_owner_user_id,
+        &pending,
+    )
+    .await?;
+    let timeout_recipient = notify_user_ids
+        .first()
+        .ok_or_else(|| AppError::Internal("approval recipient list is empty".to_string()))?;
+    let channel = notification_service::get_or_create_channel(&state.db, timeout_recipient).await?;
+    let request_key = request_key(caller, &input);
+    let binding = ExactServiceApprovalBinding {
+        request_key,
+        actor_user_id: caller.actor_user_id.clone(),
+        user_service_id: input.user_service_id,
+        endpoint_id: input.endpoint_id,
+        catalog_digest: resolution.catalog_digest,
+        endpoint_contract_digest: resolution.endpoint_contract_digest,
+        operation_digest: resolution.operation_digest,
+        operation_id: input.operation_id,
+        operation_generation: input.operation_generation,
+        effect_idempotency_key: input.idempotency_key,
+        arguments: input.arguments,
+        redemption: None,
+    };
+    let operation = approval_service::ApprovalRequestOperation::from_descriptor(
+        &descriptor,
+        pending.resolution.grant_scope.clone(),
+    )
+    .with_exact_service(binding);
+    let request = approval_service::create_approval_request(
+        &state.db,
+        &state.config,
+        &state.http_client,
+        state.fcm_auth.as_deref(),
+        state.apns_auth.as_deref(),
+        &pending.primary_owner_user_id,
+        &approval_target.service_id,
+        &approval_target.service_name,
+        &approval_target.service_slug,
+        &pending.requester_type,
+        &pending.requester_id,
+        caller.requester_label.as_deref(),
+        operation,
+        ApprovalMode::PerRequest,
+        channel.approval_timeout_secs,
+        notify_user_ids,
+        pending.resolution.from_org_policy,
+    )
+    .await?;
+
+    result_for(&request, ExactServiceApprovalState::Pending)
+}
+
+pub async fn observe_request(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    request_id: &str,
+) -> AppResult<ExactServiceApprovalResult> {
+    let request = load_bound_request(state, caller, request_id).await?;
+    let request = expire_if_needed(state, request).await?;
+    let state_value = current_state(state, caller, &request).await?;
+    result_for(&request, state_value)
+}
+
+pub async fn redeem_request(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    request_id: &str,
+    fence: ExactServiceApprovalFence,
+    billing_egress_permit: BillingEgressPermit,
+) -> AppResult<ExactServiceApprovalResult> {
+    let request = load_bound_request(state, caller, request_id).await?;
+    ensure_fence(&request, &fence)?;
+    let request = expire_if_needed(state, request).await?;
+    let state_value = current_state(state, caller, &request).await?;
+    match state_value {
+        ExactServiceApprovalState::Redeemed
+        | ExactServiceApprovalState::Redeeming
+        | ExactServiceApprovalState::Failed => return result_for(&request, state_value),
+        ExactServiceApprovalState::Approved => {}
+        other => return result_for(&request, other),
+    }
+
+    let now = Utc::now();
+    let claimed = claim_redemption(&state.db, &request, now).await?;
+
+    let claimed = match claimed {
+        Some(claimed) => claimed,
+        None => {
+            let replay = load_bound_request(state, caller, request_id).await?;
+            return result_for(&replay, redemption_state(&replay)?);
+        }
+    };
+
+    let binding = claimed.exact_service.as_ref().unwrap();
+    let resolution = match resolve_exact_catalog(
+        state,
+        caller,
+        &binding.user_service_id,
+        &binding.endpoint_id,
+        &binding.arguments,
+    )
+    .await
+    {
+        Ok(resolution) => resolution,
+        Err(error) => {
+            let (terminal_state, status, failure_code) =
+                match catalog_resolution_terminal_state(&error) {
+                    Some(ExactServiceApprovalState::Revoked) => (
+                        ExactServiceApprovalState::Revoked,
+                        ExactServiceRedemptionStatus::Revoked,
+                        "selector_revoked",
+                    ),
+                    Some(ExactServiceApprovalState::Drifted) => (
+                        ExactServiceApprovalState::Drifted,
+                        ExactServiceRedemptionStatus::Drifted,
+                        "catalog_drift",
+                    ),
+                    _ => (
+                        ExactServiceApprovalState::Failed,
+                        ExactServiceRedemptionStatus::Failed,
+                        safe_execution_failure_code(&error),
+                    ),
+                };
+            let updated = persist_redemption(
+                &state.db,
+                request_id,
+                ExactServiceApprovalRedemption {
+                    status,
+                    admitted_at: now,
+                    completed_at: Some(Utc::now()),
+                    receipt: None,
+                    failure_code: Some(failure_code.to_string()),
+                },
+            )
+            .await?;
+            return result_for(&updated, terminal_state);
+        }
+    };
+    if exact_authority_has_drift(
+        binding,
+        &resolution.service().service_id,
+        &resolution.endpoint().endpoint_id,
+        &resolution.catalog_digest,
+        &resolution.endpoint_contract_digest,
+        &resolution.operation_digest,
+    ) {
+        let updated = persist_redemption(
+            &state.db,
+            request_id,
+            ExactServiceApprovalRedemption {
+                status: ExactServiceRedemptionStatus::Drifted,
+                admitted_at: now,
+                completed_at: Some(Utc::now()),
+                receipt: None,
+                failure_code: Some("catalog_drift".to_string()),
+            },
+        )
+        .await?;
+        return result_for(&updated, ExactServiceApprovalState::Drifted);
+    }
+    let exec_ctx = mcp_service::McpExecContext {
+        api_key_id: caller.api_key_id.as_deref(),
+        allow_all_nodes: caller.allow_all_nodes,
+        allowed_node_ids: &caller.allowed_node_ids,
+    };
+    let executed = mcp_service::execute_tool(
+        &state.http_client,
+        &state.db,
+        &state.encryption_keys,
+        &state.node_ws_manager,
+        &state.billing,
+        &caller.proxy_resolution_user_id,
+        &caller.proxy_resolution_user_id,
+        resolution.service(),
+        resolution.endpoint(),
+        &binding.arguments,
+        &state.jwt_keys,
+        &state.config,
+        &state.connection_expiry_notifier,
+        &state.token_exchange_cache,
+        &state.cloud_response_cache,
+        &exec_ctx,
+        billing_egress_permit,
+    )
+    .await;
+
+    let completed_at = Utc::now();
+    let (redemption, terminal_state) = match executed {
+        Ok((http_status, response_body)) => {
+            let response_digest = format!(
+                "sha256:{}",
+                hex::encode(Sha256::digest(response_body.as_bytes()))
+            );
+            if response_body.len() > MAX_RECEIPT_RESPONSE_BYTES {
+                (
+                    ExactServiceApprovalRedemption {
+                        status: ExactServiceRedemptionStatus::Failed,
+                        admitted_at: now,
+                        completed_at: Some(completed_at),
+                        receipt: Some(ExactServiceApprovalReceipt {
+                            http_status,
+                            response_body: String::new(),
+                            response_digest,
+                        }),
+                        failure_code: Some("provider_response_too_large".to_string()),
+                    },
+                    ExactServiceApprovalState::Failed,
+                )
+            } else {
+                (
+                    ExactServiceApprovalRedemption {
+                        status: ExactServiceRedemptionStatus::Completed,
+                        admitted_at: now,
+                        completed_at: Some(completed_at),
+                        receipt: Some(ExactServiceApprovalReceipt {
+                            http_status,
+                            response_body,
+                            response_digest,
+                        }),
+                        failure_code: None,
+                    },
+                    ExactServiceApprovalState::Redeemed,
+                )
+            }
+        }
+        Err(error) => (
+            ExactServiceApprovalRedemption {
+                status: ExactServiceRedemptionStatus::Failed,
+                admitted_at: now,
+                completed_at: Some(completed_at),
+                receipt: None,
+                failure_code: Some(safe_execution_failure_code(&error).to_string()),
+            },
+            ExactServiceApprovalState::Failed,
+        ),
+    };
+    let updated = persist_redemption(&state.db, request_id, redemption).await?;
+    result_for(&updated, terminal_state)
+}
+
+async fn claim_redemption(
+    db: &Database,
+    request: &ApprovalRequest,
+    admitted_at: chrono::DateTime<Utc>,
+) -> AppResult<Option<ApprovalRequest>> {
+    let binding = request
+        .exact_service
+        .as_ref()
+        .ok_or_else(|| AppError::BadRequest("not_an_exact_service_request".to_string()))?;
+    Ok(db
+        .collection::<ApprovalRequest>(REQUESTS)
+        .find_one_and_update(
+            doc! {
+                "_id": &request.id,
+                "status": "approved",
+                "exact_service.request_key": &binding.request_key,
+                "exact_service.redemption": { "$exists": false },
+            },
+            doc! { "$set": {
+                "exact_service.redemption": bson::to_bson(&ExactServiceApprovalRedemption {
+                    status: ExactServiceRedemptionStatus::Executing,
+                    admitted_at,
+                    completed_at: None,
+                    receipt: None,
+                    failure_code: None,
+                }).map_err(|error| AppError::Internal(error.to_string()))?,
+            }},
+        )
+        .with_options(
+            FindOneAndUpdateOptions::builder()
+                .return_document(ReturnDocument::After)
+                .build(),
+        )
+        .await?)
+}
+
+async fn persist_redemption(
+    db: &Database,
+    request_id: &str,
+    redemption: ExactServiceApprovalRedemption,
+) -> AppResult<ApprovalRequest> {
+    db.collection::<ApprovalRequest>(REQUESTS)
+        .find_one_and_update(
+            doc! {
+                "_id": request_id,
+                "exact_service.redemption.status": "executing",
+            },
+            doc! { "$set": {
+                "exact_service.redemption": bson::to_bson(&redemption)
+                    .map_err(|error| AppError::Internal(error.to_string()))?,
+            }},
+        )
+        .with_options(
+            FindOneAndUpdateOptions::builder()
+                .return_document(ReturnDocument::After)
+                .build(),
+        )
+        .await?
+        .ok_or_else(|| AppError::Conflict("exact_service_redemption_state_conflict".to_string()))
+}
+
+async fn resolve_exact_catalog(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    user_service_id: &str,
+    endpoint_id: &str,
+    arguments: &serde_json::Value,
+) -> AppResult<ExactCatalogResolution<'static>> {
+    let node_scope = if caller.allow_all_nodes {
+        mcp_service::NodeScope::Unrestricted
+    } else {
+        mcp_service::NodeScope::Allowed(caller.allowed_node_ids.as_slice())
+    };
+    let service_scope = if caller.allow_all_services {
+        mcp_service::ServiceScope::Unrestricted
+    } else {
+        mcp_service::ServiceScope::Allowed(caller.allowed_service_ids.as_slice())
+    };
+    let catalog = mcp_service::load_operation_catalog(
+        &state.db,
+        state.node_ws_manager.as_ref(),
+        &caller.proxy_resolution_user_id,
+        node_scope,
+        service_scope,
+    )
+    .await?;
+    let service_index = catalog
+        .services
+        .iter()
+        .position(|service| {
+            service.service_id == user_service_id
+                && matches!(
+                    &service.source,
+                    mcp_service::McpToolSource::UserManaged { user_service_id: exact, .. }
+                        if exact == user_service_id
+                )
+        })
+        .ok_or_else(|| AppError::NotFound("exact_user_service_not_found".to_string()))?;
+    let endpoint_index = catalog.services[service_index]
+        .endpoints
+        .iter()
+        .position(|endpoint| endpoint.endpoint_id == endpoint_id)
+        .ok_or_else(|| AppError::NotFound("exact_endpoint_not_found".to_string()))?;
+    let catalog_digest = mcp_service::operation_catalog_digest(&catalog.services);
+    let endpoint = &catalog.services[service_index].endpoints[endpoint_index];
+    let endpoint_contract_digest = mcp_service::endpoint_contract_digest(endpoint);
+    let operation_digest =
+        mcp_service::exact_operation_digest(user_service_id, endpoint, arguments);
+    Ok(ExactCatalogResolution {
+        catalog,
+        service_index,
+        endpoint_index,
+        catalog_digest,
+        endpoint_contract_digest,
+        operation_digest,
+        marker: std::marker::PhantomData,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct ApprovalTarget {
+    service_id: String,
+    service_name: String,
+    service_slug: String,
+    service_owner_user_id: String,
+}
+
+async fn approval_target(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    service: &mcp_service::McpToolService,
+) -> AppResult<ApprovalTarget> {
+    let user_service_id = match &service.source {
+        mcp_service::McpToolSource::UserManaged {
+            user_service_id, ..
+        } => user_service_id,
+        mcp_service::McpToolSource::Platform { .. } => {
+            return Err(AppError::BadRequest(
+                "exact_service_requires_user_service".to_string(),
+            ));
+        }
+    };
+    let hint = proxy_service::find_approval_resolution_hint_by_user_service_id(
+        &state.db,
+        &caller.approval_owner_user_id,
+        user_service_id,
+        Some(&service.service_slug),
+        None,
+    )
+    .await?
+    .ok_or_else(|| AppError::NotFound("exact_user_service_not_found".to_string()))?;
+    Ok(ApprovalTarget {
+        service_id: hint.service_id,
+        service_name: service.service_name.clone(),
+        service_slug: service.service_slug.clone(),
+        service_owner_user_id: hint.service_owner_id,
+    })
+}
+
+async fn load_bound_request(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    request_id: &str,
+) -> AppResult<ApprovalRequest> {
+    let request = state
+        .db
+        .collection::<ApprovalRequest>(REQUESTS)
+        .find_one(doc! { "_id": request_id })
+        .await?
+        .ok_or_else(|| AppError::NotFound("exact_service_request_not_found".to_string()))?;
+    if request.exact_service.is_none()
+        || request.requester_type != caller.requester_type
+        || request.requester_id != caller.requester_id
+        || request
+            .exact_service
+            .as_ref()
+            .is_some_and(|binding| binding.actor_user_id != caller.actor_user_id)
+    {
+        return Err(AppError::Forbidden(
+            "exact_service_request_binding_mismatch".to_string(),
+        ));
+    }
+    Ok(request)
+}
+
+async fn expire_if_needed(
+    state: &AppState,
+    request: ApprovalRequest,
+) -> AppResult<ApprovalRequest> {
+    if request.status != "pending" || request.expires_at > Utc::now() {
+        return Ok(request);
+    }
+    let now = Utc::now();
+    let updated = state
+        .db
+        .collection::<ApprovalRequest>(REQUESTS)
+        .find_one_and_update(
+            doc! { "_id": &request.id, "status": "pending", "expires_at": { "$lte": bson::DateTime::from_chrono(now) } },
+            doc! { "$set": { "status": "expired", "decided_at": bson::DateTime::from_chrono(now) } },
+        )
+        .with_options(
+            FindOneAndUpdateOptions::builder()
+                .return_document(ReturnDocument::After)
+                .build(),
+        )
+        .await?;
+    match updated {
+        Some(updated) => Ok(updated),
+        None => state
+            .db
+            .collection::<ApprovalRequest>(REQUESTS)
+            .find_one(doc! { "_id": &request.id })
+            .await?
+            .ok_or_else(|| AppError::NotFound("exact_service_request_not_found".to_string())),
+    }
+}
+
+async fn current_state(
+    state: &AppState,
+    caller: &ExactServiceApprovalCaller,
+    request: &ApprovalRequest,
+) -> AppResult<ExactServiceApprovalState> {
+    match request.status.as_str() {
+        "pending" => return Ok(ExactServiceApprovalState::Pending),
+        "rejected" => return Ok(ExactServiceApprovalState::Denied),
+        "expired" => return Ok(ExactServiceApprovalState::Expired),
+        "approved" => {}
+        _ => return Ok(ExactServiceApprovalState::Revoked),
+    }
+    if request
+        .exact_service
+        .as_ref()
+        .and_then(|binding| binding.redemption.as_ref())
+        .is_some()
+    {
+        return redemption_state(request);
+    }
+    let binding = request.exact_service.as_ref().unwrap();
+    let resolution = match resolve_exact_catalog(
+        state,
+        caller,
+        &binding.user_service_id,
+        &binding.endpoint_id,
+        &binding.arguments,
+    )
+    .await
+    {
+        Ok(resolution) => resolution,
+        Err(error) => match catalog_resolution_terminal_state(&error) {
+            Some(state) => return Ok(state),
+            None => return Err(error),
+        },
+    };
+    if exact_authority_has_drift(
+        binding,
+        &resolution.service().service_id,
+        &resolution.endpoint().endpoint_id,
+        &resolution.catalog_digest,
+        &resolution.endpoint_contract_digest,
+        &resolution.operation_digest,
+    ) {
+        return Ok(ExactServiceApprovalState::Drifted);
+    }
+    let descriptor = mcp_service::build_mcp_operation_descriptor(
+        resolution.service(),
+        resolution.endpoint(),
+        &binding.arguments,
+    )?;
+    let target = approval_target(state, caller, resolution.service()).await?;
+    match approval_service::evaluate_and_check(
+        &state.db,
+        &caller.approval_owner_user_id,
+        &target.service_owner_user_id,
+        &target.service_id,
+        &descriptor,
+        Some(&caller.requester_type),
+        &caller.requester_id,
+        false,
+    )
+    .await?
+    {
+        approval_service::ApprovalOutcome::NeedsApproval(pending)
+            if pending.resolution.mode == ApprovalMode::PerRequest =>
+        {
+            Ok(ExactServiceApprovalState::Approved)
+        }
+        _ => Ok(ExactServiceApprovalState::Revoked),
+    }
+}
+
+fn redemption_state(request: &ApprovalRequest) -> AppResult<ExactServiceApprovalState> {
+    let redemption = request
+        .exact_service
+        .as_ref()
+        .and_then(|binding| binding.redemption.as_ref())
+        .ok_or_else(|| AppError::Conflict("exact_service_redemption_missing".to_string()))?;
+    Ok(match redemption.status {
+        ExactServiceRedemptionStatus::Executing => ExactServiceApprovalState::Redeeming,
+        ExactServiceRedemptionStatus::Completed => ExactServiceApprovalState::Redeemed,
+        ExactServiceRedemptionStatus::Drifted => ExactServiceApprovalState::Drifted,
+        ExactServiceRedemptionStatus::Revoked => ExactServiceApprovalState::Revoked,
+        ExactServiceRedemptionStatus::Failed => ExactServiceApprovalState::Failed,
+    })
+}
+
+fn catalog_resolution_terminal_state(error: &AppError) -> Option<ExactServiceApprovalState> {
+    match error {
+        AppError::NotFound(_)
+        | AppError::ApiKeyScopeForbidden(_)
+        | AppError::ApiKeyScopeInactive
+        | AppError::ApiKeyScopeNotFound(_) => Some(ExactServiceApprovalState::Revoked),
+        _ => None,
+    }
+}
+
+fn exact_authority_has_drift(
+    binding: &ExactServiceApprovalBinding,
+    user_service_id: &str,
+    endpoint_id: &str,
+    catalog_digest: &str,
+    endpoint_contract_digest: &str,
+    operation_digest: &str,
+) -> bool {
+    binding.user_service_id != user_service_id
+        || binding.endpoint_id != endpoint_id
+        || binding.catalog_digest != catalog_digest
+        || binding.endpoint_contract_digest != endpoint_contract_digest
+        || binding.operation_digest != operation_digest
+}
+
+fn ensure_fence(request: &ApprovalRequest, fence: &ExactServiceApprovalFence) -> AppResult<()> {
+    let binding = request.exact_service.as_ref().unwrap();
+    if binding.catalog_digest != fence.catalog_digest
+        || binding.operation_digest != fence.operation_digest
+        || binding.operation_id != fence.operation_id
+        || binding.operation_generation != fence.operation_generation
+        || binding.effect_idempotency_key != fence.idempotency_key
+    {
+        return Err(AppError::Conflict(
+            "exact_service_redemption_conflict".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn result_for(
+    request: &ApprovalRequest,
+    state: ExactServiceApprovalState,
+) -> AppResult<ExactServiceApprovalResult> {
+    let binding = request
+        .exact_service
+        .as_ref()
+        .ok_or_else(|| AppError::BadRequest("not_an_exact_service_request".to_string()))?;
+    let redemption = binding.redemption.as_ref();
+    Ok(ExactServiceApprovalResult {
+        request_id: request.id.clone(),
+        state,
+        user_service_id: binding.user_service_id.clone(),
+        endpoint_id: binding.endpoint_id.clone(),
+        catalog_digest: binding.catalog_digest.clone(),
+        endpoint_contract_digest: binding.endpoint_contract_digest.clone(),
+        operation_digest: binding.operation_digest.clone(),
+        operation_id: binding.operation_id.clone(),
+        operation_generation: binding.operation_generation,
+        idempotency_key: binding.effect_idempotency_key.clone(),
+        expires_at: request.expires_at.to_rfc3339(),
+        receipt: redemption.and_then(|value| value.receipt.clone()),
+        failure_code: redemption.and_then(|value| value.failure_code.clone()),
+    })
+}
+
+fn validate_create(input: &ExactServiceApprovalCreate) -> AppResult<()> {
+    for (field, value) in [
+        ("user_service_id", input.user_service_id.as_str()),
+        ("endpoint_id", input.endpoint_id.as_str()),
+        ("catalog_digest", input.catalog_digest.as_str()),
+        (
+            "endpoint_contract_digest",
+            input.endpoint_contract_digest.as_str(),
+        ),
+        ("operation_digest", input.operation_digest.as_str()),
+        ("operation_id", input.operation_id.as_str()),
+        ("idempotency_key", input.idempotency_key.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            return Err(AppError::BadRequest(format!("{field} is required")));
+        }
+    }
+    if input.operation_generation < 1 {
+        return Err(AppError::BadRequest(
+            "operation_generation must be positive".to_string(),
+        ));
+    }
+    if !input.arguments.is_object() {
+        return Err(AppError::BadRequest(
+            "arguments must be a JSON object".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_digest(field: &str, provided: &str, authoritative: &str) -> AppResult<()> {
+    if provided == authoritative {
+        Ok(())
+    } else {
+        Err(AppError::Conflict(format!("exact_service_{field}_drift")))
+    }
+}
+
+fn request_key(caller: &ExactServiceApprovalCaller, input: &ExactServiceApprovalCreate) -> String {
+    mcp_service::canonical_sha256(serde_json::json!({
+        "contract_version": "nyxid-exact-approval-request.v1",
+        "requester_type": caller.requester_type,
+        "requester_id": caller.requester_id,
+        "actor_user_id": caller.actor_user_id,
+        "operation_id": input.operation_id,
+        "operation_generation": input.operation_generation,
+        "idempotency_key": input.idempotency_key,
+    }))
+}
+
+fn safe_execution_failure_code(error: &AppError) -> &'static str {
+    match error {
+        AppError::ApiKeyScopeForbidden(_)
+        | AppError::ApiKeyScopeInactive
+        | AppError::ApiKeyScopeNotFound(_) => "authorization_revoked",
+        AppError::NotFound(_) => "selector_revoked",
+        AppError::NodeOffline(_) | AppError::NodeProxyTimeout => "provider_unavailable",
+        _ => "provider_execution_failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+
+    use super::*;
+
+    fn caller() -> ExactServiceApprovalCaller {
+        ExactServiceApprovalCaller {
+            actor_user_id: "user-alpha".to_string(),
+            proxy_resolution_user_id: "user-alpha".to_string(),
+            approval_owner_user_id: "user-alpha".to_string(),
+            requester_type: "delegated".to_string(),
+            requester_id: "client-alpha".to_string(),
+            requester_label: None,
+            api_key_id: None,
+            allow_all_services: true,
+            allowed_service_ids: vec![],
+            allow_all_nodes: true,
+            allowed_node_ids: vec![],
+        }
+    }
+
+    fn create() -> ExactServiceApprovalCreate {
+        ExactServiceApprovalCreate {
+            user_service_id: "service-alpha".to_string(),
+            endpoint_id: "endpoint-alpha".to_string(),
+            catalog_digest: "sha256:catalog".to_string(),
+            endpoint_contract_digest: "sha256:contract".to_string(),
+            operation_digest: "sha256:operation".to_string(),
+            operation_id: "operation-alpha".to_string(),
+            operation_generation: 3,
+            idempotency_key: "idempotency-alpha".to_string(),
+            arguments: serde_json::json!({"value": 1}),
+        }
+    }
+
+    fn binding() -> ExactServiceApprovalBinding {
+        let input = create();
+        ExactServiceApprovalBinding {
+            request_key: request_key(&caller(), &input),
+            actor_user_id: caller().actor_user_id,
+            user_service_id: input.user_service_id,
+            endpoint_id: input.endpoint_id,
+            catalog_digest: input.catalog_digest,
+            endpoint_contract_digest: input.endpoint_contract_digest,
+            operation_digest: input.operation_digest,
+            operation_id: input.operation_id,
+            operation_generation: input.operation_generation,
+            effect_idempotency_key: input.idempotency_key,
+            arguments: input.arguments,
+            redemption: None,
+        }
+    }
+
+    fn approval_request(
+        id: &str,
+        status: &str,
+        expires_at: chrono::DateTime<Utc>,
+        exact_service: Option<ExactServiceApprovalBinding>,
+    ) -> ApprovalRequest {
+        let idempotency_key = exact_service
+            .as_ref()
+            .map(|value| value.request_key.clone())
+            .unwrap_or_else(|| format!("generic-{id}"));
+        ApprovalRequest {
+            id: id.to_string(),
+            user_id: "user-alpha".to_string(),
+            service_id: "catalog-alpha".to_string(),
+            service_name: "Service".to_string(),
+            service_slug: "service".to_string(),
+            requester_type: "delegated".to_string(),
+            requester_id: "client-alpha".to_string(),
+            requester_label: None,
+            operation_summary: "write".to_string(),
+            action_description: None,
+            http_method: Some("POST".to_string()),
+            resource: Some("/items".to_string()),
+            verb: Some("write".to_string()),
+            grant_scope: None,
+            tool_name: None,
+            tool_call_id: None,
+            tool_arguments: None,
+            is_destructive: None,
+            approval_mode: ApprovalMode::PerRequest,
+            status: status.to_string(),
+            idempotency_key,
+            notification_channel: None,
+            telegram_message_id: None,
+            telegram_chat_id: None,
+            expires_at,
+            decided_at: (status != "pending").then(Utc::now),
+            decision_channel: (status != "pending").then(|| "web".to_string()),
+            decision_idempotency_key: None,
+            notify_user_ids: vec!["user-alpha".to_string()],
+            from_org_policy: false,
+            exact_service,
+            created_at: Utc::now(),
+        }
+    }
+
+    async fn create_bound_approval(
+        db: &Database,
+        exact_service: ExactServiceApprovalBinding,
+    ) -> AppResult<ApprovalRequest> {
+        let state = crate::test_utils::test_app_state(db.clone());
+        approval_service::create_approval_request(
+            db,
+            &state.config,
+            &state.http_client,
+            None,
+            None,
+            "user-alpha",
+            "catalog-alpha",
+            "Service",
+            "service",
+            "delegated",
+            "client-alpha",
+            None,
+            approval_service::ApprovalRequestOperation {
+                operation_summary: "write".to_string(),
+                action_description: None,
+                http_method: Some("POST".to_string()),
+                resource: Some("/items".to_string()),
+                verb: Some("write".to_string()),
+                grant_scope: None,
+                exact_service: Some(exact_service),
+            },
+            ApprovalMode::PerRequest,
+            300,
+            vec!["user-alpha".to_string()],
+            false,
+        )
+        .await
+    }
+
+    #[test]
+    fn request_key_is_bound_to_requester_and_operation_identity_not_selector() {
+        let caller = caller();
+        let first = create();
+        let mut conflicting_selector = create();
+        conflicting_selector.endpoint_id = "endpoint-beta".to_string();
+        assert_eq!(
+            request_key(&caller, &first),
+            request_key(&caller, &conflicting_selector)
+        );
+    }
+
+    #[test]
+    fn redemption_fence_rejects_conflicting_replay() {
+        let input = create();
+        let request = approval_request(
+            "request-alpha",
+            "approved",
+            Utc::now() + Duration::minutes(5),
+            Some(binding()),
+        );
+        let mut fence = ExactServiceApprovalFence {
+            catalog_digest: input.catalog_digest,
+            operation_digest: input.operation_digest,
+            operation_id: input.operation_id,
+            operation_generation: input.operation_generation,
+            idempotency_key: input.idempotency_key,
+        };
+        ensure_fence(&request, &fence).unwrap();
+        fence.operation_generation += 1;
+        assert!(matches!(
+            ensure_fence(&request, &fence),
+            Err(AppError::Conflict(_))
+        ));
+    }
+
+    #[test]
+    fn drift_and_revocation_are_typed_before_effect_dispatch() {
+        let binding = binding();
+        assert!(!exact_authority_has_drift(
+            &binding,
+            &binding.user_service_id,
+            &binding.endpoint_id,
+            &binding.catalog_digest,
+            &binding.endpoint_contract_digest,
+            &binding.operation_digest,
+        ));
+        assert!(exact_authority_has_drift(
+            &binding,
+            &binding.user_service_id,
+            &binding.endpoint_id,
+            &binding.catalog_digest,
+            "sha256:changed-contract",
+            &binding.operation_digest,
+        ));
+        assert_eq!(
+            catalog_resolution_terminal_state(&AppError::NotFound(
+                "exact_endpoint_not_found".to_string()
+            )),
+            Some(ExactServiceApprovalState::Revoked)
+        );
+        assert_eq!(
+            catalog_resolution_terminal_state(&AppError::Internal("transient".to_string())),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_create_replays_same_authority_and_rejects_changed_selector() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("exact_approval_create_replay").await
+        else {
+            return;
+        };
+        let first_binding = binding();
+        let first = create_bound_approval(&db, first_binding.clone())
+            .await
+            .expect("create exact approval");
+        let replay = create_bound_approval(&db, first_binding.clone())
+            .await
+            .expect("replay exact approval");
+        assert_eq!(replay.id, first.id);
+
+        let mut changed_selector = first_binding.clone();
+        changed_selector.endpoint_id = "endpoint-beta".to_string();
+        assert!(matches!(
+            create_bound_approval(&db, changed_selector).await,
+            Err(AppError::Conflict(message)) if message == "exact_service_request_conflict"
+        ));
+
+        let mut changed_actor = first_binding;
+        changed_actor.actor_user_id = "user-beta".to_string();
+        assert!(matches!(
+            create_bound_approval(&db, changed_actor).await,
+            Err(AppError::Conflict(message)) if message == "exact_service_request_conflict"
+        ));
+    }
+
+    #[tokio::test]
+    async fn bound_load_rejects_requester_mismatch_and_generic_approval() {
+        let Some(db) = crate::test_utils::connect_test_database("exact_approval_binding").await
+        else {
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db.clone());
+        let exact = approval_request(
+            "request-exact",
+            "pending",
+            Utc::now() + Duration::minutes(5),
+            Some(binding()),
+        );
+        let generic = approval_request(
+            "request-generic",
+            "pending",
+            Utc::now() + Duration::minutes(5),
+            None,
+        );
+        db.collection::<ApprovalRequest>(REQUESTS)
+            .insert_many([exact, generic])
+            .await
+            .expect("insert approval fixtures");
+
+        let mut mismatched = caller();
+        mismatched.requester_id = "client-beta".to_string();
+        assert!(matches!(
+            load_bound_request(&state, &mismatched, "request-exact").await,
+            Err(AppError::Forbidden(message)) if message == "exact_service_request_binding_mismatch"
+        ));
+        assert!(matches!(
+            load_bound_request(&state, &caller(), "request-generic").await,
+            Err(AppError::Forbidden(message)) if message == "exact_service_request_binding_mismatch"
+        ));
+    }
+
+    #[tokio::test]
+    async fn pending_expiry_and_persisted_terminal_states_are_stable() {
+        let Some(db) = crate::test_utils::connect_test_database("exact_approval_terminals").await
+        else {
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db.clone());
+        let denied = approval_request(
+            "request-denied",
+            "rejected",
+            Utc::now() + Duration::minutes(5),
+            Some(binding()),
+        );
+        let expired = approval_request(
+            "request-expired",
+            "pending",
+            Utc::now() - Duration::seconds(1),
+            Some(binding()),
+        );
+        let mut drifted_binding = binding();
+        drifted_binding.redemption = Some(ExactServiceApprovalRedemption {
+            status: ExactServiceRedemptionStatus::Drifted,
+            admitted_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            receipt: None,
+            failure_code: Some("catalog_drift".to_string()),
+        });
+        let drifted = approval_request(
+            "request-drifted",
+            "approved",
+            Utc::now() + Duration::minutes(5),
+            Some(drifted_binding),
+        );
+        let mut revoked_binding = binding();
+        revoked_binding.redemption = Some(ExactServiceApprovalRedemption {
+            status: ExactServiceRedemptionStatus::Revoked,
+            admitted_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+            receipt: None,
+            failure_code: Some("selector_revoked".to_string()),
+        });
+        let revoked = approval_request(
+            "request-revoked",
+            "approved",
+            Utc::now() + Duration::minutes(5),
+            Some(revoked_binding),
+        );
+        db.collection::<ApprovalRequest>(REQUESTS)
+            .insert_many([denied, expired, drifted, revoked])
+            .await
+            .expect("insert terminal fixtures");
+
+        for (request_id, expected) in [
+            ("request-denied", ExactServiceApprovalState::Denied),
+            ("request-expired", ExactServiceApprovalState::Expired),
+            ("request-drifted", ExactServiceApprovalState::Drifted),
+            ("request-revoked", ExactServiceApprovalState::Revoked),
+        ] {
+            let observed = observe_request(&state, &caller(), request_id)
+                .await
+                .expect("observe terminal request");
+            assert_eq!(observed.state, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn redemption_claim_is_atomic_and_terminal_receipt_is_exactly_replayed() {
+        let Some(db) = crate::test_utils::connect_test_database("exact_approval_claim").await
+        else {
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db.clone());
+        let request = approval_request(
+            "request-claim",
+            "approved",
+            Utc::now() + Duration::minutes(5),
+            Some(binding()),
+        );
+        db.collection::<ApprovalRequest>(REQUESTS)
+            .insert_one(&request)
+            .await
+            .expect("insert claim fixture");
+
+        let admitted_at = Utc::now();
+        let (first, second) = tokio::join!(
+            claim_redemption(&db, &request, admitted_at),
+            claim_redemption(&db, &request, admitted_at),
+        );
+        let winners = [first.expect("first claim"), second.expect("second claim")]
+            .into_iter()
+            .filter(Option::is_some)
+            .count();
+        assert_eq!(winners, 1);
+
+        let receipt = ExactServiceApprovalReceipt {
+            http_status: 200,
+            response_body: "{\"ok\":true}".to_string(),
+            response_digest: "sha256:receipt".to_string(),
+        };
+        persist_redemption(
+            &db,
+            &request.id,
+            ExactServiceApprovalRedemption {
+                status: ExactServiceRedemptionStatus::Completed,
+                admitted_at,
+                completed_at: Some(Utc::now()),
+                receipt: Some(receipt.clone()),
+                failure_code: None,
+            },
+        )
+        .await
+        .expect("persist winning receipt");
+
+        assert!(matches!(
+            persist_redemption(
+                &db,
+                &request.id,
+                ExactServiceApprovalRedemption {
+                    status: ExactServiceRedemptionStatus::Failed,
+                    admitted_at,
+                    completed_at: Some(Utc::now()),
+                    receipt: None,
+                    failure_code: Some("conflicting_writer".to_string()),
+                },
+            )
+            .await,
+            Err(AppError::Conflict(message)) if message == "exact_service_redemption_state_conflict"
+        ));
+
+        let replay = observe_request(&state, &caller(), &request.id)
+            .await
+            .expect("replay terminal receipt");
+        assert_eq!(replay.state, ExactServiceApprovalState::Redeemed);
+        assert_eq!(replay.receipt, Some(receipt));
+    }
+}

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -245,6 +245,123 @@ pub struct McpOperationCatalog {
     pub diagnostics: McpCatalogDiagnostics,
 }
 
+/// Digest of the exact normalized endpoint contract published by NyxID.
+/// Descriptive labels are excluded; every execution-relevant selector and
+/// schema field is included.
+pub fn endpoint_contract_digest(endpoint: &McpToolEndpoint) -> String {
+    canonical_sha256(serde_json::json!({
+        "contract_version": "nyxid-exact-endpoint.v1",
+        "endpoint_id": endpoint.endpoint_id,
+        "method": endpoint.method,
+        "path": endpoint.path,
+        "parameters": endpoint.parameters,
+        "request_body_schema": endpoint.request_body_schema,
+        "request_content_type": endpoint.request_content_type,
+        "request_body_required": endpoint.request_body_required,
+        "response": endpoint.response,
+    }))
+}
+
+/// Digest of one exact invocation. This binds the server-published endpoint
+/// contract to the canonical argument object that NyxID validates and later
+/// redeems.
+pub fn exact_operation_digest(
+    user_service_id: &str,
+    endpoint: &McpToolEndpoint,
+    arguments: &serde_json::Value,
+) -> String {
+    canonical_sha256(serde_json::json!({
+        "contract_version": "nyxid-exact-operation.v1",
+        "user_service_id": user_service_id,
+        "endpoint_id": endpoint.endpoint_id,
+        "endpoint_contract_digest": endpoint_contract_digest(endpoint),
+        "arguments": arguments,
+    }))
+}
+
+/// Digest of the complete caller-visible MCP catalog. The shape is identical
+/// to `/api/v1/mcp/config`'s contract-bearing service descriptors.
+pub fn operation_catalog_digest(services: &[McpToolService]) -> String {
+    let mut service_values: Vec<_> = services
+        .iter()
+        .map(|service| {
+            let mut endpoint_values: Vec<_> = service
+                .endpoints
+                .iter()
+                .map(|endpoint| {
+                    serde_json::json!({
+                        "endpoint_id": endpoint.endpoint_id,
+                        "name": endpoint.name,
+                        "description": endpoint.description,
+                        "method": endpoint.method,
+                        "path": endpoint.path,
+                        "parameters": endpoint.parameters,
+                        "request_body_schema": endpoint.request_body_schema,
+                        "request_content_type": endpoint.request_content_type,
+                        "request_body_required": endpoint.request_body_required,
+                        "response_description": endpoint.response_description,
+                        "response": endpoint.response,
+                        "operation_digest": endpoint_contract_digest(endpoint),
+                    })
+                })
+                .collect();
+            endpoint_values.sort_by(|left, right| {
+                left["endpoint_id"]
+                    .as_str()
+                    .cmp(&right["endpoint_id"].as_str())
+            });
+            let mut value = serde_json::json!({
+                "service_id": service.service_id,
+                "service_name": service.service_name,
+                "service_slug": service.service_slug,
+                "description": service.description,
+                "service_category": service.service_category,
+                "is_user_service": service.source.is_user_service(),
+                "is_generic_proxy": service.is_generic_proxy,
+                "endpoints": endpoint_values,
+            });
+            if !service.recommended_skills.is_empty() {
+                value["recommended_skills"] = serde_json::json!(service.recommended_skills);
+            }
+            value
+        })
+        .collect();
+    service_values.sort_by(|left, right| {
+        left["service_id"]
+            .as_str()
+            .cmp(&right["service_id"].as_str())
+    });
+    canonical_sha256(serde_json::json!({
+        "contract_version": "1.0",
+        "services": service_values,
+    }))
+}
+
+pub fn canonical_sha256(value: serde_json::Value) -> String {
+    let encoded =
+        serde_json::to_vec(&canonical_json(value)).expect("serializing JSON values cannot fail");
+    format!("sha256:{}", hex::encode(Sha256::digest(encoded)))
+}
+
+pub fn canonical_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(canonical_json).collect())
+        }
+        serde_json::Value::Object(values) => {
+            let mut entries: Vec<_> = values.into_iter().collect();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            serde_json::Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key, canonical_json(value)))
+                    .collect(),
+            )
+        }
+        other => other,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Load user tools (shared by MCP transport + REST /api/v1/mcp/config)
 // ---------------------------------------------------------------------------
@@ -3876,6 +3993,22 @@ mod tests {
             is_generic_proxy: false,
             invalid_openapi_contract: false,
         }
+    }
+
+    #[test]
+    fn exact_operation_digest_matches_cross_language_unicode_fixture() {
+        let digest = canonical_sha256(serde_json::json!({
+            "contract_version": "nyxid-exact-operation.v1",
+            "user_service_id": "us-alpha",
+            "endpoint_id": "message.create",
+            "endpoint_contract_digest": "sha256:contract",
+            "arguments": { "message": "你好 <team>" },
+        }));
+
+        assert_eq!(
+            digest,
+            "sha256:1bcaa1b49841edd6af5c6787659938cfe47196f3c6d2e38b460d955c4ccad4e3"
+        );
     }
 
     #[test]

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -44,6 +44,7 @@ pub mod device_code_service;
 pub mod dpop_jti_cache;
 pub mod durable_operation_grant_service;
 pub mod event_dedup_cache;
+pub mod exact_service_approval_service;
 pub mod feature_flag_service;
 pub mod gcp_sa_service;
 pub mod group_service;


### PR DESCRIPTION
## Problem

Aevatar cannot execute the Tier A pre-effect approval journey without a NyxID-owned exact authority. Generic tool approvals are not connected-service authorization and cannot safely admit a later effect.

## Solution

- add server-authoritative exact-service create, observe, and redeem endpoints
- bind requester, actor user, user service, endpoint, catalog/contract/operation digests, operation generation, and idempotency key
- enforce first-decision-wins and typed denial, expiry, revocation, drift, redeeming, redeemed, and failure outcomes
- atomically claim per-request redemption before the effect and replay the persisted receipt without a second downstream call
- reject generic approvals and conflicting authority replays
- publish canonical catalog/endpoint/operation digests with a cross-language Unicode fixture
- classify exact redemption as MCP egress and cover the mounted route with a real billing smoke

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p nyxid`
- `NYXID_TEST_DATABASE_URL=mongodb://127.0.0.1:27017/?directConnection=true cargo test -p nyxid exact_service -- --nocapture` (9 passed; 4 real MongoDB tests)
- `NYXID_TEST_DATABASE_URL=mongodb://127.0.0.1:27017/?directConnection=true cargo test -p nyxid billing_route_coverage_smoke -- --nocapture` (passed)
- `exact_operation_digest_matches_cross_language_unicode_fixture` (passed)
- `git diff --check`

Refs #1400 item 2.
Consumer: aevatarAI/aevatar#3377.