### PR TITLE
fix(ui): use the NyxID brand mark on CLI auth surfaces

### DIFF
--- a/frontend/src/pages/cli-auth.tsx
+++ b/frontend/src/pages/cli-auth.tsx
@@ -4,7 +4,8 @@ import { useAuthStore } from "@/stores/auth-store";
 import { api } from "@/lib/api-client";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { AlertCircle, Terminal } from "lucide-react";
+import { AlertCircle } from "lucide-react";
+import { NyxidIcon } from "@/components/brand/nyxid-icon";
 import { buildCliAuthReturnPath, type CliAuthSearch } from "./cli-auth.helpers";
 
 interface TokenResponse {
@@ -77,7 +78,7 @@ export function CliAuthPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <div className="flex max-w-sm flex-col items-center gap-4 text-center">
-        <Terminal className="h-12 w-12 text-primary/60" />
+        <NyxidIcon className="h-12 w-12" />
         <h2 className="text-lg font-semibold">
           CLI Authentication
         </h2>

--- a/frontend/src/pages/login-device.tsx
+++ b/frontend/src/pages/login-device.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  ShieldCheck,
-  Terminal,
-} from "lucide-react";
+import { AlertTriangle, CheckCircle2, ShieldCheck } from "lucide-react";
+import { NyxidIcon } from "@/components/brand/nyxid-icon";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import { Button, ButtonIcon } from "@/components/ui/button";
 import {
@@ -102,9 +98,9 @@ export function LoginDevicePage() {
 
   return (
     <LoginDeviceShell>
-      <header className="flex flex-col gap-2 text-center">
-        <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl border border-nyx-500/30 bg-nyx-500/10">
-          <Terminal className="h-4 w-4 text-nyx-secondary-400" />
+      <header className="flex flex-col gap-3 text-center">
+        <div className="flex justify-center">
+          <NyxidIcon className="h-10 w-10" />
         </div>
         <div className="space-y-1">
           <h1 className="text-[22px] font-bold leading-tight tracking-tight text-foreground sm:text-[28px]">


### PR DESCRIPTION
## What

Two NyxID sign-in surfaces used a generic lucide `Terminal` glyph (`>_`) as their page mark instead of brand identity:

- **`/login/device`** (`login-device.tsx`) — the device-code pairing page. A 16px `Terminal` inside an ad-hoc 40px `nyx-500` tile.
- **`/cli-auth`** (`cli-auth.tsx`) — the browser callback for plain `nyxid login`. A 48px `Terminal` at `text-primary/60`.

Both now render `NyxidIcon`, the brand-guide SVG (`/nyxid-coloured-icon.svg`) already used by `oauth-complete`, `oauth-launching`, the assistant thread, and `add-key-dialog`.

| | before | after |
|---|---|---|
| `/login/device` | 16px lucide `Terminal` in a 40px `nyx-500/10` tile | 40px brand mark, no tile |
| `/cli-auth` | 48px lucide `Terminal` at `text-primary/60` | 48px brand mark |

## Why icon-only, not the full lockup

`NyxidLogo` (mark + wordmark) is what `oauth-consent` and `oauth-error` use, and it was the first thing I tried. Rendered against the real compiled CSS it was worse here:

- DESIGN.md:56 reserves the wordmark for landing/legal surfaces — "the logged-in app shows only the icon". Both of these routes are auth-gated.
- On `/login/device` the "NyxID" wordmark sat directly on top of a heading reading "Sign in to NyxID **CLI** on another device".

I also tried keeping the tile and putting the brand mark inside it. The mark already carries its own app-icon silhouette, so it read as a box in a box — hence dropping the tile on `/login/device`. Header gap went `gap-2` → `gap-3`, since the mark needs slightly more separation from the h1 than the small glyph did.

## Scope note

A repo-wide sweep for the same defect (every chrome-less route, both backend-rendered HTML pages, the `credential-accept` mini-app, CLI wizard assets, mobile) turned up one more: the server-rendered OAuth success page in `handlers/oauth.rs` carried an invented ring-and-dot "NyxID" logo on a `#c084fc→#818cf8` gradient found nowhere in the brand assets. **That was already fixed upstream by #1352**, which inlined the full official lockup and rethemed the page — strictly better than the patch I had prepared, so it is not in this PR.

Everything else is correctly branded: `/cli/pair` (via `WizardShell`), the OAuth family, `/login`+`/register` (via `AuthLayout`), docs, blog, legal. `devices-bind`, `devices-onboard`, `org-join` and `providers-callback` sit inside the dashboard chrome, which already carries the mark.

Two related gaps left alone, since neither has a generic icon standing in for the brand (missing branding, not wrong icon — happy to do either as a follow-up):

- `backend/src/login_cli.rs:153` — the localhost page the CLI serves after `nyxid login` is bare text with no mark, on slate `#0f172a` rather than brand `#0a0a0b`.
- `frontend/credential-accept.html` — no icons at all, own Inter/`#0c111d` palette; deliberately dependency-free with SRI-pinned scripts.

## Verification

- `npm run test` — 243 files / 2879 tests pass
- `npm run build` (tsc -b + both vite builds + mock-footprint assertion) — clean
- `npm run lint` — 0 errors
- `cargo test -p nyxid-cli --test wizard_bundle_freshness` — passes (neither edited page is in the wizard module graph, so the committed bundle hash is unchanged)
- Rebased on `origin/main` @ 47f2e008; no Rust sources touched
- Both states rendered in a headless browser against the compiled CSS to confirm the mark reads correctly at both sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)