### PR TITLE
fix(assistant): harden against the forward_access_token 401 regression

### DIFF
--- a/backend/src/handlers/services.rs
+++ b/backend/src/handlers/services.rs
@@ -1928,12 +1928,32 @@ pub async fn update_service(
 
     tracing::info!(service_id = %service_id, updated_by = %auth_user.user_id, "Service updated");
 
-    // CR-1: Audit log for service update
+    // CR-1: Audit log for service update.
+    //
+    // Field NAMES only, never values — a service row carries credential-shaped
+    // config and the audit store is not the place for it (same discipline as
+    // `service_default_headers_updated` below). Names alone answer "which field
+    // changed?", which a bare `service_id` payload cannot: when a
+    // `forward_access_token` regression on the `aevatar` row took assistant
+    // chat down on 2026-08-12, the audit trail could name the row and the actor
+    // but not the field, so the outage could not be attributed from it.
+    // `updated_at` is stamped on every update, so it carries no signal about
+    // what the admin actually touched; excluding it keeps the list readable.
+    let mut changed_fields: Vec<&str> = set_doc
+        .keys()
+        .map(String::as_str)
+        .filter(|field| *field != "updated_at")
+        .collect();
+    changed_fields.sort_unstable();
+
     audit_service::log_for_user(
         state.db.clone(),
         &auth_user,
         "service_updated",
-        Some(serde_json::json!({ "service_id": &service_id })),
+        Some(serde_json::json!({
+            "service_id": &service_id,
+            "changed_fields": changed_fields,
+        })),
     );
 
     // Per-change audit for default_request_headers mutations. Values are

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -57,7 +57,41 @@ pub async fn resolve_admin_service(db: &mongodb::Database) -> AppResult<Downstre
         )));
     }
 
+    warn_if_bridge_disarmed(&service);
+
     Ok(service)
+}
+
+/// Surface the one row misconfiguration that silently 401s the entire chat
+/// surface, instead of waiting for a user to report it.
+///
+/// Deployed Aevatar authenticates only `Authorization: Bearer <NyxID JWT>`.
+/// The bridge that supplies it (`handlers/assistant.rs::needs_forward_token_bridge`)
+/// is gated on `Session && forward_access_token`, so clearing that flag both
+/// stops the bearer forward and disarms the mint: NyxID then sends no
+/// `Authorization` at all and every Aevatar surface answers 401. This exact
+/// flip took production chat down on 2026-08-12, and nothing in the system
+/// said so — the only signal was a user seeing a failed chat.
+///
+/// Deliberately a warning, not a hard failure: `false` becomes the CORRECT
+/// value once Aevatar validates `X-NyxID-Identity-Token` (the TD-3 cutover),
+/// and failing closed here would turn that rollout into an outage of its own.
+/// Fires once per process — the condition is process-lifetime config, so
+/// per-request logging would only add noise.
+fn warn_if_bridge_disarmed(service: &DownstreamService) {
+    if service.forward_access_token {
+        return;
+    }
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::error!(
+            service_slug = %AEVATAR_SLUG,
+            "assistant: '{AEVATAR_SLUG}' has forward_access_token=false, which disarms the \
+             session bearer bridge. Unless Aevatar now validates X-NyxID-Identity-Token, every \
+             assistant request will fail upstream with 401. Set forward_access_token=true to \
+             restore chat."
+        );
+    });
 }
 
 /// Reject ids that could escape the upstream path segment they are

--- a/docs/chat/01-architecture.md
+++ b/docs/chat/01-architecture.md
@@ -58,7 +58,7 @@ NyxID authenticates the human, selects the platform row, and supplies two differ
 
 The delegated capability scope comes from the service row's `delegation_token_scope` when that scope can call the REST proxy. An empty or LLM-only scope that cannot authorize the required REST surface falls back to `proxy` and emits one warning. The live token lifetime is the compile-time constant `backend/src/crypto/jwt.rs:MCP_DELEGATION_TOKEN_TTL_SECS`, fixed at 300 seconds. It is not an environment variable or an `AppConfig` field; changing it requires a code change.
 
