### PR TITLE
test: widen billing settlement poll budget to stop coverage-job flake

### DIFF
--- a/backend/src/billing_integration_tests.rs
+++ b/backend/src/billing_integration_tests.rs
@@ -1515,8 +1515,13 @@ async fn start_billing_downstream() -> (
     )
 }
 
+// Async settlement can lag far behind the request under coverage
+// instrumentation (llvm-cov roughly halves throughput), so the assertion
+// polls with a generous budget instead of the 2s that flaked in CI.
+const SETTLEMENT_POLL_ATTEMPTS: u32 = 500;
+
 async fn assert_direct_reported_usage(db: &mongodb::Database, service: &DownstreamService) {
-    for _ in 0..100 {
+    for _ in 0..SETTLEMENT_POLL_ATTEMPTS {
         let usage = db
             .collection::<UsageMeterRow>(USAGE_METER)
             .find_one(doc! {
@@ -1556,7 +1561,7 @@ async fn assert_direct_settled_usage_count(
     service: &DownstreamService,
     expected_count: u64,
 ) {
-    for _ in 0..100 {
+    for _ in 0..SETTLEMENT_POLL_ATTEMPTS {
         let count = db
             .collection::<UsageMeterRow>(USAGE_METER)
             .count_documents(doc! {
@@ -2278,7 +2283,7 @@ async fn assert_route_settled_count(
     metric: BillingMetric,
     expected_count: u64,
 ) {
-    for _ in 0..100 {
+    for _ in 0..SETTLEMENT_POLL_ATTEMPTS {
         let count = db
             .collection::<UsageMeterRow>(USAGE_METER)
             .count_documents(doc! {
@@ -2525,7 +2530,7 @@ async fn wait_for_route_usage_status(
     service_slug: &str,
     expected: UsageStatus,
 ) -> UsageMeterRow {
-    for _ in 0..100 {
+    for _ in 0..SETTLEMENT_POLL_ATTEMPTS {
         let row = usage_row_for_service(db, service_slug).await;
         if row.status == expected {
             return row;


### PR DESCRIPTION
## Summary

`Coverage (Backend)` intermittently fails with `expected N finalized ... rows` (most recently `billing_route_coverage_smoke` on #1454, historically on other branches too) while the uninstrumented `Backend Test` job passes the same commit.

Root cause: the billing settlement assertion helpers (`assert_direct_reported_usage`, `assert_direct_settled_usage_count`, `assert_route_settled_count`, `wait_for_route_usage_status`) poll for async settlement with a hard budget of 100 x 20ms = **2 seconds**. Under llvm-cov instrumentation the settlement pipeline regularly needs longer.

Fix: a shared `SETTLEMENT_POLL_ATTEMPTS = 500` constant (10s budget) for the four assertion loops. Passing runs return as soon as the expected state appears, so happy-path duration is unchanged; only the failure timeout widens. Intentional 20ms pacing sleeps in the node responder fixtures are untouched.

## Test plan
- [x] `cargo check -p nyxid --tests`, `cargo fmt --check`, clippy (pre-commit hook) pass
- [x] Test-only change; CI runs the full suite including the previously flaky test