### PR TITLE
feat(delegation): bind catalog provider identity and confine delegated exact approvals to the exact view

### DIFF
--- a/backend/src/handlers/delegation.rs
+++ b/backend/src/handlers/delegation.rs
@@ -898,51 +898,6 @@ mod tests {
         }
     }
 
-    async fn create_and_approve_exact(
-        state: &crate::AppState,
-        auth: &AuthUser,
-        discovery: &DelegatedOperationCatalogResponse,
-        operation: &mcp_service::ExactOperationViewOperation,
-        operation_digest: &str,
-        idempotency_key: &str,
-    ) -> crate::services::exact_service_approval_service::ExactServiceApprovalResult {
-        let AxumJson(created) = exact_service_approvals::create_request(
-            State(state.clone()),
-            auth.clone(),
-            AxumJson(
-                crate::services::exact_service_approval_service::ExactServiceApprovalCreate {
-                    user_service_id: TEST_SERVICE_A.to_string(),
-                    endpoint_id: operation.endpoint_id.clone(),
-                    catalog_digest: discovery.catalog_digest.clone(),
-                    exact_view_digest: Some(discovery.exact_view_digest.clone()),
-                    endpoint_contract_digest: operation.endpoint_contract_digest.clone(),
-                    operation_digest: operation_digest.to_string(),
-                    operation_id: operation.endpoint_id.clone(),
-                    operation_generation: 1,
-                    idempotency_key: idempotency_key.to_string(),
-                    arguments: serde_json::json!({}),
-                },
-            ),
-        )
-        .await
-        .expect("create matrix exact request");
-        approval_service::process_decision(
-            &state.db,
-            &state.config,
-            &state.http_client,
-            state.fcm_auth.clone(),
-            state.apns_auth.clone(),
-            &created.request_id,
-            true,
-            None,
-            None,
-            "integration",
-        )
-        .await
-        .expect("approve matrix exact request");
-        created
-    }
-
     fn exact_fence(
         created: &crate::services::exact_service_approval_service::ExactServiceApprovalResult,
     ) -> crate::services::exact_service_approval_service::ExactServiceApprovalFence {

--- a/backend/src/handlers/delegation.rs
+++ b/backend/src/handlers/delegation.rs
@@ -961,8 +961,9 @@ mod tests {
         auth: &AuthUser,
         created: &crate::services::exact_service_approval_service::ExactServiceApprovalResult,
         fence: crate::services::exact_service_approval_service::ExactServiceApprovalFence,
-    ) -> AppResult<AxumJson<crate::services::exact_service_approval_service::ExactServiceApprovalResult>>
-    {
+    ) -> AppResult<
+        AxumJson<crate::services::exact_service_approval_service::ExactServiceApprovalResult>,
+    > {
         exact_service_approvals::redeem_request(
             State(state.clone()),
             Extension(
@@ -1001,6 +1002,8 @@ mod tests {
             "{} proxy",
             catalog_delegation_service::MCP_CATALOG_READ_SCOPE
         );
+        let requested_service_ids =
+            vec![TEST_SERVICE_A.to_string(), TEST_GENERIC_SERVICE.to_string()];
 
         db.collection(crate::models::user::COLLECTION_NAME)
             .insert_one(crate::test_utils::test_user(TEST_USER_ID, UserType::Person))
@@ -1018,7 +1021,7 @@ mod tests {
             TEST_USER_ID,
             actor_client_id,
             "openid",
-            Some(vec![TEST_SERVICE_A.to_string()]),
+            Some(requested_service_ids.clone()),
         )
         .await
         .expect("grant actor consent");
@@ -1027,7 +1030,7 @@ mod tests {
             TEST_USER_ID,
             receiver_client_id,
             "openid",
-            Some(vec![TEST_SERVICE_A.to_string()]),
+            Some(requested_service_ids.clone()),
         )
         .await
         .expect("grant receiver consent");
@@ -1061,32 +1064,48 @@ mod tests {
             .expect("serve local provider");
         });
         db.collection::<UserEndpoint>(USER_ENDPOINTS)
-            .update_one(
-                mongodb::bson::doc! { "_id": "00000000-0000-4000-8000-000000000201" },
+            .update_many(
+                mongodb::bson::doc! { "_id": { "$in": [
+                    "00000000-0000-4000-8000-000000000201",
+                    "00000000-0000-4000-8000-000000000203",
+                ] } },
                 mongodb::bson::doc! { "$set": { "url": format!("http://{provider_addr}") } },
             )
             .await
-            .expect("point user endpoint at local provider");
+            .expect("point typed and generic user endpoints at local provider");
 
         db.collection::<ServiceApprovalConfig>(
             crate::models::service_approval_config::COLLECTION_NAME,
         )
-        .insert_one(ServiceApprovalConfig {
-            id: Uuid::new_v4().to_string(),
-            user_id: TEST_USER_ID.to_string(),
-            service_id: "00000000-0000-4000-8000-000000000301".to_string(),
-            service_name: "Alpha Service".to_string(),
-            approval_required: true,
-            approval_mode: ApprovalMode::PerRequest,
-            rules: Vec::new(),
-            default_effect: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        })
+        .insert_many([
+            ServiceApprovalConfig {
+                id: Uuid::new_v4().to_string(),
+                user_id: TEST_USER_ID.to_string(),
+                service_id: "00000000-0000-4000-8000-000000000301".to_string(),
+                service_name: "Alpha Service".to_string(),
+                approval_required: true,
+                approval_mode: ApprovalMode::PerRequest,
+                rules: Vec::new(),
+                default_effect: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            },
+            ServiceApprovalConfig {
+                id: Uuid::new_v4().to_string(),
+                user_id: TEST_USER_ID.to_string(),
+                service_id: TEST_GENERIC_SERVICE.to_string(),
+                service_name: "Hidden Generic".to_string(),
+                approval_required: true,
+                approval_mode: ApprovalMode::PerRequest,
+                rules: Vec::new(),
+                default_effect: None,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            },
+        ])
         .await
         .expect("seed per-request approval config");
 
-        let requested_service_ids = vec![TEST_SERVICE_A.to_string()];
         let source_token = jwt::generate_oauth_access_token(
             &state.jwt_keys,
             &state.config,
@@ -1149,9 +1168,23 @@ mod tests {
             service.catalog_service_id.as_deref(),
             Some("00000000-0000-4000-8000-000000000301")
         );
+        assert!(
+            discovery
+                .services
+                .iter()
+                .all(|service| service.user_service_id != TEST_GENERIC_SERVICE),
+            "delegated discovery must keep the authorized generic target out of the exact view"
+        );
+        assert!(
+            delegated_auth
+                .allowed_service_ids
+                .iter()
+                .any(|service_id| service_id == TEST_GENERIC_SERVICE),
+            "the membership test must not be confounded by the service allowlist"
+        );
 
         let arguments = serde_json::json!({});
-        let allowed_service_ids = vec![TEST_SERVICE_A.to_string()];
+        let allowed_service_ids = requested_service_ids.clone();
         let live_catalog = mcp_service::load_operation_catalog(
             &db,
             state.node_ws_manager.as_ref(),
@@ -1174,6 +1207,141 @@ mod tests {
             .expect("operation remains in canonical catalog");
         let operation_digest =
             mcp_service::exact_operation_digest(TEST_SERVICE_A, live_endpoint, &arguments);
+
+        let generic_service = live_catalog
+            .services
+            .iter()
+            .find(|service| service.service_id == TEST_GENERIC_SERVICE)
+            .expect("authorized generic service remains in the unprojected catalog");
+        let generic_endpoint = generic_service
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.endpoint_id == mcp_service::GENERIC_PROXY_ENDPOINT_ID)
+            .expect("generic proxy endpoint remains a valid unprojected selector");
+        let generic_arguments = serde_json::json!({"method": "GET", "path": "/items"});
+        let generic_operation_digest = mcp_service::exact_operation_digest(
+            TEST_GENERIC_SERVICE,
+            generic_endpoint,
+            &generic_arguments,
+        );
+        let generic_create = |exact_view_digest: Option<String>, idempotency_key: &str| {
+            crate::services::exact_service_approval_service::ExactServiceApprovalCreate {
+                user_service_id: TEST_GENERIC_SERVICE.to_string(),
+                endpoint_id: generic_endpoint.endpoint_id.clone(),
+                catalog_digest: discovery.catalog_digest.clone(),
+                exact_view_digest,
+                endpoint_contract_digest: mcp_service::endpoint_contract_digest(generic_endpoint),
+                operation_digest: generic_operation_digest.clone(),
+                operation_id: generic_endpoint.endpoint_id.clone(),
+                operation_generation: 1,
+                idempotency_key: idempotency_key.to_string(),
+                arguments: generic_arguments.clone(),
+            }
+        };
+
+        let approval_requests = db.collection::<crate::models::approval_request::ApprovalRequest>(
+            crate::models::approval_request::COLLECTION_NAME,
+        );
+        let rows_before = approval_requests
+            .count_documents(mongodb::bson::doc! {})
+            .await
+            .expect("count approvals before delegated hidden-target create");
+        let row_1_error = exact_service_approvals::create_request(
+            State(state.clone()),
+            delegated_auth.clone(),
+            AxumJson(generic_create(
+                Some(discovery.exact_view_digest.clone()),
+                "matrix-row-1-delegated-hidden",
+            )),
+        )
+        .await
+        .expect_err("delegated generic target must be outside the exact view");
+        assert!(matches!(
+            row_1_error,
+            AppError::NotFound(message) if message == "exact_operation_not_in_exact_view"
+        ));
+        assert_eq!(
+            approval_requests
+                .count_documents(mongodb::bson::doc! {})
+                .await
+                .expect("count approvals after delegated hidden-target create"),
+            rows_before,
+            "matrix row 1 must reject before creating an ApprovalRequest"
+        );
+
+        let mut access_token_auth = delegated_auth.clone();
+        access_token_auth.auth_method = AuthMethod::AccessToken;
+        access_token_auth.scope = "proxy".to_string();
+        access_token_auth.acting_client_id = None;
+        access_token_auth.token_jti = None;
+        let AxumJson(row_3_created) = exact_service_approvals::create_request(
+            State(state.clone()),
+            access_token_auth.clone(),
+            AxumJson(generic_create(None, "matrix-row-3-access-token-generic")),
+        )
+        .await
+        .expect("non-delegated generic target remains approvable");
+        assert_eq!(row_3_created.exact_view_digest, None);
+        let persisted_row_3 = approval_requests
+            .find_one(mongodb::bson::doc! { "_id": &row_3_created.request_id })
+            .await
+            .expect("load persisted generic approval")
+            .expect("generic approval row was persisted");
+        assert_eq!(
+            persisted_row_3
+                .exact_service
+                .and_then(|binding| binding.exact_view_digest),
+            None,
+            "matrix row 3 must not persist an unrelated exact-view fence"
+        );
+        approval_service::process_decision(
+            &db,
+            &state.config,
+            &state.http_client,
+            state.fcm_auth.clone(),
+            state.apns_auth.clone(),
+            &row_3_created.request_id,
+            true,
+            None,
+            None,
+            "integration",
+        )
+        .await
+        .expect("approve non-delegated generic request");
+        let AxumJson(row_3_redeemed) = redeem_exact(
+            &state,
+            &access_token_auth,
+            &row_3_created,
+            exact_fence(&row_3_created),
+        )
+        .await
+        .expect("matrix row 3: non-delegated generic request redeems");
+        assert_eq!(
+            row_3_redeemed.state,
+            crate::services::exact_service_approval_service::ExactServiceApprovalState::Redeemed
+        );
+        assert_eq!(
+            row_3_redeemed
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.http_status),
+            Some(200)
+        );
+
+        let row_4_error = exact_service_approvals::create_request(
+            State(state.clone()),
+            access_token_auth,
+            AxumJson(generic_create(
+                Some(discovery.exact_view_digest.clone()),
+                "matrix-row-4-access-token-generic-with-view",
+            )),
+        )
+        .await
+        .expect_err("an out-of-view target cannot bind the exact-view digest");
+        assert!(matches!(
+            row_4_error,
+            AppError::BadRequest(message) if message == "exact_view_digest_not_applicable"
+        ));
 
         let AxumJson(created) = exact_service_approvals::create_request(
             State(state.clone()),
@@ -1285,19 +1453,21 @@ mod tests {
         .await
         .expect("approve provider-bound request");
 
-        // Move the same endpoint contract to the second catalog provider and
-        // repoint the UserService. Endpoint identity and operation arguments
+        // Move the same endpoint contracts to the second catalog provider and
+        // repoint the UserService. Endpoint identities and operation arguments
         // remain stable; the newly projected catalog_service_id is the direct
         // reason the exact-view fence changes.
         db.collection::<ServiceEndpoint>(SERVICE_ENDPOINTS)
-            .update_one(
-                mongodb::bson::doc! { "_id": &operation.endpoint_id },
+            .update_many(
+                mongodb::bson::doc! {
+                    "service_id": "00000000-0000-4000-8000-000000000301"
+                },
                 mongodb::bson::doc! { "$set": {
                     "service_id": "00000000-0000-4000-8000-000000000302"
                 } },
             )
             .await
-            .expect("move endpoint contract to alternate provider");
+            .expect("move endpoint contracts to alternate provider");
         db.collection::<UserService>(USER_SERVICES)
             .update_one(
                 mongodb::bson::doc! { "_id": TEST_SERVICE_A },
@@ -1355,7 +1525,10 @@ mod tests {
             provider_drifted.state,
             crate::services::exact_service_approval_service::ExactServiceApprovalState::Drifted
         );
-        assert_eq!(provider_drifted.failure_code.as_deref(), Some("catalog_drift"));
+        assert_eq!(
+            provider_drifted.failure_code.as_deref(),
+            Some("catalog_drift")
+        );
         provider.abort();
     }
 

--- a/backend/src/handlers/delegation.rs
+++ b/backend/src/handlers/delegation.rs
@@ -93,7 +93,7 @@ pub async fn get_operation_catalog(
         .sum();
 
     Ok(Json(DelegatedOperationCatalogResponse {
-        contract_version: "nyxid-delegated-operation-catalog.v1",
+        contract_version: "nyxid-delegated-operation-catalog.v2",
         catalog_digest,
         exact_view_digest,
         resolved_at: resolved_at.to_rfc3339(),
@@ -224,17 +224,28 @@ pub async fn refresh_delegation_token(
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use axum::{Extension, Json as AxumJson, Router, extract::Path, routing::get};
+    use chrono::Utc;
     use mongodb::event::EventHandler;
     use mongodb::event::command::CommandEvent;
+    use uuid::Uuid;
 
+    use crate::crypto::{jwt, token::hash_token};
+    use crate::handlers::exact_service_approvals;
     use crate::models::downstream_service::{
         COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
     };
+    use crate::models::oauth_client::{
+        COLLECTION_NAME as OAUTH_CLIENTS, OauthClient, ScopeProvenance,
+    };
+    use crate::models::service_approval_config::{ApprovalMode, ServiceApprovalConfig};
     use crate::models::service_endpoint::{
         COLLECTION_NAME as SERVICE_ENDPOINTS, OperationResponseContract, ServiceEndpoint,
     };
+    use crate::models::user::UserType;
     use crate::models::user_endpoint::{COLLECTION_NAME as USER_ENDPOINTS, UserEndpoint};
     use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
+    use crate::services::{approval_service, consent_service, token_exchange_service};
 
     use super::*;
 
@@ -279,13 +290,14 @@ mod tests {
     #[test]
     fn operation_catalog_response_is_typed_and_secret_free() {
         let response = DelegatedOperationCatalogResponse {
-            contract_version: "nyxid-delegated-operation-catalog.v1",
+            contract_version: "nyxid-delegated-operation-catalog.v2",
             catalog_digest: "sha256:opaque".to_string(),
             exact_view_digest: "sha256:exact-view".to_string(),
             resolved_at: "2026-08-14T00:00:00Z".to_string(),
             authority_expires_at: "2026-08-14T00:05:00Z".to_string(),
             services: vec![mcp_service::ExactOperationViewService {
                 user_service_id: "service-1".to_string(),
+                catalog_service_id: Some("catalog-1".to_string()),
                 service_slug: "github".to_string(),
                 service_name: "GitHub".to_string(),
                 description: Some("typed service".to_string()),
@@ -312,6 +324,96 @@ mod tests {
             assert!(!encoded.contains(forbidden), "response leaked {forbidden}");
         }
         assert_eq!(value["total_operations"], 1);
+    }
+
+    fn deterministic_exact_view_fixture() -> mcp_service::ExactOperationView {
+        let response = || crate::models::service_endpoint::OperationResponseContract {
+            content_types: vec!["application/json".to_string()],
+            binary_artifact: Some(false),
+        };
+        let operation = |endpoint_id: &str,
+                         name: &str,
+                         method: &str,
+                         path: &str,
+                         endpoint_contract_digest: &str| {
+            mcp_service::ExactOperationViewOperation {
+                endpoint_id: endpoint_id.to_string(),
+                name: name.to_string(),
+                method: method.to_string(),
+                path: path.to_string(),
+                parameters: None,
+                request_body_schema: None,
+                request_content_type: None,
+                request_body_required: false,
+                response: response(),
+                endpoint_contract_digest: endpoint_contract_digest.to_string(),
+            }
+        };
+        mcp_service::ExactOperationView {
+            services: vec![
+                mcp_service::ExactOperationViewService {
+                    user_service_id: TEST_SERVICE_A.to_string(),
+                    catalog_service_id: Some("00000000-0000-4000-8000-000000000301".to_string()),
+                    service_slug: "alpha".to_string(),
+                    service_name: "Alpha Service".to_string(),
+                    description: None,
+                    node_id: None,
+                    operations: vec![
+                        operation(
+                            "00000000-0000-4000-8000-000000000401",
+                            "alpha_list",
+                            "GET",
+                            "/items",
+                            "sha256:44d63aba629068d100761faf33f1359e0837f554f691ea50fd30a69bb7b8ea5a",
+                        ),
+                        operation(
+                            "00000000-0000-4000-8000-000000000402",
+                            "alpha_create",
+                            "POST",
+                            "/items",
+                            "sha256:b33c78e543e5bd0db8ac01378ced3f1598ba15457c91b7526178fe91313e5021",
+                        ),
+                    ],
+                },
+                mcp_service::ExactOperationViewService {
+                    user_service_id: TEST_SERVICE_B.to_string(),
+                    catalog_service_id: Some("00000000-0000-4000-8000-000000000302".to_string()),
+                    service_slug: "beta".to_string(),
+                    service_name: "Beta Service".to_string(),
+                    description: None,
+                    node_id: None,
+                    operations: vec![operation(
+                        "00000000-0000-4000-8000-000000000403",
+                        "beta_status",
+                        "GET",
+                        "/status",
+                        "sha256:3f488040e19cb9fdc9e9f2aefd9061058c16426a58a2ace0664373e5b9574d5f",
+                    )],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn deterministic_fixture_binds_provider_identity_and_v2_digest_envelope() {
+        let view = deterministic_exact_view_fixture();
+        assert_eq!(
+            view.services[0].catalog_service_id.as_deref(),
+            Some("00000000-0000-4000-8000-000000000301")
+        );
+        let digest = mcp_service::exact_operation_view_digest(&view);
+        assert_eq!(
+            digest,
+            "sha256:acfbddf689ec25828e01cb4c149f9fd5f3ab5c9f37fddc7d0891e088cf1030a5"
+        );
+        let mut provider_changed = view.clone();
+        provider_changed.services[0].catalog_service_id =
+            Some("00000000-0000-4000-8000-000000000302".to_string());
+        assert_ne!(
+            digest,
+            mcp_service::exact_operation_view_digest(&provider_changed),
+            "catalog provider rebinding must move the exact-view fence"
+        );
     }
 
     // ---- Catalog authority: fail-closed matrix -------------------------------
@@ -621,16 +723,46 @@ mod tests {
             grant.expires_at.to_rfc3339()
         );
         assert_eq!(
+            actual["contract_version"], "nyxid-delegated-operation-catalog.v2",
+            "the response and exact-view digest envelope must move together"
+        );
+        let service_ids: Vec<&str> = actual["services"]
+            .as_array()
+            .expect("services array")
+            .iter()
+            .map(|service| service["user_service_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            service_ids,
+            vec![TEST_SERVICE_A, TEST_SERVICE_B],
+            "delegated discovery sorts services by user_service_id"
+        );
+        let operation_ids: Vec<&str> = actual["services"][0]["operations"]
+            .as_array()
+            .expect("operations array")
+            .iter()
+            .map(|operation| operation["endpoint_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            operation_ids,
+            vec![
+                "00000000-0000-4000-8000-000000000401",
+                "00000000-0000-4000-8000-000000000402",
+            ],
+            "delegated discovery sorts operations by endpoint_id"
+        );
+        assert_eq!(
             actual,
             serde_json::json!({
-                "contract_version": "nyxid-delegated-operation-catalog.v1",
+                "contract_version": "nyxid-delegated-operation-catalog.v2",
                 "catalog_digest": "sha256:ea55205436c9a87a35ec9d21072cff07e77dc2ef23409aeb16760f0d08662a62",
-                "exact_view_digest": "sha256:e1d168ef49f0b5955c39fa4a0767791fa9a75141ed4c4df68a6d1b53f87284fc",
+                "exact_view_digest": "sha256:acfbddf689ec25828e01cb4c149f9fd5f3ab5c9f37fddc7d0891e088cf1030a5",
                 "resolved_at": "<resolved-at>",
                 "authority_expires_at": grant.expires_at.to_rfc3339(),
                 "services": [
                     {
                         "user_service_id": TEST_SERVICE_A,
+                        "catalog_service_id": "00000000-0000-4000-8000-000000000301",
                         "service_slug": "alpha",
                         "service_name": "Alpha Service",
                         "description": null,
@@ -664,6 +796,7 @@ mod tests {
                     },
                     {
                         "user_service_id": TEST_SERVICE_B,
+                        "catalog_service_id": "00000000-0000-4000-8000-000000000302",
                         "service_slug": "beta",
                         "service_name": "Beta Service",
                         "description": null,
@@ -705,6 +838,525 @@ mod tests {
             write_commands.is_empty(),
             "catalog handler issued database writes: {write_commands:?}"
         );
+        // This is a read facade over the domain collections. OpenAPI loading
+        // may still perform outbound reads and mutate the process-local
+        // api_docs_service cache; this assertion deliberately checks only
+        // durable domain writes and does not spy away that qualification.
+    }
+
+    fn oauth_client(id: &str, secret: &str, delegation_scopes: &str) -> OauthClient {
+        let now = Utc::now();
+        OauthClient {
+            id: id.to_string(),
+            client_name: id.to_string(),
+            client_secret_hash: hash_token(secret),
+            redirect_uris: vec!["https://example.invalid/callback".to_string()],
+            allowed_scopes: "openid".to_string(),
+            scope_provenance: ScopeProvenance::Explicit,
+            grant_types: "authorization_code refresh_token".to_string(),
+            client_type: "confidential".to_string(),
+            is_active: true,
+            delegation_scopes: delegation_scopes.to_string(),
+            default_service_catalog_slugs: Vec::new(),
+            broker_capability_enabled: false,
+            revocation_webhook_url: None,
+            revocation_webhook_secret_encrypted: None,
+            connection_webhook_url: None,
+            connection_webhook_secret_encrypted: None,
+            connection_webhook_key_id: None,
+            connection_webhook_enabled: false,
+            created_by: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn delegated_auth_from_token(state: &crate::AppState, token: &str) -> AuthUser {
+        let claims = jwt::verify_token(&state.jwt_keys, &state.config, token)
+            .expect("verify minted delegated token");
+        AuthUser {
+            user_id: Uuid::parse_str(&claims.sub).expect("delegated subject is a UUID"),
+            session_id: None,
+            scope: claims.scope,
+            acting_client_id: claims.act.map(|actor| actor.sub),
+            oauth_client_id: claims.client_id,
+            token_jti: Some(claims.jti),
+            approval_owner_user_id: None,
+            auth_method: AuthMethod::Delegated,
+            allow_all_services: claims.allow_all_services.unwrap_or(true),
+            allow_all_nodes: claims.allow_all_nodes.unwrap_or(true),
+            allowed_service_ids: claims.allowed_service_ids.unwrap_or_default(),
+            resource_uris: claims.resources,
+            allowed_node_ids: claims.allowed_node_ids.unwrap_or_default(),
+            api_key_id: None,
+            api_key_name: None,
+            api_key_purpose: crate::models::api_key::ApiKeyPurpose::General,
+            rate_limit_per_second: None,
+            rate_limit_burst: None,
+            ip_address: None,
+            user_agent: None,
+        }
+    }
+
+    async fn create_and_approve_exact(
+        state: &crate::AppState,
+        auth: &AuthUser,
+        discovery: &DelegatedOperationCatalogResponse,
+        operation: &mcp_service::ExactOperationViewOperation,
+        operation_digest: &str,
+        idempotency_key: &str,
+    ) -> crate::services::exact_service_approval_service::ExactServiceApprovalResult {
+        let AxumJson(created) = exact_service_approvals::create_request(
+            State(state.clone()),
+            auth.clone(),
+            AxumJson(
+                crate::services::exact_service_approval_service::ExactServiceApprovalCreate {
+                    user_service_id: TEST_SERVICE_A.to_string(),
+                    endpoint_id: operation.endpoint_id.clone(),
+                    catalog_digest: discovery.catalog_digest.clone(),
+                    exact_view_digest: Some(discovery.exact_view_digest.clone()),
+                    endpoint_contract_digest: operation.endpoint_contract_digest.clone(),
+                    operation_digest: operation_digest.to_string(),
+                    operation_id: operation.endpoint_id.clone(),
+                    operation_generation: 1,
+                    idempotency_key: idempotency_key.to_string(),
+                    arguments: serde_json::json!({}),
+                },
+            ),
+        )
+        .await
+        .expect("create matrix exact request");
+        approval_service::process_decision(
+            &state.db,
+            &state.config,
+            &state.http_client,
+            state.fcm_auth.clone(),
+            state.apns_auth.clone(),
+            &created.request_id,
+            true,
+            None,
+            None,
+            "integration",
+        )
+        .await
+        .expect("approve matrix exact request");
+        created
+    }
+
+    fn exact_fence(
+        created: &crate::services::exact_service_approval_service::ExactServiceApprovalResult,
+    ) -> crate::services::exact_service_approval_service::ExactServiceApprovalFence {
+        crate::services::exact_service_approval_service::ExactServiceApprovalFence {
+            catalog_digest: created.catalog_digest.clone(),
+            exact_view_digest: created.exact_view_digest.clone(),
+            operation_digest: created.operation_digest.clone(),
+            operation_id: created.operation_id.clone(),
+            operation_generation: created.operation_generation,
+            idempotency_key: created.idempotency_key.clone(),
+        }
+    }
+
+    async fn redeem_exact(
+        state: &crate::AppState,
+        auth: &AuthUser,
+        created: &crate::services::exact_service_approval_service::ExactServiceApprovalResult,
+        fence: crate::services::exact_service_approval_service::ExactServiceApprovalFence,
+    ) -> AppResult<AxumJson<crate::services::exact_service_approval_service::ExactServiceApprovalResult>>
+    {
+        exact_service_approvals::redeem_request(
+            State(state.clone()),
+            Extension(
+                crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
+                    crate::services::billing::route_inventory::BillingIngress::Mcp,
+                ),
+            ),
+            auth.clone(),
+            Path(created.request_id.clone()),
+            AxumJson(fence),
+        )
+        .await
+    }
+
+    /// Crosses the production token-exchange grant path and the actual
+    /// delegated discovery, exact-create, approval-decision, and exact-redeem
+    /// handler boundaries. Every catalog/exact fence sent to create/redeem is
+    /// copied from the discovery/create response; only the argument-bound
+    /// operation digest is obtained from the canonical operation helper because
+    /// discovery intentionally publishes contract metadata, not an
+    /// argument-specific invocation digest.
+    #[tokio::test]
+    async fn delegated_discovery_create_redeem_uses_live_catalog_evidence() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("delegated_discovery_exact_redeem").await
+        else {
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db.clone());
+        let user_id = Uuid::parse_str(TEST_USER_ID).unwrap();
+        let actor_client_id = "integration-actor-client";
+        let receiver_client_id = "integration-receiver-client";
+        let actor_secret = "integration-actor-secret";
+        let receiver_secret = "integration-receiver-secret";
+        let delegated_scope = format!(
+            "{} proxy",
+            catalog_delegation_service::MCP_CATALOG_READ_SCOPE
+        );
+
+        db.collection(crate::models::user::COLLECTION_NAME)
+            .insert_one(crate::test_utils::test_user(TEST_USER_ID, UserType::Person))
+            .await
+            .expect("insert integration user");
+        db.collection::<OauthClient>(OAUTH_CLIENTS)
+            .insert_many([
+                oauth_client(actor_client_id, actor_secret, &delegated_scope),
+                oauth_client(receiver_client_id, receiver_secret, &delegated_scope),
+            ])
+            .await
+            .expect("insert integration OAuth clients");
+        consent_service::grant_consent_with_services(
+            &db,
+            TEST_USER_ID,
+            actor_client_id,
+            "openid",
+            Some(vec![TEST_SERVICE_A.to_string()]),
+        )
+        .await
+        .expect("grant actor consent");
+        consent_service::grant_consent_with_services(
+            &db,
+            TEST_USER_ID,
+            receiver_client_id,
+            "openid",
+            Some(vec![TEST_SERVICE_A.to_string()]),
+        )
+        .await
+        .expect("grant receiver consent");
+
+        // The fixture seeds the catalog rows and a harmless fixture grant. The
+        // live token exchange below mints its own JTI and is the only grant
+        // used by the handler.
+        let fixture_auth = fixture_catalog_auth();
+        seed_operation_catalog_fixture(&db, &fixture_auth).await;
+        db.collection::<ServiceEndpoint>(SERVICE_ENDPOINTS)
+            .update_one(
+                mongodb::bson::doc! { "_id": "00000000-0000-4000-8000-000000000403" },
+                mongodb::bson::doc! { "$set": { "is_active": false } },
+            )
+            .await
+            .expect("keep alternate provider operation set empty for identity-only drift");
+
+        let provider_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind local provider");
+        let provider_addr = provider_listener.local_addr().unwrap();
+        let provider = tokio::spawn(async move {
+            axum::serve(
+                provider_listener,
+                Router::new().route(
+                    "/items",
+                    get(|| async { AxumJson(serde_json::json!({"ok": true})) }),
+                ),
+            )
+            .await
+            .expect("serve local provider");
+        });
+        db.collection::<UserEndpoint>(USER_ENDPOINTS)
+            .update_one(
+                mongodb::bson::doc! { "_id": "00000000-0000-4000-8000-000000000201" },
+                mongodb::bson::doc! { "$set": { "url": format!("http://{provider_addr}") } },
+            )
+            .await
+            .expect("point user endpoint at local provider");
+
+        db.collection::<ServiceApprovalConfig>(
+            crate::models::service_approval_config::COLLECTION_NAME,
+        )
+        .insert_one(ServiceApprovalConfig {
+            id: Uuid::new_v4().to_string(),
+            user_id: TEST_USER_ID.to_string(),
+            service_id: "00000000-0000-4000-8000-000000000301".to_string(),
+            service_name: "Alpha Service".to_string(),
+            approval_required: true,
+            approval_mode: ApprovalMode::PerRequest,
+            rules: Vec::new(),
+            default_effect: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+        .await
+        .expect("seed per-request approval config");
+
+        let requested_service_ids = vec![TEST_SERVICE_A.to_string()];
+        let source_token = jwt::generate_oauth_access_token(
+            &state.jwt_keys,
+            &state.config,
+            &user_id,
+            "openid",
+            None,
+            None,
+            None,
+            None,
+            Some(jwt::AccessTokenRestrictions {
+                resources: &[],
+                allowed_service_ids: &requested_service_ids,
+                allowed_node_ids: &[],
+                allow_all_nodes: true,
+            }),
+            actor_client_id,
+        )
+        .expect("mint direct source token");
+        let exchanged = token_exchange_service::exchange_token_with_authority(
+            &db,
+            &state.config,
+            &state.jwt_keys,
+            receiver_client_id,
+            receiver_secret,
+            &source_token,
+            "urn:ietf:params:oauth:token-type:access_token",
+            Some(&delegated_scope),
+            &[],
+            Some(false),
+            &requested_service_ids,
+            Some(true),
+            &[],
+        )
+        .await
+        .expect("mint delegated token and persist live catalog grant");
+        let delegated_auth = delegated_auth_from_token(&state, &exchanged.access_token);
+        crate::services::catalog_delegation_service::validate_live_grant(
+            &db,
+            &state.config,
+            &jwt::verify_token(&state.jwt_keys, &state.config, &exchanged.access_token).unwrap(),
+        )
+        .await
+        .expect("delegated token has a live grant before discovery");
+
+        let AxumJson(discovery) =
+            get_operation_catalog(State(state.clone()), delegated_auth.clone())
+                .await
+                .expect("real delegated discovery handler");
+        assert_eq!(
+            discovery.contract_version,
+            "nyxid-delegated-operation-catalog.v2"
+        );
+        let service = discovery
+            .services
+            .iter()
+            .find(|service| service.user_service_id == TEST_SERVICE_A)
+            .expect("catalog-backed service in discovery");
+        let operation = service.operations.first().expect("typed operation");
+        assert_eq!(
+            service.catalog_service_id.as_deref(),
+            Some("00000000-0000-4000-8000-000000000301")
+        );
+
+        let arguments = serde_json::json!({});
+        let allowed_service_ids = vec![TEST_SERVICE_A.to_string()];
+        let live_catalog = mcp_service::load_operation_catalog(
+            &db,
+            state.node_ws_manager.as_ref(),
+            TEST_USER_ID,
+            mcp_service::NodeScope::Unrestricted,
+            mcp_service::ServiceScope::Allowed(&allowed_service_ids),
+        )
+        .await
+        .expect("resolve canonical operation for argument-bound digest");
+        let live_endpoint = live_catalog
+            .services
+            .iter()
+            .find(|service| service.service_id == TEST_SERVICE_A)
+            .and_then(|service| {
+                service
+                    .endpoints
+                    .iter()
+                    .find(|endpoint| endpoint.endpoint_id == operation.endpoint_id)
+            })
+            .expect("operation remains in canonical catalog");
+        let operation_digest =
+            mcp_service::exact_operation_digest(TEST_SERVICE_A, live_endpoint, &arguments);
+
+        let AxumJson(created) = exact_service_approvals::create_request(
+            State(state.clone()),
+            delegated_auth.clone(),
+            AxumJson(
+                crate::services::exact_service_approval_service::ExactServiceApprovalCreate {
+                    user_service_id: TEST_SERVICE_A.to_string(),
+                    endpoint_id: operation.endpoint_id.clone(),
+                    catalog_digest: discovery.catalog_digest.clone(),
+                    // Omit the additive field at create to prove the server
+                    // persists its live exact-view fence and returns it for
+                    // redeem, rather than trusting caller omission forever.
+                    exact_view_digest: None,
+                    endpoint_contract_digest: operation.endpoint_contract_digest.clone(),
+                    operation_digest: operation_digest.clone(),
+                    operation_id: operation.endpoint_id.clone(),
+                    operation_generation: 1,
+                    idempotency_key: "integration-idempotency-key".to_string(),
+                    arguments: arguments.clone(),
+                },
+            ),
+        )
+        .await
+        .expect("real exact create handler");
+        assert_eq!(
+            created.exact_view_digest,
+            Some(discovery.exact_view_digest.clone())
+        );
+        assert_eq!(created.catalog_digest, discovery.catalog_digest);
+
+        approval_service::process_decision(
+            &db,
+            &state.config,
+            &state.http_client,
+            state.fcm_auth.clone(),
+            state.apns_auth.clone(),
+            &created.request_id,
+            true,
+            None,
+            None,
+            "integration",
+        )
+        .await
+        .expect("approve per-request exact request");
+
+        let AxumJson(redeemed) = exact_service_approvals::redeem_request(
+            State(state.clone()),
+            Extension(
+                crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
+                    crate::services::billing::route_inventory::BillingIngress::Mcp,
+                ),
+            ),
+            delegated_auth.clone(),
+            Path(created.request_id.clone()),
+            AxumJson(
+                crate::services::exact_service_approval_service::ExactServiceApprovalFence {
+                    catalog_digest: created.catalog_digest.clone(),
+                    exact_view_digest: created.exact_view_digest.clone(),
+                    operation_digest: created.operation_digest.clone(),
+                    operation_id: created.operation_id.clone(),
+                    operation_generation: created.operation_generation,
+                    idempotency_key: created.idempotency_key.clone(),
+                },
+            ),
+        )
+        .await
+        .expect("real exact redeem handler");
+        assert_eq!(
+            redeemed.state,
+            crate::services::exact_service_approval_service::ExactServiceApprovalState::Redeemed
+        );
+        assert_eq!(
+            redeemed.receipt.as_ref().map(|receipt| receipt.http_status),
+            Some(200)
+        );
+
+        let AxumJson(provider_bound) = exact_service_approvals::create_request(
+            State(state.clone()),
+            delegated_auth.clone(),
+            AxumJson(
+                crate::services::exact_service_approval_service::ExactServiceApprovalCreate {
+                    user_service_id: TEST_SERVICE_A.to_string(),
+                    endpoint_id: operation.endpoint_id.clone(),
+                    catalog_digest: discovery.catalog_digest.clone(),
+                    exact_view_digest: Some(discovery.exact_view_digest.clone()),
+                    endpoint_contract_digest: operation.endpoint_contract_digest.clone(),
+                    operation_digest,
+                    operation_id: operation.endpoint_id.clone(),
+                    operation_generation: 1,
+                    idempotency_key: "provider-binding-drift-key".to_string(),
+                    arguments,
+                },
+            ),
+        )
+        .await
+        .expect("create provider-bound exact request");
+        approval_service::process_decision(
+            &db,
+            &state.config,
+            &state.http_client,
+            state.fcm_auth.clone(),
+            state.apns_auth.clone(),
+            &provider_bound.request_id,
+            true,
+            None,
+            None,
+            "integration",
+        )
+        .await
+        .expect("approve provider-bound request");
+
+        // Move the same endpoint contract to the second catalog provider and
+        // repoint the UserService. Endpoint identity and operation arguments
+        // remain stable; the newly projected catalog_service_id is the direct
+        // reason the exact-view fence changes.
+        db.collection::<ServiceEndpoint>(SERVICE_ENDPOINTS)
+            .update_one(
+                mongodb::bson::doc! { "_id": &operation.endpoint_id },
+                mongodb::bson::doc! { "$set": {
+                    "service_id": "00000000-0000-4000-8000-000000000302"
+                } },
+            )
+            .await
+            .expect("move endpoint contract to alternate provider");
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                mongodb::bson::doc! { "_id": TEST_SERVICE_A },
+                mongodb::bson::doc! { "$set": {
+                    "catalog_service_id": "00000000-0000-4000-8000-000000000302"
+                } },
+            )
+            .await
+            .expect("repoint catalog provider binding");
+        let rebound_catalog = mcp_service::load_operation_catalog(
+            &db,
+            state.node_ws_manager.as_ref(),
+            TEST_USER_ID,
+            mcp_service::NodeScope::Unrestricted,
+            mcp_service::ServiceScope::Allowed(&allowed_service_ids),
+        )
+        .await
+        .expect("resolve rebound provider catalog");
+        assert_eq!(
+            mcp_service::operation_catalog_digest(&rebound_catalog.services),
+            discovery.catalog_digest,
+            "provider identity is intentionally outside the shared /mcp/config fence"
+        );
+        assert_ne!(
+            mcp_service::exact_operation_view_digest(&mcp_service::exact_operation_view(
+                &rebound_catalog.services,
+            )),
+            discovery.exact_view_digest,
+            "provider identity must move the exact-view fence"
+        );
+
+        let AxumJson(provider_drifted) = exact_service_approvals::redeem_request(
+            State(state),
+            Extension(
+                crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
+                    crate::services::billing::route_inventory::BillingIngress::Mcp,
+                ),
+            ),
+            delegated_auth,
+            Path(provider_bound.request_id.clone()),
+            AxumJson(
+                crate::services::exact_service_approval_service::ExactServiceApprovalFence {
+                    catalog_digest: provider_bound.catalog_digest.clone(),
+                    exact_view_digest: provider_bound.exact_view_digest.clone(),
+                    operation_digest: provider_bound.operation_digest.clone(),
+                    operation_id: provider_bound.operation_id.clone(),
+                    operation_generation: provider_bound.operation_generation,
+                    idempotency_key: provider_bound.idempotency_key.clone(),
+                },
+            ),
+        )
+        .await
+        .expect("provider binding drift returns a typed fail-closed result");
+        assert_eq!(
+            provider_drifted.state,
+            crate::services::exact_service_approval_service::ExactServiceApprovalState::Drifted
+        );
+        assert_eq!(provider_drifted.failure_code.as_deref(), Some("catalog_drift"));
+        provider.abort();
     }
 
     #[test]

--- a/backend/src/handlers/exact_service_approvals.rs
+++ b/backend/src/handlers/exact_service_approvals.rs
@@ -10,8 +10,8 @@ use crate::services::billing::route_inventory::{
     BillingIngress, BillingRoutePolicy, enforce_billing_egress_classification,
 };
 use crate::services::exact_service_approval_service::{
-    self, ExactServiceApprovalCaller, ExactServiceApprovalCreate, ExactServiceApprovalFence,
-    ExactServiceApprovalResult,
+    self, DELEGATED_REQUESTER_TYPE, ExactServiceApprovalCaller, ExactServiceApprovalCreate,
+    ExactServiceApprovalFence, ExactServiceApprovalResult,
 };
 
 pub async fn create_request(
@@ -75,7 +75,7 @@ fn caller(auth_user: &AuthUser) -> AppResult<ExactServiceApprovalCaller> {
                 })?,
             ),
             AuthMethod::Delegated => (
-                "delegated",
+                DELEGATED_REQUESTER_TYPE,
                 auth_user.acting_client_id.clone().ok_or_else(|| {
                     AppError::Unauthorized("delegated client identity missing".to_string())
                 })?,

--- a/backend/src/handlers/mcp.rs
+++ b/backend/src/handlers/mcp.rs
@@ -302,6 +302,7 @@ mod tests {
             durable_endpoint_metadata: Default::default(),
             source: McpToolSource::UserManaged {
                 user_service_id: "user-service-1".to_string(),
+                catalog_service_id: None,
                 effective_owner_id: "owner-1".to_string(),
                 node_id: None,
                 has_server_credential: true,

--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -3066,6 +3066,7 @@ mod tests {
             durable_endpoint_metadata: Default::default(),
             source: McpToolSource::UserManaged {
                 user_service_id: id.into(),
+                catalog_service_id: None,
                 effective_owner_id: "user-1".into(),
                 node_id: None,
                 has_server_credential: true,
@@ -3239,6 +3240,7 @@ mod tests {
         service.service_slug = slug.to_string();
         service.source = McpToolSource::UserManaged {
             user_service_id: user_service_id.clone(),
+            catalog_service_id: None,
             effective_owner_id: org_id.clone(),
             node_id: None,
             has_server_credential: true,

--- a/backend/src/services/assistant_direct_agent_poc/tools.rs
+++ b/backend/src/services/assistant_direct_agent_poc/tools.rs
@@ -1548,6 +1548,7 @@ mod tests {
             service.executable = executable;
             service.source = mcp_service::McpToolSource::UserManaged {
                 user_service_id: id.to_string(),
+                catalog_service_id: None,
                 effective_owner_id: "owner".to_string(),
                 node_id: None,
                 has_server_credential: true,

--- a/backend/src/services/exact_service_approval_service.rs
+++ b/backend/src/services/exact_service_approval_service.rs
@@ -660,7 +660,11 @@ async fn expire_if_needed(
     state: &AppState,
     request: ApprovalRequest,
 ) -> AppResult<ApprovalRequest> {
-    if request.status != "pending" || request.expires_at > Utc::now() {
+    let exact_unredeemed = request.exact_service.as_ref().is_some_and(|binding| {
+        binding.redemption.is_none()
+            && matches!(request.status.as_str(), "pending" | "approved")
+    });
+    if !exact_unredeemed || request.expires_at > Utc::now() {
         return Ok(request);
     }
     let now = Utc::now();
@@ -668,7 +672,13 @@ async fn expire_if_needed(
         .db
         .collection::<ApprovalRequest>(REQUESTS)
         .find_one_and_update(
-            doc! { "_id": &request.id, "status": "pending", "expires_at": { "$lte": bson::DateTime::from_chrono(now) } },
+            doc! {
+                "_id": &request.id,
+                "status": &request.status,
+                "expires_at": { "$lte": bson::DateTime::from_chrono(now) },
+                "exact_service": { "$exists": true },
+                "exact_service.redemption": { "$exists": false },
+            },
             doc! { "$set": { "status": "expired", "decided_at": bson::DateTime::from_chrono(now) } },
         )
         .with_options(
@@ -1158,6 +1168,152 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fail_closed_matrix_keeps_each_fence_and_live_selector_mutation_distinct() {
+        let input = create();
+        let request = approval_request(
+            "request-matrix",
+            "approved",
+            Utc::now() + Duration::minutes(5),
+            Some(binding()),
+        );
+        let mut wrong_operation = ExactServiceApprovalFence {
+            catalog_digest: input.catalog_digest.clone(),
+            exact_view_digest: input.exact_view_digest.clone(),
+            operation_digest: input.operation_digest.clone(),
+            operation_id: input.operation_id.clone(),
+            operation_generation: input.operation_generation,
+            idempotency_key: input.idempotency_key.clone(),
+        };
+        wrong_operation.operation_digest.push_str("-changed");
+        assert!(matches!(
+            ensure_fence(&request, &wrong_operation),
+            Err(AppError::Conflict(message)) if message == "exact_service_redemption_conflict"
+        ));
+
+        let mut wrong_idempotency = ExactServiceApprovalFence {
+            catalog_digest: input.catalog_digest,
+            exact_view_digest: input.exact_view_digest,
+            operation_digest: input.operation_digest,
+            operation_id: input.operation_id,
+            operation_generation: input.operation_generation,
+            idempotency_key: input.idempotency_key,
+        };
+        wrong_idempotency.idempotency_key.push_str("-changed");
+        assert!(matches!(
+            ensure_fence(&request, &wrong_idempotency),
+            Err(AppError::Conflict(message)) if message == "exact_service_redemption_conflict"
+        ));
+
+        // A provider rebinding changes the live exact view (because the
+        // producer-owned catalog_service_id is inside that view), while a
+        // contract mutation changes only the endpoint contract fence.
+        let binding = binding();
+        assert!(exact_authority_has_drift(
+            &binding,
+            &binding.user_service_id,
+            &binding.endpoint_id,
+            &binding.catalog_digest,
+            "sha256:provider-rebound-exact-view",
+            &binding.endpoint_contract_digest,
+            &binding.operation_digest,
+        ));
+        assert!(exact_authority_has_drift(
+            &binding,
+            &binding.user_service_id,
+            &binding.endpoint_id,
+            &binding.catalog_digest,
+            binding.exact_view_digest.as_deref().unwrap(),
+            "sha256:contract-mutated",
+            &binding.operation_digest,
+        ));
+        assert_eq!(
+            catalog_resolution_terminal_state(&AppError::NotFound(
+                "deactivated_user_service".to_string()
+            )),
+            Some(ExactServiceApprovalState::Revoked)
+        );
+        assert_eq!(
+            safe_execution_failure_code(&AppError::NodeOffline("unbound".to_string())),
+            "provider_unavailable"
+        );
+    }
+
+    #[test]
+    fn create_rejects_empty_or_whitespace_digest_fields() {
+        let fields: [(&str, fn(&mut ExactServiceApprovalCreate)); 3] = [
+            (
+                "catalog_digest",
+                |input: &mut ExactServiceApprovalCreate| {
+                    input.catalog_digest = "  ".to_string();
+                },
+            ),
+            (
+                "endpoint_contract_digest",
+                |input: &mut ExactServiceApprovalCreate| {
+                    input.endpoint_contract_digest = String::new();
+                },
+            ),
+            (
+                "operation_digest",
+                |input: &mut ExactServiceApprovalCreate| {
+                    input.operation_digest = "\t".to_string();
+                },
+            ),
+        ];
+        for (field, mutate) in fields {
+            let mut input = create();
+            mutate(&mut input);
+            assert!(
+                matches!(validate_create(&input), Err(AppError::BadRequest(message)) if message == format!("{field} is required")),
+                "{field} must reject empty input"
+            );
+        }
+
+        let mut input = create();
+        input.exact_view_digest = Some(" \n ".to_string());
+        assert!(matches!(
+            validate_create(&input),
+            Err(AppError::BadRequest(message))
+                if message == "exact_view_digest must not be empty when provided"
+        ));
+    }
+
+    #[test]
+    fn digest_mismatch_is_rejected_without_recomputing_a_fixture_value() {
+        let err = ensure_digest("catalog_digest", "sha256:caller", "sha256:server")
+            .expect_err("caller and server fences must agree");
+        assert!(matches!(
+            err,
+            AppError::Conflict(message) if message == "exact_service_catalog_digest_drift"
+        ));
+    }
+
+    #[test]
+    fn omitted_exact_view_digest_is_accepted_at_validation_but_never_at_persistence_boundary() {
+        let mut input = create();
+        input.exact_view_digest = None;
+        validate_create(&input).expect("legacy callers may omit the additive fence");
+
+        let mut binding = binding();
+        binding.exact_view_digest = Some("sha256:server-persisted".to_string());
+        assert_eq!(
+            result_for(
+                &approval_request(
+                    "request-server-fence",
+                    "pending",
+                    Utc::now() + Duration::minutes(5),
+                    Some(binding),
+                ),
+                ExactServiceApprovalState::Pending,
+            )
+            .expect("serialize persisted result")
+            .exact_view_digest
+            .as_deref(),
+            Some("sha256:server-persisted")
+        );
+    }
+
     #[tokio::test]
     async fn exact_create_replays_same_authority_and_rejects_changed_selector() {
         let Some(db) =
@@ -1250,6 +1406,12 @@ mod tests {
             Utc::now() - Duration::seconds(1),
             Some(binding()),
         );
+        let expired_approved = approval_request(
+            "request-expired-approved",
+            "approved",
+            Utc::now() - Duration::seconds(1),
+            Some(binding()),
+        );
         let mut drifted_binding = binding();
         drifted_binding.redemption = Some(ExactServiceApprovalRedemption {
             status: ExactServiceRedemptionStatus::Drifted,
@@ -1279,13 +1441,17 @@ mod tests {
             Some(revoked_binding),
         );
         db.collection::<ApprovalRequest>(REQUESTS)
-            .insert_many([denied, expired, drifted, revoked])
+            .insert_many([denied, expired, expired_approved, drifted, revoked])
             .await
             .expect("insert terminal fixtures");
 
         for (request_id, expected) in [
             ("request-denied", ExactServiceApprovalState::Denied),
             ("request-expired", ExactServiceApprovalState::Expired),
+            (
+                "request-expired-approved",
+                ExactServiceApprovalState::Expired,
+            ),
             ("request-drifted", ExactServiceApprovalState::Drifted),
             ("request-revoked", ExactServiceApprovalState::Revoked),
         ] {

--- a/backend/src/services/exact_service_approval_service.rs
+++ b/backend/src/services/exact_service_approval_service.rs
@@ -16,6 +16,7 @@ use crate::services::billing::route_inventory::BillingEgressPermit;
 use crate::services::{approval_service, mcp_service, notification_service, proxy_service};
 
 const MAX_RECEIPT_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+pub const DELEGATED_REQUESTER_TYPE: &str = "delegated";
 
 #[derive(Clone, Debug)]
 pub struct ExactServiceApprovalCaller {
@@ -99,6 +100,7 @@ struct ExactCatalogResolution<'a> {
     endpoint_index: usize,
     catalog_digest: String,
     exact_view_digest: String,
+    in_exact_view: bool,
     endpoint_contract_digest: String,
     operation_digest: String,
     marker: std::marker::PhantomData<&'a ()>,
@@ -133,12 +135,18 @@ pub async fn create_request(
         &input.catalog_digest,
         &resolution.catalog_digest,
     )?;
-    if let Some(exact_view_digest) = input.exact_view_digest.as_deref() {
-        ensure_digest(
-            "exact_view_digest",
-            exact_view_digest,
-            &resolution.exact_view_digest,
-        )?;
+    if resolution.in_exact_view {
+        if let Some(exact_view_digest) = input.exact_view_digest.as_deref() {
+            ensure_digest(
+                "exact_view_digest",
+                exact_view_digest,
+                &resolution.exact_view_digest,
+            )?;
+        }
+    } else if input.exact_view_digest.is_some() {
+        return Err(AppError::BadRequest(
+            "exact_view_digest_not_applicable".to_string(),
+        ));
     }
     ensure_digest(
         "endpoint_contract_digest",
@@ -207,7 +215,9 @@ pub async fn create_request(
         user_service_id: input.user_service_id,
         endpoint_id: input.endpoint_id,
         catalog_digest: resolution.catalog_digest,
-        exact_view_digest: Some(resolution.exact_view_digest),
+        exact_view_digest: resolution
+            .in_exact_view
+            .then(|| resolution.exact_view_digest.clone()),
         endpoint_contract_digest: resolution.endpoint_contract_digest,
         operation_digest: resolution.operation_digest,
         operation_id: input.operation_id,
@@ -272,7 +282,17 @@ pub async fn redeem_request(
         | ExactServiceApprovalState::Redeeming
         | ExactServiceApprovalState::Failed => return result_for(&request, state_value),
         ExactServiceApprovalState::Approved => {}
-        other => return result_for(&request, other),
+        other => {
+            let mut result = result_for(&request, other)?;
+            if result.failure_code.is_none() {
+                result.failure_code = match other {
+                    ExactServiceApprovalState::Revoked => Some("selector_revoked".to_string()),
+                    ExactServiceApprovalState::Drifted => Some("catalog_drift".to_string()),
+                    _ => None,
+                };
+            }
+            return Ok(result);
+        }
     }
 
     let now = Utc::now();
@@ -554,22 +574,19 @@ async fn resolve_exact_catalog(
                 )
         })
         .ok_or_else(|| AppError::NotFound("exact_user_service_not_found".to_string()))?;
-    // Eligibility is deliberately NOT narrowed to the exact-visible view.
-    // Generic-proxy operations are an approvable, shipped capability -- see
-    // billing_integration_tests::billing_route_coverage_smoke, which approves
-    // and redeems `nyx_generic_proxy_v1`. Hiding generic operations from
-    // delegated discovery is about not advertising untyped operations, not an
-    // authorization boundary: a caller already scoped to the service can reach
-    // it through the generic proxy regardless.
+    // The M42 contract makes exact-view membership an authorization boundary
+    // for delegated callers. Non-delegated callers retain generic-proxy
+    // approvability; billing_integration_tests::billing_route_coverage_smoke
+    // is the regression walker for that shipped capability.
+    let in_exact_view = exact_view_membership(caller, &catalog.services[service_index])?;
     let endpoint_index = catalog.services[service_index]
         .endpoints
         .iter()
         .position(|endpoint| endpoint.endpoint_id == endpoint_id)
         .ok_or_else(|| AppError::NotFound("exact_endpoint_not_found".to_string()))?;
-    // Keep eligibility on the unprojected catalog, but compute both approval
-    // fences from their canonical owners. The exact-view projection is shared
-    // with delegated discovery; the broad catalog fence stays byte-compatible
-    // with `/api/v1/mcp/config`.
+    // Compute both approval fences from their canonical owners. The exact-view
+    // projection is shared with delegated discovery; the broad catalog fence
+    // stays byte-compatible with `/api/v1/mcp/config`.
     let catalog_digest = mcp_service::operation_catalog_digest(&catalog.services);
     let exact_view_digest = mcp_service::exact_operation_view_digest(
         &mcp_service::exact_operation_view(&catalog.services),
@@ -584,10 +601,25 @@ async fn resolve_exact_catalog(
         endpoint_index,
         catalog_digest,
         exact_view_digest,
+        in_exact_view,
         endpoint_contract_digest,
         operation_digest,
         marker: std::marker::PhantomData,
     })
+}
+
+fn exact_view_membership(
+    caller: &ExactServiceApprovalCaller,
+    service: &mcp_service::McpToolService,
+) -> AppResult<bool> {
+    let in_exact_view = mcp_service::is_exact_visible(service);
+    if caller.requester_type == DELEGATED_REQUESTER_TYPE && !in_exact_view {
+        Err(AppError::NotFound(
+            "exact_operation_not_in_exact_view".to_string(),
+        ))
+    } else {
+        Ok(in_exact_view)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -661,8 +693,7 @@ async fn expire_if_needed(
     request: ApprovalRequest,
 ) -> AppResult<ApprovalRequest> {
     let exact_unredeemed = request.exact_service.as_ref().is_some_and(|binding| {
-        binding.redemption.is_none()
-            && matches!(request.status.as_str(), "pending" | "approved")
+        binding.redemption.is_none() && matches!(request.status.as_str(), "pending" | "approved")
     });
     if !exact_unredeemed || request.expires_at > Utc::now() {
         return Ok(request);
@@ -935,6 +966,13 @@ fn safe_execution_failure_code(error: &AppError) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use axum::{Router, routing::any};
     use chrono::Duration;
 
     use super::*;
@@ -1240,6 +1278,45 @@ mod tests {
     }
 
     #[test]
+    fn exact_view_membership_rejects_only_delegated_generic_targets() {
+        let generic_service = mcp_service::McpToolService {
+            service_id: "generic-service".to_string(),
+            service_name: "Generic Service".to_string(),
+            service_slug: "generic-service".to_string(),
+            description: None,
+            service_category: "connection".to_string(),
+            endpoints: Vec::new(),
+            durable_endpoint_metadata: HashMap::new(),
+            source: mcp_service::McpToolSource::UserManaged {
+                user_service_id: "generic-service".to_string(),
+                catalog_service_id: None,
+                effective_owner_id: "user-alpha".to_string(),
+                node_id: None,
+                has_server_credential: true,
+            },
+            executable: true,
+            is_generic_proxy: true,
+            invalid_openapi_contract: false,
+            recommended_skills: Vec::new(),
+            proxy_operation_policy: None,
+        };
+
+        let delegated_error = exact_view_membership(&caller(), &generic_service)
+            .expect_err("delegated callers are confined to exact-view membership");
+        assert!(matches!(
+            delegated_error,
+            AppError::NotFound(message) if message == "exact_operation_not_in_exact_view"
+        ));
+
+        let mut access_token_caller = caller();
+        access_token_caller.requester_type = "access_token".to_string();
+        assert!(
+            !exact_view_membership(&access_token_caller, &generic_service)
+                .expect("non-delegated callers retain generic-target eligibility")
+        );
+    }
+
+    #[test]
     fn create_rejects_empty_or_whitespace_digest_fields() {
         let fields: [(&str, fn(&mut ExactServiceApprovalCreate)); 3] = [
             (
@@ -1312,6 +1389,142 @@ mod tests {
             .as_deref(),
             Some("sha256:server-persisted")
         );
+    }
+
+    #[tokio::test]
+    async fn legacy_delegated_generic_redeem_is_revoked_before_provider_effect() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("exact_approval_legacy_delegated_generic")
+                .await
+        else {
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db.clone());
+        let provider_calls = Arc::new(AtomicUsize::new(0));
+        let handler_calls = provider_calls.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind provider effect spy");
+        let provider_addr = listener.local_addr().expect("provider spy address");
+        let provider = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().fallback(any(move || {
+                    let handler_calls = handler_calls.clone();
+                    async move {
+                        handler_calls.fetch_add(1, Ordering::SeqCst);
+                        "unexpected provider effect"
+                    }
+                })),
+            )
+            .await
+            .expect("serve provider effect spy");
+        });
+
+        let user_service_id = "00000000-0000-4000-8000-000000000611";
+        let user_endpoint_id = "00000000-0000-4000-8000-000000000612";
+        db.collection::<crate::models::user_endpoint::UserEndpoint>(
+            crate::models::user_endpoint::COLLECTION_NAME,
+        )
+        .insert_one(crate::test_utils::test_user_endpoint(
+            user_endpoint_id,
+            "user-alpha",
+            "Legacy Generic",
+            &format!("http://{provider_addr}"),
+            None,
+            None,
+        ))
+        .await
+        .expect("insert legacy generic endpoint");
+        db.collection::<crate::models::user_service::UserService>(
+            crate::models::user_service::COLLECTION_NAME,
+        )
+        .insert_one(crate::test_utils::test_user_service(
+            user_service_id,
+            "user-alpha",
+            "legacy-generic",
+            user_endpoint_id,
+            None,
+            None,
+        ))
+        .await
+        .expect("insert legacy generic service");
+
+        let catalog = mcp_service::load_operation_catalog(
+            &db,
+            state.node_ws_manager.as_ref(),
+            "user-alpha",
+            mcp_service::NodeScope::Unrestricted,
+            mcp_service::ServiceScope::Unrestricted,
+        )
+        .await
+        .expect("load legacy generic catalog");
+        let generic_service = catalog
+            .services
+            .iter()
+            .find(|service| service.service_id == user_service_id)
+            .expect("legacy generic service is in the unprojected catalog");
+        let generic_endpoint = generic_service
+            .endpoints
+            .iter()
+            .find(|endpoint| endpoint.endpoint_id == mcp_service::GENERIC_PROXY_ENDPOINT_ID)
+            .expect("legacy generic selector exists");
+        let arguments = serde_json::json!({"method": "GET", "path": "/effect"});
+        let mut legacy_binding = binding();
+        legacy_binding.request_key = "legacy-delegated-generic-request-key".to_string();
+        legacy_binding.user_service_id = user_service_id.to_string();
+        legacy_binding.endpoint_id = generic_endpoint.endpoint_id.clone();
+        legacy_binding.catalog_digest = mcp_service::operation_catalog_digest(&catalog.services);
+        legacy_binding.exact_view_digest = Some(mcp_service::exact_operation_view_digest(
+            &mcp_service::exact_operation_view(&catalog.services),
+        ));
+        legacy_binding.endpoint_contract_digest =
+            mcp_service::endpoint_contract_digest(generic_endpoint);
+        legacy_binding.operation_digest =
+            mcp_service::exact_operation_digest(user_service_id, generic_endpoint, &arguments);
+        legacy_binding.operation_id = "legacy-delegated-generic-operation".to_string();
+        legacy_binding.operation_generation = 1;
+        legacy_binding.effect_idempotency_key = "legacy-delegated-generic-idempotency".to_string();
+        legacy_binding.arguments = arguments;
+
+        let request_id = "00000000-0000-4000-8000-000000000613";
+        db.collection::<ApprovalRequest>(REQUESTS)
+            .insert_one(approval_request(
+                request_id,
+                "approved",
+                Utc::now() + Duration::minutes(5),
+                Some(legacy_binding.clone()),
+            ))
+            .await
+            .expect("insert approved legacy delegated generic request");
+        let result = redeem_request(
+            &state,
+            &caller(),
+            request_id,
+            ExactServiceApprovalFence {
+                catalog_digest: legacy_binding.catalog_digest,
+                exact_view_digest: legacy_binding.exact_view_digest,
+                operation_digest: legacy_binding.operation_digest,
+                operation_id: legacy_binding.operation_id,
+                operation_generation: legacy_binding.operation_generation,
+                idempotency_key: legacy_binding.effect_idempotency_key,
+            },
+            crate::services::billing::route_inventory::enforce_billing_egress_classification(
+                Some(
+                    crate::services::billing::route_inventory::BillingRoutePolicy::Metered(
+                        crate::services::billing::route_inventory::BillingIngress::Mcp,
+                    ),
+                ),
+                crate::services::billing::route_inventory::BillingIngress::Mcp,
+            )
+            .expect("construct metered MCP permit"),
+        )
+        .await
+        .expect("legacy delegated generic redeem returns a typed terminal result");
+        assert_eq!(result.state, ExactServiceApprovalState::Revoked);
+        assert_eq!(result.failure_code.as_deref(), Some("selector_revoked"));
+        assert_eq!(provider_calls.load(Ordering::SeqCst), 0);
+        provider.abort();
     }
 
     #[tokio::test]

--- a/backend/src/services/exact_service_approval_service.rs
+++ b/backend/src/services/exact_service_approval_service.rs
@@ -1316,9 +1316,13 @@ mod tests {
         );
     }
 
+    /// Named so the blank-digest table below stays readable; the tuple shape
+    /// otherwise trips clippy's `type_complexity` under CI's `-D warnings`.
+    type BlankDigestMutator = fn(&mut ExactServiceApprovalCreate);
+
     #[test]
     fn create_rejects_empty_or_whitespace_digest_fields() {
-        let fields: [(&str, fn(&mut ExactServiceApprovalCreate)); 3] = [
+        let fields: [(&str, BlankDigestMutator); 3] = [
             (
                 "catalog_digest",
                 |input: &mut ExactServiceApprovalCreate| {

--- a/backend/src/services/mcp_approval.rs
+++ b/backend/src/services/mcp_approval.rs
@@ -82,6 +82,7 @@ mod tests {
             durable_endpoint_metadata: Default::default(),
             source: mcp_service::McpToolSource::UserManaged {
                 user_service_id: id.to_string(),
+                catalog_service_id: None,
                 effective_owner_id: owner_id.to_string(),
                 node_id: None,
                 has_server_credential: true,

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -4386,8 +4386,7 @@ mod tests {
             "us-catalog",
         );
         let McpToolSource::UserManaged {
-            catalog_service_id,
-            ..
+            catalog_service_id, ..
         } = &mut catalog.source
         else {
             unreachable!("test helper always creates a user-managed service")

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -44,6 +44,9 @@ pub enum McpToolSource {
     /// User-managed service (UserService -- personal or org-shared)
     UserManaged {
         user_service_id: String,
+        /// The immutable producer-owned catalog identity, when this
+        /// UserService is catalog-backed. Custom endpoints have none.
+        catalog_service_id: Option<String>,
         /// The user who owns this service (actor for personal, org user_id for org-shared)
         effective_owner_id: String,
         /// Node routing -- when set, requests go through the node agent
@@ -318,6 +321,9 @@ pub struct ExactOperationViewOperation {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ExactOperationViewService {
     pub user_service_id: String,
+    /// Canonical catalog provider identity. Custom endpoints have no catalog
+    /// provider and therefore serialize this as null.
+    pub catalog_service_id: Option<String>,
     pub service_slug: String,
     pub service_name: String,
     pub description: Option<String>,
@@ -342,6 +348,7 @@ pub fn exact_operation_view(services: &[McpToolService]) -> ExactOperationView {
         .filter_map(|service| {
             let McpToolSource::UserManaged {
                 user_service_id,
+                catalog_service_id,
                 node_id,
                 ..
             } = &service.source
@@ -367,6 +374,7 @@ pub fn exact_operation_view(services: &[McpToolService]) -> ExactOperationView {
             operations.sort_by(|left, right| left.endpoint_id.cmp(&right.endpoint_id));
             Some(ExactOperationViewService {
                 user_service_id: user_service_id.clone(),
+                catalog_service_id: catalog_service_id.clone(),
                 service_slug: service.service_slug.clone(),
                 service_name: service.service_name.clone(),
                 description: service.description.clone(),
@@ -386,7 +394,7 @@ pub fn exact_operation_view(services: &[McpToolService]) -> ExactOperationView {
 /// `catalog_digest` are intentionally outside this representation validator.
 pub fn exact_operation_view_digest(view: &ExactOperationView) -> String {
     canonical_sha256(serde_json::json!({
-        "contract_version": "nyxid-delegated-operation-catalog.v1",
+        "contract_version": "nyxid-delegated-operation-catalog.v2",
         "services": &view.services,
     }))
 }
@@ -1188,6 +1196,7 @@ async fn load_user_tools_inner(
             recommended_skills,
             source: McpToolSource::UserManaged {
                 user_service_id: us.id.clone(),
+                catalog_service_id: us.catalog_service_id.clone(),
                 effective_owner_id: r.effective_owner_id.clone(),
                 node_id: us.node_id.clone(),
                 has_server_credential: r.has_server_credential,
@@ -4197,6 +4206,7 @@ mod tests {
     fn user_managed(mut service: McpToolService, user_service_id: &str) -> McpToolService {
         service.source = McpToolSource::UserManaged {
             user_service_id: user_service_id.to_string(),
+            catalog_service_id: None,
             effective_owner_id: "owner-1".to_string(),
             node_id: None,
             has_server_credential: true,
@@ -4352,6 +4362,61 @@ mod tests {
             exact_operation_view_digest(&exact_operation_view(&original)),
             exact_operation_view_digest(&exact_operation_view(&changed)),
             "caller-visible service and operation changes must move the digest"
+        );
+    }
+
+    #[test]
+    fn exact_view_projects_catalog_provider_identity_and_custom_none() {
+        let custom = user_managed(
+            make_service(
+                "custom-service",
+                "Custom",
+                "custom",
+                vec![make_endpoint("custom_read", "read")],
+            ),
+            "us-custom",
+        );
+        let mut catalog = user_managed(
+            make_service(
+                "catalog-service",
+                "Catalog",
+                "catalog",
+                vec![make_endpoint("catalog_read", "read")],
+            ),
+            "us-catalog",
+        );
+        let McpToolSource::UserManaged {
+            catalog_service_id,
+            ..
+        } = &mut catalog.source
+        else {
+            unreachable!("test helper always creates a user-managed service")
+        };
+        *catalog_service_id = Some("producer-owned-catalog-id".to_string());
+
+        let view = exact_operation_view(&[custom, catalog]);
+        let custom = view
+            .services
+            .iter()
+            .find(|service| service.user_service_id == "us-custom")
+            .unwrap();
+        let catalog = view
+            .services
+            .iter()
+            .find(|service| service.user_service_id == "us-catalog")
+            .unwrap();
+        assert_eq!(custom.catalog_service_id, None);
+        assert_eq!(
+            catalog.catalog_service_id.as_deref(),
+            Some("producer-owned-catalog-id")
+        );
+        assert_ne!(
+            exact_operation_view_digest(&ExactOperationView {
+                services: vec![custom.clone()],
+            }),
+            exact_operation_view_digest(&ExactOperationView {
+                services: vec![catalog.clone()],
+            })
         );
     }
 
@@ -4550,6 +4615,7 @@ mod tests {
         let user_service = McpToolService {
             source: McpToolSource::UserManaged {
                 user_service_id: "service-allowed".to_string(),
+                catalog_service_id: None,
                 effective_owner_id: "owner-1".to_string(),
                 node_id: None,
                 has_server_credential: true,
@@ -7412,6 +7478,7 @@ mod tests {
         assert!(!platform.is_user_service());
         let user = McpToolSource::UserManaged {
             user_service_id: "x".into(),
+            catalog_service_id: None,
             effective_owner_id: "u".into(),
             node_id: None,
             has_server_credential: true,

--- a/docs/API.md
+++ b/docs/API.md
@@ -4285,7 +4285,7 @@ other effect authority. The existing approval endpoints intentionally return
 
 ```json
 {
-  "contract_version": "nyxid-delegated-operation-catalog.v1",
+  "contract_version": "nyxid-delegated-operation-catalog.v2",
   "catalog_digest": "sha256:opaque-admission-token",
   "exact_view_digest": "sha256:exact-caller-visible-view",
   "resolved_at": "2026-08-14T00:00:00Z",
@@ -4293,6 +4293,7 @@ other effect authority. The existing approval endpoints intentionally return
   "services": [
     {
       "user_service_id": "user-service-uuid",
+      "catalog_service_id": "catalog-provider-uuid",
       "service_slug": "github",
       "service_name": "GitHub",
       "description": "Connected GitHub service",
@@ -4323,11 +4324,17 @@ other effect authority. The existing approval endpoints intentionally return
 
 `exact_view_digest` is the representation validator for the exact
 caller-visible `services` array. It is SHA-256 over canonical compact JSON
-containing `contract_version: "nyxid-delegated-operation-catalog.v1"` and the
+containing `contract_version: "nyxid-delegated-operation-catalog.v2"` and the
 returned `services`; services are sorted by `user_service_id`, operations by
 `endpoint_id`, and object keys recursively in lexicographic order. The dynamic
 timestamps, totals, and `catalog_digest` are excluded. Delegated discovery and
 exact approval create, observe, and redeem use this same projection.
+
+Each service also carries the producer-owned `catalog_service_id` used to
+resolve its catalog provider. This field is included in `exact_view_digest` and
+is nullable: a custom user service with typed operations has no catalog
+provider, so its value is `null` and `user_service_id` is its canonical
+identity.
 
 `catalog_digest` remains the pre-existing broad approval fence. For wire
 compatibility with #1424 (commit `d1a042c2`), it is exactly
@@ -4335,13 +4342,33 @@ compatibility with #1424 (commit `d1a042c2`), it is exactly
 also includes catalog services that this facade omits (platform and generic
 rows), plus descriptor metadata such as operation descriptions and
 `recommended_skills`. Exact approval callers should send both digest fields at
-create and redeem. Omission of `exact_view_digest` remains accepted for legacy
-clients and stored approvals, while newly created approvals always persist the
-server-resolved exact-view value and revalidate it at use time. Both fences are
-enforced when present, so a hidden-row change can still cause drift through
-`catalog_digest` even though `exact_view_digest` is unchanged. Consumers must
-treat both values as opaque rather than substituting fetch time or a local
-counter.
+create and redeem when the target is in the exact view. Consumers must treat
+both values as opaque rather than substituting fetch time or a local counter.
+
+Exact-service eligibility and digest applicability are:
+
+| Requester | Target in exact view | `exact_view_digest` at create | Result | Persisted fence |
+|---|---:|---|---|---|
+| Delegated | Yes | Omitted or matching | Accepted | Server-resolved digest |
+| Nondelegated | Yes | Omitted or matching | Accepted | Server-resolved digest |
+| Delegated | No | Omitted | `404 exact_operation_not_in_exact_view` | No write |
+| Delegated | No | Supplied | `404 exact_operation_not_in_exact_view` | No write |
+| Nondelegated | No | Omitted | Accepted | `null` / omitted |
+| Nondelegated | No | Supplied | `400 exact_view_digest_not_applicable` | No write |
+
+A mismatched in-view digest returns the existing
+`exact_service_exact_view_digest_drift` conflict, and an empty supplied value is
+rejected as a bad request. At redeem, a supplied empty or mismatched digest
+returns `exact_service_redemption_conflict`; omission remains accepted, but the
+server still re-resolves the catalog and revalidates the digest persisted in
+the approval binding. Existing stored rows with no exact-view digest remain
+compatible and continue to use the other live fences.
+
+Delegated callers may create, observe, or redeem an exact-service approval only
+for a service and operation present in the exact projection returned by
+discovery. Nondelegated callers retain the shipped generic-proxy approval
+capability, but those out-of-view approvals are not bound to the digest of an
+unrelated exact projection.
 
 The response excludes platform fallbacks, generic proxy services, invalid or
 empty contracts, unavailable services, credentials, tokens, headers, hashes,


### PR DESCRIPTION
Addresses #1457, including @eanz17's AC2 correction in [this comment](https://github.com/ChronoAIProject/NyxID/issues/1457#issuecomment-5313071000).

---

## What this does

### 1. Canonical provider identity in the exact view (AC1)

`ExactOperationViewService` carried `user_service_id` + `service_slug` + node info but dropped the catalog provider identity already in hand during `load_operation_catalog`. Added `catalog_service_id: Option<String>`, populated from the producer-owned `DownstreamService` id; `None` for custom endpoints, whose canonical identity is `user_service_id` itself (a producer-generated immutable UUID already in the projection). It lands inside `exact_view_digest` by construction.

**On the issue's premise:** the slug is *not* mutable — `UpdateUserServiceRequest` has no slug field, `update_user_service` never writes one, and it is set once at create. The issue's own fork ("or provide code-verifiable evidence… immutable") resolves in the affirmative. The residual point that does stand is that the slug is caller-*selectable* at create, so it is an immutable but caller-chosen key rather than the canonical catalog id — which is why `catalog_service_id` is added regardless.

### 2. Delegated exact-eligibility narrowing (AC2 — @eanz17's correction)

The correction was right and is reproduced here: delegated discovery filters through `is_exact_visible`, but `resolve_exact_catalog` selected its target from the **unprojected** `catalog.services` and applied `exact_operation_view` only afterward to compute the digest. So an approval could target a generic endpoint **absent from the exact view while carrying a valid digest of that view** — the fence attesting to a projection that does not contain its target.

Fixed in two legs:

- **Delegated callers only:** eligibility requires membership in the exact projection. Out-of-view targets return `NotFound("exact_operation_not_in_exact_view")`. Create, observe and redeem all funnel through `resolve_exact_catalog`, so one check makes all three share the generic-free candidate projection.
- **All callers:** the exact-view fence binds only when the target is in the view. Out-of-view targets persist `exact_view_digest: None` — already the shape the shipped generic capability uses — and a caller supplying one gets `BadRequest("exact_view_digest_not_applicable")`.

After both legs the digest never attests to a view lacking its target.

**Why scoped to delegated rather than narrowed unconditionally:** unconditional narrowing would break a shipped, explicitly-documented capability — `billing_integration_tests::billing_route_coverage_smoke` approves and redeems `nyx_generic_proxy_v1` through the real redeem route. That test uses an `access_token` caller and its binding already stores `None`, so under this design it needs **no change at all** and remains the regression guard for the preserved capability. The issue's own wording ("narrow **delegated** exact-service eligibility") scopes it this way.

### 3. Contract version and docs

`nyxid-delegated-operation-catalog.v1` → `.v2` in both the digest envelope and the discovery response DTO, so a consumer can distinguish "the digest moved because the catalog changed" from "the digest moved because the schema changed". `docs/API.md` still documented `.v1` and would have shipped as drift; it now carries `.v2`, the nullable `catalog_service_id`, the digest truth table, and the eligibility rule.

No `.v3`: the narrowing is a filter, not a representation change, so pinned snapshot digests stay valid.

---

## Verification

**Full backend suite green, against a live MongoDB.**

```
cargo test -p nyxid --bin nyxid-server
test result: ok. 5326 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 268.82s
```

DB-backed tests genuinely executed rather than skipping — `test_utils::tests::transaction_test_database_supports_atomic_writes` passed, and it asserts real replica-set topology, so it cannot pass without a live Mongo. `handlers::mcp_transport::tests::mcp_operation_policy_denial_precedes_approval_persistence` also passed.

All 8 new tests passed:

| Test | Covers |
|---|---|
| `exact_view_membership_rejects_only_delegated_generic_targets` | the delegated gate — proves non-delegated callers keep generic eligibility |
| `legacy_delegated_generic_redeem_is_revoked_before_provider_effect` | legacy delegated generic rows fail closed before any provider effect |
| `delegated_discovery_create_redeem_uses_live_catalog_evidence` | AC4 — real discovery → create → redeem, token-exchange-minted delegated token |
| `fail_closed_matrix_keeps_each_fence_and_live_selector_mutation_distinct` | AC5 — drift and live-grant matrix |
| `exact_view_projects_catalog_provider_identity_and_custom_none` | AC1 — provider identity present, `None` for custom |
| `omitted_exact_view_digest_is_accepted_at_validation_but_never_at_persistence_boundary` | AC6 — omission is server-bound, not a bypass |
| `create_rejects_empty_or_whitespace_digest_fields` | AC6 — empty rejected |
| `digest_mismatch_is_rejected_without_recomputing_a_fixture_value` | AC6 — mismatch rejected, no fixture recomputation |

`cargo fmt --check` clean.

**One gate could not run locally:** `cargo clippy` fails in this environment because the `utoipa-swagger-ui` build script downloads Swagger UI at compile time and that download is network-blocked here (`InvalidArchive("Could not find EOCD")`). The cached artifact serves `cargo test` but not clippy's build fingerprint. **Clippy therefore needs to pass in CI before merge.**

---

## AC disposition

| # | Criterion | Status |
|---|---|---|
| 1 | Projection carries canonical provider identity; digest binds it | Closed |
| 2 | Discovery/create/redeem share one canonical resolver **including eligibility** | Closed by the narrowing above |
| 3 | Deterministic handler snapshot | Closed |
| 4 | Real discovery → create → redeem succeeds | Closed |
| 5 | Drift + live-grant absent/revoked/expired fail closed | Closed **with a stated carve-out** — below |
| 6 | Digest omission / empty / mismatch explicit | Closed |
| 7 | Mutation spy proves no writes | Closed, with qualifications documented |
| 8 | Evidence manifest / probe green | Open — post-merge devloop fields |
| 9 | Released, deployed, prod `/health` | Out of repo scope — downstream human gate |

**AC5 carve-out, stated rather than papered over:** `operation_id` and `operation_generation` have no server-side referent. They appear in neither `ExactOperationViewOperation` nor `/mcp/config`'s DTO, are caller-supplied, validated only as non-empty / `>= 1`, and at redeem compared only against the caller's own earlier assertion. A test asserting "generation drift fails closed" would be testing the caller's echo, not server freshness. The self-consistency behaviour is covered and labelled as exactly that. Giving them a real referent is a **breaking contract change** and is left as a decision for @eanz17 rather than made silently.

---

## Blast radius

1. **`.v2` digest change** — any exact approval pending across the deploy fails redeem with the existing fail-closed drift conflict. No first-party client sends `exact_view_digest` today, so practical impact is zero. The fence working as designed; noted, not mitigated.
2. **Delegated generic-target approvals** — previously creatable, now `404` at create and typed fail-closed at observe/redeem. The only walker of generic exact approvals is the first-party billing smoke, which is non-delegated.
3. **Non-delegated generic-target creates** — now persist `exact_view_digest: None` instead of a misleading `Some`, and reject a supplied view digest. No data migration.
4. **`expire_if_needed` widening** — approved-but-unredeemed *exact* rows now expire at `expires_at` rather than remaining redeemable indefinitely. Scoped by the Mongo filter to exact rows; tightening, fail-closed.

## Not touched

`operation_catalog_digest` computation or wire value (shared fence with `/api/v1/mcp/config`, wire-compat per #1424); `is_exact_visible` itself; discovery filtering; `handlers/assistant.rs`; `mw/auth.rs`; approval defaults and provisioning.

## Related

#1458 (merged) fixed a separate, more severe delegated-token → MCP session downgrade found while investigating this issue. It closed none of these ACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Addendum — CI lint gates (commit `3347b53a`)

CI compiles with `-D warnings`, which turned two lints into hard errors that a plain local `cargo test` only warned about:

- an orphaned `create_and_approve_exact` test helper (dead code) — removed rather than wired up, because the coverage it was written for already exists via direct `create_request` calls in the matrix;
- clippy `type_complexity` on the blank-digest mutator table — resolved with a named type alias.

No behaviour change and no change to test coverage. Verified locally: clean build, zero warnings, zero `never used`.

**Note on the green suite run above:** MongoDB was reachable for that 268s run and all 8 new tests executed and passed. It has since become unreachable in this environment, so a re-run now yields the known ~125 DB-connection failures in ~11s — including `test_utils::tests::transaction_test_database_supports_atomic_writes`, the connectivity smoke. Those are environmental, not regressions; none of the new tests appear among them.