-The stable service-row intent is therefore:
+The required live service-row configuration is therefore:
 
 ```text
 slug:                         aevatar
@@ -68,16 +68,18 @@ identity_propagation_mode:    jwt or both
 identity_jwt_audience:        urn:aevatar:api
 inject_delegation_token:      true
 delegation_token_scope:       proxy or another REST-capable scope
-forward_access_token:         false
+forward_access_token:         true    <-- REQUIRED. Setting this false takes chat down.
 ```
 
 Identity and delegated-capability construction live in `backend/src/handlers/proxy.rs`; assistant-specific forwarding and fallback scope selection live in `backend/src/handlers/assistant.rs:resolve_forward_scope` and `build_forward_authorization`.
 
 ### Authorization is not caller passthrough
 
-The configured steady state sets `forward_access_token` to `false`. The browser's inbound Authorization value is not copied to Aevatar. NyxID generates the identity assertion and delegated capability from the verified authentication context.
+`forward_access_token` must be `true` on the live row. That flag does not mean "copy the browser's inbound Authorization value" — it never does that. It is the enable switch for the bridge in `backend/src/handlers/assistant.rs:needs_forward_token_bridge`, which for a cookie-authenticated session mints a NyxID delegated token server-side and *overwrites* the upstream `Authorization` header. A verified bearer caller keeps its own verified bearer; the assistant route policy excludes API keys, service accounts, delegated tokens, and relay tokens before the handler runs.
 
-There is a compatibility bridge when `forward_access_token` is enabled on the service row. For a cookie-authenticated session, NyxID mints a standard delegated token and overwrites the upstream `Authorization` header; it does not forward an arbitrary browser-supplied value. A verified bearer caller can retain its verified bearer on that configuration, but the assistant route policy excludes API keys, service accounts, delegated tokens, and relay tokens before the handler runs.
+Deployed Aevatar authenticates **only** `Authorization: Bearer <NyxID JWT>`. It does not yet validate the `X-NyxID-Identity-Token` or `X-NyxID-Delegation-Token` headers that NyxID also sends. Because the bridge is gated on `Session && forward_access_token`, setting the flag to `false` both stops the bearer forward *and* disarms the mint, so NyxID sends no `Authorization` at all and **every** Aevatar surface returns 401 `authentication_required` — the typed `/api/chat`, `/api/chat/conversations`, and legacy `v1/chat/completions` alike. This is not a theoretical failure mode: it took production chat down on 2026-08-12 and was resolved only by setting the flag back to `true`.
+
+`forward_access_token: false` becomes correct **only after** Aevatar ships identity-assertion validation (the TD-3 cutover). Until that is verified live against the deployed Aevatar, do not set it. The bridge is designed to retire itself with no code change on that day; flipping the flag ahead of the upstream capability is what breaks it.
 
 `JWT_ASSISTANT_FORWARD_TTL_SECS`, `crypto/jwt.rs:generate_assistant_forward_access_token`, and the `assistant_forward` claim are compatibility tombstones. They preserve rejection behavior for a prior token shape and do not control live assistant authentication. New code must not depend on them.
 

