### PR TITLE
fix: redact auto-connected service endpoints from user-facing surfaces

### DIFF
--- a/backend/src/handlers/keys.rs
+++ b/backend/src/handlers/keys.rs
@@ -420,7 +420,9 @@ pub struct KeyResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub service_category: String,
-    pub endpoint_url: String,
+    /// Omitted for auto-connected services whose target is platform managed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint_url: Option<String>,
     pub endpoint_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key_id: Option<String>,
@@ -1169,6 +1171,7 @@ pub async fn get_key(
         (status = 200, description = "Key updated", body = KeyResponse),
         (status = 400, description = "Validation error", body = crate::errors::ErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected service is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Key not found", body = crate::errors::ErrorResponse)
     ),
     tag = "AI Services"
@@ -1191,7 +1194,7 @@ pub async fn update_key(
             .await?;
 
     if view.auto_connected {
-        return Err(crate::errors::AppError::BadRequest(
+        return Err(crate::errors::AppError::Forbidden(
             "Auto-connected services cannot be modified".to_string(),
         ));
     }
@@ -2064,6 +2067,7 @@ pub struct DeleteKeyQuery {
         (status = 200, description = "Key revoked (or skipped when only_if_pending)", body = DeleteKeyResponse),
         (status = 400, description = "Invalid or conflicting revocation options", body = crate::errors::ErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected service is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Key not found", body = crate::errors::ErrorResponse),
         (status = 409, description = "OAuth grant cascade confirmation required", body = crate::errors::ErrorResponse)
     ),
@@ -2091,7 +2095,7 @@ pub async fn delete_key(
         unified_key_service::get_key(&state.db, &state.encryption_keys, &user_id_str, &key_id)
             .await?;
     if view.auto_connected {
-        return Err(crate::errors::AppError::BadRequest(
+        return Err(crate::errors::AppError::Forbidden(
             "Auto-connected services cannot be deleted".to_string(),
         ));
     }
@@ -2168,7 +2172,7 @@ fn key_response_from_result(result: &unified_key_service::CreateKeyResult) -> Ke
         slug: result.service.slug.clone(),
         description: None,
         service_category: source.clone(),
-        endpoint_url: result.endpoint.url.clone(),
+        endpoint_url: Some(result.endpoint.url.clone()),
         endpoint_id: result.endpoint.id.clone(),
         api_key_id: result.api_key.as_ref().map(|api_key| api_key.id.clone()),
         credential_missing: false,
@@ -2284,6 +2288,7 @@ fn key_response_from_view(view: unified_key_service::KeyView) -> KeyResponse {
         .node_id
         .as_ref()
         .is_some_and(|node_id| !node_id.is_empty());
+    let endpoint_url = (!view.auto_connected).then_some(view.endpoint_url);
 
     KeyResponse {
         id: view.id,
@@ -2295,7 +2300,7 @@ fn key_response_from_view(view: unified_key_service::KeyView) -> KeyResponse {
         slug: view.slug,
         description: None,
         service_category: source.clone(),
-        endpoint_url: view.endpoint_url,
+        endpoint_url,
         endpoint_id: view.endpoint_id,
         api_key_id: view.api_key_id,
         credential_missing: view.credential_missing,
@@ -2610,7 +2615,9 @@ mod tests {
     use crate::models::user_api_key::COLLECTION_NAME as USER_API_KEYS;
     use crate::models::user_api_key::UserApiKey;
     use crate::models::user_endpoint::{COLLECTION_NAME as USER_ENDPOINTS, UserEndpoint};
-    use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
+    use crate::models::user_service::{
+        AUTO_PROVISION_SOURCE, COLLECTION_NAME as USER_SERVICES, UserService,
+    };
     use crate::telemetry::TelemetryContext;
     use crate::test_utils::{
         connect_test_database, test_app_state, test_auth_user, test_membership, test_user,
@@ -3054,6 +3061,85 @@ mod tests {
 
         assert_eq!(response.id, service_id);
         assert_eq!(response.slug, "routeros");
+    }
+
+    #[tokio::test]
+    async fn auto_connected_key_responses_omit_endpoint_url() {
+        let Some(db) = connect_test_database("keys_auto_endpoint_redaction").await else {
+            eprintln!("skipping keys handler integration test: no local MongoDB available");
+            return;
+        };
+        let state = test_app_state(db.clone());
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let catalog_id = uuid::Uuid::new_v4().to_string();
+        insert_user(&db, &actor_id, UserType::Person).await;
+        insert_key_fixture(
+            &db,
+            &actor_id,
+            &service_id,
+            "platform-service",
+            "Platform Service",
+        )
+        .await;
+        let mut catalog = crate::models::downstream_service::test_helpers::dummy_service();
+        catalog.id = catalog_id.clone();
+        catalog.name = "Platform Service".to_string();
+        catalog.slug = "platform-service".to_string();
+        catalog.base_url = "https://api.example.com".to_string();
+        catalog.visibility = "public".to_string();
+        catalog.service_category = "internal".to_string();
+        catalog.service_type = "http".to_string();
+        catalog.auth_method = "none".to_string();
+        catalog.auth_key_name = String::new();
+        catalog.requires_user_credential = false;
+        catalog.provider_config_id = None;
+        catalog.is_active = true;
+        db.collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+            .insert_one(catalog)
+            .await
+            .unwrap();
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id },
+                doc! { "$set": {
+                    "source": AUTO_PROVISION_SOURCE,
+                    "catalog_service_id": &catalog_id,
+                } },
+            )
+            .await
+            .unwrap();
+
+        let Json(detail) = super::get_key(
+            State(state.clone()),
+            test_auth_user(&actor_id),
+            Path(service_id.clone()),
+        )
+        .await
+        .unwrap();
+        let detail_json = serde_json::to_value(&detail).unwrap();
+        assert!(detail.auto_connected);
+        assert!(detail.endpoint_url.is_none());
+        assert!(
+            !detail_json
+                .as_object()
+                .unwrap()
+                .contains_key("endpoint_url")
+        );
+        assert!(!detail_json.to_string().contains("api.example.com"));
+
+        let Json(list) = super::list_keys(State(state), test_auth_user(&actor_id))
+            .await
+            .unwrap();
+        let listed = list
+            .keys
+            .iter()
+            .find(|key| key.id == service_id)
+            .expect("auto-connected service should remain in the management listing");
+        let list_json = serde_json::to_value(listed).unwrap();
+        assert!(listed.endpoint_url.is_none());
+        assert!(!list_json.as_object().unwrap().contains_key("endpoint_url"));
+        assert!(!list_json.to_string().contains("api.example.com"));
     }
 
     /// A disabled service stays addressable by UUID, and stays hidden by slug.
@@ -3543,7 +3629,10 @@ mod tests {
 
         assert_eq!(response.label, "My Custom API");
         assert_eq!(response.slug, "my-custom-api");
-        assert_eq!(response.endpoint_url, "https://api.example.com");
+        assert_eq!(
+            response.endpoint_url.as_deref(),
+            Some("https://api.example.com")
+        );
         assert_eq!(response.auth_method, "bearer");
         assert!(response.api_key_id.is_some());
         assert!(response.is_active);

--- a/backend/src/handlers/user_endpoints.rs
+++ b/backend/src/handlers/user_endpoints.rs
@@ -106,7 +106,10 @@ pub struct UpdateEndpointRequest {
 pub struct EndpointResponse {
     pub id: String,
     pub label: String,
-    pub url: String,
+    /// Omitted when the endpoint belongs to an auto-connected service.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub auto_connected: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub catalog_service_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -166,7 +169,15 @@ pub async fn list_endpoints(
         actor
     };
     let endpoints = user_endpoint_service::list_endpoints(&state.db, &user_id_str).await?;
-    let items = endpoints.into_iter().map(endpoint_response).collect();
+    let auto_connected_ids =
+        user_service_service::auto_connected_endpoint_ids(&state.db, &user_id_str).await?;
+    let items = endpoints
+        .into_iter()
+        .map(|endpoint| {
+            let auto_connected = auto_connected_ids.contains(&endpoint.id);
+            endpoint_response(endpoint, auto_connected)
+        })
+        .collect();
     Ok(Json(EndpointListResponse { endpoints: items }))
 }
 
@@ -180,6 +191,7 @@ pub async fn list_endpoints(
     responses(
         (status = 200, description = "Updated endpoint", body = EndpointResponse),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected endpoint is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Endpoint not found", body = crate::errors::ErrorResponse)
     ),
     tag = "Endpoints"
@@ -194,6 +206,7 @@ pub async fn update_endpoint(
 ) -> AppResult<Json<EndpointResponse>> {
     let actor = auth_user.user_id.to_string();
     let owner_id = resolve_endpoint_write_owner(&state, &actor, &endpoint_id).await?;
+    user_service_service::ensure_user_managed_endpoint(&state.db, &owner_id, &endpoint_id).await?;
 
     if let Some(url) = body.url.as_deref()
         && !endpoint_is_only_node_routed(&state, &owner_id, &endpoint_id).await?
@@ -249,7 +262,7 @@ pub async fn update_endpoint(
         },
     );
 
-    Ok(Json(endpoint_response(ep)))
+    Ok(Json(endpoint_response(ep, false)))
 }
 
 #[utoipa::path(
@@ -261,6 +274,7 @@ pub async fn update_endpoint(
     responses(
         (status = 204, description = "Endpoint deleted"),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected endpoint is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Endpoint not found", body = crate::errors::ErrorResponse)
     ),
     tag = "Endpoints"
@@ -274,6 +288,7 @@ pub async fn delete_endpoint(
 ) -> AppResult<impl IntoResponse> {
     let actor = auth_user.user_id.to_string();
     let owner_id = resolve_endpoint_write_owner(&state, &actor, &endpoint_id).await?;
+    user_service_service::ensure_user_managed_endpoint(&state.db, &owner_id, &endpoint_id).await?;
 
     // Capture endpoint_type pre-delete so telemetry can classify custom vs
     // catalog-derived endpoints even though the record will be gone after
@@ -306,11 +321,12 @@ pub async fn delete_endpoint(
     Ok(StatusCode::NO_CONTENT)
 }
 
-fn endpoint_response(ep: UserEndpoint) -> EndpointResponse {
+fn endpoint_response(ep: UserEndpoint, auto_connected: bool) -> EndpointResponse {
     EndpointResponse {
         id: ep.id,
         label: ep.label,
-        url: ep.url,
+        url: (!auto_connected).then_some(ep.url),
+        auto_connected,
         catalog_service_id: ep.catalog_service_id,
         openapi_spec_url: ep.openapi_spec_url,
         created_at: ep.created_at.to_rfc3339(),
@@ -430,8 +446,12 @@ mod tests {
     use super::*;
     use crate::models::user::{COLLECTION_NAME as USERS, User, UserType};
     use crate::models::user_endpoint::{COLLECTION_NAME as EP_COLLECTION, UserEndpoint};
+    use crate::models::user_service::{
+        AUTO_PROVISION_SOURCE, COLLECTION_NAME as USER_SERVICE_COLLECTION, UserService,
+    };
     use crate::test_utils::{
         connect_test_database, test_app_state, test_auth_user, test_user, test_user_endpoint,
+        test_user_service,
     };
     use axum::extract::State;
 
@@ -634,10 +654,11 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-        let resp = endpoint_response(ep);
+        let resp = endpoint_response(ep, false);
         assert_eq!(resp.id, "ep-1");
         assert_eq!(resp.label, "My EP");
-        assert_eq!(resp.url, "https://api.example.com/v1");
+        assert_eq!(resp.url.as_deref(), Some("https://api.example.com/v1"));
+        assert!(!resp.auto_connected);
         assert_eq!(resp.catalog_service_id.as_deref(), Some("cat-1"));
         assert_eq!(
             resp.openapi_spec_url.as_deref(),
@@ -658,7 +679,7 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-        let resp = endpoint_response(ep);
+        let resp = endpoint_response(ep, false);
         assert!(resp.catalog_service_id.is_none());
         assert!(resp.openapi_spec_url.is_none());
     }
@@ -728,10 +749,115 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-        let resp = endpoint_response(ep);
+        let resp = endpoint_response(ep, false);
         let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["url"], "https://example.com");
+        assert_eq!(json["auto_connected"], false);
         assert!(!json.as_object().unwrap().contains_key("catalog_service_id"));
         assert!(!json.as_object().unwrap().contains_key("openapi_spec_url"));
+    }
+
+    #[test]
+    fn auto_connected_endpoint_response_omits_url() {
+        let ep = UserEndpoint {
+            id: "ep-auto".into(),
+            user_id: "u-auto".into(),
+            label: "Platform service".into(),
+            url: "https://platform.internal.example/v1".into(),
+            catalog_service_id: Some("cat-1".into()),
+            openapi_spec_url: None,
+            recommended_skills: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        let response = endpoint_response(ep, true);
+        let json = serde_json::to_value(&response).unwrap();
+        assert!(response.url.is_none());
+        assert_eq!(json["auto_connected"], true);
+        assert!(!json.as_object().unwrap().contains_key("url"));
+        assert!(!json.to_string().contains("platform.internal.example"));
+    }
+
+    #[tokio::test]
+    async fn auto_connected_endpoint_is_redacted_and_cannot_be_updated() {
+        let Some(db) = connect_test_database("h_user_ep_auto_managed").await else {
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let ep_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let platform_url = "https://platform.internal.example/v1";
+        db.collection::<User>(USERS)
+            .insert_one(test_user(&user_id, UserType::Person))
+            .await
+            .unwrap();
+        db.collection::<UserEndpoint>(EP_COLLECTION)
+            .insert_one(test_user_endpoint(
+                &ep_id,
+                &user_id,
+                "Platform service",
+                platform_url,
+                Some("cat-1"),
+                None,
+            ))
+            .await
+            .unwrap();
+        let mut service = test_user_service(
+            &service_id,
+            &user_id,
+            "platform-service",
+            &ep_id,
+            Some("cat-1"),
+            None,
+        );
+        service.source = Some(AUTO_PROVISION_SOURCE.to_string());
+        db.collection::<UserService>(USER_SERVICE_COLLECTION)
+            .insert_one(service)
+            .await
+            .unwrap();
+        let state = test_app_state(db.clone());
+        let auth = test_auth_user(&user_id);
+
+        let Json(list) = list_endpoints(
+            State(state.clone()),
+            auth.clone(),
+            Query(EndpointListQuery { org_id: None }),
+        )
+        .await
+        .unwrap();
+        let response = &list.endpoints[0];
+        assert!(response.auto_connected);
+        assert!(response.url.is_none());
+        assert!(
+            !serde_json::to_string(response)
+                .unwrap()
+                .contains(platform_url)
+        );
+
+        let error = update_endpoint(
+            State(state),
+            auth,
+            tele(),
+            Path(ep_id.clone()),
+            Json(UpdateEndpointRequest {
+                url: Some("https://attacker.example/v1".to_string()),
+                label: None,
+                openapi_spec_url: None,
+                recommended_skills: None,
+            }),
+        )
+        .await
+        .expect_err("platform-managed endpoint update must be rejected");
+        assert!(matches!(error, AppError::Forbidden(_)));
+
+        let stored = db
+            .collection::<UserEndpoint>(EP_COLLECTION)
+            .find_one(doc! { "_id": ep_id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.url, platform_url);
     }
 
     #[tokio::test]

--- a/backend/src/handlers/user_services_handler.rs
+++ b/backend/src/handlers/user_services_handler.rs
@@ -312,6 +312,7 @@ pub async fn list_user_services(
     responses(
         (status = 200, description = "Updated user service", body = UserServiceResponse),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected service is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Service not found", body = crate::errors::ErrorResponse)
     ),
     tag = "User Services"
@@ -459,6 +460,7 @@ pub async fn update_user_service(
         (status = 200, description = "Updated SSH auth mode", body = UserServiceResponse),
         (status = 400, description = "Validation error", body = crate::errors::ErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected service is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Service not found", body = crate::errors::ErrorResponse)
     ),
     tag = "User Services"
@@ -494,6 +496,7 @@ pub async fn patch_user_service_ssh_auth_mode(
     responses(
         (status = 204, description = "User service deactivated"),
         (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 403, description = "Auto-connected service is platform managed", body = crate::errors::ErrorResponse),
         (status = 404, description = "Service not found", body = crate::errors::ErrorResponse)
     ),
     tag = "User Services"

--- a/backend/src/models/user_service.rs
+++ b/backend/src/models/user_service.rs
@@ -6,6 +6,7 @@ use crate::models::ssh_auth_mode::{SshAuthMode, default_ssh_auth_mode};
 use crate::models::ws_frame_injection::WsFrameInjection;
 
 pub const COLLECTION_NAME: &str = "user_services";
+pub const AUTO_PROVISION_SOURCE: &str = "auto_provision";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserService {

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -17,7 +17,7 @@ use crate::models::user_endpoint::{COLLECTION_NAME as USER_ENDPOINTS, UserEndpoi
 use crate::models::user_provider_token::{
     COLLECTION_NAME as USER_PROVIDER_TOKENS, UserProviderToken,
 };
-use crate::models::user_service::UserService;
+use crate::models::user_service::{AUTO_PROVISION_SOURCE, UserService};
 use crate::models::user_service_connection::{
     COLLECTION_NAME as USER_SERVICE_CONNECTIONS, UserServiceConnection,
 };
@@ -32,8 +32,6 @@ use crate::services::{
     user_service_service, user_token_service,
 };
 use nyxid_cloud_auth::aws_sigv4::{self, AwsCredentials};
-
-const AUTO_PROVISION_SOURCE: &str = "auto_provision";
 
 /// Default User-Agent injected at the proxy boundary when neither the
 /// caller nor the resolved service supplies one. Resolved at compile

--- a/backend/src/services/unified_key_service.rs
+++ b/backend/src/services/unified_key_service.rs
@@ -20,7 +20,7 @@ use crate::models::user_endpoint::UserEndpoint;
 use crate::models::user_provider_token::{
     COLLECTION_NAME as USER_PROVIDER_TOKENS, UserProviderToken,
 };
-use crate::models::user_service::UserService;
+use crate::models::user_service::{AUTO_PROVISION_SOURCE, UserService};
 use crate::models::ws_frame_injection::WsFrameInjection;
 use crate::services::{
     audit_service::{self, AuditActor},
@@ -28,7 +28,6 @@ use crate::services::{
     user_endpoint_service, user_service_service, user_token_service, ws_frame_injector,
 };
 
-const AUTO_PROVISION_SOURCE: &str = "auto_provision";
 const MAX_SERVICE_SLUG_LEN: usize = 80;
 const HUMAN_SLUG_SUFFIX_MAX: u8 = 9;
 const RANDOM_SLUG_SUFFIX_ATTEMPTS: usize = 5;
@@ -5512,6 +5511,10 @@ mod tests {
         assert_eq!(view.credential_type, "none");
         assert_eq!(view.status, "active");
         assert!(view.auto_connected);
+        assert_eq!(
+            view.endpoint_url, "https://example.com",
+            "the internal view keeps the target for routing; response DTOs redact it"
+        );
     }
 
     #[test]

--- a/backend/src/services/user_service_service.rs
+++ b/backend/src/services/user_service_service.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use futures::TryStreamExt;
 use mongodb::bson::{self, doc};
+use mongodb::options::FindOptions;
 use uuid::Uuid;
 
 use crate::errors::{AppError, AppResult};
@@ -9,7 +10,7 @@ use crate::models::ssh_auth_mode::SshAuthMode;
 use crate::models::user::{COLLECTION_NAME as USERS, User};
 use crate::models::user_api_key::COLLECTION_NAME as USER_API_KEYS;
 use crate::models::user_endpoint::COLLECTION_NAME as USER_ENDPOINTS;
-use crate::models::user_service::{COLLECTION_NAME, UserService};
+use crate::models::user_service::{AUTO_PROVISION_SOURCE, COLLECTION_NAME, UserService};
 use crate::models::ws_frame_injection::WsFrameInjection;
 use crate::mw::auth::SERVICE_DELEGATION_SCOPES;
 use crate::services::{
@@ -64,6 +65,75 @@ pub struct IdentityConfig {
     pub forward_access_token: bool,
     pub inject_delegation_token: bool,
     pub delegation_token_scope: String,
+}
+
+fn ensure_user_managed_service(service: &UserService) -> AppResult<()> {
+    if service.source.as_deref() == Some(AUTO_PROVISION_SOURCE) {
+        return Err(AppError::Forbidden(
+            "Auto-connected services are platform managed and cannot be modified".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Return endpoint ids whose target URL is owned by platform auto-provisioning.
+/// The URL remains stored normally for proxy resolution; callers use this set
+/// only when constructing user-facing endpoint responses.
+pub async fn auto_connected_endpoint_ids(
+    db: &mongodb::Database,
+    user_id: &str,
+) -> AppResult<std::collections::HashSet<String>> {
+    let services: Vec<bson::Document> = db
+        .collection::<bson::Document>(COLLECTION_NAME)
+        .find(doc! {
+            "user_id": user_id,
+            "source": AUTO_PROVISION_SOURCE,
+        })
+        .with_options(
+            FindOptions::builder()
+                .projection(doc! { "endpoint_id": 1 })
+                .build(),
+        )
+        .await?
+        .try_collect()
+        .await?;
+    services
+        .into_iter()
+        .map(|service| {
+            service
+                .get_str("endpoint_id")
+                .map(str::to_owned)
+                .map_err(|error| {
+                    AppError::Internal(format!(
+                        "Invalid auto-connected endpoint_id projection: {error}"
+                    ))
+                })
+        })
+        .collect()
+}
+
+/// Reject user mutations against an endpoint referenced by any
+/// auto-connected service owned by `user_id`.
+pub async fn ensure_user_managed_endpoint(
+    db: &mongodb::Database,
+    user_id: &str,
+    endpoint_id: &str,
+) -> AppResult<()> {
+    let count = db
+        .collection::<mongodb::bson::Document>(COLLECTION_NAME)
+        .count_documents(doc! {
+            "user_id": user_id,
+            "endpoint_id": endpoint_id,
+            "source": AUTO_PROVISION_SOURCE,
+        })
+        .await?;
+    if count > 0 {
+        return Err(AppError::Forbidden(
+            "Auto-connected service endpoints are platform managed and cannot be modified"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 impl IdentityConfig {
@@ -616,7 +686,7 @@ pub async fn create_user_service(
     let platform_managed_catalog_service = api_key_id.is_none()
         && auth_method != "none"
         && catalog_service_id.is_some()
-        && source == Some("auto_provision");
+        && source == Some(AUTO_PROVISION_SOURCE);
     if api_key_id.is_none() && auth_method != "none" && !platform_managed_catalog_service {
         return Err(AppError::ValidationError(
             "Services without an API key must use auth_method 'none'".to_string(),
@@ -787,6 +857,7 @@ pub async fn update_user_service(
     admin_only: Option<bool>,
 ) -> AppResult<()> {
     let current = get_user_service(db, user_id, service_id).await?;
+    ensure_user_managed_service(&current)?;
     let mut set_doc = doc! {
         "updated_at": bson::DateTime::from_chrono(Utc::now()),
     };
@@ -1050,6 +1121,8 @@ pub async fn validate_update_inputs(
     new_endpoint_url: Option<&str>,
     new_openapi_spec_url: Option<&str>,
 ) -> AppResult<()> {
+    ensure_user_managed_service(current)?;
+
     if let Some(am) = auth_method {
         validate_auth_method(am)?;
     }
@@ -1572,6 +1645,7 @@ pub async fn update_ssh_auth_mode(
     mode: SshAuthMode,
 ) -> AppResult<UserService> {
     let current = get_user_service(db, user_id, service_id).await?;
+    ensure_user_managed_service(&current)?;
     if current.service_type != "ssh" {
         return Err(AppError::ValidationError(
             "SSH auth mode can only be changed for SSH services".to_string(),
@@ -1820,6 +1894,53 @@ mod tests {
             inject_delegation_token: true,
             delegation_token_scope: "llm:proxy".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn update_user_service_rejects_auto_connected_service() {
+        let Some(db) = connect_test_database("user_service_auto_managed_update").await else {
+            eprintln!("skipping user_service_service integration test: no local MongoDB available");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let mut service = test_user_service(
+            &service_id,
+            &user_id,
+            "platform-service",
+            "ep-auto",
+            Some("cat-1"),
+            None,
+        );
+        service.source = Some(AUTO_PROVISION_SOURCE.to_string());
+        db.collection::<UserService>(COLLECTION_NAME)
+            .insert_one(&service)
+            .await
+            .unwrap();
+
+        let error = update_user_service(
+            &db,
+            &user_id,
+            &user_id,
+            &service_id,
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("auto-connected services must reject user mutations");
+        assert!(matches!(error, AppError::Forbidden(_)));
+
+        let stored = get_user_service(&db, &user_id, &service_id).await.unwrap();
+        assert!(stored.is_active);
+        assert_eq!(stored.source.as_deref(), Some(AUTO_PROVISION_SOURCE));
     }
 
     fn test_downstream_ssh_service(

--- a/cli/src/commands/endpoint.rs
+++ b/cli/src/commands/endpoint.rs
@@ -36,10 +36,8 @@ pub async fn run(command: EndpointCommands) -> Result<()> {
                             let id = ep["id"].as_str().or(ep["_id"].as_str()).unwrap_or("-");
                             let short_id = crate::commands::short_id(id);
                             let label = ep["label"].as_str().or(ep["name"].as_str()).unwrap_or("-");
-                            let url = ep["url"]
-                                .as_str()
-                                .or(ep["base_url"].as_str())
-                                .unwrap_or("-");
+                            let url =
+                                crate::commands::display_endpoint(ep, "url", Some("base_url"));
                             table.add_row([short_id, label, url]);
                         }
                         eprintln!("{table}");

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -54,9 +54,26 @@ pub(crate) fn short_id(id: &str) -> &str {
     id.get(..8).unwrap_or(id)
 }
 
+/// Render a user-facing target from a response row without disclosing the
+/// server-owned URL of an auto-connected service. The marker wins even when
+/// an older backend still includes the raw field.
+pub(crate) fn display_endpoint<'a>(
+    item: &'a serde_json::Value,
+    field: &str,
+    legacy_field: Option<&str>,
+) -> &'a str {
+    if item["auto_connected"].as_bool() == Some(true) {
+        return "platform managed";
+    }
+    item[field]
+        .as_str()
+        .or_else(|| legacy_field.and_then(|name| item[name].as_str()))
+        .unwrap_or("-")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::short_id;
+    use super::{display_endpoint, short_id};
 
     #[test]
     fn short_id_truncates_long_ascii_to_eight_bytes() {
@@ -77,5 +94,34 @@ mod tests {
         let id = "日本語テスト";
         assert!(id.len() > 8, "precondition: more than 8 bytes");
         assert_eq!(short_id(id), id);
+    }
+
+    #[test]
+    fn display_endpoint_hides_auto_connected_targets() {
+        let omitted = serde_json::json!({ "auto_connected": true });
+        assert_eq!(
+            display_endpoint(&omitted, "endpoint_url", None),
+            "platform managed"
+        );
+
+        let old_server = serde_json::json!({
+            "auto_connected": true,
+            "endpoint_url": "https://platform.internal.example/v1",
+        });
+        let rendered = display_endpoint(&old_server, "endpoint_url", None);
+        assert_eq!(rendered, "platform managed");
+        assert!(!rendered.contains("platform.internal.example"));
+    }
+
+    #[test]
+    fn display_endpoint_keeps_user_managed_targets() {
+        let item = serde_json::json!({
+            "auto_connected": false,
+            "endpoint_url": "https://api.example.com/v1",
+        });
+        assert_eq!(
+            display_endpoint(&item, "endpoint_url", None),
+            "https://api.example.com/v1"
+        );
     }
 }

--- a/cli/src/commands/service.rs
+++ b/cli/src/commands/service.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 
 use crate::api::ApiClient;
 use crate::cli::{OutputFormat, ServiceCommands};
+use crate::commands::display_endpoint;
 use crate::commands::lark_permission::print_permission_block;
 use crate::commands::node_credential::RciCliHintLines;
 use crate::org_resolver::resolve_org_id;
@@ -975,7 +976,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
                                 .or(svc["service_slug"].as_str())
                                 .unwrap_or("-");
                             let label = svc["label"].as_str().unwrap_or("-");
-                            let endpoint = svc["endpoint_url"].as_str().unwrap_or("-");
+                            let endpoint = display_endpoint(svc, "endpoint_url", None);
                             let status = display_status(svc);
                             let access = if svc["admin_only"].as_bool().unwrap_or(false) {
                                 "admin-only"
@@ -1025,7 +1026,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
                     } else {
                         svc["status"].as_str().unwrap_or("active")
                     };
-                    let endpoint = svc["endpoint_url"].as_str().unwrap_or("-");
+                    let endpoint = display_endpoint(&svc, "endpoint_url", None);
                     let auth_method = svc["auth_method"].as_str().unwrap_or("-");
                     let auth_key = svc["auth_key_name"].as_str().unwrap_or("-");
                     let node = svc["node_id"].as_str().unwrap_or("-- (direct)");
@@ -2176,7 +2177,7 @@ fn print_add_result(api: &ApiClient, result: &Value, output: OutputFormat) -> Re
                 .as_str()
                 .or(result["service_slug"].as_str())
                 .unwrap_or("-");
-            let endpoint = result["endpoint_url"].as_str().unwrap_or("-");
+            let endpoint = display_endpoint(result, "endpoint_url", None);
             let status = result["status"].as_str().unwrap_or("active");
 
             eprintln!("Service added successfully!");
@@ -3267,6 +3268,27 @@ mod command_tests {
     use crate::test_support::{mock_auth, mock_auth_with_output};
     use wiremock::matchers::{body_json, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn auto_connected_service_endpoint_is_platform_managed() {
+        let omitted = serde_json::json!({
+            "id": "svc-auto",
+            "auto_connected": true,
+        });
+        assert_eq!(
+            display_endpoint(&omitted, "endpoint_url", None),
+            "platform managed"
+        );
+
+        let legacy = serde_json::json!({
+            "id": "svc-auto",
+            "auto_connected": true,
+            "endpoint_url": "https://platform.internal.example/v1",
+        });
+        let rendered = display_endpoint(&legacy, "endpoint_url", None);
+        assert_eq!(rendered, "platform managed");
+        assert!(!rendered.contains("platform.internal.example"));
+    }
 
     #[tokio::test]
     async fn list_fetches_services_json() {

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -69,7 +69,7 @@ fn print_table_output(user: &Value, services: &Value, api_keys: &Value, nodes: &
                 .as_str()
                 .or(svc["service_slug"].as_str())
                 .unwrap_or("-");
-            let endpoint = svc["endpoint_url"].as_str().unwrap_or("-");
+            let endpoint = crate::commands::display_endpoint(svc, "endpoint_url", None);
             // `status` is the CREDENTIAL's status, which stays healthy while a
             // service is disabled — so a disabled service would print "active"
             // here and read as usable. `is_active` wins when it is false.

--- a/docs/AI_SERVICES_ARCHITECTURE.md
+++ b/docs/AI_SERVICES_ARCHITECTURE.md
@@ -237,6 +237,14 @@ also the healthy representation for a service that requires no credential.
 The degraded row may be reconnected or deleted, but it cannot be enabled until
 a replacement credential has been attached.
 
+Auto-connected rows (`auto_connected: true`) are platform managed. Their
+`endpoint_url` is omitted from both key-list and key-detail responses; clients
+must render a neutral platform-managed label rather than treating the missing
+field as an unknown or empty user endpoint. `GET /endpoints` follows the same
+contract by returning `auto_connected: true` and omitting `url`. The stored
+`UserEndpoint.url` remains intact for proxy routing and MCP configuration, and
+user-facing endpoint or service mutation routes reject changes to these rows.
+
 Because a disabled row keeps its slug while a new active service may reuse it,
 this listing can contain two rows with the same slug. Consumers that resolve by
 slug should prefer the active row.

--- a/frontend/src/lib/assistant/plugins.test.ts
+++ b/frontend/src/lib/assistant/plugins.test.ts
@@ -89,6 +89,23 @@ describe("deriveConnectorItems", () => {
     expect(added[0]?.description).toBe("GPT models.");
   });
 
+  it("does not expose an auto-connected endpoint in fallback copy", () => {
+    const { added } = deriveConnectorItems(
+      [
+        makeKey({
+          catalog_service_slug: null,
+          auto_connected: true,
+          endpoint_url: "https://platform.internal.example/v1",
+          description: null,
+        }),
+      ],
+      [],
+    );
+
+    expect(added[0]?.description).toBe("Connected through the NyxID proxy.");
+    expect(added[0]?.description).not.toContain("platform.internal.example");
+  });
+
   it("keeps a disabled connection in Added, flagged, rather than offering Connect", () => {
     // Regression: while the backend hid disabled services from GET /keys, the
     // catalog entry fell back into "Available to add", so a paused connector

--- a/frontend/src/lib/assistant/plugins.ts
+++ b/frontend/src/lib/assistant/plugins.ts
@@ -110,6 +110,9 @@ function addedServiceItem(
   const first = group[0] as KeyInfo;
   const catalogEntry = catalogBySlug.get(slug);
   const name = catalogEntry?.name ?? first.label;
+  const endpointDescription = !first.auto_connected && first.endpoint_url
+    ? `Connected through the NyxID proxy (${first.endpoint_url}).`
+    : "Connected through the NyxID proxy.";
   return {
     id: `service:${slug}`,
     name,
@@ -119,7 +122,7 @@ function addedServiceItem(
     description:
       catalogEntry?.description ??
       first.description ??
-      `Connected through the NyxID proxy (${first.endpoint_url}).`,
+      endpointDescription,
     meta:
       group.length > 1
         ? `${String(group.length)} connections`
@@ -131,6 +134,9 @@ function addedServiceItem(
 }
 
 function addedCustomItem(key: KeyInfo): ConnectorCardItem {
+  const endpointDescription = !key.auto_connected && key.endpoint_url
+    ? `Connected through the NyxID proxy (${key.endpoint_url}).`
+    : "Connected through the NyxID proxy.";
   return {
     id: `key:${key.id}`,
     name: key.label,
@@ -139,7 +145,7 @@ function addedCustomItem(key: KeyInfo): ConnectorCardItem {
     category: categoryOf(key.service_type),
     description:
       key.description ??
-      `Connected through the NyxID proxy (${key.endpoint_url}).`,
+      endpointDescription,
     meta: key.credential_type.replaceAll("_", " "),
     added: true,
     disabled: key.is_active === false,

--- a/frontend/src/pages/key-detail.test.tsx
+++ b/frontend/src/pages/key-detail.test.tsx
@@ -711,6 +711,7 @@ describe("KeyDetailPage — org read-only branch", () => {
 describe("KeyDetailPage — auto-connected branch", () => {
   it("renders the platform-managed service details card instead of editors", () => {
     hooks.key.data = makeKey({
+      endpoint_url: "https://platform.internal.example/v1",
       auto_connected: true,
       api_key_id: null,
       credential_type: "none",
@@ -725,12 +726,66 @@ describe("KeyDetailPage — auto-connected branch", () => {
     expect(
       screen.getByText("None (no credentials required)"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Platform managed")).toBeInTheDocument();
+    expect(
+      screen.queryByText("https://platform.internal.example/v1"),
+    ).not.toBeInTheDocument();
     // No node bound → routing shows Direct.
     expect(screen.getByText("Direct")).toBeInTheDocument();
     // Editable sections (e.g. the rotate button) are absent.
     expect(
       screen.queryByRole("button", { name: /Rotate Credentials/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("uses a catalog /v1 base only to shape the proxy example path", () => {
+    const catalogBaseUrl = "https://platform.internal.example/v1";
+    hooks.key.data = makeKey({
+      endpoint_url: undefined,
+      auto_connected: true,
+      api_key_id: null,
+      credential_type: "none",
+      auth_method: "none",
+    });
+    hooks.catalogEntry = {
+      slug: "openai",
+      name: "OpenAI",
+      base_url: catalogBaseUrl,
+      service_type: "http",
+    };
+
+    render(<KeyDetailPage />);
+
+    const body = document.body.textContent ?? "";
+    const proxyUrl = `${window.location.origin}/api/v1/proxy/s/openai-x`;
+    expect(body).toContain(`${proxyUrl}/chat/completions`);
+    expect(body).not.toContain(`${proxyUrl}/v1/chat/completions`);
+    expect(body).not.toContain(catalogBaseUrl);
+  });
+
+  it("keeps /v1 in the proxy example when the catalog base has no /v1 suffix", () => {
+    const catalogBaseUrl = "https://platform.internal.example/api";
+    hooks.key.data = makeKey({
+      endpoint_url: undefined,
+      auto_connected: true,
+      api_key_id: null,
+      credential_type: "none",
+      auth_method: "none",
+    });
+    hooks.catalogEntry = {
+      slug: "openai",
+      name: "OpenAI",
+      base_url: catalogBaseUrl,
+      service_type: "http",
+    };
+
+    render(<KeyDetailPage />);
+
+    const body = document.body.textContent ?? "";
+    const proxyUrl = `${window.location.origin}/api/v1/proxy/s/openai-x`;
+    expect(body).toContain(`${proxyUrl}/v1/chat/completions`);
+    expect(body).not.toContain(`${proxyUrl}/chat/completions`);
+    expect(body).not.toContain(catalogBaseUrl);
   });
 });
 

--- a/frontend/src/pages/key-detail.tsx
+++ b/frontend/src/pages/key-detail.tsx
@@ -1362,7 +1362,8 @@ function ApiUsageSection({
   ]);
   const showGenericEndpointExample = isBotOrWebhookService(metadataText);
   const llmDetected = isLlmService(metadataText);
-  const llmExamplePath = chatCompletionsPath(endpointUrl);
+  const endpointUrlForPathShape = endpointUrl || catalogEntry?.base_url || "";
+  const llmExamplePath = chatCompletionsPath(endpointUrlForPathShape);
   const genericExamplePath = showGenericEndpointExample
     ? genericEndpointPathFor(metadataText)
     : null;
@@ -2433,7 +2434,7 @@ export function KeyDetailPage() {
                   <span className="text-xs font-medium text-muted-foreground">
                     Endpoint
                   </span>
-                  <p className="truncate text-xs">{keyInfo.endpoint_url}</p>
+                  <p className="text-xs">Platform managed</p>
                 </div>
                 <div>
                   <span className="text-xs font-medium text-muted-foreground">
@@ -2481,7 +2482,7 @@ export function KeyDetailPage() {
               serviceId={keyInfo.id}
               slug={keyInfo.slug}
               authMethod={keyInfo.auth_method}
-              endpointUrl={keyInfo.endpoint_url}
+              endpointUrl={keyInfo.endpoint_url ?? ""}
               catalogServiceSlug={keyInfo.catalog_service_slug}
               label={keyInfo.label}
               catalogEntry={catalogEntry}
@@ -2520,7 +2521,7 @@ export function KeyDetailPage() {
           <TabsContent value="overview" className="space-y-4">
             <div className="grid gap-4 lg:grid-cols-2">
               <EndpointSection
-                endpointUrl={keyInfo.endpoint_url}
+                endpointUrl={keyInfo.endpoint_url ?? ""}
                 endpointId={keyInfo.endpoint_id}
                 nodeRouted={keyInfo.node_id !== null}
                 readOnly={readOnly}
@@ -2560,7 +2561,7 @@ export function KeyDetailPage() {
                 serviceId={keyInfo.id}
                 slug={keyInfo.slug}
                 authMethod={keyInfo.auth_method}
-                endpointUrl={keyInfo.endpoint_url}
+                endpointUrl={keyInfo.endpoint_url ?? ""}
                 catalogServiceSlug={keyInfo.catalog_service_slug}
                 label={keyInfo.label}
                 catalogEntry={catalogEntry}
@@ -2644,7 +2645,7 @@ export function KeyDetailPage() {
                 {keyInfo.node_id && (
                   <NodeSetupHelper
                     slug={keyInfo.slug}
-                    endpointUrl={keyInfo.endpoint_url}
+                    endpointUrl={keyInfo.endpoint_url ?? ""}
                     authMethod={keyInfo.auth_method}
                     authKeyName={keyInfo.auth_key_name}
                     catalogServiceName={keyInfo.catalog_service_name}

--- a/frontend/src/pages/keys.test.tsx
+++ b/frontend/src/pages/keys.test.tsx
@@ -210,10 +210,16 @@ describe("KeysPage", () => {
   it("hides auto-connected services until the toggle is enabled", async () => {
     const user = userEvent.setup();
     state.keys = [
-      makeKey({ id: "user-1", label: "Manual Key", auto_connected: false }),
+      makeKey({
+        id: "user-1",
+        label: "Manual Key",
+        endpoint_url: "https://manual.example/v1",
+        auto_connected: false,
+      }),
       makeKey({
         id: "auto-1",
         label: "Auto Key",
+        endpoint_url: "https://platform.internal.example/v1",
         auto_connected: true,
         source_app_name: "Claude Code",
       }),
@@ -223,13 +229,50 @@ describe("KeysPage", () => {
 
     // Auto-connected hidden by default.
     expect(screen.getByText("Manual Key")).toBeInTheDocument();
+    expect(screen.getByText("https://manual.example/v1")).toBeInTheDocument();
     expect(screen.queryByText("Auto Key")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("https://platform.internal.example/v1"),
+    ).not.toBeInTheDocument();
     // The toggle label reflects the auto-connected count.
     expect(screen.getByText("Show auto-connected (1)")).toBeInTheDocument();
 
     await user.click(screen.getByRole("switch"));
 
     expect(screen.getByText("Auto Key")).toBeInTheDocument();
+    expect(
+      screen.queryByText("https://platform.internal.example/v1"),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("Platform managed").length).toBeGreaterThan(0);
+  });
+
+  it("hides auto-connected endpoint URLs in table rows without changing normal rows", async () => {
+    localStorage.setItem("nyxid-view-mode:keys-services", "table");
+    const user = userEvent.setup();
+    state.keys = [
+      makeKey({
+        id: "manual-table",
+        label: "Manual Table",
+        endpoint_url: "https://manual-table.example/v1",
+      }),
+      makeKey({
+        id: "auto-table",
+        label: "Auto Table",
+        endpoint_url: "https://platform-table.internal/v1",
+        auto_connected: true,
+      }),
+    ];
+
+    try {
+      render(<KeysPage />);
+      await user.click(screen.getByRole("switch"));
+
+      expect(screen.getByText("https://manual-table.example/v1")).toBeInTheDocument();
+      expect(screen.queryByText("https://platform-table.internal/v1")).not.toBeInTheDocument();
+      expect(screen.getAllByText("Platform managed").length).toBeGreaterThan(0);
+    } finally {
+      localStorage.removeItem("nyxid-view-mode:keys-services");
+    }
   });
 
   it("groups org-inherited services into a labelled section with a role badge", () => {

--- a/frontend/src/pages/keys.tsx
+++ b/frontend/src/pages/keys.tsx
@@ -131,11 +131,14 @@ function KeyCardContent({
     ? (nodes?.find((n) => n.id === keyInfo.node_id)?.name ??
       keyInfo.node_id.slice(0, 8))
     : null;
-  const displayUrl = isSsh
-    ? `${keyInfo.ssh_host ?? "unknown"}:${keyInfo.ssh_port ?? 22}`
-    : keyInfo.endpoint_url.length > 50
-      ? `${keyInfo.endpoint_url.slice(0, 50)}...`
-      : keyInfo.endpoint_url;
+  const endpointUrl = keyInfo.endpoint_url ?? "";
+  const displayUrl = keyInfo.auto_connected
+    ? "Platform managed"
+    : isSsh
+      ? `${keyInfo.ssh_host ?? "unknown"}:${keyInfo.ssh_port ?? 22}`
+      : endpointUrl.length > 50
+        ? `${endpointUrl.slice(0, 50)}...`
+        : endpointUrl;
 
   const isOrgInherited = source?.type === "org";
   // Viewers and out-of-scope members see the card with reduced opacity.
@@ -343,9 +346,11 @@ function ServiceTableRow({
       ? "Node Deleted"
       : displayStatus.charAt(0).toUpperCase() + displayStatus.slice(1);
 
-  const displayUrl = isSsh
-    ? `${keyInfo.ssh_host ?? "unknown"}:${keyInfo.ssh_port ?? 22}`
-    : keyInfo.endpoint_url;
+  const displayUrl = keyInfo.auto_connected
+    ? "Platform managed"
+    : isSsh
+      ? `${keyInfo.ssh_host ?? "unknown"}:${keyInfo.ssh_port ?? 22}`
+      : (keyInfo.endpoint_url ?? "");
 
   const authLabel = keyInfo.auto_connected
     ? keyInfo.auth_method === "none"

--- a/frontend/src/types/keys.ts
+++ b/frontend/src/types/keys.ts
@@ -11,7 +11,8 @@ export interface KeyInfo {
   readonly slug: string;
   readonly description?: string | null;
   readonly service_category?: string;
-  readonly endpoint_url: string;
+  /** Omitted when the service endpoint is managed by the platform. */
+  readonly endpoint_url?: string;
   readonly endpoint_id: string;
   readonly api_key_id?: string | null;
   /** The service references a credential row that no longer exists. */
@@ -237,7 +238,9 @@ export interface CatalogListResponse {
 export interface UserEndpointInfo {
   readonly id: string;
   readonly label: string;
-  readonly url: string;
+  /** Omitted when the endpoint belongs to an auto-connected service. */
+  readonly url?: string;
+  readonly auto_connected: boolean;
   readonly catalog_service_id: string | null;
   readonly created_at: string;
   readonly updated_at: string;

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -156,7 +156,6 @@ export async function listServices(
       slug: string;
       label: string;
       status: string;
-      endpoint_url: string;
       service_type: string;
       catalog_service_name: string | null;
       is_active: boolean;


### PR DESCRIPTION
## Summary

Auto-connected (platform auto-provisioned) services expose platform infrastructure endpoint URLs to users. This PR hides them everywhere user-facing, with redaction at the API response layer as the single source of truth.

- `GET /api/v1/keys` (list + detail) omits `endpoint_url` for `auto_connected` rows (`skip_serializing_if`, field now optional)
- `GET /api/v1/endpoints` marks rows `auto_connected: true` and omits `url`
- Frontend AI Services cards, table rows, detail header, and assistant connector descriptions render "Platform managed" instead; usage examples derive the chat-completions path shape from public catalog `base_url` so copyable snippets stay correct without the endpoint URL
- CLI (`nyxid status`, `service list/show/add`, `endpoint list`) renders "platform managed" via a shared `display_endpoint` helper that also defensively hides the URL if an older backend still sends it
- Consistency hardening: mutations on auto-connected rows now return 403 (`AppError::Forbidden`) across key update/delete, endpoint update/delete, user-service update/deactivate, and SSH auth mode changes; documented in the OpenAPI annotations
- Stored `UserEndpoint.url` is untouched: proxy resolution, MCP config, node routing, and the auto-provision reconciliation sweep read the database directly and are unaffected
- Docs: contract recorded in `docs/AI_SERVICES_ARCHITECTURE.md`

Wire shape is omission (not null/empty) so loose CLI JSON parsing and strict frontend types both degrade safely; clients distinguish platform management via `auto_connected`.

## Test plan

- [x] Backend: redaction integration tests (list + detail JSON asserts field absent and URL string never serialized), endpoint list/update guard tests, service-layer mutation guard tests — 5309 passed against real MongoDB
- [x] CLI: `display_endpoint` unit tests incl. legacy-backend defensive case, service fixtures — 1095 passed
- [x] Frontend: keys page card/table redaction tests, key-detail auto-connected branch tests incl. example path shape (`/v1` and non-`/v1` catalog bases), connector description fallback — 2837 passed
- [x] `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`, frontend lint + production build