### PR TITLE
fix(mcp): stop delegated tokens minting long-lived MCP sessions

### DIFF
--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -304,8 +304,22 @@ impl McpAuthContext {
     /// silently upgrades to `AuthMethod::Session` (allow-all, approval-bypassing)
     /// on the session-fallback path. Forcing statelessness re-runs the relay
     /// liveness check and allowlist inheritance on every call.
+    ///
+    /// Delegated tokens carry the same hazard and then some. They are minted
+    /// with a short TTL (300s on the assistant bridge), carry an actor plus
+    /// service/node restriction claims, and their catalog authority is online-
+    /// revocable through `CatalogDelegationGrant`. A persisted MCP session
+    /// records none of that -- only the user id, activated services and a
+    /// `proxy_authorized` bit -- so allowing one to be minted would let an
+    /// expired, narrowly-scoped, approval-gated delegated token be replayed for
+    /// up to 30 idle days as unrestricted `AuthMethod::Session`, which bypasses
+    /// the approval flow outright (`approval_service::evaluate_and_check` is
+    /// called with `bypass_approval_flow = true` for Session). Statelessness
+    /// keeps every delegated call bound to a live, unexpired credential.
     fn is_stateless(&self) -> bool {
-        self.is_api_key || self.auth_method == AuthMethod::Relay
+        self.is_api_key
+            || self.auth_method == AuthMethod::Relay
+            || self.auth_method == AuthMethod::Delegated
     }
 
     fn approval_requester_type(&self) -> Option<&'static str> {
@@ -3697,6 +3711,47 @@ mod tests {
         let mut api_key = McpAuthContext::user("user-1".to_string(), AuthMethod::ApiKey);
         api_key.is_api_key = true;
         assert!(api_key.is_stateless());
+    }
+
+    #[test]
+    fn delegated_auth_is_stateless_and_cannot_mint_a_session() {
+        // A delegated token is short-lived (300s on the assistant bridge),
+        // actor-bound, service/node-restricted and online-revocable. A persisted
+        // MCP session records none of that, so minting one would let an expired
+        // delegated token be replayed as unrestricted `AuthMethod::Session` --
+        // which bypasses approval entirely -- for up to 30 idle days.
+        let delegated = McpAuthContext::user("user-1".to_string(), AuthMethod::Delegated);
+        assert!(delegated.is_stateless());
+
+        // Statelessness is what `initialize` consults to decide whether to mint
+        // a session at all, so the guarantee is "no session exists to fall back
+        // to", not merely "the fallback is refused".
+        assert!(!McpAuthContext::user("user-1".to_string(), AuthMethod::Session).is_stateless());
+    }
+
+    #[test]
+    fn every_short_lived_or_revocable_auth_method_is_stateless() {
+        // Guard against a new AuthMethod being added to the MCP transport
+        // without deciding its session posture. Session and AccessToken are the
+        // only long-lived, unrestricted, human-owned credentials that may back a
+        // persisted MCP session.
+        for (method, is_api_key, expected_stateless) in [
+            (AuthMethod::ApiKey, true, true),
+            (AuthMethod::Relay, false, true),
+            (AuthMethod::Delegated, false, true),
+            (AuthMethod::ServiceAccount, false, false),
+            (AuthMethod::AccessToken, false, false),
+            (AuthMethod::Session, false, false),
+        ] {
+            let label = format!("{method:?}");
+            let mut ctx = McpAuthContext::user("user-1".to_string(), method);
+            ctx.is_api_key = is_api_key;
+            assert_eq!(
+                ctx.is_stateless(),
+                expected_stateless,
+                "unexpected MCP session posture for {label}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`McpAuthContext::is_stateless()` (`backend/src/handlers/mcp_transport.rs`) classified API-key and relay auth as stateless, but **not delegated auth**:

```rust
self.is_api_key || self.auth_method == AuthMethod::Relay
```

`is_stateless()` is what `initialize` consults to decide whether to mint a persisted MCP session. So a delegated token could mint one — and the session-fallback path reconstructs authority from the session id alone:

1. A valid delegated token calls `initialize` → persisted session with `proxy_authorized`
2. The token expires (300s on the assistant bridge)
3. Any later request with an expired/absent JWT falls through to session auth, which builds `McpAuthContext::user(user_id, AuthMethod::Session)` — full user authority
4. `McpSessionRecord` stores only user id, `activated_service_ids` and `proxy_authorized`. The delegated actor, TTL, scope and service/node restriction claims are all dropped
5. `AuthMethod::Session` is exactly the method that passes `bypass_approval_flow = true` into `approval_service::evaluate_and_check`, which returns `Allowed` without an approval
6. `MCP_SESSION_MAX_IDLE_SECS` is 30 days and is refreshed by `touch()` on every request

Net: a 300-second, actor-bound, service/node-restricted, approval-gated delegated token can be downgraded into an **allow-all, approval-bypassing session renewable indefinitely**.

This is the identical hazard the existing doc comment already describes for relay tokens — "a relay token must NOT be able to mint a long-lived Session that outlives its short TTL / agent-key revocation and silently upgrades to `AuthMethod::Session` (allow-all, approval-bypassing)". Relay was forced stateless for that reason; delegated was never given the same treatment, despite additionally carrying online-revocable catalog authority via `CatalogDelegationGrant`.

## Fix

Add `AuthMethod::Delegated` to `is_stateless()`. No session is minted at `initialize`, so there is nothing to fall back to — the guarantee is "no session exists", not merely "the fallback is refused". Every delegated call stays bound to a live, unexpired credential.

## Tests

- `delegated_auth_is_stateless_and_cannot_mint_a_session` — asserts the new posture and documents why
- `every_short_lived_or_revocable_auth_method_is_stateless` — table-driven guard over all six `AuthMethod` variants, so a newly added method can't silently inherit a session posture nobody chose

## Verification

`cargo test -p nyxid --bin nyxid-server`, run on this branch and on `origin/main` with the change stashed:

| | passed | failed |
|---|---|---|
| `origin/main` (baseline) | 5192 | 125 |
| this branch | 5192 + 2 new | 125 |

The 125 failures are byte-identical between the two runs (`diff` clean) and are all DB-backed — this environment has no MongoDB replica set, so `test_utils::tests::transaction_test_database_supports_atomic_writes` and the service-layer suites fail on connection. **They are pre-existing and unrelated to this change.** Worth a re-run in CI where Mongo is available.

## Scope note

Found while investigating #1457. It is not what that issue asks for — it's a separate and more severe finding on the same delegated-auth surface, so it ships on its own. The #1457 analysis is tracked separately.

## Risk

Behavioral change for any delegated caller that relied on MCP session reuse: it must now present a valid token on every request rather than an `mcp-session-id`. That is the intended posture and matches how API-key and relay callers already work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)