--- a/frontend/src/hooks/use-assistant.test.tsx
+++ b/frontend/src/hooks/use-assistant.test.tsx
@@ -629,11 +629,12 @@ describe("assistant hooks", () => {
 });
 
 describe("describeTransportError", () => {
-  // A downstream 401 from `/proxy/s/aevatar` means aevatar rejected the
-  // forwarded identity, NOT that the NyxID session died. The copy must say
-  // "you are still signed in" — the whole point of the fix is that we no
-  // longer bounce to /login here.
-  it("explains a downstream 401 without implying the session died", () => {
+  // An upstream 401 is passed through from Aevatar, whose body never carries
+  // NyxID's numeric `error_code` (the api-client falls back to -1). The NyxID
+  // session really is fine here, but the copy must not send the user off to
+  // reconnect a service — the cause is the platform's `aevatar` row, which no
+  // end user can reach.
+  it("attributes a 401 with no NyxID error code to the chat backend", () => {
     const { message, description } = describeTransportError(
       new ApiError(401, {
         error: "unknown_error",
@@ -642,7 +643,25 @@ describe("describeTransportError", () => {
       }),
     );
     expect(message).toBe("Assistant chat is unavailable");
-    expect(description).toContain("still signed in");
+    expect(description).toContain("chat backend rejected");
+    expect(description).toContain("platform admin");
+    expect(description).not.toContain("reconnect");
+  });
+
+  // Regression: the assistant transport opts out of the global sign-out, so a
+  // genuinely dead session used to render as "you are still signed in" — false,
+  // and it hid an expired session behind an Aevatar-shaped complaint.
+  it("attributes a 401 carrying a NyxID auth code to the expired session", () => {
+    const { message, description } = describeTransportError(
+      new ApiError(401, {
+        error: "token_expired",
+        error_code: 2001,
+        message: "Token expired",
+      }),
+    );
+    expect(message).toBe("Your session has expired");
+    expect(description).toContain("Sign in again");
+    expect(description).not.toContain("still signed in");
   });
 
   it("falls back to a generic message for non-401 failures", () => {
@@ -652,7 +671,20 @@ describe("describeTransportError", () => {
 });
 
 describe("describeSendFailure", () => {
-  it("explains a downstream 401/403 without implying the session died", () => {
+  it("attributes a 401 with no NyxID error code to the chat backend", () => {
+    const { message, description } = describeSendFailure(
+      new ApiError(401, {
+        error: "unknown_error",
+        error_code: -1,
+        message: "Request failed with status 401",
+      }),
+    );
+    expect(message).toBe("Message not sent");
+    expect(description).toContain("chat backend rejected");
+    expect(description).not.toContain("still signed in");
+  });
+
+  it("attributes a 401 carrying a NyxID auth code to the expired session", () => {
     const { message, description } = describeSendFailure(
       new ApiError(401, {
         error: "unauthorized",
@@ -661,7 +693,7 @@ describe("describeSendFailure", () => {
       }),
     );
     expect(message).toBe("Message not sent");
-    expect(description).toContain("still signed in");
+    expect(description).toContain("Sign in again");
   });
 
   it("asks the user to wait when a turn is already active", () => {

--- a/frontend/src/hooks/use-assistant.ts
+++ b/frontend/src/hooks/use-assistant.ts
@@ -8,9 +8,12 @@ import {
 import { toast } from "sonner";
 import { ApiError } from "@/lib/api-client";
 import {
+  ASSISTANT_SESSION_EXPIRED_MESSAGE,
+  ASSISTANT_UPSTREAM_AUTH_MESSAGE,
   AssistantConversationNotFoundError,
   AssistantTurnActiveError,
   AssistantTurnCancelledError,
+  isNyxIdSessionAuthFailure,
 } from "@/lib/assistant/errors";
 import {
   useApprovalRequests,
@@ -247,22 +250,31 @@ const TRANSPORT_TOAST_ID = "assistant-transport-unavailable";
 
 /**
  * Chat reaches aevatar through NyxID's `/api/v1/assistant/*` pass-through,
- * which forwards the DOWNSTREAM's status straight through. A 401 there means
- * aevatar rejected the identity NyxID forwarded — the NyxID session itself is
- * fine — so the transport opts those requests out of the global sign-out
- * (`preserveSessionOn401` in aevatar-transport) and the route stays put.
- * Without a toast that failure is invisible: the sidebar just renders empty,
- * which reads as "no chats yet" rather than "chat is down".
+ * which forwards the DOWNSTREAM's status straight through. The transport opts
+ * those requests out of the global sign-out (`preserveSessionOn401` in
+ * aevatar-transport) so the route stays put. Without a toast that failure is
+ * invisible: the sidebar just renders empty, which reads as "no chats yet"
+ * rather than "chat is down".
+ *
+ * A 401 can come from either side, so attribute it by `errorCode` rather than
+ * assuming — see `isNyxIdSessionAuthFailure`. Guessing "aevatar rejected it"
+ * is what made an admin-only config outage look like a user's broken
+ * connection.
  */
 export function describeTransportError(error: unknown): {
   readonly message: string;
   readonly description: string;
 } {
   if (error instanceof ApiError && error.status === 401) {
+    if (isNyxIdSessionAuthFailure(error.errorCode)) {
+      return {
+        message: "Your session has expired",
+        description: ASSISTANT_SESSION_EXPIRED_MESSAGE,
+      };
+    }
     return {
       message: "Assistant chat is unavailable",
-      description:
-        "NyxID could not authenticate you to the chat backend. You are still signed in — reconnect the aevatar service and try again.",
+      description: ASSISTANT_UPSTREAM_AUTH_MESSAGE,
     };
   }
   return {
@@ -778,8 +790,9 @@ export function describeSendFailure(error: unknown): {
   ) {
     return {
       message: "Message not sent",
-      description:
-        "NyxID could not authenticate you to the chat backend. You are still signed in — reconnect the aevatar service and try again.",
+      description: isNyxIdSessionAuthFailure(error.errorCode)
+        ? ASSISTANT_SESSION_EXPIRED_MESSAGE
+        : ASSISTANT_UPSTREAM_AUTH_MESSAGE,
     };
   }
   if (error instanceof AssistantTurnActiveError) {

--- a/frontend/src/lib/assistant/aevatar-transport.test.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.test.ts
@@ -1179,7 +1179,7 @@ describe("AevatarAssistantTransport", () => {
     expect(error?.message).toBe("Aevatar timed out.");
   });
 
-  it("gives a stream 401 an auth-specific message, not a bare status", async () => {
+  it("blames the chat backend for a stream 401 carrying no NyxID error code", async () => {
     stubFetch((url, init) =>
       url.endsWith("/stream") && init?.method === "POST"
         ? jsonResponse({ error: "unauthorized" }, 401)
@@ -1194,7 +1194,36 @@ describe("AevatarAssistantTransport", () => {
     const error =
       terminal?.event === "turn.completed" ? terminal.error : undefined;
     expect(error?.code).toBe("unauthorized");
-    expect(error?.message).toContain("still signed in");
+    expect(error?.message).toContain("chat backend rejected");
+    expect(error?.message).not.toContain("still signed in");
+  });
+
+  // The same status with NyxID's numeric `error_code` is the opposite
+  // diagnosis: our session died, and telling the user they are still signed in
+  // would send them chasing an upstream that is healthy.
+  it("blames the expired session for a stream 401 carrying a NyxID auth code", async () => {
+    stubFetch((url, init) =>
+      url.endsWith("/stream") && init?.method === "POST"
+        ? jsonResponse(
+            {
+              error: "token_expired",
+              error_code: 2001,
+              message: "Token expired",
+            },
+            401,
+          )
+        : undefined,
+    );
+    const transport = new AevatarAssistantTransport();
+    await seedActorConversation(transport);
+
+    const events = await collectTurn(transport, "Hello");
+
+    const terminal = events[events.length - 1];
+    const error =
+      terminal?.event === "turn.completed" ? terminal.error : undefined;
+    expect(error?.code).toBe("token_expired");
+    expect(error?.message).toContain("Sign in again");
   });
 
   it("reports EOF without a terminal frame as a truncated run, keeping partial text", async () => {

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -5,10 +5,13 @@ import {
   composeUnreportedCompletedNote,
 } from "@/lib/assistant/action-notes";
 import {
+  ASSISTANT_SESSION_EXPIRED_MESSAGE,
+  ASSISTANT_UPSTREAM_AUTH_MESSAGE,
   AssistantConversationNotFoundError,
   AssistantProtocolError,
   AssistantTurnActiveError,
   AssistantTurnCancelledError,
+  isNyxIdSessionAuthFailure,
 } from "@/lib/assistant/errors";
 import { resolveAssistantAction } from "@/lib/assistant/action-registry";
 import {
@@ -1058,10 +1061,9 @@ function matchesCommittedActionRequest(
  * Map a pre-stream rejection to a turn error. Errors before the SSE stream
  * starts arrive as a JSON envelope — NyxID's `{error, error_code, message}`
  * or Aevatar's `{code, message}` — and must not collapse to a bare
- * `http_<status>`. A 401/403 here means the downstream rejected the
- * identity NyxID forwarded, not that the NyxID session died — this raw
- * fetch never touches auth state, so it cannot trigger a sign-out; the
- * copy says so explicitly.
+ * `http_<status>`. A 401/403 is attributed to whichever side actually
+ * rejected it (see `isNyxIdSessionAuthFailure`); this raw fetch never touches
+ * auth state, so it cannot trigger a sign-out on its own.
  */
 function streamStartError(
   status: number,
@@ -1071,6 +1073,7 @@ function streamStartError(
     readonly error?: unknown;
     readonly code?: unknown;
     readonly message?: unknown;
+    readonly error_code?: unknown;
   }
   let envelope: ErrorEnvelope | null = null;
   try {
@@ -1091,8 +1094,9 @@ function streamStartError(
   if (status === 401 || status === 403) {
     return {
       code: envelopeCode ?? "unauthorized",
-      message:
-        "NyxID could not authenticate you to the chat backend. You are still signed in — reconnect the aevatar service and try again.",
+      message: isNyxIdSessionAuthFailure(envelope?.error_code)
+        ? ASSISTANT_SESSION_EXPIRED_MESSAGE
+        : ASSISTANT_UPSTREAM_AUTH_MESSAGE,
     };
   }
   return {

--- a/frontend/src/lib/assistant/errors.ts
+++ b/frontend/src/lib/assistant/errors.ts
@@ -1,3 +1,37 @@
+/**
+ * NyxID's own auth rejections carry a NUMERIC `error_code` from
+ * `backend/src/errors/mod.rs`: 1001 `unauthorized`, 2000
+ * `authentication_failed`, 2001 `token_expired`, 2002 `mfa_required`.
+ * Aevatar's rejections never carry that field, so its presence is the
+ * discriminator between "your NyxID session is dead" and "the chat backend
+ * rejected the identity NyxID sent".
+ *
+ * The distinction is load-bearing. The assistant transport opts every request
+ * out of the global sign-out (`preserveSessionOn401`) on the assumption that a
+ * 401 there is always the downstream's. When that assumption is wrong, an
+ * expired session renders as "you are still signed in" — false, and it sends
+ * the user to reconnect a service that is not the problem.
+ */
+const NYXID_AUTH_ERROR_CODES: ReadonlySet<number> = new Set([
+  1001, 2000, 2001, 2002,
+]);
+
+export function isNyxIdSessionAuthFailure(errorCode: unknown): boolean {
+  return typeof errorCode === "number" && NYXID_AUTH_ERROR_CODES.has(errorCode);
+}
+
+/** Copy for a 401 that NyxID itself raised: the user's session is gone. */
+export const ASSISTANT_SESSION_EXPIRED_MESSAGE =
+  "Your NyxID session has expired. Sign in again to keep chatting.";
+
+/**
+ * Copy for a 401 the chat backend raised. Deliberately does NOT tell the user
+ * to reconnect anything: this is platform configuration on the `aevatar`
+ * service row, which no end user can reach.
+ */
+export const ASSISTANT_UPSTREAM_AUTH_MESSAGE =
+  "The chat backend rejected NyxID's credentials. Your NyxID session is unaffected; this needs a platform admin.";
+
 export class AssistantTurnActiveError extends Error {
   constructor() {
     super("A turn is already active for this conversation.");


### PR DESCRIPTION
## Context

The 2026-08-12 production chat outage — every Aevatar surface (typed `/api/chat`, `/conversations`, legacy `v1/chat/completions`) returning 401 shortly after the #1408 deploy — was **not** a #1408 code fault. The `aevatar` DownstreamService row had `forward_access_token` flipped to `false` by a direct DB write (no PR, no audit entry). That flag gates `needs_forward_token_bridge()` (`Session && forward_access_token`), so clearing it both stops the bearer forward *and* disarms the mint: NyxID sends no `Authorization` header at all, and deployed Aevatar authenticates only that bearer. Prod was fixed by flipping the boolean back (no deploy); this PR removes the traps that let it happen silently.

## Changes

1. **Doc fix** (`docs/chat/01-architecture.md`) — the doc stated `forward_access_token: false` was "the configured steady state"; anyone aligning prod to that doc takes chat down (and most likely someone did). Now documents `true` as REQUIRED until the TD-3 identity-assertion cutover is verified live in Aevatar.
2. **Disarmed-bridge alarm** (`backend/src/services/assistant_service.rs`) — a once-per-process error-level log when the aevatar row has the bridge disarmed, naming the flag and the fix. Deliberately a warning, not a hard failure: `false` becomes correct after TD-3, and failing closed would turn that rollout into an outage of its own.
3. **Audit attribution** (`backend/src/handlers/services.rs`) — `service_updated` events now record changed field **names** (never values, same discipline as the default-headers audit). During the outage forensics the audit trail could name the row and actor but not the field.
4. **Frontend 401 attribution** (`frontend/src/lib/assistant/errors.ts`, `use-assistant.ts`, `aevatar-transport.ts`) — the transport opts out of the global sign-out and previously hardcoded "you are still signed in — reconnect the aevatar service" for every 401. That copy was wrong on both sides: a genuinely dead session rendered as "still signed in", and users were told to reconnect a platform-admin-only service row. Now attributed by NyxID's numeric `error_code` (1001/2000/2001/2002 = session expired → "Sign in again"; absent = upstream rejection → "needs a platform admin").

## Verification

Backend, against a transaction-capable MongoDB (single-node replica set — the 26 failures on a
standalone server are `test_utils` topology guards, not regressions):

- `cargo test -p nyxid` — **5172 passed, 0 failed**, byte-identical to the count on clean `main`
- `cargo clippy -p nyxid --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean

Frontend:

- `npm run test` — **2747 passed, 240 files**
- `npm run build` (the CI gate: `tsc -b` + prod build) — clean
- `npm run lint` — 0 errors (23 pre-existing warnings)
- 4 new attribution regression tests (stream + pre-stream, both error-code shapes)

Production (`nyx-api.chrono-ai.fun`), before/after the config fix:

- `GET /api/v1/assistant/conversations` 401 -> **200** (123 rows: 45 typed + 78 legacy, both index
  sources paginating)
- `POST /api/v1/assistant/chat` 401 -> **200**, full typed turn `RUN_STARTED` -> `RUN_FINISHED/completed`
- upstream echo (`x-nyxid-debug-upstream`) confirms `forward_access_token: true`, upstream 200

No wizard-bundle sources touched (checked `cli/src/wizard/bundle-meta/index.manifest`).

**Not verified by me:** the browser/`Session` path takes the delegated-token branch
(`bridge_minted: true`) rather than the bearer forward. I traced that chain end to end and the minted
token is claim-identical to the one Aevatar accepted (`iss`/`aud`/`sub`/`token_type`/signature; only
`scope`/`act`/`delegated` differ, additively), but I could not execute it without a session cookie.
Confirm with one hard reload before merging.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
