### PR TITLE
Fix Assistant hydration after same-task steering

### DIFF
--- a/frontend/src/lib/assistant/task-plan.test.ts
+++ b/frontend/src/lib/assistant/task-plan.test.ts
@@ -148,13 +148,42 @@ describe("decodeTaskPlan", () => {
       plan({ steps: [step("step-a", 1), step("step-a", 2)] }),
     ],
     [
-      "operation identity mismatch",
+      "operation actor identity mismatch",
+      plan({
+        steps: [
+          step("step-a", 1, {
+            operation: {
+              conversationActorId: "nyxid-chat-actor-other",
+              taskId: "task-alpha",
+              stepId: "step-a",
+              operationGeneration: 1,
+            },
+          }),
+        ],
+      }),
+    ],
+    [
+      "operation task identity mismatch",
       plan({
         steps: [
           step("step-a", 1, {
             operation: {
               taskId: "task-other",
               stepId: "step-a",
+              operationGeneration: 1,
+            },
+          }),
+        ],
+      }),
+    ],
+    [
+      "operation step identity mismatch",
+      plan({
+        steps: [
+          step("step-a", 1, {
+            operation: {
+              taskId: "task-alpha",
+              stepId: "step-other",
               operationGeneration: 1,
             },
           }),

--- a/frontend/src/lib/assistant/task-plan.ts
+++ b/frontend/src/lib/assistant/task-plan.ts
@@ -138,10 +138,12 @@ export function assertTaskPlanRelationships(plan: TaskPlan): void {
       }
     }
     const operation = step.operation;
+    // A same-task steering continuation advances the plan turn while retaining
+    // operations committed by earlier turns. Their actor, task, and step
+    // identities remain authoritative; the operation turn records provenance.
     if (
       (operation?.conversationActorId &&
         operation.conversationActorId !== plan.actorId) ||
-      (operation?.turnId && operation.turnId !== plan.turnId) ||
       (operation?.taskId && operation.taskId !== plan.taskId) ||
       (operation?.stepId && operation.stepId !== step.stepId)
     ) {

--- a/frontend/src/lib/assistant/task-state.test.ts
+++ b/frontend/src/lib/assistant/task-state.test.ts
@@ -95,6 +95,39 @@ describe("assistant task projection", () => {
     expect(reloaded.pendingActions).toHaveLength(1);
   });
 
+  it("hydrates retained operations from an earlier turn after same-task steering", () => {
+    const steered = currentState();
+    const snapshot = steered.snapshot as Record<string, unknown>;
+    snapshot.activeTurn = {
+      turnId: "turn-continuation",
+      taskId: "task-alpha",
+      status: "active",
+    };
+    snapshot.activeTask = {
+      ...plan({
+        operation: {
+          conversationActorId: ACTOR_ID,
+          turnId: "turn-origin",
+          taskId: "task-alpha",
+          stepId: "step-alpha",
+          operationId: "operation-origin",
+          operationGeneration: 1,
+        },
+      }),
+      turnId: "turn-continuation",
+    };
+
+    const reloaded = applyCurrentTaskState(
+      createTaskProjection(ACTOR_ID),
+      steered,
+    ).projection;
+
+    expect(reloaded.task?.turnId).toBe("turn-continuation");
+    expect(reloaded.steps.get("step-alpha")?.operation?.turnId).toBe(
+      "turn-origin",
+    );
+  });
+
   it("applies only newer exact-plan step changes", () => {
     const snapshot = reduceTaskFrame(
       createTaskProjection(ACTOR_ID),


### PR DESCRIPTION
## Problem

The Assistant current-state reducer rejected a valid same-task steering snapshot when retained historical steps carried the operation turn that originally executed them. The task and current plan advance to the continuation turn, while committed operation provenance remains on the origin turn. This caused the production facade to discard a current state that Studio rendered correctly.

## Solution

- allow retained step operations to preserve their historical turn identity;
- keep actor, task, and step identity mismatches fail-closed;
- cover production-shaped current-state hydration after steering;
- cover actor, task, and step mismatch regressions independently.

## Impact

Assistant TaskPlan decoding and reload hydration only. The Aevatar contract, control commands, action verbs, gates, and backend routes are unchanged.

Tracks aevatarAI/aevatar#3366.

## Verification

- `npx vitest run src/lib/assistant/task-state.test.ts src/lib/assistant/task-plan.test.ts` - 16 passed
- `npx vitest run src/lib/assistant src/components/assistant src/hooks/use-assistant.aevatar.test.tsx src/pages/assistant.test.tsx` - 822 passed
- `npm run build` - passed
- `npx prettier --check src/lib/assistant/task-plan.ts src/lib/assistant/task-plan.test.ts src/lib/assistant/task-state.test.ts` - passed

## Documentation

No documentation change: this restores the existing same-task steering and current-state hydration contract.