### PR TITLE
feat(assistant): reasoning-effort picker for direct chat

### DIFF
--- a/backend/src/handlers/assistant_direct.rs
+++ b/backend/src/handlers/assistant_direct.rs
@@ -30,6 +30,12 @@ pub struct DirectModelResponse {
     default: bool,
 }
 
+#[derive(Serialize)]
+pub struct DirectEffortResponse {
+    id: &'static str,
+    label: &'static str,
+}
+
 async fn require_direct_chat_enabled(state: &AppState, auth_user: &AuthUser) -> AppResult<()> {
     let enabled =
         feature_flag_service::resolve_personal_features(&state.db, &auth_user.user_id.to_string())
@@ -75,6 +81,22 @@ pub async fn models(
     ))
 }
 
+pub async fn efforts(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AppResult<Json<Vec<DirectEffortResponse>>> {
+    require_direct_chat_enabled(&state, &auth_user).await?;
+    Ok(Json(
+        assistant_direct::DIRECT_EFFORTS
+            .iter()
+            .map(|effort| DirectEffortResponse {
+                id: effort.id,
+                label: effort.label,
+            })
+            .collect(),
+    ))
+}
+
 pub async fn completions(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -101,6 +123,7 @@ pub async fn completions(
         .clone()
         .unwrap_or_else(|| assistant_direct::DEFAULT_DIRECT_MODEL.to_string());
     let skill_slug = direct_request.skill_slug.clone();
+    let effort = direct_request.effort.clone();
     let upstream_body = assistant_direct::build_upstream_body(direct_request);
     let payload = serde_json::to_vec(&upstream_body).map_err(|_| {
         AppError::Internal("assistant: failed to encode direct chat request".to_string())
@@ -134,6 +157,7 @@ pub async fn completions(
         user_id = %auth_user.user_id,
         model = %model,
         skill_slug = skill_slug.as_deref().unwrap_or("none"),
+        effort = effort.as_deref().unwrap_or("default"),
         message_count,
         content_bytes,
         "assistant_direct_request"
@@ -155,6 +179,7 @@ pub async fn completions(
         user_id = %auth_user.user_id,
         model = %model,
         skill_slug = skill_slug.as_deref().unwrap_or("none"),
+        effort = effort.as_deref().unwrap_or("default"),
         message_count,
         content_bytes,
         status = response.status().as_u16(),
@@ -335,6 +360,10 @@ mod tests {
             models(State(state.clone()), auth_user.clone()).await,
             Err(AppError::NotFound(_))
         ));
+        assert!(matches!(
+            efforts(State(state.clone()), auth_user.clone()).await,
+            Err(AppError::NotFound(_))
+        ));
         let request = Request::builder()
             .method("POST")
             .uri("/api/v1/assistant/direct/completions")
@@ -373,9 +402,20 @@ mod tests {
             .await
             .unwrap()
             .0;
-        let model_rows = models(State(state), auth_user).await.unwrap().0;
+        let model_rows = models(State(state.clone()), auth_user.clone())
+            .await
+            .unwrap()
+            .0;
+        let effort_rows = efforts(State(state), auth_user).await.unwrap().0;
         assert_eq!(skill_rows.len(), assistant_direct::DIRECT_SKILLS.len());
         assert_eq!(model_rows.len(), assistant_direct::DIRECT_MODELS.len());
+        assert_eq!(
+            effort_rows.iter().map(|row| row.id).collect::<Vec<_>>(),
+            assistant_direct::DIRECT_EFFORTS
+                .iter()
+                .map(|row| row.id)
+                .collect::<Vec<_>>()
+        );
         assert_eq!(
             skill_rows.iter().map(|row| row.slug).collect::<Vec<_>>(),
             assistant_direct::DIRECT_SKILLS

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1476,6 +1476,7 @@ pub fn build_router(
         )
         .route("/direct/skills", get(handlers::assistant_direct::skills))
         .route("/direct/models", get(handlers::assistant_direct::models))
+        .route("/direct/efforts", get(handlers::assistant_direct::efforts))
         .route(
             "/actions/key-create",
             post(handlers::assistant_action_effects::create_key),

--- a/backend/src/services/assistant_direct.rs
+++ b/backend/src/services/assistant_direct.rs
@@ -114,6 +114,42 @@ pub const DIRECT_MODELS: &[DirectModel] = &[
     },
 ];
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DirectEffort {
+    pub id: &'static str,
+    pub label: &'static str,
+}
+
+/// Reasoning-effort levels offered to the picker. Absent effort means "send
+/// no `reasoning_effort` at all", which keeps the upstream's own default and
+/// leaves the historical request shape byte-identical.
+///
+/// This table is curated, not discovered: the upstream advertises no effort
+/// catalog, so an entry the deployed model rejects surfaces as a 4xx on that
+/// turn. Adjust the list here when the live Chrono-LLM contract is confirmed.
+pub const DIRECT_EFFORTS: &[DirectEffort] = &[
+    DirectEffort {
+        id: "low",
+        label: "Low",
+    },
+    DirectEffort {
+        id: "medium",
+        label: "Medium",
+    },
+    DirectEffort {
+        id: "high",
+        label: "High",
+    },
+    DirectEffort {
+        id: "xhigh",
+        label: "Extra high",
+    },
+    DirectEffort {
+        id: "max",
+        label: "Max",
+    },
+];
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DirectMessageRole {
@@ -134,6 +170,7 @@ pub struct DirectChatRequest {
     pub messages: Vec<DirectMessage>,
     pub model: Option<String>,
     pub skill_slug: Option<String>,
+    pub effort: Option<String>,
 }
 
 pub fn validate_direct_request(bytes: &[u8]) -> AppResult<DirectChatRequest> {
@@ -181,6 +218,16 @@ pub fn validate_direct_request(bytes: &[u8]) -> AppResult<DirectChatRequest> {
             allowed_skills()
         )));
     }
+    if let Some(effort) = request.effort.as_deref()
+        && !DIRECT_EFFORTS
+            .iter()
+            .any(|candidate| candidate.id == effort)
+    {
+        return Err(AppError::BadRequest(format!(
+            "Unknown effort. Allowed values: {}.",
+            allowed_efforts()
+        )));
+    }
 
     Ok(request)
 }
@@ -200,12 +247,19 @@ pub fn build_upstream_body(request: DirectChatRequest) -> serde_json::Value {
             .map(|message| serde_json::to_value(message).expect("direct message serializes")),
     );
 
-    serde_json::json!({
+    let mut body = serde_json::json!({
         "model": model,
         "stream": true,
         "stream_options": { "include_usage": true },
         "messages": messages,
-    })
+    });
+    // Omitted rather than defaulted: no effort means the upstream keeps its
+    // own default and the request shape is unchanged from before this option
+    // existed.
+    if let Some(effort) = request.effort.as_deref().and_then(find_effort) {
+        body["reasoning_effort"] = serde_json::Value::String(effort.id.to_string());
+    }
+    body
 }
 
 fn compose_system_prompt(skill_slug: Option<&str>) -> String {
@@ -223,6 +277,10 @@ fn find_skill(slug: &str) -> Option<&'static DirectSkill> {
     DIRECT_SKILLS.iter().find(|skill| skill.slug == slug)
 }
 
+fn find_effort(id: &str) -> Option<&'static DirectEffort> {
+    DIRECT_EFFORTS.iter().find(|effort| effort.id == id)
+}
+
 fn allowed_models() -> String {
     DIRECT_MODELS
         .iter()
@@ -235,6 +293,14 @@ fn allowed_skills() -> String {
     DIRECT_SKILLS
         .iter()
         .map(|skill| skill.slug)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn allowed_efforts() -> String {
+    DIRECT_EFFORTS
+        .iter()
+        .map(|effort| effort.id)
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -311,6 +377,34 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn rejects_unknown_effort_and_omits_the_field_when_unset() {
+        let effort_error = validate_direct_request(
+            &serde_json::to_vec(&json!({
+                "messages": [{"role": "user", "content": "hi"}],
+                "effort": "ultra",
+            }))
+            .unwrap(),
+        )
+        .unwrap_err();
+        assert!(effort_error.to_string().contains("xhigh"));
+
+        let without = build_upstream_body(valid_request(json!({
+            "messages": [{"role": "user", "content": "hi"}],
+        })));
+        assert!(without.get("reasoning_effort").is_none());
+        assert_eq!(without.as_object().unwrap().len(), 4);
+
+        for effort in DIRECT_EFFORTS {
+            let with = build_upstream_body(valid_request(json!({
+                "messages": [{"role": "user", "content": "hi"}],
+                "effort": effort.id,
+            })));
+            assert_eq!(with["reasoning_effort"], effort.id);
+            assert_eq!(with.as_object().unwrap().len(), 5);
+        }
     }
 
     #[test]

--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -37,6 +37,7 @@ a not-found-shaped error after syntactic validation and make no upstream call.
 | `POST /chat` | typed command | `POST /api/chat` with top-level `type` |
 | `GET /direct/skills` | curated Direct skill metadata | no upstream call |
 | `GET /direct/models` | curated Direct model metadata | no upstream call |
+| `GET /direct/efforts` | curated Direct reasoning-effort metadata | no upstream call |
 | `POST /direct/completions` | stateless Direct text turn | `POST /chat/completions` on `chrono-llm-public` |
 
 With the default-off `experimental:direct-chat-engine` flag disabled, the
@@ -61,8 +62,9 @@ caller's effective feature grants on every request. When
 without contacting an upstream.
 
 `GET /direct/skills` returns the server's curated `slug` and `label` rows;
-`GET /direct/models` returns curated `id`, `label`, and `default` rows. Neither
-metadata route accepts a caller-selected service or calls Chrono LLM.
+`GET /direct/models` returns curated `id`, `label`, and `default` rows;
+`GET /direct/efforts` returns curated `id` and `label` rows. No metadata route
+accepts a caller-selected service or calls Chrono LLM.
 
 `POST /direct/completions` accepts only:
 
@@ -73,22 +75,32 @@ metadata route accepts a caller-selected service or calls Chrono LLM.
     { "role": "assistant", "content": "prior reply" }
   ],
   "model": "gpt-5.5",
-  "skill_slug": "nyxid"
+  "skill_slug": "nyxid",
+  "effort": "xhigh"
 }
 ```
 
-`messages` contains 1-64 user/assistant messages; `model` and `skill_slug` are
-optional but, when present, must name a curated row. The server rejects unknown
-fields and client-supplied system roles, validates the 256 KiB body and
-aggregate-content limits, then rebuilds the upstream body. The rebuilt body
-prepends the server-owned base system prompt and optional curated skill, forces
-`stream: true` and `stream_options.include_usage: true`, and is sent to the
-fixed admin-managed `chrono-llm-public` service at upstream path
+`messages` contains 1-64 user/assistant messages; `model`, `skill_slug`, and
+`effort` are optional but, when present, must name a curated row. The server
+rejects unknown fields and client-supplied system roles, validates the 256 KiB
+body and aggregate-content limits, then rebuilds the upstream body. The rebuilt
+body prepends the server-owned base system prompt and optional curated skill,
+forces `stream: true` and `stream_options.include_usage: true`, and is sent to
+the fixed admin-managed `chrono-llm-public` service at upstream path
 `chat/completions`.
+
+`effort` is the only optional field that is **omitted rather than defaulted**:
+absent `effort` sends no `reasoning_effort` key at all, leaving the upstream
+model's own default and reproducing the pre-effort request byte for byte. When
+present it is emitted as `reasoning_effort`. The effort table is curated
+server-side and unverified against the live Chrono-LLM contract — the upstream
+publishes no effort catalog, so a value the deployed model rejects surfaces as a
+4xx on that turn rather than being caught at validation.
 
 The completion route is limited per user to 10 requests per rolling 60 seconds
 and 2 concurrent streams. Exceeding either limit returns `429 Too Many
-Requests`; the skills and models metadata routes do not consume this limiter.
+Requests`; the skills, models, and efforts metadata routes do not consume this
+limiter.
 
 The response is OpenAI-compatible SSE passed through without creating a NyxID
 conversation resource. The frontend interprets content deltas, terminal finish

--- a/frontend/src/components/assistant/direct-chat-controls.test.tsx
+++ b/frontend/src/components/assistant/direct-chat-controls.test.tsx
@@ -52,6 +52,12 @@ describe("DirectChatControls", () => {
           { id: "gpt-5.2", label: "GPT-5.2", default: false },
         ] as never;
       }
+      if (endpoint === "/assistant/direct/efforts") {
+        return [
+          { id: "high", label: "High" },
+          { id: "xhigh", label: "Extra high" },
+        ] as never;
+      }
       return [
         { slug: "nyxid", label: "NyxID" },
         { slug: "github-via-nyxid", label: "GitHub via NyxID" },
@@ -60,9 +66,10 @@ describe("DirectChatControls", () => {
     const event = userEvent.setup();
     renderWithQuery(<DirectChatControls conversationId={undefined} />);
 
-    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(3));
     expect(get).toHaveBeenCalledWith("/assistant/direct/models");
     expect(get).toHaveBeenCalledWith("/assistant/direct/skills");
+    expect(get).toHaveBeenCalledWith("/assistant/direct/efforts");
     expect(
       screen.getByText(
         "A skill teaches the model about NyxID; it cannot take actions here.",
@@ -72,6 +79,7 @@ describe("DirectChatControls", () => {
       expect(directAssistantTransport.getSettings()).toEqual({
         model: "gpt-5.4",
         skillSlug: null,
+        effort: null,
       }),
     );
 
@@ -81,15 +89,21 @@ describe("DirectChatControls", () => {
       screen.getByRole("combobox", { name: "NyxID knowledge" }),
     );
     await event.click(screen.getByRole("option", { name: "NyxID" }));
+    await event.click(
+      screen.getByRole("combobox", { name: "Reasoning effort" }),
+    );
+    await event.click(screen.getByRole("option", { name: "Extra high" }));
 
     expect(directAssistantTransport.getSettings()).toEqual({
       model: "gpt-5.2",
       skillSlug: "nyxid",
+      effort: "xhigh",
     });
     const conversation = await directAssistantTransport.createConversation();
     expect(directAssistantTransport.getSettings(conversation.id)).toEqual({
       model: "gpt-5.2",
       skillSlug: "nyxid",
+      effort: "xhigh",
     });
   });
 
@@ -125,7 +139,7 @@ describe("DirectChatControls", () => {
 
     renderWithQuery(<DirectChatControls conversationId={undefined} />);
 
-    await waitFor(() => expect(get).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(3));
     await waitFor(() => {
       expect(screen.getByRole("combobox", { name: "Model" })).toHaveTextContent(
         "User Choice",
@@ -165,6 +179,7 @@ describe("DirectChatControls", () => {
     expect(directAssistantTransport.getSettings("direct-missing")).toEqual({
       model: "gpt-5.5",
       skillSlug: null,
+      effort: null,
     });
   });
 

--- a/frontend/src/components/assistant/direct-chat-controls.tsx
+++ b/frontend/src/components/assistant/direct-chat-controls.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/select";
 import {
   useDirectConversationSettings,
+  useDirectEfforts,
   useDirectModels,
   useDirectSkills,
 } from "@/hooks/use-assistant-direct";
@@ -51,9 +52,10 @@ export function DirectChatControls({
 }) {
   const models = useDirectModels();
   const skills = useDirectSkills();
+  const efforts = useDirectEfforts();
   const defaultModel =
     models.data?.find((model) => model.default)?.id ?? models.data?.[0]?.id;
-  const { settings, canUpdate, setModel, setSkill } =
+  const { settings, canUpdate, setModel, setSkill, setEffort } =
     useDirectConversationSettings(conversationId, defaultModel);
 
   return (
@@ -77,6 +79,36 @@ export function DirectChatControls({
             {(models.data ?? []).map((model) => (
               <SelectItem key={model.id} value={model.id}>
                 {model.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="w-[150px] min-w-0">
+        <label
+          htmlFor="direct-chat-effort"
+          className="mb-1 block text-[10px] font-medium text-text-tertiary"
+        >
+          Reasoning effort
+        </label>
+        <Select
+          value={settings.effort ?? "default"}
+          onValueChange={(value) =>
+            setEffort(value === "default" ? null : value)
+          }
+          disabled={disabled || !canUpdate || efforts.isLoading}
+        >
+          <SelectTrigger
+            id="direct-chat-effort"
+            className="h-7 rounded-md px-2"
+          >
+            <SelectValue placeholder="Model default" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">Model default</SelectItem>
+            {(efforts.data ?? []).map((effort) => (
+              <SelectItem key={effort.id} value={effort.id}>
+                {effort.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/frontend/src/hooks/use-assistant-direct.ts
+++ b/frontend/src/hooks/use-assistant-direct.ts
@@ -6,6 +6,7 @@ import {
   type DirectConversationSettings,
 } from "@/lib/assistant/direct-transport";
 import {
+  directEffortsSchema,
   directModelsSchema,
   directSkillsSchema,
 } from "@/schemas/assistant-direct";
@@ -13,6 +14,7 @@ import {
 const directCatalogKeys = {
   skills: ["assistant", "direct", "skills"] as const,
   models: ["assistant", "direct", "models"] as const,
+  efforts: ["assistant", "direct", "efforts"] as const,
 };
 
 export function useDirectSkills() {
@@ -37,6 +39,17 @@ export function useDirectModels() {
   });
 }
 
+export function useDirectEfforts() {
+  return useQuery({
+    queryKey: directCatalogKeys.efforts,
+    queryFn: async () =>
+      directEffortsSchema.parse(
+        await api.get<unknown>("/assistant/direct/efforts"),
+      ),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}
+
 export function useDirectConversationSettings(
   conversationId: string | undefined,
   defaultModel: string | undefined,
@@ -45,6 +58,7 @@ export function useDirectConversationSettings(
   readonly canUpdate: boolean;
   readonly setModel: (model: string) => void;
   readonly setSkill: (skillSlug: string | null) => void;
+  readonly setEffort: (effort: string | null) => void;
 } {
   const [, forceRender] = useReducer((revision: number) => revision + 1, 0);
 
@@ -62,6 +76,10 @@ export function useDirectConversationSettings(
     },
     setSkill: (skillSlug) => {
       directAssistantTransport.setSkill(conversationId, skillSlug);
+      forceRender();
+    },
+    setEffort: (effort) => {
+      directAssistantTransport.setEffort(conversationId, effort);
       forceRender();
     },
   };

--- a/frontend/src/lib/assistant/direct-transport.test.ts
+++ b/frontend/src/lib/assistant/direct-transport.test.ts
@@ -123,6 +123,45 @@ describe("DirectAssistantTransport streaming", () => {
     });
   });
 
+  it("sends the selected effort and omits it entirely when unset", async () => {
+    const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+      void args;
+      return sseResponse(fixture);
+    });
+    const transport = new DirectAssistantTransport({ fetch: fetchMock });
+    const conversationId = await startedConversation(transport);
+    const events: TurnEvent[] = [];
+
+    transport.sendMessage(conversationId, "no effort", (event) =>
+      events.push(event),
+    );
+    await waitForTerminal(events);
+    const withoutEffort = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body),
+    ) as Record<string, unknown>;
+    expect(withoutEffort).not.toHaveProperty("effort");
+
+    transport.setEffort(conversationId, "xhigh");
+    const second: TurnEvent[] = [];
+    transport.sendMessage(conversationId, "with effort", (event) =>
+      second.push(event),
+    );
+    await waitForTerminal(second);
+    expect(
+      JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)),
+    ).toMatchObject({ effort: "xhigh" });
+
+    transport.setEffort(conversationId, null);
+    const third: TurnEvent[] = [];
+    transport.sendMessage(conversationId, "cleared", (event) =>
+      third.push(event),
+    );
+    await waitForTerminal(third);
+    expect(
+      JSON.parse(String(fetchMock.mock.calls[2]?.[1]?.body)),
+    ).not.toHaveProperty("effort");
+  });
+
   it("keeps later replies when the upstream reuses a completion id", async () => {
     const transport = new DirectAssistantTransport({
       fetch: vi.fn(async () => sseResponse(fixture)),
@@ -575,6 +614,7 @@ describe("DirectAssistantTransport identity isolation", () => {
     expect(transport.getSettings()).toEqual({
       model: "gpt-5.5",
       skillSlug: null,
+      effort: null,
     });
     expect(useAssistantDraftStore.getState().drafts).toEqual({});
     await expect(transport.getHistory(conversationId)).rejects.toThrow(

--- a/frontend/src/lib/assistant/direct-transport.ts
+++ b/frontend/src/lib/assistant/direct-transport.ts
@@ -56,12 +56,26 @@ interface DirectRequest {
   readonly messages: readonly DirectMessage[];
   readonly model: string;
   readonly skill_slug?: string;
+  readonly effort?: string;
 }
 
 export interface DirectConversationSettings {
   readonly model: string;
   readonly skillSlug: string | null;
+  /** `null` sends no `effort`, leaving the upstream default in place. */
+  readonly effort: string | null;
 }
+
+/**
+ * One definition of "nothing chosen yet", shared by the draft seed, both
+ * identity resets, and the unknown-conversation fallback — so a new setting
+ * cannot be added to some of those four and forgotten in the rest.
+ */
+const DEFAULT_DIRECT_SETTINGS: DirectConversationSettings = {
+  model: DEFAULT_DIRECT_MODEL,
+  skillSlug: null,
+  effort: null,
+};
 
 interface StoredConversation {
   conversation: Conversation;
@@ -193,8 +207,7 @@ export class DirectAssistantTransport implements AssistantTransport {
   private readonly now: () => number;
   private ownerUserId: string | null = getAssistantIdentityUserId();
   private draftSettings: DirectConversationSettings = {
-    model: DEFAULT_DIRECT_MODEL,
-    skillSlug: null,
+    ...DEFAULT_DIRECT_SETTINGS,
   };
   private draftModelSelected = false;
 
@@ -218,7 +231,7 @@ export class DirectAssistantTransport implements AssistantTransport {
     }
     this.running.clear();
     this.conversations.clear();
-    this.draftSettings = { model: DEFAULT_DIRECT_MODEL, skillSlug: null };
+    this.draftSettings = { ...DEFAULT_DIRECT_SETTINGS };
     this.draftModelSelected = false;
     this.ownerUserId = userId;
   }
@@ -232,8 +245,7 @@ export class DirectAssistantTransport implements AssistantTransport {
     if (!conversationId) return this.draftSettings;
     return (
       this.conversations.get(conversationId)?.settings ?? {
-        model: DEFAULT_DIRECT_MODEL,
-        skillSlug: null,
+        ...DEFAULT_DIRECT_SETTINGS,
       }
     );
   }
@@ -274,6 +286,10 @@ export class DirectAssistantTransport implements AssistantTransport {
     this.updateSettings(conversationId, { skillSlug });
   }
 
+  setEffort(conversationId: string | undefined, effort: string | null): void {
+    this.updateSettings(conversationId, { effort });
+  }
+
   async listConversations(): Promise<Conversation[]> {
     this.ensureOwner();
     return [...this.conversations.values()]
@@ -299,7 +315,7 @@ export class DirectAssistantTransport implements AssistantTransport {
       settings: { ...this.draftSettings },
       modelSelected: this.draftModelSelected,
     });
-    this.draftSettings = { model: DEFAULT_DIRECT_MODEL, skillSlug: null };
+    this.draftSettings = { ...DEFAULT_DIRECT_SETTINGS };
     this.draftModelSelected = false;
     return conversation;
   }
@@ -393,6 +409,7 @@ export class DirectAssistantTransport implements AssistantTransport {
       ...(stored.settings.skillSlug
         ? { skill_slug: stored.settings.skillSlug }
         : {}),
+      ...(stored.settings.effort ? { effort: stored.settings.effort } : {}),
     };
     while (
       request.messages.length > 1 &&
@@ -741,10 +758,7 @@ export class DirectAssistantTransport implements AssistantTransport {
     return false;
   }
 
-  private openMessage(
-    conversationId: string,
-    run: RunningTurn,
-  ): void {
+  private openMessage(conversationId: string, run: RunningTurn): void {
     if (run.currentBlockId) return;
     // OpenAI-compatible `id` values identify upstream responses, but they are
     // not a safe key for our in-memory transcript: gateways and deterministic

--- a/frontend/src/schemas/assistant-direct.ts
+++ b/frontend/src/schemas/assistant-direct.ts
@@ -11,8 +11,15 @@ export const directModelSchema = z.object({
   default: z.boolean(),
 });
 
+export const directEffortSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+});
+
 export const directSkillsSchema = z.array(directSkillSchema);
 export const directModelsSchema = z.array(directModelSchema);
+export const directEffortsSchema = z.array(directEffortSchema);
 
 export type DirectSkill = z.infer<typeof directSkillSchema>;
 export type DirectModel = z.infer<typeof directModelSchema>;
+export type DirectEffort = z.infer<typeof directEffortSchema>;


### PR DESCRIPTION
Stacked on #1426. Adds the reasoning-effort control to direct chat, alongside the existing Model and NyxID-knowledge pickers.

## Shape

`GET /assistant/direct/efforts` serves a curated `id`/`label` table (flag-gated like the other two metadata routes), and `POST /direct/completions` accepts an optional `effort` validated against it. Selecting a level emits `reasoning_effort` on the rebuilt upstream body.

**Effort is omitted, not defaulted.** With nothing selected the upstream body carries no `reasoning_effort` key at all, so the default path is byte-identical to before this PR. An arbitrary string cannot reach the platform-credentialed upstream — unknown values are rejected at validation with the allowed list, same as `model` and `skill_slug`.

## The one thing that is not verified

The effort table (`low`, `medium`, `high`, `xhigh`, `max`) is **curated, not discovered**. Chrono LLM publishes no effort catalog, and the local stack points at the PM-verification mock on `:3099`, which accepts any body — so nothing here proves the deployed model accepts `xhigh` or `max`. A level the model rejects surfaces as a 4xx on that turn, not at validation. The table is one edit away from correction once the live contract is confirmed; that check is one request against the real endpoint.

This is called out in `docs/chat/02-wire-contract.md` rather than left implicit.

## Also

`DEFAULT_DIRECT_SETTINGS` now holds the single definition of "nothing chosen yet", shared by the draft seed, both identity resets, and the unknown-conversation fallback. Previously that object was written out four times — the same duplicate-constant shape that caused the `draft-` routing blocker on #1426.

## Verification

`cargo fmt` · `cargo clippy --all-targets -D warnings` · backend targeted **14/14** against live Mongo · frontend **244 files / 2,785 tests** · `npm run build` (`tsc -b` caught a mistyped mock in my new test that vitest alone did not) · ESLint/Prettier · CLI wizard-bundle freshness.

New coverage: backend rejects an unknown effort and emits `reasoning_effort` for every curated level while omitting the key when unset; the transport sends the selected effort, omits it when unset, and omits it again after clearing; the controls test drives a real click through the third picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
