### PR TITLE
feat(assistant): execute service reauthorization actions

### DIFF
--- a/backend/src/handlers/assistant_actions.rs
+++ b/backend/src/handlers/assistant_actions.rs
@@ -6,9 +6,10 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 pub const ASSISTANT_ACTIONS_SCHEMA_VERSION: u32 = 4;
-pub const ASSISTANT_ACTIONS_REVISION: &str = "nyxid-assistant-actions.v7";
+pub const ASSISTANT_ACTIONS_REVISION: &str = "nyxid-assistant-actions.v8";
 
 const SERVICE_CONNECT_DESCRIPTION: &str = "Ask the user's browser to connect a service through NyxID. Use when a task needs a catalog service (by slug) or a custom HTTPS endpoint that the user has not connected yet. NyxID owns the entire journey - auth modality, consent copy, and credential storage - and reports back only completion or decline with a safe resource reference. Never ask the user for keys, tokens, or passwords in chat.";
+const SERVICE_REAUTHORIZE_DESCRIPTION: &str = "Ask the user's browser to re-authorize an existing connected service and review its requested scopes. Use when a task needs permissions that the referenced user service does not currently grant. NyxID owns the authorization journey and credential storage, and reports only a safe user-service reference. Never ask the user for keys, tokens, passwords, or authorization codes in chat.";
 const KEY_CREATE_DESCRIPTION: &str = "Ask the user's browser to create a scoped NyxID API key for the named platform and allowed services. Use when the user wants a new agent identity bounded to specific user-service IDs. NyxID owns key creation and one-time key display, and reports only a safe key reference. Never request, expose, or repeat key material in chat.";
 const KEY_ROTATE_DESCRIPTION: &str = "Ask the user's browser to rotate one exact NyxID API key. Use when the user needs a replacement credential for the identified key. NyxID commits an authoritative predecessor-successor relation, displays replacement key material once in the browser, and reports only the replacement key reference. Never request, expose, or repeat key material in chat.";
 
@@ -86,6 +87,25 @@ static MANIFEST_BODY: LazyLock<String> = LazyLock::new(|| {
                 risk: "grant",
                 tier: "v1",
                 remember_eligible: true,
+            },
+            AssistantActionDescriptor {
+                action: "service.reauthorize",
+                description: SERVICE_REAUTHORIZE_DESCRIPTION,
+                params_schema: json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["userServiceId", "requestedScopes"],
+                    "properties": {
+                        "userServiceId": { "type": "string" },
+                        "requestedScopes": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        }
+                    }
+                }),
+                risk: "grant",
+                tier: "v1",
+                remember_eligible: false,
             },
             AssistantActionDescriptor {
                 action: "key.create",
@@ -262,6 +282,21 @@ mod tests {
         })
     }
 
+    fn service_reauthorize_params_schema() -> Value {
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["userServiceId", "requestedScopes"],
+            "properties": {
+                "userServiceId": { "type": "string" },
+                "requestedScopes": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            }
+        })
+    }
+
     fn key_rotate_params_schema() -> Value {
         json!({
             "type": "object",
@@ -276,7 +311,7 @@ mod tests {
     fn golden_manifest() -> Value {
         json!({
             "schema_version": 4,
-            "revision": "nyxid-assistant-actions.v7",
+            "revision": "nyxid-assistant-actions.v8",
             "actions": [
                 {
                     "action": "service.connect",
@@ -285,6 +320,14 @@ mod tests {
                     "risk": "grant",
                     "tier": "v1",
                     "remember_eligible": true
+                },
+                {
+                    "action": "service.reauthorize",
+                    "description": super::SERVICE_REAUTHORIZE_DESCRIPTION,
+                    "params_schema": service_reauthorize_params_schema(),
+                    "risk": "grant",
+                    "tier": "v1",
+                    "remember_eligible": false
                 },
                 {
                     "action": "key.create",
@@ -452,6 +495,7 @@ mod tests {
         }
 
         assert!(seen_actions.contains("service.connect"));
+        assert!(seen_actions.contains("service.reauthorize"));
         assert!(seen_actions.contains("key.create"));
         assert!(seen_actions.contains("key.rotate"));
     }
@@ -462,31 +506,39 @@ mod tests {
         let actions = manifest["actions"].as_array().unwrap();
 
         assert_eq!(manifest["schema_version"], 4);
-        assert_eq!(manifest["revision"], "nyxid-assistant-actions.v7");
-        assert_eq!(actions.len(), 3);
+        assert_eq!(manifest["revision"], "nyxid-assistant-actions.v8");
+        assert_eq!(actions.len(), 4);
         assert_eq!(actions[0]["action"], "service.connect");
         assert_eq!(actions[0]["risk"], "grant");
         assert_eq!(actions[0]["tier"], "v1");
         assert_eq!(actions[0]["remember_eligible"], true);
         assert_eq!(actions[0]["params_schema"], service_connect_params_schema());
-        assert_eq!(actions[1]["action"], "key.create");
+        assert_eq!(actions[1]["action"], "service.reauthorize");
         assert_eq!(actions[1]["risk"], "grant");
         assert_eq!(actions[1]["tier"], "v1");
         assert_eq!(actions[1]["remember_eligible"], false);
-        assert_eq!(actions[1]["params_schema"], key_create_params_schema());
         assert_eq!(
-            actions[1]["params_schema"]["properties"]["allowedServiceIds"]["minItems"],
-            1
+            actions[1]["params_schema"],
+            service_reauthorize_params_schema()
         );
-        assert_eq!(
-            actions[1]["params_schema"]["properties"]["allowedServiceIds"]["uniqueItems"],
-            true
-        );
-        assert_eq!(actions[2]["action"], "key.rotate");
+        assert_eq!(actions[2]["action"], "key.create");
         assert_eq!(actions[2]["risk"], "grant");
         assert_eq!(actions[2]["tier"], "v1");
         assert_eq!(actions[2]["remember_eligible"], false);
-        assert_eq!(actions[2]["params_schema"], key_rotate_params_schema());
+        assert_eq!(actions[2]["params_schema"], key_create_params_schema());
+        assert_eq!(
+            actions[2]["params_schema"]["properties"]["allowedServiceIds"]["minItems"],
+            1
+        );
+        assert_eq!(
+            actions[2]["params_schema"]["properties"]["allowedServiceIds"]["uniqueItems"],
+            true
+        );
+        assert_eq!(actions[3]["action"], "key.rotate");
+        assert_eq!(actions[3]["risk"], "grant");
+        assert_eq!(actions[3]["tier"], "v1");
+        assert_eq!(actions[3]["remember_eligible"], false);
+        assert_eq!(actions[3]["params_schema"], key_rotate_params_schema());
         assert_eq!(manifest, golden_manifest());
     }
 

--- a/backend/src/handlers/keys.rs
+++ b/backend/src/handlers/keys.rs
@@ -433,7 +433,6 @@ pub struct KeyResponse {
     pub auth_method: String,
     pub auth_key_name: String,
     pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub catalog_service_id: Option<String>,
@@ -496,12 +495,12 @@ pub struct KeyResponse {
     /// parsed from the backing `UserApiKey.token_scopes`. The connect UIs
     /// pre-select and lock these when adding scopes to an existing connection
     /// (append-only edit). Omitted for non-OAuth keys / never-authorized
-    /// connections.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// connections. Always serialized because authorization evidence readers
+    /// distinguish an explicit null from a missing property.
     pub granted_scopes: Option<Vec<String>>,
     /// RFC3339 timestamp of the last fresh OAuth authorization (NyxID#917).
-    /// Completion signal for the manage-scopes re-auth flow.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Completion signal for the manage-scopes re-auth flow. Always serialized
+    /// because authorization evidence readers require a stable property shape.
     pub last_authorized_at: Option<String>,
     /// Per-user default HTTP headers (NyxID#356). Only user-owned entries
     /// are surfaced here; catalog-level admin defaults are described on
@@ -2660,6 +2659,92 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    #[test]
+    fn key_response_always_serializes_authorization_evidence_properties() {
+        let result = crate::services::unified_key_service::CreateKeyResult {
+            endpoint: test_user_endpoint(
+                "endpoint-1",
+                "user-1",
+                "Example",
+                "https://api.example.com",
+                None,
+                None,
+            ),
+            api_key: None,
+            service: test_user_service("service-1", "user-1", "example", "endpoint-1", None, None),
+            ssh_host: None,
+            ssh_port: None,
+            ssh_ca_public_key: None,
+            ssh_allowed_principals: None,
+            ssh_certificate_ttl_minutes: None,
+        };
+        let response = serde_json::to_value(super::key_response_from_result(&result)).unwrap();
+
+        for property in ["connection_status", "granted_scopes", "last_authorized_at"] {
+            assert_eq!(response.get(property), Some(&serde_json::Value::Null));
+        }
+
+        assert_aevatar_secret_free(&response);
+    }
+
+    fn assert_aevatar_secret_free(value: &serde_json::Value) {
+        const FORBIDDEN_NAMES: &[&str] = &[
+            "apikey",
+            "fullkey",
+            "keyhash",
+            "credential",
+            "credentials",
+            "accesstoken",
+            "refreshtoken",
+            "authorization",
+            "cookie",
+            "cookies",
+            "secret",
+            "secrets",
+            "clientsecret",
+            "password",
+            "token",
+            "passphrase",
+            "usercode",
+            "devicecode",
+            "rawbody",
+            "rawupstreambody",
+        ];
+        let secret_value =
+            regex::Regex::new(r"(?i)(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})").unwrap();
+
+        fn visit(value: &serde_json::Value, secret_value: &regex::Regex) {
+            match value {
+                serde_json::Value::Object(properties) => {
+                    for (name, nested) in properties {
+                        let normalized: String = name
+                            .chars()
+                            .filter(char::is_ascii_alphanumeric)
+                            .map(|character| character.to_ascii_lowercase())
+                            .collect();
+                        assert!(
+                            !FORBIDDEN_NAMES.contains(&normalized.as_str()),
+                            "secret-bearing response property: {name}"
+                        );
+                        visit(nested, secret_value);
+                    }
+                }
+                serde_json::Value::Array(items) => {
+                    for item in items {
+                        visit(item, secret_value);
+                    }
+                }
+                serde_json::Value::String(text) => assert!(
+                    !secret_value.is_match(text),
+                    "secret-shaped response value at serialization boundary"
+                ),
+                _ => {}
+            }
+        }
+
+        visit(value, &secret_value);
     }
 
     async fn insert_user(db: &mongodb::Database, user_id: &str, user_type: UserType) {

--- a/backend/src/services/unified_key_service.rs
+++ b/backend/src/services/unified_key_service.rs
@@ -3822,7 +3822,8 @@ fn parse_granted_scopes(raw: &str) -> Option<Vec<String>> {
     let scopes: Vec<String> = raw
         .split(|character: char| character == ',' || character.is_whitespace())
         .filter(|scope| !scope.is_empty())
-        .filter_map(|scope| seen.insert(scope).then(|| scope.to_string()))
+        .filter(|scope| seen.insert(*scope))
+        .map(str::to_string)
         .collect();
     (!scopes.is_empty()).then_some(scopes)
 }

--- a/backend/src/services/unified_key_service.rs
+++ b/backend/src/services/unified_key_service.rs
@@ -3770,20 +3770,10 @@ fn build_key_view(
         // `EncryptionKeys` operations are async and `build_key_view`
         // is intentionally sync.
         oauth_client_id: None,
-        // Granted scopes for append-only scope editing (NyxID#917 follow-up).
-        // `token_scopes` is stored space-joined; split into a list. Empty /
-        // whitespace-only yields None so the UI treats it as "no recorded
-        // grant" and falls back to provider defaults.
-        granted_scopes: ak.and_then(|k| {
-            k.token_scopes.as_deref().and_then(|s| {
-                let scopes: Vec<String> = s.split_whitespace().map(str::to_string).collect();
-                if scopes.is_empty() {
-                    None
-                } else {
-                    Some(scopes)
-                }
-            })
-        }),
+        // OAuth providers echo scopes using either spaces or commas. Normalize
+        // both forms at the read boundary while preserving the raw provider
+        // response in storage and the first-occurrence display order.
+        granted_scopes: ak.and_then(|k| k.token_scopes.as_deref().and_then(parse_granted_scopes)),
         last_authorized_at: ak.and_then(|k| k.last_authorized_at.map(|dt| dt.to_rfc3339())),
         expires_at: ak.and_then(|k| k.expires_at.map(|dt| dt.to_rfc3339())),
         last_used_at: ak.and_then(|k| k.last_used_at.map(|dt| dt.to_rfc3339())),
@@ -3810,14 +3800,31 @@ pub(crate) fn oauth_connection_status(api_key: &UserApiKey) -> Option<String> {
     ) {
         return Some("expired".to_string());
     }
-    api_key.expires_at.map(|expires_at| {
-        if expires_at <= Utc::now() && api_key.refresh_token_encrypted.is_none() {
-            "expired"
-        } else {
-            "active"
-        }
-        .to_string()
-    })
+    if api_key.status != "active" || api_key.access_token_encrypted.is_none() {
+        return None;
+    }
+    Some(
+        api_key
+            .expires_at
+            .map_or("active", |expires_at| {
+                if expires_at <= Utc::now() && api_key.refresh_token_encrypted.is_none() {
+                    "expired"
+                } else {
+                    "active"
+                }
+            })
+            .to_string(),
+    )
+}
+
+fn parse_granted_scopes(raw: &str) -> Option<Vec<String>> {
+    let mut seen = HashSet::new();
+    let scopes: Vec<String> = raw
+        .split(|character: char| character == ',' || character.is_whitespace())
+        .filter(|scope| !scope.is_empty())
+        .filter_map(|scope| seen.insert(scope).then(|| scope.to_string()))
+        .collect();
+    (!scopes.is_empty()).then_some(scopes)
 }
 
 /// Async post-pass for `build_key_view`: decrypt
@@ -3986,6 +3993,13 @@ mod tests {
     fn oauth_connection_health_uses_stored_status_expiry_and_refreshability() {
         let mut key = sample_api_key("oauth2");
         assert!(oauth_connection_status(&key).is_none());
+
+        key.access_token_encrypted = Some(vec![9, 8, 7]);
+        assert_eq!(oauth_connection_status(&key).as_deref(), Some("active"));
+
+        key.status = "pending_auth".to_string();
+        assert!(oauth_connection_status(&key).is_none());
+        key.status = "active".to_string();
 
         key.expires_at = Some(Utc::now() + chrono::Duration::minutes(5));
         assert_eq!(oauth_connection_status(&key).as_deref(), Some("active"));
@@ -5842,7 +5856,8 @@ mod tests {
         let service = sample_service("bearer");
         let endpoint = sample_endpoint();
         let mut ak = sample_api_key("oauth2");
-        ak.token_scopes = Some("tweet.read  tweet.write users.read".to_string());
+        ak.token_scopes =
+            Some("tweet.read, tweet.write  users.read,tweet.read\ntweet.write".to_string());
 
         let view = build_key_view(
             &service,

--- a/docs/chat/06-actions-registry.md
+++ b/docs/chat/06-actions-registry.md
@@ -1,6 +1,6 @@
 # Assistant Actions Registry
 
-Last verified against `feat/2026-08-11_assistant-key-rotate` (2026-08-11).
+Last verified against the `service.reauthorize` implementation (2026-08-17).
 
 `GET /api/v1/assistant/actions` publishes the immutable action vocabulary that Aevatar may compose into typed NyxIdChat turns. It is a public, static JSON endpoint with an exact-path exemption from the global rate limiter. It does not depend on a session, database row, user scope, or model state.
 
@@ -13,7 +13,7 @@ The response content type is `application/json`. The current body is equivalent 
 ```json
 {
   "schema_version": 4,
-  "revision": "nyxid-assistant-actions.v7",
+  "revision": "nyxid-assistant-actions.v8",
   "actions": [
     {
       "action": "service.connect",
@@ -68,6 +68,25 @@ The response content type is `application/json`. The current body is equivalent 
       "remember_eligible": true
     },
     {
+      "action": "service.reauthorize",
+      "description": "Ask the user's browser to re-authorize an existing connected service and review its requested scopes. Use when a task needs permissions that the referenced user service does not currently grant. NyxID owns the authorization journey and credential storage, and reports only a safe user-service reference. Never ask the user for keys, tokens, passwords, or authorization codes in chat.",
+      "params_schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["userServiceId", "requestedScopes"],
+        "properties": {
+          "userServiceId": { "type": "string" },
+          "requestedScopes": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "risk": "grant",
+      "tier": "v1",
+      "remember_eligible": false
+    },
+    {
       "action": "key.create",
       "description": "Ask the user's browser to create a scoped NyxID API key for the named platform and allowed services. Use when the user wants a new agent identity bounded to specific user-service IDs. NyxID owns key creation and one-time key display, and reports only a safe key reference. Never request, expose, or repeat key material in chat.",
       "params_schema": {
@@ -116,7 +135,7 @@ The serialized body is created once through `LazyLock<String>` and reused. The h
 | Field | Value | Meaning |
 | --- | --- | --- |
 | `schema_version` | `4` | action request/report envelope generation |
-| `revision` | `nyxid-assistant-actions.v7` | exact composition snapshot expected by the pinned Aevatar client |
+| `revision` | `nyxid-assistant-actions.v8` | exact composition snapshot expected by the pinned Aevatar client |
 | `actions` | descriptor array | actions that are both shipped by NyxID and executable by this Aevatar composition |
 
 Schema version and revision are independent checks. Aevatar rejects a version mismatch and rejects a revision mismatch. The registry is startup-pinned; a running host does not periodically refresh or replace it.
@@ -128,6 +147,7 @@ The registry ships these descriptors:
 | Action | Parameters | Risk | Remember eligible |
 | --- | --- | --- | --- |
 | `service.connect` | strict catalog-service or custom-service variant | `grant` | `true` |
+| `service.reauthorize` | exact `userServiceId` plus nonempty normalized unique `requestedScopes` enforced by the consumer and browser | `grant` | `false` |
 | `key.create` | `name`, `platform`, exact nonempty unique `allowedServiceIds` | `grant` | `false` |
 | `key.rotate` | exact predecessor `keyId` | `grant` | `false` |
 
@@ -187,12 +207,12 @@ Startup then parses the JSON and validates at least:
 
 - valid JSON object shape;
 - `schema_version == 4`;
-- `revision == "nyxid-assistant-actions.v7"`;
+- `revision == "nyxid-assistant-actions.v8"`;
 - `actions` is an array;
 - action names, tier, risk, remember policy, description, and parameter-schema shape;
 - no duplicate action descriptor;
 - supported schema constructs; and
-- presence of every action this Aevatar version marks executable: `service.connect`, `key.create`, and `key.rotate` for the v7 composition.
+- presence of every action this Aevatar version marks executable: `service.connect`, `service.reauthorize`, `key.create`, and `key.rotate` for the v8 composition.
 
 Enabled startup fails if fetch, size, JSON, schema, revision, or required-action validation fails. The host therefore does not accept typed chat work with a partially loaded or ambiguous registry.
 

--- a/docs/chat/wave1-service-reauthorize-actions.md
+++ b/docs/chat/wave1-service-reauthorize-actions.md
@@ -1,0 +1,328 @@
+# Wave 1 `service.reauthorize` — consolidated action list
+
+**This is the working document for PR #1462.** It is the single place that says what
+is done, what is outstanding, and who owns each item. The three documents it
+consolidates are evidence, not instructions:
+
+| Document | Author | Role now |
+| --- | --- | --- |
+| `wave1-service-reauthorize-plan.md` | planner | Contract reference (§1 target contract, §5 rollout). Task breakdown is **superseded by this file**. |
+| `wave1-service-reauthorize-review-sol.md` | implementer's pre-build review | Evidence for the plan corrections that shaped the build. |
+| `wave1-service-reauthorize-review-opus.md` | independent adversarial review | Evidence for every A-item below; full reproductions live there. |
+
+Where any source document disagrees with this file, this file wins. Where a
+finding was overturned by a later pass, it is recorded in §5 so it is not
+re-litigated.
+
+Scope: ChronoAIProject/NyxID#1400 **item 1** only. Items 2 and 3 of that issue are
+out of scope (item 3 shipped separately in #1404).
+
+---
+
+## 1. Status at a glance
+
+| | Count | Blocking merge? |
+| --- | --- | --- |
+| Shipped and verified | 4 workstreams | — |
+| **A. NyxID actions outstanding** | 3 major, 5 minor | 3 major: yes |
+| **B. Aevatar prerequisites** | 4 code sites | **yes — hard gate** |
+| **C. Verification gaps** | 2 | 1 should clear before merge |
+| **D. Coordination (Calvin)** | 2 posts | not code-blocking |
+
+**Overall: BLOCKED.** PR #1462 stays draft. Two independent gates — the Aevatar
+consumer (§3) and the three MAJOR defects (§2) — must both clear.
+
+---
+
+## 2. Section A — NyxID actions outstanding
+
+Severity, owner, and status per item. File references are on this branch unless
+marked otherwise.
+
+### A1 · MAJOR · open — user-controlled `Bearer …` strings permanently break the journey
+
+**Where** (line numbers re-verified on `5b1189ee` for this document).
+`backend/src/handlers/keys.rs:514` (`ws_frame_injections: Vec<WsFrameInjection>` —
+a bare `Vec`, always serialized), `:509` (`default_request_headers`), `:417-418`
+(`name` / `label`); `services/ws_frame_injector.rs:189-197` (the validator that
+permits the offending template);
+`frontend/src/components/assistant/blocks/action-card.tsx:110-128`
+(`assertSecretFreeReadBack`).
+
+**What.** Two recursive scanners run over the whole `/keys/{id}` body — Aevatar's
+`RejectSecretBearingRead` and this PR's `assertSecretFreeReadBack` — both matching
+`(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})`. NyxID's own WS-template
+validator explicitly permits `{"headers":{"Authorization":"Bearer ${credential}"}}`
+(it strips `${credential}` before checking, leaving `Bearer ` — no `nyxid_`, no JWT
+segment). So NyxID stores a value it then refuses to read back. The service can
+never be re-authorized through the assistant; the user sees only the generic
+"NyxID could not verify this service for re-authorization" and is pointed at AI
+Services, where nothing is visibly wrong.
+
+Fail mode is closed, not leaky — no secret escapes. But this is reachable through a
+documented, supported feature (CLAUDE.md §6), not a hypothetical.
+
+**Fix — preferred.** Serve a minimal evidence projection for this read. Aevatar
+consumes only `id`, `api_key_id`, `is_active`, `status`, `connection_status`,
+`granted_scopes`, `last_authorized_at`; every other field on that response is pure
+tripwire surface. Alternatives (reject `Bearer\s` at write time; browser-side error
+differentiation) are documented in the Opus review §M1 and are strictly worse — the
+write-time option does not repair rows already stored.
+
+**Also required.** Extend `assert_aevatar_secret_free`
+(`backend/src/handlers/keys.rs:2692`, called from
+`key_response_always_serializes_authorization_evidence_properties` at `:2665`) to
+run over a *fully populated* `KeyResponse` including a `Bearer ${credential}` WS
+template. Today it runs over a near-empty response — no `ws_frame_injections`, no
+`default_request_headers`, fixed test label — so it cannot fail. Written correctly
+it would fail today, which is the point.
+
+### A2 · MAJOR · open — `completed` is reported without checking scopes were granted
+
+**Where.** `frontend/src/components/assistant/blocks/action-card.tsx:513-541`
+(watch path), `:965-973` (dialog path).
+
+**What.** Both completion paths report `completed` on identity match + `status ==
+active` + `last_authorized_at` advancement. Neither reads `granted_scopes`. Aevatar
+*does* check (`NyxIdActionPostconditionPort.cs:294-296`), so the model is not
+misled — it receives `MismatchCode`. **The user is**: the card renders the
+`Re-authorized` badge while the conversation proceeds as though nothing happened.
+
+Three reachable paths: the user deselects a prefilled scope before clicking Connect
+(`prefillScopes` only seeds the `useState` initializer,
+`add-key-dialog.tsx:1530-1536`, nothing pins it after); the provider grants a subset
+(unapproved GitHub org access, unchecked Google consent scopes, pending Lark review);
+or the provider omits `scope` from the token response, in which case the backend
+deliberately preserves the previous `token_scopes`
+(`services/user_api_key_service.rs:568-580`, per NyxID#917) while still stamping
+`last_authorized_at` — so the freshness gate passes on a completely unchanged grant.
+
+**Fix.** In both completion paths, re-read `/keys/{id}` and require
+`requested_scopes ⊆ granted_scopes` (case-sensitive, matching Aevatar's
+`StringComparer.Ordinal`) before `report("completed", …)`. On shortfall call
+`onBlock` naming the missing scopes.
+
+### A3 · MAJOR · open — the freshness gate proves "some authorization advanced", not "this one"
+
+**Where.** `frontend/src/hooks/use-keys.ts:213-216`;
+`frontend/src/components/dashboard/add-key-dialog.tsx:1764, 1792-1794, 3191-3203`.
+
+**What.** The predicate is a bare timestamp inequality with no server-side
+correlation to the attempt. `attemptId` is a client-side `crypto.randomUUID()` used
+only as a TanStack Query cache generation (`use-keys.ts:154`); it never reaches the
+server. The baseline comes from a **stale snapshot** — `ensureAuthKey` returns the
+`reconnectKey` prop verbatim, i.e. the object fetched at *card-click* time, which
+may be minutes old by the time the user presses Connect.
+
+Consequence: any unrelated fresh authorization of the same key inside that window —
+the AI Services page, a second tab, `nyxid service scopes`, the CLI wizard, a second
+assistant card for the same service — satisfies the gate and settles the card as
+`completed`. Two concurrent cards for one service share a baseline; completing
+either settles both.
+
+Combined with A2 this is the real false-`completed` surface: not a background
+refresh (that path is genuinely closed — see §5), but *someone else's*
+authorization being claimed as this attempt's.
+
+**Fix.** Correlate to the server-side attempt. `initiateOAuthAsync` already returns
+an `attempt_nonce` and the flow threads a `connection_id`; settle on evidence that
+*this* attempt landed. If that is too large for this wave, at minimum re-read
+`/keys/{id}` inside `handleConnect` and derive the baseline from that fresh read —
+closes the card-click→Connect-click window, does not close the concurrent-flow case.
+
+### A4 · MINOR · open — PR body misattributes the freshness fix
+
+The disposition table claims the freshness mechanism was delivered here. All three
+parts pre-exist on `origin/main` (`stores/pending-connect-store.ts:12`,
+`action-card.tsx:285`, `hooks/use-keys.ts` ×11); neither `use-keys.ts` nor
+`pending-connect-store.ts` is in this PR's diffstat. What this PR actually adds on
+that axis is the exact-service **identity** guard (`action-card.tsx:513-525`) —
+real and correct, but a different control.
+
+Sol's review was accurate about its pre-rebase branch point; the PR body carried
+"Fixed" forward without re-checking what the rebase brought in.
+
+**Fix.** Correct the table entry to "already present on `main`; this PR adds the
+exact-service identity guard and relies on the inherited baseline gate."
+
+### A5 · MINOR · open — the freshness test does not test freshness
+
+`action-card.test.tsx`, "waits for a fresh authorization timestamp before
+auto-completing reauthorization". Delete the entire freshness gate from
+`use-keys.ts` and this test still passes — the assertion its name promises (an
+unchanged `last_authorized_at` must **not** settle the card) is absent.
+
+**Fix.** Add a case whose key read always returns the original
+`last_authorized_at`; assert `onResolve` is never called and the card reports the
+timeout note.
+
+### A6 · MINOR · open — browser scope grammar is stricter than the published contract
+
+`frontend/src/schemas/assistant-actions.ts:49-56` enforces
+`/^[A-Za-z0-9._:/~+*=-]+$/` and `.min(1)`. The published `params_schema` says
+`{"type": "string"}` and permits an empty array; RFC 6749 §3.3 allows every
+printable ASCII except space, `"` and `\`. A conforming scope outside that regex
+parses at Aevatar, then degrades to `{variant: "unknown"}` → "Unsupported action
+request" with no indication which scope was rejected.
+
+No real catalog provider trips it (Google, GitHub, Slack, Lark, Microsoft, Zoom,
+HubSpot, Atlassian all pass), so likelihood is low.
+
+**Fix.** Document the divergence in `docs/chat/06-actions-registry.md` — the
+published schema is the contract and this restriction is invisible from it.
+
+### A7 · MINOR · open — org-admin preflight guard fails open
+
+`action-card.tsx:79-88, 158-163` declares `credential_source` `.optional()`, but
+`KeyResponse.credential_source` is mandatory (`keys.rs:544-546`), so the guard is
+currently unreachable. An `.optional()` schema means it silently vanishes if the
+response shape changes — the opposite of defence in depth.
+
+**Fix.** Make it required so a shape change fails loudly. (The backend remains the
+real gate.)
+
+### A8 · MINOR · open — preflight fetches the whole catalog for one entry
+
+`action-card.tsx:167-169` does `GET /catalog?include_all=true` then finds one slug.
+`GET /api/v1/catalog/{slug}` returns the same `provider_type` /
+`provider_config_id` / `device_code_format`. One full-catalog fetch per card click.
+
+---
+
+## 3. Section B — Aevatar prerequisites (hard merge gate)
+
+Owner: **eanz17** / Aevatar, on `aevatarAI/aevatar` `feature/integrate`.
+All four sites are in `agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs`
+and **all four fail closed with the same catastrophic symptom** — `Load()` throws,
+`CreateDisabled()` initializes, and every NyxID action card goes dark on Aevatar
+processes started afterward (chat itself survives).
+
+Editing only the first two is the likely mistake: it ships a consumer that passes
+its own revision-map tests and still kills the registry.
+
+| # | Site | Required change |
+| --- | --- | --- |
+| B1 | `PinnedActionsByRevision` (~line 207) | add `v8` → all four actions |
+| B2 | `ExecutableActionsByRevision` (~line 234) | add `v8` → all four actions |
+| B3 | `IsActionExecutable` wire-action switch (~line 293) | **`ServiceReauthorize` currently falls through to `null`** — map it to `"service.reauthorize"` or the verb stays non-executable regardless of B1/B2 |
+| B4 | `ValidatePinnedContract` revision ternary (~line 886) | v8 is in neither branch, so `key.create` would be compared against the *unconstrained* schema while NyxID publishes the least-scope variant → `DeepEquals` fails → `RegistryInvalid` |
+
+Plus: `docs/contracts/nyxid-assistant-conformance/v1/registry-v8.json` matching the
+published manifest, and registry/conformance test updates.
+
+**Rollout order (binding).**
+1. Aevatar merges + deploys the additive v8 consumer.
+2. Restart an Aevatar process while NyxID still serves **v7**; prove the registry
+   still loads with all current actions.
+3. Only then NyxID merges + deploys v8.
+4. Restart another Aevatar process, prove it loads v8, run one end-to-end
+   `service.reauthorize`.
+
+---
+
+## 4. Section C — verification gaps
+
+### C1 · open · should clear before merge — nobody has run the full backend suite
+
+The implementer reported 5,189 passed / 129 failed with all failures attributed to
+a missing MongoDB replica set (`NYXID_TEST_DATABASE_URL` unset, Docker unavailable),
+and explicitly did **not** claim green — the correct posture. The reviewer could not
+reproduce it for the same reason. So the split and its attribution are unverified in
+both directions, and **no full backend run exists for this change**.
+
+**Action.** Someone with a replica set runs `cargo test` before merge.
+
+Everything else reproduced exactly on an independent re-run:
+
+| Command | Result |
+| --- | --- |
+| `npm --prefix frontend run test` | 246 files / 2,847 passed, 0 failed |
+| `npm --prefix frontend run lint` | 0 errors, 23 pre-existing warnings |
+| `npm --prefix frontend run build` (CI parity: `tsc -b`) | passed — 3,470 + 107 modules |
+| `cargo test assistant_actions` | 5 passed, 0 failed |
+| `cargo test unified_key_service` | 163 passed, 0 failed |
+| `cargo fmt --check` / `clippy -D warnings` | passed |
+| `cargo test -p nyxid-cli` | 1,100 + 1 wizard-freshness passed |
+
+No wizard-bundle rebuild is required: `add-key-dialog.tsx` is not in
+`cli/src/wizard/bundle-meta/index.manifest`.
+
+### C2 · open · low — one unreachability claim is inferred, not proven
+
+`oauth_connection_status` regressing a row from `"expired"` to `null` requires
+`status == "active"` + `access_token_encrypted == None` + past `expires_at`. That
+shape was argued unreachable from the write paths
+(`user_api_key_service.rs:397-407`, `write_oauth_tokens_to_key`), not proven by
+test. If constructible, the affected row loses its Reconnect button.
+
+---
+
+## 5. Findings that did not survive — do not re-raise
+
+Each was checked against code by the independent pass.
+
+- **Evidence endpoint** is `GET /api/v1/keys/{id}` via `NyxIdApiClient.GetServiceAsync`
+  (`NyxIdApiClient.cs:279`), **not** `/api/v1/user-services`. The original briefing
+  was wrong; the correction is what made this a serializer-sized change.
+- **`params_schema` `DeepEquals`** — exact. Verified independently again for this
+  document: `backend/src/handlers/assistant_actions.rs:92-110` is structurally
+  identical to Aevatar's `ServiceReauthorizeParamsSchema`, with `risk=grant`,
+  `tier=v1`, `remember_eligible=false`, `schema_version=4`.
+- **All six evidence conditions** are satisfiable; removing `skip_serializing_if`
+  on the three fields was necessary (Aevatar uses `RequireProperty`, so an omitted
+  property is a hard `MalformedResponse`). Re-verified for this document:
+  `keys.rs:436` (`connection_status`), `:500` (`granted_scopes`), `:504`
+  (`last_authorized_at`) all serialize unconditionally, each with a comment
+  recording why.
+- **Serializer blast radius** — no Rust or TypeScript consumer of the three fields
+  exists in `cli/src`, `sdk/`, or `mobile/src`; no frontend Zod schema parses the
+  key response; Aevatar's `/keys` list parser reads only named properties and does
+  not run the secret scan.
+- **`oauth_connection_status` override was right.** The one non-evidence consumer
+  (`frontend/src/pages/keys.tsx`) falls back to `connection_status ?? status`; the
+  `pending_auth` case now *adds* a Reconnect affordance.
+- **Comma-scope normalization is correct** and strictly better — the old
+  `split_whitespace` turned a GitHub echo of `repo,read:user` into one garbage
+  token that was then re-submitted verbatim as a scope.
+- **No scope is silently dropped in the picker** — `buildPills` takes `value` as
+  input, and `platformScopeAllowlist` is gated on `!isReconnect`.
+- **A background token refresh cannot falsely satisfy the freshness gate** —
+  `last_authorized_at` is written only on fresh-authorization paths, never by
+  refresh (pre-existing NyxID#917 discipline).
+- **Malformed params degrade gracefully** — `{variant: "unknown"}` yields
+  `unsupportedDescriptor`, no CTA renders, `beginJourney` is unreachable.
+- **Merge gate is real** — PR is draft, no reviews, nothing posted to #1400, no
+  Aevatar issue filed, nothing deployed.
+
+---
+
+## 6. Section D — coordination, owner: Calvin
+
+| # | Action | Status |
+| --- | --- | --- |
+| D1 | Post the drafted Aevatar issue (text in PR #1462 body) — **add the B3/B4 code sites, which the draft under-specifies** | not posted |
+| D2 | Post the drafted #1400 comment (text in PR #1462 body) | not posted |
+
+Both were deliberately left unposted.
+
+---
+
+## 7. Issue #1400 item 1 — alignment check
+
+Verified against the issue text and this branch on 2026-08-18.
+
+| Issue item-1 requirement | State |
+| --- | --- |
+| Registry **descriptor** in the compile-time manifest for `service.reauthorize`, `key.create`, `key.rotate` — grammar-conformant params, model-facing description, `risk`/`tier`/`remember_eligible`; new revision pin | **Met.** `assistant_actions.rs:9` pins `nyxid-assistant-actions.v8`; four descriptors in order `[service.connect, service.reauthorize, key.create, key.rotate]`. `key.create`/`key.rotate` shipped earlier (v6/v7); `service.reauthorize` added here. |
+| **Card + journey** — browser executes the verb with the user's own session and reports exactly one typed safe resource (`userService` for reauthorize; `key` for key.create/rotate); key material shown once, never in a report | **Met structurally, defective in completion logic.** Journey reports only `{userService:{userServiceId}}`. A2/A3 mean it can report `completed` when the grant did not actually change — the *shape* is right, the *truth* is not yet. |
+| **Facade acceptance of non-`userService` completed resources** (gap G6(c)) | **Met — no code change needed.** `ActionResource` (`assistant_service.rs:472-479`) carries all six variants including `Key`; verified directly. Closed by #1404. |
+| Param-shape confirmation: `{keyId, requestedScopes}` vs `{userServiceId, requestedScopes[]}` (aevatar#3315 item 6) | **Settled: `{userServiceId, requestedScopes[]}`.** Aevatar already implemented this shape on `feature/integrate`; NyxID now publishes it byte-identically. No decision outstanding. |
+| Wave 1 hardening follow-ups #1405, #1406 | **Both closed.** |
+
+**Conclusion.** Item 1 is fully addressed in scope and contract. It is not yet
+*complete* — completion requires §2 A1–A3 fixed and §3 B1–B4 shipped and deployed
+by Aevatar. The issue's framing that this "extends verb coverage beyond
+`service.connect`" is now accurate for all three Wave-1 verbs.
+
+Items 2 (exact-service non-blocking approval) and 3 (facade v4 conformance) of
+#1400 are untouched by this work; item 3 shipped in #1404.

--- a/docs/chat/wave1-service-reauthorize-plan.md
+++ b/docs/chat/wave1-service-reauthorize-plan.md
@@ -1,5 +1,13 @@
 # Wave 1 — `service.reauthorize` implementation plan (issue #1400, item 1)
 
+> **Superseded as an instruction set.** The live action list is
+> [`wave1-service-reauthorize-actions.md`](./wave1-service-reauthorize-actions.md).
+> This document is retained as the **contract reference** — §1 (target contract)
+> and §5 (rollout order) remain accurate and are cited from the action list. Its
+> §3 task breakdown was executed and partly overridden during implementation; do
+> not work from it. Several §0 claims were amended by later passes — see the
+> action list §5 for what did and did not survive.
+
 **Status:** plan only, nothing implemented. Written 2026-08-17 against NyxID `origin/main`
 `ed372d8c` and Aevatar `origin/feature/integrate` `05db6b4b0` (clone at
 `~/Desktop/aelf-frontend-work/aevatar`; read files with

--- a/docs/chat/wave1-service-reauthorize-plan.md
+++ b/docs/chat/wave1-service-reauthorize-plan.md
@@ -1,0 +1,586 @@
+# Wave 1 — `service.reauthorize` implementation plan (issue #1400, item 1)
+
+**Status:** plan only, nothing implemented. Written 2026-08-17 against NyxID `origin/main`
+`ed372d8c` and Aevatar `origin/feature/integrate` `05db6b4b0` (clone at
+`~/Desktop/aelf-frontend-work/aevatar`; read files with
+`git show origin/feature/integrate:<path>`, do not trust the checkout).
+
+**Scope:** issue #1400 item 1 reduces to exactly one verb. `key.create` and `key.rotate`
+already shipped in NyxID revision `nyxid-assistant-actions.v7`
+(`backend/src/handlers/assistant_actions.rs` on `origin/main`:
+`ASSISTANT_ACTIONS_SCHEMA_VERSION = 4`, `ASSISTANT_ACTIONS_REVISION = "nyxid-assistant-actions.v7"`,
+descriptors for `service.connect`, `key.create`, `key.rotate`; `service.reauthorize` appears only
+in the test module's 14-verb `SUPPORTED_ACTIONS` allowlist). What remains is publishing the
+`service.reauthorize` descriptor, closing three small evidence-serialization gaps on
+`GET /api/v1/keys/{id}`, the facade acceptance check, and the browser journey.
+
+---
+
+## 0. Corrections to the issue text and the briefing (verified 2026-08-17)
+
+Read these before anything else; they change the shape of the work.
+
+1. **The evidence endpoint is `GET /api/v1/keys/{id}`, not `/api/v1/user-services`.**
+   Aevatar's `NyxIdActionEvidenceReadPort.GetUserServiceAuthorizationAsync` calls
+   `client.GetServiceAsync(bearerToken, userServiceId)`, and in
+   `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs`:
+
+   ```csharp
+   public Task<string> GetServiceAsync(string token, string id, CancellationToken ct) =>
+       GetAsync(token, $"/api/v1/keys/{Uri.EscapeDataString(id)}", ct);
+   ```
+
+   (`/api/v1/user-services` at `NyxIdApiClient.cs:1027` backs a *different* parser,
+   `ParseUserServicesDocument`, which is not used for reauthorize evidence.)
+
+2. **All six evidence facts already exist on the `KeyResponse`** returned by
+   `GET /api/v1/keys/{id}` (shipped with the NyxID#917 manage-scopes work). This is a
+   serializer-level change, not a model or write-path change. Details in §2.
+
+3. **Aevatar does not "pin v7" as a single value.** `NyxIdAssistantActionRegistry.cs`
+   keeps a *map* of accepted revisions — `IsSupportedRegistryRevision` accepts
+   `nyxid-assistant-actions.v4/v5/v6/v7` plus the Aevatar-owned
+   `aevatar-nyxid-actions.v1`. Two separate maps matter:
+   - `PinnedActionsByRevision`: `service.reauthorize` appears only in **v5**'s pinned set.
+   - `ExecutableActionsByRevision`: `service.reauthorize` appears in **no revision's**
+     executable set (v7 = `{service.connect, key.create, key.rotate}`).
+
+   So even though Aevatar's parser, schema constant, postcondition port, browser-action
+   producer, wire mapper, audit translators, and tests for `service.reauthorize` are all
+   built, **no revision makes the verb executable today**.
+
+4. **No v8 exists anywhere in Aevatar.** `docs/contracts/nyxid-assistant-conformance/v1/`
+   holds fixtures `registry-v4.json` … `registry-v7.json` only; a grep for `v8` across
+   `agents/Aevatar.GAgents.NyxidChat`, the registry tests, and the conformance directory
+   returns nothing. The Aevatar-side consumer for the new revision **must be filed and
+   shipped as a prerequisite** — see §5.
+
+5. **Blast radius of publishing early, precisely:** Aevatar's startup gate
+   (`NyxIdAssistantActionRegistryStartup.cs`) fetches `GET /api/v1/assistant/actions`
+   once at process start; on any load failure (including an unknown revision) it logs
+   `"NyxID Assistant action registry startup failed … Assistant actions are disabled for
+   this process"` and initializes `NyxIdAssistantActionRegistry.CreateDisabled()`.
+   Chat itself survives, but **every assistant action card (connect, key.create,
+   key.rotate) stops working** on Aevatar processes started after the NyxID deploy.
+   Deployment order is therefore binding (§5) even though "chat breaks" overstates it.
+
+6. **Param shape is settled and must be byte-exact.** Aevatar's
+   `ValidatePinnedContract` parses NyxID's published `params_schema` and requires
+   `JsonNode.DeepEquals` with its pinned constant, plus exact `risk` and
+   `remember_eligible` matches. Do not add `minItems`/`uniqueItems`/`maxLength` or any
+   other refinement to the published schema — it would fail the deep-equality pin.
+
+---
+
+## 1. Target contract (what Aevatar already enforces — do not re-open)
+
+### 1.1 Params schema (publish exactly this)
+
+`agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs`,
+`ServiceReauthorizeParamsSchema`:
+
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["userServiceId", "requestedScopes"],
+  "properties": {
+    "userServiceId": {"type": "string"},
+    "requestedScopes": {"type": "array", "items": {"type": "string"}}
+  }
+}
+```
+
+Pinned metadata: `risk = grant`, `remember_eligible = false` (registry entry
+`["service.reauthorize"] = new(…, NyxIdAssistantActionRisk.Grant, false)`), tier `v1`.
+
+At postcondition time Aevatar additionally requires `requestedScopes` to be a
+**non-empty set of unique, normalized strings** (`ValidNormalizedSet(…, requireAny: true)`,
+`Ordinal` dedup). The NyxID journey should refuse to launch with an empty or duplicated
+scope list even though the published schema cannot say so.
+
+### 1.2 Descriptor text (already authored — reuse verbatim)
+
+Aevatar's `registry-v5.json` fixture carries the full descriptor eanz17 authored on the
+NyxID draft branch `feat/2026-08-10_wave1-action-registry` (still on origin at
+`ee3b8f81e36647c67a06505b10ec0444ab064000`):
+
+```json
+{
+  "action": "service.reauthorize",
+  "description": "Ask the user's browser to re-authorize an existing connected service and review its requested scopes. Use when a task needs permissions that the referenced user service does not currently grant. NyxID owns the authorization journey and credential storage, and reports only a safe user-service reference. Never ask the user for keys, tokens, passwords, or authorization codes in chat.",
+  "params_schema": { …exactly §1.1… },
+  "risk": "grant",
+  "tier": "v1",
+  "remember_eligible": false
+}
+```
+
+Ordering precedent (v5 fixture): `["service.connect", "service.reauthorize", "key.create", "key.rotate"]`
+— insert the new descriptor at **index 1**, after `service.connect`.
+
+### 1.3 Postcondition verify (what "success" means to Aevatar)
+
+`agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs`,
+`VerifyServiceReauthorizeAsync`, after reading `GET /api/v1/keys/{userServiceId}` with the
+human session's NyxID bearer (`AgentToolHumanSessionNyxIdCredential.ResolveBearerToken` —
+the same credential already used for the shipped `key.create`/`key.rotate` evidence reads
+against `GET /api-keys/{id}`):
+
+- `evidence.UserServiceId == params.userServiceId` (Ordinal)
+- `evidence.IsActive == true`
+- `evidence.CredentialStatus == Active`
+- `evidence.OAuthConnectionStatus == Active`
+- `evidence.GrantedScopes != null` and contains **every** requested scope (Ordinal)
+- `evidence.LastAuthorizedAtUtc != null`, `>= requestedAt` (the action's request time)
+  and `<= now`
+
+Any resource hint on the completion report must be `userService` (or absent) and, when
+present, must equal `params.userServiceId`.
+
+### 1.4 Evidence parser field contract (`NyxIdApiAccessContracts.cs`,
+`ParseUserServiceAuthorizationDocument`)
+
+On the JSON **root** of the `GET /api/v1/keys/{id}` response:
+
+| JSON field | Requirement |
+|---|---|
+| `id` | required, non-empty normalized string |
+| `api_key_id` | optional normalized string |
+| `is_active` | required boolean |
+| `status` | required string, exactly one of `active` / `expired` / `revoked` / `failed` / `refresh_failed` / `pending_auth` |
+| `connection_status` | **property must be present**; `null` → `Unspecified` (fails verify), else exactly `"active"` or `"expired"` |
+| `granted_scopes` | **property must be present**; `null` allowed, else array of unique non-empty normalized strings (duplicates → malformed) |
+| `last_authorized_at` | **property must be present**; `null` allowed, else RFC3339 (`Z` or `±HH:MM` offset, ≤9 fractional digits — chrono's `to_rfc3339()` conforms) |
+
+An absent required property, an out-of-domain `status`, or duplicate scopes makes the
+whole read **malformed** (`ProviderReadFailure`), not merely unverified.
+
+**Secret-scan tripwire:** the parser recursively walks the entire response and throws if
+any field's lowercased-alphanumeric name is in
+`{apikey, fullkey, keyhash, credential, credentials, accesstoken, refreshtoken,
+authorization, cookie, cookies, secret, secrets, clientsecret, password, token,
+passphrase, usercode, devicecode, rawbody, rawupstreambody}`, or any string value matches
+`(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})` (case-insensitive). Current
+`KeyResponse` field names all normalize clear of the set (`api_key_id` → `apikeyid`,
+`credential_type` → `credentialtype`, etc.). **Never add a field whose normalized name
+lands in that set to `KeyResponse`.**
+
+---
+
+## 2. Evidence-field answer: current state of `GET /api/v1/keys/{id}` on `origin/main`
+
+Handler: `backend/src/handlers/keys.rs` `get_key` (lines 1090–1161, route
+`GET /api/v1/keys/{key_id}`), which returns `KeyResponse` at the JSON root (no envelope;
+`Ok(Json(response))`) via `unified_key_service::get_key` → `build_key_view`
+(`backend/src/services/unified_key_service.rs`, `KeyView` struct at line 392, response
+mapping `key_response_from_view` in `keys.rs` lines 2280–2360). Accepts UUID **or slug**
+(`find_user_service_for_actor`, keys.rs:115–160) and enforces personal/org ACL through
+`resolve_key_read_owner` → `org_service::resolve_owner_access` (keys.rs:214–228;
+unauthorized → NotFound, no metadata leak). Aevatar passes the `userServiceId` (a UUID),
+which hits the `_id` branch.
+
+Freshness stamping is covered on **all three** fresh-authorization write paths
+(`user_api_key_service.rs`): multi-connection `write_oauth_tokens_to_key` (line 484),
+the chat connect-card popup's `write_chat_oauth_tokens_to_key` (line 569), and the
+legacy fan-out `sync_provider_token_to_api_keys_after_authorization` (line 337, invoked
+with `fresh_authorization = true` only from the OAuth callback,
+`user_tokens.rs:1467-1505`). Token refresh, disconnect, and manual sync deliberately do
+NOT stamp — so the `last_authorized_at`-advance completion signal cannot false-fire.
+
+Field-by-field against §1.3/§1.4 — **all six facts exist; the underlying Mongo data
+exists for all of them; the gaps are serialization/derivation only:**
+
+| Verify condition | Field on `KeyResponse` | State | Gap |
+|---|---|---|---|
+| identity match | `id: String` | ✅ always serialized | none |
+| `IsActive` | `is_active: bool` | ✅ always serialized | none |
+| `CredentialStatus == Active` | `status: String` | ✅ always serialized; value domain on `models/user_api_key.rs:68` is exactly the six values Aevatar's parser accepts | none |
+| `OAuthConnectionStatus == Active` | `connection_status: Option<String>` | ⚠️ exists (`unified_key_service::oauth_connection_status`, line 3803) | **(a)** `skip_serializing_if = "Option::is_none"` → property absent when `None`, parser requires presence. **(b)** returns `None` for an `oauth2` key whose `expires_at` is `None` — i.e. expiry-less providers (GitHub-class OAuth apps) can **never** verify. Both fixable in the serializer/derivation; no new data needed (`credential_type`, `status`, `expires_at`, `refresh_token_encrypted` are all on the Mongo row). |
+| `GrantedScopes ⊇ requested` | `granted_scopes: Option<Vec<String>>` | ⚠️ exists — `build_key_view` splits `UserApiKey.token_scopes` on whitespace (line ~3777); `token_scopes` is written by the OAuth callback | **(a)** same absent-when-`None` issue. **(b)** no dedup — Aevatar rejects duplicate entries as malformed. **(c)** caveat: `write_oauth_tokens_to_key` deliberately *preserves* the old `token_scopes` when the provider's token response omits `scope`; for such providers a scope-adding reauth may verify against stale scopes or fail the superset check (see Open Question Q3). |
+| `LastAuthorizedAt` fresh | `last_authorized_at: Option<String>` | ⚠️ exists — `UserApiKey.last_authorized_at` (model doc `models/user_api_key.rs:72-80`) is stamped **only** by `user_api_key_service::write_oauth_tokens_to_key` (line 457; `"last_authorized_at": &now` in the `$set`) on a fresh OAuth/device-code callback, never by token refresh — exactly the freshness semantics Aevatar checks. `to_rfc3339()` output is parser-compatible. | same absent-when-`None` issue only |
+| (optional) | `api_key_id: Option<String>` | ✅ present when the credential row resolves | none (parser treats as optional) |
+
+**Bottom line:** no model change, no write-path change, no migration. The work is:
+always-serialize three fields (emit `null` instead of omitting), fix the
+`oauth_connection_status` derivation for expiry-less tokens, and dedup the scope split.
+
+---
+
+## 3. NyxID task breakdown
+
+Execute in this order. Backend first (tasks B1–B3 are independent of the frontend and of
+Aevatar timing — only the **merge/deploy** of B1 is gated, see §5).
+
+### B1. Publish the `service.reauthorize` descriptor + revision bump
+
+File: `backend/src/handlers/assistant_actions.rs`.
+
+1. Insert a descriptor struct literal at **index 1** (between `service.connect` and
+   `key.create`) with:
+   - `action: "service.reauthorize"`
+   - description: the exact §1.2 text
+   - params schema: the exact §1.1 JSON
+   - `risk = grant`, `tier = v1`, `remember_eligible = false`
+   Match the existing descriptor struct/format in the file — the shipped `key.create`
+   entry is the pattern (grant / v1 / false). Consult the draft branch
+   `feat/2026-08-10_wave1-action-registry` @ `ee3b8f81` for eanz17's original authoring
+   (it was written against v5; **port the one descriptor, do not merge the branch** —
+   the manifest has since moved to v7 with the least-scope `key.create` schema).
+2. Bump `ASSISTANT_ACTIONS_REVISION` from `"nyxid-assistant-actions.v7"` to the revision
+   string agreed with Aevatar (expected `"nyxid-assistant-actions.v8"` — Open Question
+   Q1). `ASSISTANT_ACTIONS_SCHEMA_VERSION` stays `4` (the frontend gate
+   `resolveAssistantAction` requires `schemaVersion === 4`, and Aevatar's fixtures pin
+   `schema_version: 4`).
+3. Descriptor mechanics (verified): descriptors are `AssistantActionDescriptor` struct
+   literals (lines 22–30: `action`, `description`, `params_schema: Value` via `json!`,
+   `risk`, `tier`, `remember_eligible`) inside a `static MANIFEST_BODY: LazyLock<String>`
+   (line 33); descriptions are `const` strings (`SERVICE_CONNECT_DESCRIPTION` line 11).
+   Add a `SERVICE_REAUTHORIZE_DESCRIPTION` const with the §1.2 text and a `json!` schema
+   matching §1.1 exactly.
+4. Update the test module (lines 147–541; all four fns enumerated and verified on
+   `origin/main`):
+   - `assistant_actions_manifest_matches_golden_payload` (459–491): pins the revision
+     string (line 465), `actions.len() == 3` (line 466), per-index
+     id/risk/tier/remember_eligible/params_schema assertions in order, and a full
+     `assert_eq!(manifest, golden_manifest())` (line 490). Update: revision, count → 4,
+     shifted index assertions (`actions[1]` becomes `service.reauthorize`), a new
+     `service_reauthorize_params_schema()` test helper, and a new entry in
+     `golden_manifest()` (lines 276–307).
+   - `assistant_actions_manifest_conforms_to_aevatar_parser_contract` (493–496) →
+     `assert_manifest_conforms` (387–457): the new descriptor passes automatically if
+     schema-compliant — every action must be in `SUPPORTED_ACTIONS` (line 418, already
+     contains `service.reauthorize` at line 163), objects need
+     `additionalProperties: false`, property names are checked against
+     `FORBIDDEN_SECRET_NAMES` (lines 177–196), risk ∈ {low, grant, destructive}, tier
+     must be `"v1"`. `userServiceId`/`requestedScopes` are clean of the forbidden-name
+     set. No parser/grammar change.
+   - `secret_name_normalization_is_ascii_alphanumeric_only` (498–503): untouched.
+   - `assistant_actions_route_is_public_json_and_matches_static_body` (505–541):
+     inherits the golden update automatically.
+5. Bump every other consumer of the revision string (whole-tree grep verified — this is
+   the complete list): `docs/chat/06-actions-registry.md` lines 16 (sample payload),
+   119 (composition-snapshot field table), 190 (validation rule
+   `revision == "nyxid-assistant-actions.v7"`). (`docs/assistant/TRAVEL_BOOKING.md:36`
+   references v4 and is already stale — optional.) No frontend/CLI consumer pins the
+   revision string.
+
+**Acceptance:** `cargo test assistant_actions` green; manifest JSON for the new revision,
+filtered to `service.reauthorize`, deep-equals the §1.2 object; action order is
+`[service.connect, service.reauthorize, key.create, key.rotate]`.
+
+### B2. Evidence serialization fixes on `KeyResponse`
+
+Files: `backend/src/handlers/keys.rs`, `backend/src/services/unified_key_service.rs`.
+
+1. Remove `#[serde(skip_serializing_if = "Option::is_none")]` from exactly these three
+   `KeyResponse` fields so they serialize as `null` when `None`:
+   `connection_status`, `granted_scopes`, `last_authorized_at`.
+   Leave every other optional field as-is. Note `KeyResponse` is also used by
+   `list_keys`, `create_key`, `update_key`, `delete_key` responses — the change is
+   intentionally global to the type (Aevatar's `/keys` list parser
+   (`ParseUserServiceKeysDocument`) does not read these three fields, so list responses
+   are unaffected on the Aevatar side).
+2. `oauth_connection_status` (unified_key_service.rs:3803): for a `credential_type ==
+   "oauth2"` key in a non-terminal status with `expires_at == None`, return
+   `Some("active")` instead of `None` (an OAuth credential without a recorded expiry is
+   live, not unknown). Terminal statuses keep returning `"expired"`; non-OAuth keys keep
+   returning `None` (serialized as `null` after step 1 — which Aevatar maps to
+   `Unspecified`, correctly failing reauthorize verify for non-OAuth services).
+3. `build_key_view` granted-scopes split (~line 3777): dedup preserving first-occurrence
+   order after `split_whitespace` (Aevatar hard-rejects duplicates).
+4. Unit tests: extend the existing `oauth_connection_status` tests (~line 3988) with the
+   no-expiry case; extend `build_key_view_parses_granted_scopes_from_token_scopes`
+   (~5841) with a duplicate-scope input; add a serialization test asserting the three
+   fields are present-as-null on a minimal `KeyResponse`.
+
+**Frontend/CLI fallout check (required in the same PR):**
+- `frontend/src/schemas/` key schemas: any `granted_scopes` / `last_authorized_at` /
+  `connection_status` declared `.optional()` must become `.nullish()` (or equivalent) —
+  `null` now arrives where the property used to be absent. Also check the strict
+  read-back snapshot schemas used by the assistant key dialogs
+  (`assistant-key-create-dialog.tsx` `verifyAllowedServices` and the rotate dialog's
+  read-back) — they parse `GET /keys/{id}` / `GET /api-keys/{id}` responses strictly and
+  may reject unexpected `null`s.
+- CLI: serde `Option<T>` handles `null` natively; no change expected, but run
+  `cargo test -p nyxid-cli`.
+- > TODO — not investigated: whether any frontend zod schema for keys uses `.strict()`
+  > with `.optional()` on these fields. Grep `granted_scopes` and `last_authorized_at`
+  > under `frontend/src/schemas/` and `frontend/src/components/` before assuming.
+
+**Acceptance:** backend suite green (`cargo test` — see §6 test-environment note);
+frontend `npm --prefix frontend run build && npm --prefix frontend run test` green; a
+manual `curl` of `GET /api/v1/keys/{id}` for (a) an OAuth key, (b) a plain API key shows
+all three properties present (value or `null`), and an expiry-less OAuth key shows
+`"connection_status": "active"`.
+
+### B3. Facade: completed `userService` report for `service.reauthorize` — **no code change needed (verified)**
+
+Parsing lives in `backend/src/services/assistant_service.rs` (NOT `handlers/assistant.rs`
+— the handler at `assistant.rs:986` just calls
+`assistant_service::parse_assistant_chat_command(&bytes)?`). Verified on `origin/main`:
+
+- `ActionResource` enum (lines 471–479) already has all six variants;
+  `parse_action_resource` (lines 748–798) accepts `{"userService":{"userServiceId": …}}`
+  with `validate_control_identity` hardening.
+- **There is no action-id → resource-kind gating map.** `RawActionReport` (lines
+  550–558) carries only `action_request_id`, `origin_turn_id`, `disposition`,
+  `resource` — the action id never appears in the report. The only completed-report rule
+  (lines 900–906) is that a `completed` disposition must carry *some* resource. A
+  completed `service.reauthorize` report with a `userService` resource **parses and
+  forwards today**. Test `completed_action_reports_round_trip_each_safe_resource_variant`
+  (lines 2124–2156) already round-trips all six variants.
+
+Remaining (optional, cheap): no new backend test is strictly required; if adding one,
+extend the existing round-trip test's comment to note `service.reauthorize` relies on
+the `userService` variant. Do not invent per-action gating that doesn't exist.
+
+**Acceptance:** none beyond the existing suite — `cargo test assistant_service` green.
+
+### F1. Frontend: registry descriptor + params schema
+
+Files: `frontend/src/schemas/assistant-actions.ts`,
+`frontend/src/lib/assistant/action-registry.ts`.
+
+1. `assistant-actions.ts`: add `serviceReauthorizeActionParamsSchema` — strict object
+   `{ userServiceId: requiredActionIdentitySchema, requestedScopes: <array of
+   actionControlIdentitySchema, min 1, max ~64, unique> }` (mirror
+   `keyCreateActionParamsSchema`'s allowedServiceIds constraints; the *frontend* may be
+   stricter than the published schema — Aevatar's postcondition requires non-empty
+   unique anyway). Add the params union member and a new `ActionCardParams` variant
+   (suggested `variant: "service_reauthorize"`, snake_case fields per existing pattern).
+   No `ActionResource` change needed (`userService` already exists).
+2. `action-registry.ts`: add `serviceReauthorizeDescriptor` following the existing
+   pattern —
+
+   ```ts
+   const serviceReauthorizeDescriptor: ActionDescriptor = {
+     title: () => "Re-authorize service",
+     body: (params) =>
+       params.variant === "service_reauthorize"
+         ? `NyxID will re-authorize this connected service with the requested permissions. Your credential stays in NyxID and is never shared with the model.`
+         : "NyxID will re-authorize one exact connected service.",
+     cta: () => "Re-authorize",
+     risk: "credential_access",
+     journey: (params) =>
+       params.variant === "service_reauthorize" ? "service_reauthorize" : null,
+   };
+   ```
+
+   Register under `"service.reauthorize"` in `ACTION_REGISTRY`, add the
+   `normalizeParams` branch (schema `safeParse` → variant, `{variant:"unknown"}` on
+   failure), and extend the `ActionJourney` union with `"service_reauthorize"`.
+   Copy tone/length from the existing descriptors; final copy per DESIGN.md voice.
+
+### F2. Frontend: the journey (reuse the reconnect flow — do not invent an OAuth path)
+
+The existing re-authorization UX is `AddKeyDialog`'s **reconnect mode**
+(`frontend/src/components/dashboard/add-key-dialog.tsx`, `reconnectKey` prop): it reuses
+the key's `connection_id`, seeds/locks already-granted scopes via `OAuthStep`
+(`grantedScopes` / `lockedScopes`, scope UI in
+`frontend/src/components/shared/upstream-scope-picker.tsx`), starts the flow with
+`useInitiateOAuth()` (`frontend/src/hooks/use-providers.ts:111` —
+`GET /providers/{providerId}/connect/oauth?scope_override=…&key_id=…&flow=cc`), runs the
+managed popup from `frontend/src/lib/oauth-popup.ts` (#1349), and completion is detected
+by polling `GET /keys/{id}` until `status === "active"` **and** `last_authorized_at`
+advances past the pre-flow baseline (`useKeyAuthorizationWatch` /
+`useKeyAuthorizationStatus`, `frontend/src/hooks/use-keys.ts:56-240`, with
+`previousAuthorizationAt` captured before launch). The chat `connect-card.tsx` already
+drives exactly this for its `NYXID_UNAUTHORIZED` reconnect banner, and
+`action-card.tsx`'s `service.connect` journey already handles the out-of-band completion
+via `pending-connect-store` + auto-resolve.
+
+Implementation in `frontend/src/components/assistant/blocks/action-card.tsx` (plus a new
+`assistant-service-reauthorize-*` wrapper if the logic warrants its own file):
+
+1. On CTA for `variant === "service_reauthorize"`:
+   a. Resolve the key: `GET /keys/{userServiceId}` with the same secret-free read-back
+      assertion pattern the key dialogs use (`assertSecretFreeReadBack` + a minimal
+      strict snapshot: `is_active`, OAuth-manageable — `credential_type === "oauth2"` or
+      `auth_method` `oauth2|oidc`, mirroring `connect-card.tsx`'s `reconnectKey`
+      predicate). Not found / not OAuth / org-managed-not-manageable → block the card
+      with a typed note (never report completed).
+   b. Capture `previousAuthorizationAt = key.last_authorized_at` and open `AddKeyDialog`
+      with `reconnectKey={key}`, `launch="popup"`, `flow="cc"`, and the **requested
+      scopes pre-selected**.
+2. **`AddKeyDialog`/`OAuthStep` extension (the one new capability):** a prop
+   (suggested `prefillScopes?: string[]`) that unions the action's `requestedScopes`
+   into the initial scope-picker selection on top of `grantedScopes`. Unknown scope
+   strings (not in the catalog's scope list) must still be sent — pass through to
+   `scope_override` — or, if the picker cannot represent them, block the journey with a
+   clear note rather than silently dropping a requested scope (a dropped scope means
+   Aevatar's superset check fails and the action reads as a broken promise).
+   > TODO — not investigated: whether `upstream-scope-picker.tsx` supports free-form /
+   > unknown scope entries today. Check before choosing between "pass through" and
+   > "block".
+3. Completion: reuse the `service.connect` out-of-band pattern — write the attempt into
+   `pending-connect-store`, run `useKeyAuthorizationWatch` with the
+   `previousAuthorizationAt` baseline; on `authorized` report
+   `report("completed", { userService: { userServiceId } })`; on failure → `onBlock`
+   with the backend reason; on `connectWatchDeadline` timeout → timeout note. Dedupe /
+   origin-turn rules come free from the existing `actionContinueBodySchema` path.
+4. Do NOT gate completion on the granted scopes matching client-side — Aevatar's
+   postcondition is the authority (§1.3). The card reports the journey outcome; the
+   verify happens server-side on Aevatar with fresh evidence.
+
+**UI constraints (DESIGN.md, read it before building):** compact dark UI; purple
+(`nyx-secondary-400` / `variant="primary"`) only on the primary CTA; dialogs `p-5 gap-4
+rounded-xl`, title `text-[15px] font-semibold`; buttons `h-8 text-[12px] rounded-lg`
+with `isLoading`; 12/11/10px type scale; badges `text-[10px] … rounded-md` tint style;
+scope lists in the existing picker component; ids in `font-mono text-[12px]`; no colored
+top accent rail (the action-card tests assert this). Caveat: the live `frontend/src/app.css`
+(+ Mona Sans) is the source of truth for concrete hex/font values; DESIGN.md is stale on
+those — follow DESIGN.md for structure/density, verify hex/fonts against `app.css`.
+
+**Tests (mirror the existing suites):**
+- `assistant-actions.test.ts`: params parsing (valid, empty scopes rejected, dup scopes
+  rejected, control-identity rules), unknown-variant fallback, resource-variant pairing
+  for the new verb.
+- `action-card.test.tsx` additions: journey opens `AddKeyDialog` in reconnect mode with
+  requested scopes pre-selected; popup handoff; auto-completion when the watch sees
+  `last_authorized_at` advance; failure/timeout notes; reports only
+  `{userService:{userServiceId}}`; non-OAuth key blocks the card.
+- `add-key-dialog.test.tsx`: `prefillScopes` union behavior (incl. unknown-scope
+  handling per the decision above).
+
+**Acceptance:** `npm --prefix frontend run test`, `run lint`, `run build` (note: CI runs
+`build` = `tsc -b` with `noUncheckedIndexedAccess`; `tsc --noEmit` passing is NOT
+sufficient).
+
+### C1. Coordination artifacts (part of this work, not optional)
+
+1. Comment on ChronoAIProject/NyxID#1400 stating: item-1 residual scope =
+   `service.reauthorize` only; NyxID-side branch/PR link; the deployment-order
+   constraint (§5) restated; the evidence-endpoint correction (§0.1).
+2. File (or ask eanz17 to file) the **Aevatar prerequisite issue** (consumer for the new
+   revision — §5 list), referencing aevatar#3312 (the Wave-1 consumer issue named in
+   #1400) and aevatar#3315 item 6 (param-shape confirmation — answer: settled as
+   `{userServiceId, requestedScopes[]}`, already implemented on `feature/integrate`).
+3. Mark the NyxID PR **DO-NOT-MERGE** until the Aevatar consumer is deployed and
+   verified against the live v7 manifest.
+
+---
+
+## 4. What does NOT need building (verified already shipped / already built)
+
+- Aevatar `service.reauthorize` machinery: `ServiceReauthorizeParamsSchema`,
+  `ParseServiceReauthorize`, `VerifyServiceReauthorizeAsync`, browser-action producer,
+  AGUI frame builder, TaskPlan wire mapper, audit translators, state projector, tests —
+  all present on `origin/feature/integrate`. Blocked only by the revision gate.
+- NyxID `last_authorized_at` freshness semantics (`write_oauth_tokens_to_key` stamps on
+  fresh authorization only, not refresh) — exactly what the verify needs; no change.
+- The manage-scopes reconnect UX, managed OAuth popup (#1349), key-authorization
+  watch/polling, pending-connect store, six-variant safe-resource union, and the
+  `service.connect` completed-`userService` report path — all shipped on `origin/main`.
+- The 14-verb `SUPPORTED_ACTIONS` parser allowlist already includes
+  `service.reauthorize` (backend test module) — no parser change.
+
+---
+
+## 5. Deployment order (binding) and the Aevatar prerequisite
+
+**Order: Aevatar consumer first, NyxID manifest second.** Rationale in §0.5 — a NyxID
+deploy publishing an unknown revision flips every Aevatar process (started thereafter)
+to a disabled action registry: all assistant actions dark, silently.
+
+The Aevatar-side prerequisite (does not exist today; §0.4) is, on
+`aevatarAI/aevatar` `feature/integrate`:
+
+1. New revision constant (expected `nyxid-assistant-actions.v8`) accepted by
+   `IsSupportedRegistryRevision`.
+2. `PinnedActionsByRevision[v8] = {service.connect, service.reauthorize, key.create, key.rotate}`.
+3. `ExecutableActionsByRevision[v8]` = same four (this is what finally makes the verb
+   executable).
+4. Pinned-schema wiring in `ValidatePinnedContract` so v8's `key.create` pins
+   `LeastScopeKeyCreateParamsSchema` (the existing `revision is LeastScopeRegistryRevision
+   or SupportedRegistryRevision && action == KeyCreate` special-case must include v8) and
+   `service.reauthorize` pins its schema + grant/false metadata.
+5. `docs/contracts/nyxid-assistant-conformance/v1/registry-v8.json` fixture =
+   the exact manifest NyxID will publish (v7 fixture + §1.2 descriptor at index 1,
+   revision bumped).
+6. Registry test updates (`NyxIdAssistantActionRegistryTests.cs`,
+   `NyxIdActionPostconditionPortTests.cs` already covers the verify path).
+
+Sequence:
+1. Aevatar merges + deploys the v8-accepting consumer; verify its startup against the
+   **live v7** manifest (must stay fully functional — v8 acceptance is additive).
+2. NyxID merges + deploys B1 (manifest bump) — B2/B3/F1/F2 can merge earlier; only the
+   revision bump is order-sensitive. (If B1 is split so the descriptor+bump is its own
+   final PR, everything else is unblocked immediately.)
+3. Verify an Aevatar process restarted after the NyxID deploy loads v8 and advertises
+   `service.reauthorize` as executable; run one end-to-end reauthorize through chat.
+
+---
+
+## 6. Test commands
+
+```bash
+# Backend (repo root). Backend tests need a MongoDB replica set +
+# NYXID_TEST_DATABASE_URL (thousands of tests failing within seconds = connection
+# failure, not code regressions — fix the test DB first).
+source "$HOME/.cargo/env" 2>/dev/null
+cargo test assistant_actions          # B1 focused
+cargo test unified_key_service        # B2 focused
+cargo test                            # full suite
+cargo fmt --check
+
+# CLI
+cargo test -p nyxid-cli
+
+# Frontend (CI parity: build, not just typecheck)
+npm --prefix frontend run test
+npm --prefix frontend run lint
+npm --prefix frontend run build
+```
+
+Do not blanket-rebuild the CLI wizard bundle: the freshness CI check is source-only over
+`index.manifest`; rebuild (`npm --prefix frontend run build:wizard` + commit
+`cli/src/wizard/`) **only if** frontend deps/lockfile changed, and if the branch is
+rebased after a rebuild, rebuild again.
+
+---
+
+## 7. Open questions for Calvin / eanz17
+
+- **Q1 (blocking B1's final revision string):** confirm the next revision is
+  `nyxid-assistant-actions.v8` and that Aevatar (eanz17) will author the consumer
+  (§5 items 1–6). No v8 exists in Aevatar today; NyxID must not invent the pin
+  unilaterally since Aevatar's map is the acceptance gate.
+- **Q2 (auth posture of the evidence read) — RESOLVED, no work needed.** Verified on
+  `origin/main`: `/keys` routes are nested inside `api_v1_human_only` (`routes.rs`
+  lines 1507–1569). `reject_delegated_tokens` permits delegated GETs via
+  `delegated_request_allowed` (`mw/auth.rs:466-479`: GET + `account:read` scope +
+  path not in `delegated_read_denied_path` + not a WS upgrade), and `keys` is **not** in
+  the deny list — confirmed by the test constant `DELEGATED_ALLOWED_MANAGEMENT_PATHS`
+  (`mw/auth.rs:1371`, includes `"/api/v1/keys"` at line 1374) and test
+  `delegated_account_read_allows_expected_management_families` (line 1469). So a
+  session JWT or a delegated `account:read` token reads the evidence fine. Relay tokens
+  (`reject_relay_tokens`, unconditional 403) and agent API keys / SA tokens are blocked
+  — same posture as the already-working `GET /api-keys/{id}` reads for
+  `key.create`/`key.rotate`, so Aevatar's human-session credential is proven compatible
+  in production.
+- **Q3 (provider scope-echo caveat):** `write_oauth_tokens_to_key` preserves old
+  `token_scopes` when the provider token response omits `scope`, and `build_key_view`
+  splits on whitespace. Two per-provider risks: a provider that never echoes scopes
+  leaves `granted_scopes` stale (superset check may pass/fail incorrectly), and a
+  provider that returns comma-separated scopes (GitHub-style `repo,read:user`) would
+  yield a single comma-joined entry that can never match Aevatar's per-scope Ordinal
+  contains. `TODO — not investigated`: what NyxID's callback actually stores per catalog
+  provider (check `handle_oauth_callback` normalization). Decide whether to normalize
+  commas→spaces at the callback write for affected providers as part of B2.
+- **Q4 (product):** for `scope_removal === "unsupported"` catalogs (GitHub), granted
+  scopes are locked in the picker; requested-scope pre-selection is purely additive
+  there — confirm that is acceptable UX (it matches the existing manage-scopes flow).
+
+---
+
+## 8. Execution notes for the implementing agent
+
+- Verify every "current state" quote in this plan against `origin/main` before editing —
+  worktrees here are known to go stale.
+- Branch: work on `feat/2026-08-17_wave1-service-reauthorize`; PR targets `main`;
+  conventional commits; push with the `ctkm-aelf` gh account.
+- Never place key material, tokens, or scope-bearing secrets in chat transcripts, audit
+  events, or test fixtures (§1.4 tripwire list is a useful blocklist to test against).
+- Rollup/branch CI caveat: `ci.yml` gates `main`/`dev` only — a green-looking PR into
+  any other branch has NOT run the suite; run §6 locally.

--- a/docs/chat/wave1-service-reauthorize-review-opus.md
+++ b/docs/chat/wave1-service-reauthorize-review-opus.md
@@ -1,0 +1,614 @@
+# Adversarial review: Wave 1 `service.reauthorize` (PR #1462)
+
+> **Evidence document, not an action list.** The live action list is
+> [`wave1-service-reauthorize-actions.md`](./wave1-service-reauthorize-actions.md),
+> where every finding below appears as a tracked item (A1–A8, B1–B4, C1–C2).
+> This document holds the full reproductions, code citations, and the record of
+> which earlier concerns did **not** survive scrutiny.
+
+Reviewer: Opus (third pass, adversarial). Reviewed commit `5b1189ee` on
+`feat/2026-08-17_wave1-reauthorize-impl`, diffed against `origin/main`.
+Aevatar consumer read from `aevatarAI/aevatar` `origin/feature/integrate`
+(fetched 2026-08-17).
+
+Prior artifacts: `docs/chat/wave1-service-reauthorize-plan.md` (Fable),
+`docs/chat/wave1-service-reauthorize-review-sol.md` (Sol).
+
+---
+
+## Overall verdict
+
+**BLOCKED** — on the consumer prerequisite the PR already declares, plus two
+MAJOR defects that should be fixed before the Aevatar-first rollout completes.
+
+| Severity | Count |
+| --- | --- |
+| BLOCKER | 1 |
+| MAJOR | 3 |
+| MINOR | 5 |
+
+The single most dangerous finding is **M1**: an ordinary, NyxID-validated,
+user-configurable WebSocket auth template of the shape
+`{"headers":{"Authorization":"Bearer ${credential}"}}` makes `GET
+/api/v1/keys/{id}` permanently unparseable by *both* Aevatar's evidence parser
+and this PR's own browser preflight. The affected service can never be
+re-authorized through the assistant, and the only user-facing signal is the
+generic "NyxID could not verify this service for re-authorization."
+
+The contract work itself is correct. I re-derived the published descriptor
+against Aevatar's `ValidatePinnedContract` and all six evidence conditions in
+`VerifyServiceReauthorizeAsync` and found no near-miss. Several concerns raised
+in the review brief turned out to be unfounded; those are recorded in
+§"Concerns that did not survive" so they are not re-litigated.
+
+---
+
+## BLOCKER
+
+### B1. Publishing v8 before Aevatar ships a v8 consumer disables the entire assistant-action registry
+
+**Verified.** `agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs`
+`PinnedActionsByRevision` (~line 207) contains only v4, v5, v6, v7. `Load()`
+(~line 322) does:
+
+```csharp
+if (!PinnedActionsByRevision.TryGetValue(revision, out var pinnedActions) ||
+    !ExecutableActionsByRevision.TryGetValue(revision, out var executableActions))
+    throw Error(RevisionUnsupported, "The NyxID action registry revision is not supported.");
+```
+
+`nyxid-assistant-actions.v8` (`backend/src/handlers/assistant_actions.rs:9`) hits
+that throw. Every Aevatar process started after a NyxID v8 deploy loses **all**
+NyxID action cards, not just `service.reauthorize`.
+
+This is the PR's own declared merge gate and it is correctly and prominently
+stated. I confirm the gate is real (see §"Merge gate" below). It stays a BLOCKER
+because it is not yet retired.
+
+**Two prerequisite details the PR body under-specifies.** Adding v8 to the two
+revision maps is *not* sufficient. Both of these are in
+`NyxIdAssistantActionRegistry.cs` and both fail closed in ways that look like the
+same catastrophic symptom:
+
+1. `IsActionExecutable` (~line 293) maps action kinds to wire actions through a
+   hardcoded switch:
+
+   ```csharp
+   var wireAction = action switch
+   {
+       NyxIdAssistantActionKind.ServiceConnect => "service.connect",
+       NyxIdAssistantActionKind.KeyCreate => "key.create",
+       NyxIdAssistantActionKind.KeyRotate => "key.rotate",
+       _ => null,
+   };
+   ```
+
+   `ServiceReauthorize` falls through to `null`, so the verb stays
+   non-executable no matter what the revision maps say.
+
+2. `ValidatePinnedContract` (~line 886) selects the pinned `key.create` schema
+   by revision:
+
+   ```csharp
+   var pinnedParamsSchema = revision is LeastScopeRegistryRevision or SupportedRegistryRevision &&
+                            contract.Action == NyxIdAssistantActionKind.KeyCreate
+       ? LeastScopeKeyCreateParamsSchema
+       : contract.PinnedParamsSchema;
+   ```
+
+   v8 is in neither branch, so `key.create` would be `DeepEquals`-compared
+   against the *unconstrained* `KeyCreateParamsSchema`. NyxID publishes the
+   least-scope variant with `minItems: 1` / `maxItems: 64` / `uniqueItems: true`
+   (asserted at `backend/src/handlers/assistant_actions.rs:527-536`), so the
+   comparison fails and `Load()` throws `RegistryInvalid` — again killing the
+   whole registry.
+
+   The PR body's prerequisite 3 does say "Preserve the least-scope `key.create`
+   schema pin for v8 as well", which is the right instruction; it does not name
+   the code site, and a reader who only edits the revision maps will ship a
+   broken consumer that passes its own revision-map tests.
+
+**Fix:** keep the merge gate. When drafting the Aevatar issue, name all four
+edit sites explicitly: `PinnedActionsByRevision`, `ExecutableActionsByRevision`,
+the `IsActionExecutable` wire-action switch, and the `ValidatePinnedContract`
+revision ternary.
+
+---
+
+## MAJOR
+
+### M1. User-controlled `Bearer …` strings in `KeyResponse` permanently break both the journey and the verify
+
+**Verified, with a reproduction.** Two independent recursive scanners run over
+the *entire* `/keys/{id}` body:
+
+- Aevatar: `NyxIdApiAccessContracts.cs` `RejectSecretBearingRead`, called first
+  in `ParseUserServiceAuthorizationDocument`. Value pattern:
+  `(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})`, `IgnoreCase`. A hit
+  throws `NyxIdContractException` → `MalformedResponse` → `ProviderReadFailure`
+  → the action is never verified.
+- This PR: `frontend/src/components/assistant/blocks/action-card.tsx:110-128`
+  (`assertSecretFreeReadBack`), same pattern, run on the raw response in
+  `readReauthorizationKey` (`:135-137`) *before* the journey opens.
+
+`KeyResponse` carries at least three user-controlled free-text carriers that
+reach both scanners:
+
+| Field | `keys.rs` | Serialization |
+| --- | --- | --- |
+| `ws_frame_injections[].template` | `:509-511` | always (bare `Vec`) |
+| `default_request_headers[].value` | `:504-506` | present whenever the user set any; only `sensitive: true` entries are redacted (`models/default_request_header.rs:344-364`) |
+| `label` / `name` | `:417-418` | always |
+
+The WS template case is the sharp one, because **NyxID's own validator
+explicitly permits exactly the string Aevatar rejects**.
+`services/ws_frame_injector.rs:189-197`:
+
+```rust
+fn validate_template_does_not_embed_credentials(idx: usize, template: &str) -> AppResult<()> {
+    let stripped = template.replace("${credential}", "");
+    if stripped.contains("nyxid_") || contains_jwt_like_literal(&stripped) { ... }
+```
+
+`{"headers":{"Authorization":"Bearer ${credential}"}}` strips to
+`{"headers":{"Authorization":"Bearer "}}` — no `nyxid_`, no `eyJ` segment —
+so NyxID stores it, and then refuses to read it back. Verified against the
+literal regex:
+
+```
+TRIPS  ws_frame_injections[].template   ->   {"headers":{"Authorization":"Bearer ${credential}"}}
+ok     ws_frame_injections[].template   ->   {"type":"auth","access_token":"${credential}"}   (the HA example in NyxID's own tests)
+TRIPS  default_request_headers[].value  ->   Bearer sk-live-abc123
+TRIPS  UserService.label                ->   Bearer Bot
+```
+
+Sol's mitigation (`backend/src/handlers/keys.rs:2664-2749`) asserts the scan
+over `key_response_from_result` built from a `CreateKeyResult` with
+`api_key: None` — a near-empty response with no `ws_frame_injections` entries,
+no `default_request_headers`, and a fixed test label. It cannot catch any of the
+three carriers above. Sol's own review flagged this as a residual hardening gap;
+it is not hypothetical, it is reachable through a documented, admin- and
+user-supported feature (CLAUDE.md §6 describes `ws_frame_injections` as the
+supported WS auth mechanism).
+
+Fail mode is closed, not leaky — no secret escapes. But the feature is silently
+dead for the affected service, and the user sees only
+`REAUTHORIZE_UNAVAILABLE_NOTE` ("NyxID could not verify this service for
+re-authorization"), which points them at AI Services where nothing is wrong.
+
+**Fix (pick one):**
+
+1. Preferred — serve a minimal evidence projection. Either a dedicated
+   representation for the evidence read, or drop `ws_frame_injections`,
+   `default_request_headers`, and any other free-text carrier from it. Aevatar
+   only reads `id`, `api_key_id`, `is_active`, `status`, `connection_status`,
+   `granted_scopes`, `last_authorized_at`; everything else on that response is
+   pure attack surface for the tripwire.
+2. Cheaper stopgap — reject `Bearer\s` (and the rest of the Aevatar value
+   pattern) in `validate_template_does_not_embed_credentials`, in
+   `default_request_header` value validation, and in label validation, so NyxID
+   never stores a value it cannot read back. This is a behaviour change for
+   existing rows and does not repair data already stored, so it is strictly
+   worse than (1).
+3. At minimum — make the browser distinguish this case from a transport
+   failure, and add a backend test that runs `assert_aevatar_secret_free` over a
+   *fully populated* `KeyResponse` including a `Bearer ${credential}` WS
+   template. Today that test would fail, which is the point.
+
+### M2. `completed` is reported without checking that the requested scopes were actually granted
+
+**Verified.** Both completion paths report `completed` on identity match plus
+`status == active` plus `last_authorized_at` advancement. Neither looks at
+`granted_scopes`:
+
+- watch path — `action-card.tsx:513-541`: guards `keyId !== user_service_id`,
+  then `onResolve({disposition: "completed", resource: {userService: {userServiceId: keyId}}})`.
+- dialog path — `action-card.tsx:965-973`: `onSuccess` guards
+  `userServiceId !== params.user_service_id`, then `report("completed", ...)`.
+
+Aevatar's condition 5 (`NyxIdActionPostconditionPort.cs:294-296`) *does* check
+it:
+
+```csharp
+!input.Params.ServiceReauthorize.RequestedScopes.All(scope =>
+    evidence.GrantedScopes.Contains(scope, StringComparer.Ordinal))
+```
+
+so the model is not misled — it gets `MismatchCode`. The **user** is: the card
+renders the `Re-authorized` badge and the footer "The assistant received only
+the verified service reference", and the conversation then behaves as if nothing
+happened.
+
+Three reachable ways to land here:
+
+1. The user deselects a requested scope in `UpstreamScopePicker` before
+   clicking Connect. `prefillScopes` only seeds the `useState` initializer
+   (`add-key-dialog.tsx:1530-1536`); nothing pins it afterwards.
+2. The provider grants a subset (GitHub org access not approved, Google consent
+   screen with scopes unchecked, Lark app permission still pending review).
+3. The provider omits `scope` from the token response. The backend then
+   **preserves the previous `token_scopes`**
+   (`services/user_api_key_service.rs:568-580`, deliberately, per the NyxID#917
+   comment) while still stamping `last_authorized_at`. So the freshness gate
+   passes with a completely unchanged grant set.
+
+**Fix:** in both completion paths, re-read `/keys/{id}` and require
+`requested_scopes ⊆ granted_scopes` (case-sensitive, matching Aevatar's
+`StringComparer.Ordinal`) before `report("completed", …)`. On a shortfall, call
+`onBlock` with a note naming the missing scopes — that is a far better user
+outcome than a green badge followed by an assistant that says the permission
+isn't there.
+
+### M3. The freshness gate proves "some authorization advanced", not "this attempt's authorization completed"
+
+**Verified.** The predicate is a timestamp inequality with no server-side
+correlation to the attempt:
+
+```ts
+// frontend/src/hooks/use-keys.ts:213-216
+const authorizationAdvanced =
+  previousAuthorizationAt === undefined ||
+  (query.data?.last_authorized_at != null &&
+    query.data.last_authorized_at !== previousAuthorizationAt);
+```
+
+`attemptId` is a client-side `crypto.randomUUID()` used only as a TanStack Query
+cache generation (`use-keys.ts:154`); it never reaches the server and is never
+matched against anything.
+
+The baseline is captured from a **stale snapshot**. `handleConnect` does
+`key = await ensureKey()` (`add-key-dialog.tsx:1764`), and for reconnect mode
+`ensureAuthKey` returns the `reconnectKey` prop verbatim
+(`add-key-dialog.tsx:3191-3203`) — the object `readReauthorizationKey` fetched at
+*card-click* time, which may be minutes old by the time the user presses
+Connect. The baseline is then `key.last_authorized_at`
+(`add-key-dialog.tsx:1792-1794`).
+
+Consequences:
+
+- Any unrelated fresh authorization of the same key inside that window (the AI
+  Services page, a second browser tab, `nyxid service scopes`, the CLI wizard, a
+  second assistant card for the same service with different scopes) satisfies
+  the gate and settles the card as `completed`.
+- Two concurrent reauthorize cards for one service share the same baseline;
+  completing either settles both.
+
+Combined with M2 this is the real "false `completed`" surface: not a background
+refresh (that path is genuinely closed — see §"Concerns that did not survive"),
+but *someone else's* authorization being claimed as this attempt's.
+
+**Fix:** correlate to the server-side attempt rather than to a timestamp delta.
+`initiateOAuthAsync` already returns an `attempt_nonce` and the flow already
+threads a `connection_id`; settle on evidence that *this* attempt landed. If
+that is too large for this wave, at minimum re-read `/keys/{id}` inside
+`handleConnect` and derive the baseline from that fresh read, which closes the
+card-click→Connect-click window (it does not close the concurrent-flow case).
+
+---
+
+## MINOR
+
+### m4. The PR body misattributes the M3-class fix; no freshness code is in this diff
+
+The disposition table says:
+
+> MAJOR: a currently-active key could make F2 report completed without a new
+> authorization — **Fixed.** Pending attempts carry `previousAuthorizationAt`;
+> the watcher requires `last_authorized_at` to advance for reconnects.
+
+All three parts of that mechanism already exist on `origin/main`:
+
+- `git show origin/main:frontend/src/stores/pending-connect-store.ts` → line 12,
+  `readonly previousAuthorizationAt: string | null | undefined;`
+- `git show origin/main:frontend/src/components/assistant/blocks/action-card.tsx`
+  → line 285, `previousAuthorizationAt: pendingAuth?.previousAuthorizationAt,`
+- `git show origin/main:frontend/src/hooks/use-keys.ts` → 11 occurrences
+
+`frontend/src/hooks/use-keys.ts` and
+`frontend/src/stores/pending-connect-store.ts` are not in this PR's diffstat at
+all. What this PR actually adds on that axis is the **identity** guard
+(`action-card.tsx:513-525`), which is real and correct but is a different
+control.
+
+This matters because it is the line a reader trusts to conclude the risk was
+retired *and re-verified here*. It was inherited, and it happens to be reachable
+only because `reconnectMode` is true for this journey
+(`add-key-dialog.tsx:2911, 3499`) — a coupling nothing in this PR tests or
+documents. Sol's review §3 was written against the pre-rebase branch point and
+is accurate about that branch; the PR body then carried the "Fixed" verdict
+forward without re-checking what the rebase brought in.
+
+**Fix:** correct the table entry to "already present on `main`; this PR adds the
+exact-service identity guard and relies on the inherited baseline gate", and add
+the negative test in m5.
+
+### m5. The freshness test does not test freshness
+
+`frontend/src/components/assistant/blocks/action-card.test.tsx` — "waits for a
+fresh authorization timestamp before auto-completing reauthorization". The mock
+returns the original `last_authorized_at` on read 1 and an advanced one on read
+2, then asserts `onResolve` was called once with `completed`.
+
+Delete the entire freshness gate from `use-keys.ts` and this test still passes.
+The assertion that carries the name — an unchanged `last_authorized_at` must
+*not* settle the card — is absent.
+
+**Fix:** add a case whose key read always returns the original
+`last_authorized_at`, and assert `onResolve` is never called (and that the card
+eventually reports the timeout note). The rest of the new tests in this PR are
+genuine behavioural tests, not padding; this one overclaims in its name.
+
+### m6. Browser scope grammar is stricter than both the published schema and RFC 6749
+
+`frontend/src/schemas/assistant-actions.ts:49-56`:
+
+```ts
+.regex(/^[A-Za-z0-9._:/~+*=-]+$/, "Scope contains characters NyxID cannot request")
+```
+
+The published `params_schema` says `{"type": "string"}`, and Aevatar's
+`ValidateRequest` enforces only that. RFC 6749 §3.3 `scope-token` permits every
+printable ASCII except space, `"` and `\`. A provider scope containing
+`! # $ % & ' ( ) , ; < > ? @ [ ] ^ { | }` parses fine at Aevatar, then fails
+`serviceReauthorizeActionParamsSchema` → `{variant: "unknown"}` →
+`resolveAssistantAction` returns `unsupportedDescriptor` → the user sees
+"Unsupported action request" with no indication which scope was rejected.
+
+I could not find a real catalog provider that trips this (Google, GitHub, Slack,
+Lark, Microsoft, Zoom, HubSpot, Atlassian scopes all pass), so the practical
+likelihood is low. It is worth documenting the divergence in
+`docs/chat/06-actions-registry.md`, since the published schema is the contract
+and this restriction is invisible from it.
+
+Same class, same file: `requestedScopes` rejects an empty array (`.min(1)`)
+while the published schema permits one. Aevatar's `VerifyServiceReauthorizeAsync`
+also requires non-empty (`requireAny: true`), but its *production* path
+(`ValidateRequest`) does not — so an LLM emitting `requestedScopes: []` produces
+a dead card rather than a clear error.
+
+### m7. The org-admin preflight guard is optional-and-fails-open
+
+`action-card.tsx:79-88, 158-163`:
+
+```ts
+credential_source: reauthorizationCredentialSourceSchema.optional(),
+...
+if (snapshot.credential_source?.type === "org" && snapshot.credential_source.role !== "admin")
+```
+
+`KeyResponse.credential_source` is mandatory (`keys.rs:544-546`, no
+`skip_serializing_if`), so this is currently unreachable. But an `.optional()`
+schema means the guard silently vanishes if the response shape ever changes,
+and the whole point of this preflight is defence in depth. Make it required so a
+shape change fails loudly instead of quietly widening who can drive a re-auth on
+a shared org credential. (The backend remains the real gate.)
+
+### m8. Preflight fetches the whole catalog to read one entry
+
+`readReauthorizationKey` does `api.get("/catalog?include_all=true")`
+(`action-card.tsx:167-169`) and then `.find(entry => entry.slug === catalogSlug)`.
+`GET /api/v1/catalog/{slug}` exists and returns the same
+`provider_type` / `provider_config_id` / `device_code_format` fields. This is one
+full-catalog fetch per card click.
+
+---
+
+## Concerns from the review brief that did not survive
+
+Recorded so they are not re-raised. Each was checked against code, not against
+the prior reviews.
+
+**Evidence endpoint — Sol is right, the original briefing was wrong.**
+`NyxIdActionEvidenceReadPort.GetUserServiceAuthorizationAsync` calls
+`client.GetServiceAsync`, which is `GET /api/v1/keys/{id}`
+(`NyxIdApiClient.cs:279`). Not `/api/v1/user-services`.
+
+**Params-schema `DeepEquals` — exact.** Aevatar already carries
+`ServiceReauthorizeParamsSchema` (`NyxIdAssistantActionRegistry.cs:90-101`) and
+it is structurally identical to what NyxID publishes
+(`assistant_actions.rs:91-108`). `JsonNode.DeepEquals` is whitespace- and
+property-order-insensitive. `risk=grant`, `tier=v1`,
+`remember_eligible=false`, `schema_version=4` all line up with
+`SupportedActions["service.reauthorize"]` and `SupportedSchemaVersion`.
+
+**All six evidence conditions are satisfiable.**
+
+| Aevatar requirement | NyxID source | Status |
+| --- | --- | --- |
+| `RequireNormalizedString(root, "id")` | `KeyResponse.id` | ok |
+| `RequireBoolean(root, "is_active")` | `KeyResponse.is_active` (`keys.rs:469`) | ok |
+| `status` ∈ {active, expired, revoked, failed, refresh_failed, pending_auth} | `UserApiKey.status`, documented domain at `models/user_api_key.rs:68` | exact match |
+| `connection_status` **property present**; null or active/expired | now always serialized (`keys.rs:435`) | fixed by this PR |
+| `granted_scopes` **property present**; null or **distinct** normalized strings | now always serialized (`keys.rs:498`); `parse_granted_scopes` dedups Ordinal | fixed by this PR — the dedup is load-bearing, `ReadNormalizedStringArray` throws on duplicates |
+| `last_authorized_at` **property present**; null or RFC3339 | now always serialized (`keys.rs:503`); `chrono::to_rfc3339` emits `…+00:00`, which matches Aevatar's `Rfc3339Pattern` | fixed by this PR |
+
+Removing `skip_serializing_if` on those three was necessary and correct:
+Aevatar uses `RequireProperty` (not `TryGetProperty`) for all three, so an
+omitted property is a hard `MalformedResponse`, not a soft miss.
+
+**Blast radius of the serializer change — both of Sol's claims re-derived and
+they hold.**
+
+- No Rust or TypeScript consumer of `granted_scopes`, `connection_status`, or
+  `last_authorized_at` exists in `cli/src`, `sdk/`, or `mobile/src` (grepped;
+  zero hits). The classic `#[serde(default)]`-on-a-non-`Option`-field-breaks-on-
+  explicit-null hazard has no target here.
+- No frontend Zod schema parses the key response;
+  `frontend/src/types/keys.ts:24` types `connection_status` as
+  `?: "active" | "expired" | null`, which already accepts an explicit null.
+- Aevatar's `ParseUserServiceKeysDocument` (the `/keys` list parser) reads only
+  named properties, ignores additive fields, and — importantly — does **not**
+  call `RejectSecretBearingRead`. The list path is unaffected.
+- `frontend/src/components/dashboard/add-key-dialog.tsx` is **not** in
+  `cli/src/wizard/bundle-meta/index.manifest`, so no wizard-bundle rebuild is
+  required and the freshness test is legitimately green.
+
+**`oauth_connection_status` override — Sol overrode the plan and was right.**
+The only consumer outside the evidence path is
+`frontend/src/pages/keys.tsx:100,152,338`, and it falls back to
+`connection_status ?? status`. Walking every credential shape:
+
+- expiry-less oauth2, `status == active`, access token stored → was `None`,
+  now `Some("active")`; `effectiveStatus` is `"active"` either way. No change.
+- `status == pending_auth` with a stale `expires_at` → was `Some("active")`,
+  now `None` → `effectiveStatus` becomes `"pending_auth"`, which *adds* the
+  Reconnect affordance (`RECONNECTABLE_STATUSES`, `keys.tsx:84-89`). An
+  improvement.
+- terminal states still short-circuit to `"expired"` before the new guards.
+- the ordinary expired case (`status == active`, past `expires_at`, no refresh
+  token, access token present) still yields `"expired"`.
+
+The one shape that would regress — `status == "active"` with
+`access_token_encrypted == None` and a past `expires_at` — I could not
+construct: `sync_provider_token_to_api_keys_impl`
+(`user_api_key_service.rs:397-407`) writes the access token whenever it writes
+`active`, and `write_oauth_tokens_to_key` always writes both. *Inferred, not
+proven by test* — flagging the reasoning so it can be challenged.
+
+**Comma-scope normalization — correct, and strictly better than what it
+replaced.** `parse_granted_scopes` (`unified_key_service.rs:3819-3828`) splits on
+comma-or-Unicode-whitespace, drops empties, and dedups on first occurrence with
+`HashSet<&str>` (case-sensitive). That matches Aevatar's `Ordinal` `Distinct`
+requirement and its `Ordinal` `Contains` comparison. Order is preserved and no
+consumer depends on order (the frontend diffs granted-vs-selected as sets;
+Aevatar uses `Contains`). The old `split_whitespace` turned a GitHub echo of
+`repo,read:user` into the single garbage token `repo,read:user`, which was then
+re-submitted verbatim as a scope on the next reconnect — the new behaviour fixes
+that too.
+
+**No scope is silently dropped in the picker.** I specifically looked for this.
+`UpstreamScopePicker.buildPills` takes `value` as an input, so an
+assistant-requested scope outside the catalog still becomes a pill, and
+`toggle` re-emits from `pills.map(...).filter(...)`
+(`upstream-scope-picker.tsx:165-176`) rather than from the catalog — so touching
+any pill does not drop an unknown prefill scope. `platformScopeAllowlist`, the
+other place that filters `submittedScopes`, is gated on `!isReconnect`
+(`add-key-dialog.tsx:3512`) and is therefore inactive for this journey.
+
+**A background token refresh cannot falsely satisfy the freshness gate.** This
+was the worst hypothetical and it is closed by pre-existing NyxID#917
+discipline: `last_authorized_at` is written only by
+`sync_provider_token_to_api_keys_after_authorization`
+(`user_api_key_service.rs:338-345`) and `write_oauth_tokens_to_key` /
+`store_device_code_tokens` — never by refresh paths, which call the
+non-stamping wrapper. The `OAUTH_REFRESH_SWEEP_INTERVAL_SECS` sweep cannot
+advance it.
+
+**Malformed params degrade gracefully, they do not strand the card.**
+`resolveAssistantAction` (`action-registry.ts:141-165`) returns
+`unsupportedDescriptor` whenever `journey === null`, which is what
+`{variant: "unknown"}` produces, so `unsupported` is true and no CTA renders.
+`beginJourney` is unreachable in that state.
+
+**Merge gate is real.** `gh pr view 1462`: `isDraft: true`, `reviews: []`, the
+only comment is the `github-actions` coverage bot. `gh issue view 1400`: newest
+comments are 2026-08-10 from eanz17 on unrelated work — the drafted #1400
+comment was not posted. No `aevatarAI/aevatar` issue mentioning
+`assistant-actions v8` exists. Nothing was deployed. The drafted coordination
+text lives only in the PR body, as instructed.
+
+---
+
+## Test results (re-run by me on this branch)
+
+| Command | Sol's claim | My result |
+| --- | --- | --- |
+| `npm --prefix frontend run test` | 246 files / 2,847 tests, 0 failed | **246 files / 2,847 tests passed, 0 failed** — matches exactly |
+| `npm --prefix frontend run lint` | 0 errors, 23 warnings | **0 errors, 23 warnings** — matches exactly |
+| `npm --prefix frontend run build` (CI parity: `tsc -b`, `noUncheckedIndexedAccess`) | passed | **passed** — main build 3,470 modules, credential-accept 107 modules, mock-footprint assertion passed |
+| `cargo test assistant_actions` | 5 passed | **5 passed, 0 failed** (5,330 filtered out) |
+| `cargo test unified_key_service` | 163 passed | **163 passed, 0 failed** (5,172 filtered out) |
+| `cargo fmt --check` | passed | **passed** |
+| `cargo clippy --workspace --all-targets -- -D warnings` | passed | **passed**, exit 0, no warnings emitted |
+| `cargo test -p nyxid-cli` | 1,100 + 1 wizard freshness | **1,100 passed + 1 wizard-freshness passed, 0 failed** — matches exactly |
+| full `cargo test` | 5,189 passed / 129 failed, all attributed to a missing MongoDB replica set | **not re-run** — see below |
+
+Notes:
+
+- The machine's disk was at 100% (0 bytes free) when I started, which corrupted
+  a cached `utoipa-swagger-ui` archive mid-build. I reclaimed one month-stale
+  cargo build cache (`worktrees/3571ce16/we-are-plannign-to-pivot/target`, 27G,
+  last touched 2026-07-16 — build output only, no source) and re-seeded the
+  archive from a sibling worktree. All numbers above are from clean runs after
+  that.
+- **I did not attempt the full backend suite.** No MongoDB replica set is
+  available here and `NYXID_TEST_DATABASE_URL` is unset, so I would reproduce
+  exactly the connection-failure signature Sol describes and learn nothing. I
+  can neither confirm nor refute the 5,189/129 split or the attribution of all
+  129 failures to fixtures. Sol was explicit that this is not a green-suite
+  claim, which is the right posture; it also means **nobody has run the full
+  backend suite against this change**. Someone with a replica set should, before
+  the eventual merge.
+- Coverage bot on the PR reports frontend line coverage 65.28% (+0.06 vs base),
+  above the 15% gate.
+
+### Are the new tests meaningful?
+
+Mostly yes. Concretely:
+
+- `frontend/src/schemas/assistant-actions.test.ts` — the seven-case rejection
+  table (empty, duplicate, untrimmed, space-packed, comma-packed, widened
+  object, invalid identity) is real negative testing, and the URL-shaped-scope
+  case pins the grammar against a realistic Google scope. Keep.
+- `add-key-dialog.test.tsx` — the three scope-merge tests assert the exact
+  `scopeOverride` array reaching `initiateOAuth`/`initiateDeviceCode`, including
+  dedup order and the RFC 8628 path. Real. Keep.
+- `action-card.test.tsx` — the non-OAuth block, the OpenAI-device-code block,
+  and the wiring test (`data-reconnect-key`, `data-prefill-scopes`,
+  `data-launch`, `data-flow`) are real behavioural tests. Keep.
+- `action-card.test.tsx` freshness test — see **m5**. It would pass with the
+  feature deleted.
+- `backend/src/handlers/keys.rs::key_response_always_serializes_authorization_evidence_properties`
+  — the three `Some(Value::Null)` assertions are exactly right and would catch a
+  regression on the `skip_serializing_if` removal. The
+  `assert_aevatar_secret_free` half is near-worthless as written: it scans a
+  response with no api_key, no WS injections, no headers, and a fixed test
+  label, so it can never fail. See **M1** for what it would need to cover to
+  earn its place.
+- `backend/src/handlers/assistant_actions.rs` golden-manifest changes — index
+  shifts plus one added descriptor, compared against a hand-written expected
+  value. Not a tautology (the expected literal is independent of the
+  production constant except for the shared `SERVICE_REAUTHORIZE_DESCRIPTION`
+  reference). Fine.
+
+---
+
+## Claims I could not confirm
+
+Every numeric test claim in the PR body that I could execute reproduced
+exactly. Two things remain open:
+
+1. **The full-suite 5,189 / 129 split and the fixture attribution.** Not
+   reproducible here — no MongoDB replica set, `NYXID_TEST_DATABASE_URL` unset.
+   Unverified either way. Sol did not claim it green, which is correct, but it
+   also means no full backend run exists for this change.
+2. **That the `status == "active"` + missing-access-token + past-`expires_at`
+   shape is unreachable.** Argued from the write paths
+   (`sync_provider_token_to_api_keys_impl`, `write_oauth_tokens_to_key`), not
+   proven by test. If someone can construct it, `oauth_connection_status`
+   regresses that row from `"expired"` to `null` and hides its Reconnect button.
+
+Separately, the PR body's **disposition-table claim that the freshness fix was
+delivered here is wrong** (see **m4**) — the mechanism was inherited from
+`main`. That is an attribution error, not a test-number error.
+
+---
+
+## Verdict
+
+**BLOCKED.**
+
+The PR is honest about its own gate and the contract work is exact — I went
+looking for a near-miss against `DeepEquals` and the six evidence conditions and
+did not find one. Before this lands:
+
+- keep B1's Aevatar-first gate, and add the two under-specified Aevatar code
+  sites to the coordination text;
+- fix **M1** (minimal evidence projection) — this is the one that silently
+  bricks real user services;
+- fix **M2** (require `requested_scopes ⊆ granted_scopes` before reporting
+  `completed`);
+- fix or explicitly accept **M3** with a written rationale;
+- correct **m4** in the PR body and add the negative freshness test from **m5**.
+
+m6–m8 are safe to defer.

--- a/docs/chat/wave1-service-reauthorize-review-sol.md
+++ b/docs/chat/wave1-service-reauthorize-review-sol.md
@@ -1,0 +1,295 @@
+# Adversarial review: Wave 1 `service.reauthorize`
+
+**Reviewed:** 2026-08-17
+
+**NyxID plan source:** `51cab391` (`docs/chat/wave1-service-reauthorize-plan.md`)
+
+**NyxID source checked:** `origin/main` at `ed372d8c`, plus the required implementation
+branch starting point at `51cab391`
+
+**Aevatar source checked:** `origin/feature/integrate` at `05db6b4b0` in
+`~/Desktop/aelf-frontend-work/aevatar` (all citations below are from `git show`, not the
+stale checkout)
+
+## Overall verdict
+
+**BUILD-WITH-FIXES.** There is **1 BLOCKER**, **4 MAJOR** findings, and **2 MINOR**
+findings. The blocker is a merge/deploy gate, not a local implementation blocker: build
+against the working v8 assumption, but the NyxID PR must remain draft and
+**DO-NOT-MERGE** until Aevatar accepts and deploys that exact revision.
+
+The plan's central endpoint and Aevatar-contract corrections are independently verified.
+Its frontend completion path and provider-scope normalization are not sufficient as
+written, and the required implementation branch is missing a backend prerequisite that
+the plan assumed was already present.
+
+## BLOCKER
+
+### 1. Aevatar has no v8 consumer; publishing v8 first disables every NyxID assistant action in newly started processes
+
+**Evidence.** Aevatar defines accepted revisions only through v7 at
+`agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs:30-36`. Its pinned map
+contains `service.reauthorize` only for v5
+(`NyxIdAssistantActionRegistry.cs:207-232`), while its executable maps expose only
+`service.connect` in v4/v5, add `key.create` in v6, and add `key.rotate` in v7
+(`NyxIdAssistantActionRegistry.cs:234-248`). `IsActionExecutable` does not even map the
+`ServiceReauthorize` enum to a wire action (`NyxIdAssistantActionRegistry.cs:295-316`).
+Registry loading rejects any revision absent from both maps
+(`NyxIdAssistantActionRegistry.cs:319-334`). The conformance tree contains
+`registry-v4.json` through `registry-v7.json` and no v8 fixture; a branch-wide grep found
+no v8 revision constant.
+
+The failure mode is exactly the plan's corrected wording. Startup fetches and loads once;
+any exception logs that assistant actions are disabled and initializes an empty disabled
+registry (`agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistryStartup.cs:119-140`).
+Chat startup is not aborted, but `TryGetDefinition` can no longer return any registry
+action (`NyxIdAssistantActionRegistry.cs:421-443`). Thus chat survives while all NyxID
+action cards are unavailable on Aevatar processes started after an early NyxID deploy.
+
+**Concrete fix.** Implement NyxID against the explicitly provisional
+`nyxid-assistant-actions.v8`, but keep the PR draft and prominently marked
+**DO-NOT-MERGE**. Aevatar must first add v8 to both maps, make all four actions executable,
+pin the exact schemas/metadata, add `registry-v8.json`, merge, deploy, and prove a restart
+still loads the live v7 manifest. Only then may NyxID merge/deploy the v8 manifest.
+
+## MAJOR
+
+### 2. The implementation branch does not contain the `connection_status` baseline assumed by B2
+
+**Evidence.** The plan was reviewed against `origin/main` at `ed372d8c`, where
+`KeyResponse.connection_status` exists at `backend/src/handlers/keys.rs:437`, maps from
+`KeyView` at `backend/src/handlers/keys.rs:2311`, and is derived by
+`oauth_connection_status` at `backend/src/services/unified_key_service.rs:3803-3821`.
+Those changes came from `206720f5` (`feat(keys): expose OAuth connection health`). The
+required reset, however, leaves this branch at `51cab391`, whose source does not contain
+`KeyResponse.connection_status`, `KeyView.connection_status`, or
+`oauth_connection_status`. Therefore B2 cannot be implemented here merely by removing
+three serde attributes and adjusting an existing helper.
+
+The other five facts do exist: `id`, `status`, and `is_active` are stable response fields;
+`granted_scopes` and `last_authorized_at` are on `KeyResponse` and mapped from `KeyView`;
+the six credential statuses are documented on `UserApiKey.status` at
+`backend/src/models/user_api_key.rs:68-80`. The plan is correct about `origin/main`, but
+not about the actual build starting point mandated for this task.
+
+**Concrete fix.** After this review commit, port only `206720f5` before applying B2. Do
+not merge all of `origin/main`; it contains unrelated churn. Preserve the later branch's
+current response fields and tests while resolving the two-file port.
+
+### 3. F2 can report `completed` before any reauthorization occurs
+
+**Evidence.** The baseline-aware dialog hook is real:
+`useKeyAuthorizationStatus` accepts `previousAuthorizationAt` and requires
+`last_authorized_at` to change before an active row is terminal
+(`frontend/src/hooks/use-keys.ts:55-107`). But the background card hook cited by F2 is
+not baseline-aware. `useKeyAuthorizationWatch` accepts only `enabled` and `deadlineAt`,
+stops as soon as `status` is `active`, and returns that raw status
+(`frontend/src/hooks/use-keys.ts:133-203`). `ActionCard` stores only `keyId` and
+`startedAt`, invokes that hook without an authorization baseline, and reports completed
+on the first active read (`frontend/src/components/assistant/blocks/action-card.tsx:203-206`,
+`:222-251`). That behavior is correct for `service.connect`, whose new placeholder begins
+as `pending_auth`, but it is wrong for reauthorization, whose existing key is already
+`active`.
+
+This is a real false-positive path: click Re-authorize, close or even fail to complete the
+provider flow, and the first cached/network read of the existing active key can settle the
+action. Aevatar's postcondition will later reject the stale `last_authorized_at`, but the
+NyxID browser has still emitted a false completed journey and forced an avoidable
+postcondition failure.
+
+**Concrete fix.** Carry `previousAuthorizationAt` in the card's pending-authorization
+state and extend `useKeyAuthorizationWatch` with an optional baseline. An active row is
+terminal only when the baseline is absent (the existing connect behavior) or when
+`last_authorized_at` is non-null and differs from the baseline. Add regression tests in
+the hook/action-card suites proving an already-active unchanged row does not complete and
+an advanced timestamp does.
+
+### 4. Whitespace-only scope parsing makes GitHub-style token responses structurally unverifiable
+
+**Evidence.** All catalog providers share one callback path; there is no per-provider
+scope normalizer. The callback reads `token_payload["scope"]` as a raw string
+(`backend/src/services/user_token_service.rs:1762-1789`) and passes it unchanged to both
+chat and ordinary multi-connection writers (`user_token_service.rs:1809-1839`). The
+writer stores that raw string verbatim when present
+(`backend/src/services/user_api_key_service.rs:444-489`). The legacy path likewise stores
+the raw string, preserving the previous value only when a provider omits `scope`
+(`user_token_service.rs:1883-1927`). Device-code storage follows the same rule
+(`user_token_service.rs:1435-1460`).
+
+By contrast, `build_key_view` uses only `split_whitespace`
+(`backend/src/services/unified_key_service.rs:3773-3786` on `origin/main`). GitHub is a
+seeded OAuth provider (`backend/src/services/provider_service.rs:655-688`) and GitHub-style
+comma-separated echoes such as `repo,read:user` therefore become one array item. Aevatar
+requires Ordinal per-scope containment and rejects duplicate arrays, so the requested
+`repo` and `read:user` can never match that single item. NyxID already treats commas and
+whitespace as separators for user-supplied OAuth scopes
+(`backend/src/services/user_token_service.rs:90-142`), so the read behavior is internally
+inconsistent too.
+
+Deduplication itself is safe if it is case-sensitive and first-occurrence preserving.
+OAuth scopes are compared as an unordered set by Aevatar
+(`agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs:291-303`, `:624-637`),
+and no inspected NyxID consumer assigns semantic meaning to duplicate occurrences.
+Preserving first occurrence keeps display and request order stable.
+
+**Concrete fix.** At the `KeyView` read boundary, split on comma **or** Unicode
+whitespace, trim empty items, and deduplicate with Ordinal/case-sensitive first-occurrence
+order. Add whitespace, duplicate, and GitHub comma-style tests. Keep the stored provider
+echo unchanged to avoid silently rewriting persistence used by other paths. Document the
+remaining fail-closed behavior: when a provider omits `scope`, NyxID preserves the last
+known set; Aevatar still requires both a fresh authorization timestamp and the requested
+scope superset.
+
+### 5. The proposed expiry-less derivation incorrectly labels `pending_auth` as an active OAuth connection
+
+**Evidence.** `UserApiKey.status` includes `pending_auth`
+(`backend/src/models/user_api_key.rs:68-80`). The helper first maps only terminal states
+to `expired`, then derives from `expires_at`
+(`backend/src/services/unified_key_service.rs:3803-3821` on `origin/main`). B2 says every
+non-terminal expiry-less OAuth row should become `active`; that includes a placeholder
+with no completed callback and normally no access token. `connection_status` is a global
+`KeyResponse` field used by list/create/update/detail responses, not an assistant-only
+projection (`backend/src/handlers/keys.rs:414-541`, `:2280-2360`). Aevatar would still
+reject the row because credential `status != active`, but other callers would receive a
+misleading health signal.
+
+**Concrete fix.** Return expiry-less `active` only when the credential status is exactly
+`active` and OAuth token material exists. Keep terminal states mapped to `expired`, and
+return `None`/JSON `null` for `pending_auth`, non-OAuth rows, and inconsistent active rows
+without token material. Cover each branch in unit tests. This deliberately narrows the
+plan's proposed non-terminal rule to avoid changing non-assistant behavior incorrectly.
+
+## MINOR
+
+### 6. The plan overstates the secret-scan audit by checking names but not user-controlled values
+
+**Evidence.** The Aevatar parser recursively visits every object and array and rejects
+both forbidden normalized field names and secret-shaped strings
+(`src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs:262-296`, `:564-591`).
+`KeyResponse` contains user-controlled display strings, URLs, custom User-Agent, default
+headers, and WebSocket injection configuration, not just the six evidence fields
+(`backend/src/handlers/keys.rs:414-531`). Sensitive default-header values are redacted at
+the response boundary (`backend/src/models/default_request_header.rs:333-364`), but a
+non-sensitive value or label that happens to match `Bearer ...` or the NyxID-key regex
+still causes a malformed evidence read.
+
+The three serializer changes themselves are safe: they add only `null`, scope arrays,
+and RFC3339 timestamps under non-forbidden names. This is therefore not a blocker to the
+current build, but the plan's statement that field names are clear is not a complete
+tripwire analysis.
+
+**Concrete fix.** Add the requested `KeyResponse` serialization test and include an
+Aevatar-compatible recursive tripwire assertion over the representative evidence
+response. Do not add or rename unrelated response fields in this PR. Track a future
+minimal evidence projection or a less false-positive-prone Aevatar scan if arbitrary
+user-controlled display/configuration values become an operational problem.
+
+### 7. The response-shape compatibility conclusion is safe, but the plan cites frontend helpers that do not exist on this branch
+
+**Evidence.** No `assertSecretFreeReadBack`, `verifyAllowedServices`, or strict assistant
+key read-back schema exists in this checkout. `useKey` and `useKeys` use TypeScript
+generic response typing rather than runtime Zod parsing
+(`frontend/src/hooks/use-keys.ts:17-34`). The only key-domain Zod response schema is for
+`/user-services`, explicitly permits unknown fields, and does not declare these evidence
+fields (`frontend/src/schemas/keys.ts:27-49`). `KeyInfo.granted_scopes` and
+`last_authorized_at` already accept absent or null values
+(`frontend/src/types/keys.ts:55-105`); `connection_status` is ignored. CLI `/keys`
+consumers use `serde_json::Value`, for example
+`cli/src/commands/node.rs:692-708` and `cli/src/commands/service.rs:911-920`. Whole-tree
+searches found no mobile or SDK parser for these fields.
+
+Aevatar's `/keys` list parser reads selected properties and ignores extras
+(`src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs:397-428`). Therefore
+always serializing the three fields does not break the audited frontend, CLI, mobile,
+SDK, or Aevatar list consumer. Rust/serde `Option<T>` also accepts explicit null for any
+future typed CLI consumer.
+
+**Concrete fix.** Do not invent schema changes or nonexistent helper calls. Keep the
+three fields null-compatible in `KeyInfo`, add the narrow runtime secret-free assertion
+inside the new reauthorize read path if one is needed, and rely on frontend build/tests
+plus CLI tests as the compatibility gate.
+
+## Re-derived contract facts
+
+### Evidence endpoint: confirmed
+
+`NyxIdApiClient.GetServiceAsync` calls
+`GET /api/v1/keys/{Uri.EscapeDataString(id)}`
+(`src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs:266-275`). The
+`/api/v1/user-services` method is a separate list method at
+`NyxIdApiClient.cs:1022-1033`. The reauthorize evidence port calls the former with the
+exact requested user-service id
+(`agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs:277-289`). Section
+0.1 is correct.
+
+### Evidence parser: confirmed
+
+`ParseUserServiceAuthorizationDocument` runs the recursive secret scan, then requires
+`id`, `is_active`, `status`, and the **presence** of `connection_status`,
+`granted_scopes`, and `last_authorized_at`; only `api_key_id` is optional
+(`src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs:431-442`). Credential
+status accepts exactly `active`, `expired`, `revoked`, `failed`, `refresh_failed`, and
+`pending_auth` (`NyxIdApiAccessContracts.cs:593-602`). Connection status accepts only
+`active`, `expired`, or explicit null as `Unspecified`
+(`NyxIdApiAccessContracts.cs:604-617`). Scope arrays reject non-normalized values and
+Ordinal duplicates (`NyxIdApiAccessContracts.cs:517-542`); timestamps must match the
+RFC3339 regex and parse successfully (`NyxIdApiAccessContracts.cs:286-288`, `:545-557`,
+`:843-855`).
+
+Malformed JSON or any contract exception becomes a failed provider read
+(`NyxIdApiAccessContracts.cs:325-350`), which the postcondition maps to provider-read
+unavailable/not-found rather than an evidence mismatch
+(`NyxIdActionPostconditionPort.cs:283-313`, `:596-611`). A syntactically valid document
+that parses but fails identity, activation, status, scope-superset, or freshness checks is
+merely unverified. Section 1.4 is correct.
+
+### Exact params-schema pin: confirmed
+
+`ValidatePinnedContract` parses the pinned and published schemas into `JsonNode` values
+and calls `JsonNode.DeepEquals`, then checks exact risk and remember eligibility
+(`agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs:879-903`). NyxID must
+publish the schema exactly as written, with no `minItems`, `uniqueItems`, length bounds,
+or other refinements. Section 0.6 is correct.
+
+### Facade/B3: confirmed no code change
+
+The backend report does not carry an action id. `RawActionReport` contains request id,
+origin turn, disposition, and optional resource only
+(`backend/src/services/assistant_service.rs:550-558`). `parse_action_resource` already
+accepts the exact `userService.userServiceId` shape with identity validation
+(`assistant_service.rs:748-798`), and the only completed-report rule is that some resource
+must be present (`assistant_service.rs:885-912`). The existing test round-trips all six
+safe resource variants, including `userService`
+(`assistant_service.rs:2124-2156`). B3 needs no implementation change.
+
+## Explicit TODO resolutions
+
+### Frontend strict/null schemas
+
+Resolved: no frontend Zod schema strictly parses `GET /keys/{id}` or `/keys` into a
+closed object. The key fields are TypeScript-only and already null-compatible; no schema
+change is required. The assistant action schemas are strict request/report schemas, not
+key-response parsers.
+
+### Unknown/free-form OAuth scopes
+
+Resolved: `UpstreamScopePicker` explicitly supports free-form scopes. It unions catalog,
+defaults, locked scopes, and unknown selected values into pills
+(`frontend/src/components/shared/upstream-scope-picker.tsx:80-128`), and `addCustom`
+parses/deduplicates unknown values (`upstream-scope-picker.tsx:179-202`). A shared
+platform OAuth allowlist can intentionally reject an unknown scope
+(`upstream-scope-picker.tsx:147-152`, `:181-194`). The reauthorize journey must preserve
+unknown requested scopes and surface a typed block when the selected managed OAuth path
+forbids one; it must never silently drop them.
+
+### Q3: what callbacks store in `token_scopes`
+
+Resolved from source: there is no catalog-provider-specific normalization. OAuth and
+device-code callbacks store the provider's raw string-valued `scope` exactly as returned;
+when `scope` is absent, multi-connection and legacy flows preserve the previous stored
+value. Authorization initiation normalizes comma/whitespace user input and sends a
+space-joined request, but the callback does not normalize the provider echo. Consequently
+the response read boundary must handle both comma- and whitespace-delimited echoes, and
+provider omission remains a last-known-scope behavior guarded by Aevatar's fresh timestamp
+and scope-superset verification.
+

--- a/docs/chat/wave1-service-reauthorize-review-sol.md
+++ b/docs/chat/wave1-service-reauthorize-review-sol.md
@@ -1,5 +1,12 @@
 # Adversarial review: Wave 1 `service.reauthorize`
 
+> **Evidence document, not an action list.** The live action list is
+> [`wave1-service-reauthorize-actions.md`](./wave1-service-reauthorize-actions.md).
+> This is the implementer's pre-build review of the plan; its findings were
+> dispositioned during implementation. Note it was written against the
+> **pre-rebase** branch point, which makes its §3 freshness finding accurate for
+> that branch but not for what shipped — see action list A4.
+
 **Reviewed:** 2026-08-17
 
 **NyxID plan source:** `51cab391` (`docs/chat/wave1-service-reauthorize-plan.md`)

--- a/docs/chat/wave1-service-reauthorize-review-sol.md
+++ b/docs/chat/wave1-service-reauthorize-review-sol.md
@@ -292,4 +292,3 @@ space-joined request, but the callback does not normalize the provider echo. Con
 the response read boundary must handle both comma- and whitespace-delimited echoes, and
 provider omission remains a last-known-scope behavior guarded by Aevatar's fresh timestamp
 and scope-superset verification.
-

--- a/frontend/src/components/assistant/blocks/action-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.test.tsx
@@ -24,17 +24,25 @@ import { usePendingConnectStore } from "@/stores/pending-connect-store";
 import type { ActionCardContentBlock } from "@/types/assistant";
 import { ActionCard } from "./action-card";
 
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
 // The pending-authorization store outlives any one card by design, so it also
 // outlives any one test. Reset it or a stranded attempt leaks forward.
 beforeEach(() => {
+  mockGet.mockReset();
   usePendingConnectStore.setState({ attempts: {} });
 });
 
-const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
-
 vi.mock("@/lib/api-client", () => ({
   api: { get: mockGet },
-  ApiError: class ApiError extends Error {},
+  ApiError: class ApiError extends Error {
+    readonly status: number;
+
+    constructor(status: number) {
+      super("API request failed");
+      this.status = status;
+    }
+  },
 }));
 
 vi.mock("@/components/service-icon", () => ({
@@ -59,6 +67,8 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     prefillSlug,
     prefillIncludeAllCatalog,
     prefillCustom,
+    prefillScopes,
+    reconnectKey,
     onSuccess,
     onAuthorizationPending,
     onAuthorizationAborted,
@@ -71,6 +81,11 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
     readonly prefillSlug?: string;
     readonly prefillIncludeAllCatalog?: boolean;
     readonly prefillCustom?: { readonly name?: string };
+    readonly prefillScopes?: readonly string[];
+    readonly reconnectKey?: {
+      readonly id: string;
+      readonly last_authorized_at?: string | null;
+    } | null;
     readonly onSuccess?: (result: AddKeyDialogCompletion) => void;
     readonly onAuthorizationPending?: (attempt: AuthorizationAttempt) => void;
     readonly onAuthorizationAborted?: (attemptId: string) => void;
@@ -83,12 +98,16 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
         role="dialog"
         data-prefill={prefillSlug ?? prefillCustom?.name ?? ""}
         data-prefill-include-all={String(prefillIncludeAllCatalog ?? false)}
+        data-prefill-scopes={prefillScopes?.join(",") ?? ""}
+        data-reconnect-key={reconnectKey?.id ?? ""}
         data-launch={launch ?? ""}
         data-flow={flow ?? ""}
       >
         <button
           type="button"
-          onClick={() => onPopupViewResult?.("key-pending-1")}
+          onClick={() =>
+            onPopupViewResult?.(reconnectKey?.id ?? "key-pending-1")
+          }
         >
           Return from popup
         </button>
@@ -96,7 +115,8 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
           type="button"
           onClick={() =>
             onSuccess?.({
-              userServiceId: "00000000-0000-4000-8000-000000000123",
+              userServiceId:
+                reconnectKey?.id ?? "00000000-0000-4000-8000-000000000123",
             })
           }
         >
@@ -118,9 +138,9 @@ vi.mock("@/components/dashboard/add-key-dialog", () => ({
           type="button"
           onClick={() =>
             onAuthorizationPending?.({
-              keyId: "key-pending-1",
+              keyId: reconnectKey?.id ?? "key-pending-1",
               attemptId: "attempt-pending-1",
-              previousAuthorizationAt: undefined,
+              previousAuthorizationAt: reconnectKey?.last_authorized_at,
             })
           }
         >
@@ -242,6 +262,84 @@ function keyCreateBlock(
   };
 }
 
+function reauthorizeBlock(
+  overrides: Partial<ActionCardContentBlock> = {},
+): ActionCardContentBlock {
+  return {
+    type: "action_card",
+    block_id: "action-card-reauthorize",
+    action: "service.reauthorize",
+    action_request_id: "act-reauthorize",
+    origin_turn_id: "turn-origin-1",
+    task_id: "task-1",
+    step_id: "step-1",
+    params: {
+      variant: "service_reauthorize",
+      user_service_id: "service-existing",
+      requested_scopes: ["repo", "workflow"],
+    },
+    status: "pending",
+    outcome_note: "",
+    ...overrides,
+  };
+}
+
+function reauthorizationKey(
+  overrides: Readonly<Record<string, unknown>> = {},
+): Readonly<Record<string, unknown>> {
+  return {
+    id: "service-existing",
+    slug: "github-user",
+    label: "GitHub",
+    api_key_id: "credential-existing",
+    credential_missing: false,
+    credential_type: "oauth2",
+    auth_method: "oauth2",
+    is_active: true,
+    auto_connected: false,
+    catalog_service_slug: "github",
+    credential_source: { type: "personal" },
+    status: "active",
+    last_authorized_at: "2026-08-17T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function reauthorizationCatalog(
+  overrides: Readonly<Record<string, unknown>> = {},
+) {
+  return {
+    entries: [
+      {
+        slug: "github",
+        provider_type: "oauth2",
+        provider_config_id: "provider-github",
+        device_code_format: null,
+        ...overrides,
+      },
+      {
+        slug: "plain-api",
+        provider_type: "api_key",
+        provider_config_id: null,
+        device_code_format: null,
+      },
+    ],
+  };
+}
+
+function mockReauthorizationReads(
+  key: Readonly<Record<string, unknown>> = reauthorizationKey(),
+  catalog = reauthorizationCatalog(),
+) {
+  mockGet.mockImplementation((path: string) => {
+    if (path === "/keys/service-existing") return Promise.resolve(key);
+    if (path === "/catalog?include_all=true") {
+      return Promise.resolve(catalog);
+    }
+    return Promise.reject(new Error(`Unexpected read: ${path}`));
+  });
+}
+
 function keyRotateBlock(
   overrides: Partial<ActionCardContentBlock> = {},
 ): ActionCardContentBlock {
@@ -273,6 +371,151 @@ function expectNoBlueAccent(card: HTMLElement | null) {
 }
 
 describe("ActionCard", () => {
+  it("opens exact reconnect mode with every requested scope and reports only the service id", async () => {
+    mockReauthorizationReads();
+    const onProgress = vi.fn();
+    const onResolve = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={onProgress}
+        onBlock={vi.fn()}
+        onResolve={onResolve}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Re-authorize service" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("service-existing")).toBeInTheDocument();
+    expect(screen.getByText("workflow")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    expect(onProgress).toHaveBeenCalledWith("action-card-reauthorize", true);
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveAttribute("data-reconnect-key", "service-existing");
+    expect(dialog).toHaveAttribute("data-prefill-scopes", "repo,workflow");
+    expect(dialog).toHaveAttribute("data-prefill-include-all", "true");
+    expect(dialog).toHaveAttribute("data-launch", "popup");
+    expect(dialog).toHaveAttribute("data-flow", "cc");
+    expect(mockGet).toHaveBeenCalledWith("/keys/service-existing");
+    expect(mockGet).toHaveBeenCalledWith("/catalog?include_all=true");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Finish mock connection" }),
+    );
+    expect(onResolve).toHaveBeenCalledWith({
+      actionRequestId: "act-reauthorize",
+      originTurnId: "turn-origin-1",
+      disposition: "completed",
+      resource: { userService: { userServiceId: "service-existing" } },
+    });
+  });
+
+  it("blocks non-OAuth services before opening a reauthorization dialog", async () => {
+    mockReauthorizationReads(
+      reauthorizationKey({
+        credential_type: "api_key",
+        auth_method: "header",
+      }),
+    );
+    const onBlock = vi.fn();
+    const onResolve = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={onResolve}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await waitFor(() => {
+      expect(onBlock).toHaveBeenCalledWith(
+        "action-card-reauthorize",
+        expect.stringContaining("does not support browser re-authorization"),
+      );
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(onResolve).not.toHaveBeenCalled();
+    expect(mockGet).not.toHaveBeenCalledWith("/catalog?include_all=true");
+  });
+
+  it("blocks OpenAI-format device authorization instead of dropping requested scopes", async () => {
+    mockReauthorizationReads(
+      reauthorizationKey({ catalog_service_slug: "codex" }),
+      reauthorizationCatalog({
+        slug: "codex",
+        provider_type: "device_code",
+        provider_config_id: "provider-codex",
+        device_code_format: "openai",
+      }),
+    );
+    const onBlock = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await waitFor(() => {
+      expect(onBlock).toHaveBeenCalledWith(
+        "action-card-reauthorize",
+        expect.stringContaining("does not accept requested scope changes"),
+      );
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("waits for a fresh authorization timestamp before auto-completing reauthorization", async () => {
+    let keyReads = 0;
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/keys/service-existing") {
+        keyReads += 1;
+        return Promise.resolve(
+          keyReads === 1
+            ? reauthorizationKey()
+            : reauthorizationKey({
+                last_authorized_at: "2026-08-17T00:01:00Z",
+              }),
+        );
+      }
+      if (path === "/catalog?include_all=true") {
+        return Promise.resolve(reauthorizationCatalog());
+      }
+      return Promise.reject(new Error(`Unexpected read: ${path}`));
+    });
+    const onResolve = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={vi.fn()}
+        onResolve={onResolve}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Hand off to provider" }),
+    );
+
+    await waitFor(() => {
+      expect(onResolve).toHaveBeenCalledWith({
+        actionRequestId: "act-reauthorize",
+        originTurnId: "turn-origin-1",
+        disposition: "completed",
+        resource: { userService: { userServiceId: "service-existing" } },
+      });
+    });
+    expect(onResolve).toHaveBeenCalledTimes(1);
+  });
+
   it("opens the key.create journey and reports only the safe key identity", async () => {
     const onProgress = vi.fn();
     const onResolve = vi.fn();

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
 import {
   AlertTriangle,
   Globe,
@@ -21,9 +22,11 @@ import {
   descriptorForAction,
 } from "@/lib/assistant/action-registry";
 import { connectWatchDeadline } from "@/lib/assistant/connect-watch";
+import { ApiError, api } from "@/lib/api-client";
 import type { ActionReport, ActionResource } from "@/schemas/assistant-actions";
 import { usePendingConnectStore } from "@/stores/pending-connect-store";
 import type { ActionCardContentBlock } from "@/types/assistant";
+import type { KeyInfo } from "@/types/keys";
 
 interface ActionCardProps {
   readonly block: ActionCardContentBlock;
@@ -37,6 +40,174 @@ const VERIFICATION_BLOCKED_NOTE =
 
 const AUTHORIZATION_TIMEOUT_NOTE =
   "NyxID stopped waiting for this connection to finish authorizing. If you did complete it, find it in AI Services — otherwise ask the assistant to request it again.";
+
+const REAUTHORIZE_NOT_FOUND_NOTE =
+  "NyxID could not find that connected service. Ask the assistant to refresh its service list and request re-authorization again.";
+const REAUTHORIZE_UNAVAILABLE_NOTE =
+  "NyxID could not verify this service for re-authorization. Manage it in AI Services, then ask the assistant to request it again.";
+const REAUTHORIZE_IDENTITY_NOTE =
+  "NyxID returned a different connected service than the one requested. The re-authorization was blocked.";
+const REAUTHORIZE_INACTIVE_NOTE =
+  "This service is disabled. Enable it in AI Services before re-authorizing it.";
+const REAUTHORIZE_CREDENTIAL_NOTE =
+  "This service does not have a usable OAuth credential to re-authorize. Repair it in AI Services first.";
+const REAUTHORIZE_MODALITY_NOTE =
+  "This service does not support browser re-authorization. Manage its credential in AI Services instead.";
+const REAUTHORIZE_PLATFORM_NOTE =
+  "Platform-managed services cannot be re-authorized from an assistant request.";
+const REAUTHORIZE_ORG_NOTE =
+  "Only an organization admin can re-authorize this shared service.";
+const REAUTHORIZE_CATALOG_NOTE =
+  "NyxID could not resolve this service's OAuth provider. Manage it in AI Services, then ask the assistant to try again.";
+const REAUTHORIZE_SCOPES_UNSUPPORTED_NOTE =
+  "This provider does not accept requested scope changes during device authorization, so NyxID did not start a re-authorization that could drop the request.";
+
+const reauthorizationCredentialSourceSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("personal") }).passthrough(),
+  z
+    .object({
+      type: z.literal("org"),
+      role: z.string(),
+    })
+    .passthrough(),
+]);
+const reauthorizationKeySchema = z
+  .object({
+    id: z.string().min(1).max(256),
+    slug: z.string().min(1),
+    api_key_id: z.string().min(1).optional(),
+    credential_missing: z.boolean().optional(),
+    credential_type: z.string(),
+    auth_method: z.string(),
+    is_active: z.boolean(),
+    auto_connected: z.boolean(),
+    catalog_service_slug: z.string().nullish(),
+    credential_source: reauthorizationCredentialSourceSchema.optional(),
+  })
+  .passthrough();
+const reauthorizationCatalogSchema = z
+  .object({
+    entries: z.array(
+      z
+        .object({
+          slug: z.string().min(1),
+          provider_type: z.string().nullish(),
+          provider_config_id: z.string().nullish(),
+          device_code_format: z.string().nullish(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
+const FORBIDDEN_READ_BACK_FIELDS = new Set([
+  "apikey",
+  "fullkey",
+  "keyhash",
+  "credential",
+  "credentials",
+  "accesstoken",
+  "refreshtoken",
+  "authorization",
+  "cookie",
+  "cookies",
+  "secret",
+  "secrets",
+  "clientsecret",
+  "password",
+  "token",
+  "passphrase",
+  "usercode",
+  "devicecode",
+  "rawbody",
+  "rawupstreambody",
+]);
+const SECRET_READ_BACK_VALUE =
+  /(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})/i;
+
+function assertSecretFreeReadBack(value: unknown): void {
+  if (typeof value === "string" && SECRET_READ_BACK_VALUE.test(value)) {
+    throw new Error("NyxID returned secret-bearing verification data.");
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) assertSecretFreeReadBack(entry);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, entry] of Object.entries(value)) {
+    const normalized = key
+      .replace(/[^A-Za-z0-9]/g, "")
+      .toLocaleLowerCase("en-US");
+    if (FORBIDDEN_READ_BACK_FIELDS.has(normalized)) {
+      throw new Error("NyxID returned secret-bearing verification data.");
+    }
+    assertSecretFreeReadBack(entry);
+  }
+}
+
+class ReauthorizationBlockedError extends Error {}
+
+async function readReauthorizationKey(userServiceId: string): Promise<KeyInfo> {
+  const value = await api.get<unknown>(
+    `/keys/${encodeURIComponent(userServiceId)}`,
+  );
+  assertSecretFreeReadBack(value);
+  const snapshot = reauthorizationKeySchema.parse(value);
+  if (snapshot.id !== userServiceId) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_IDENTITY_NOTE);
+  }
+  if (!snapshot.is_active) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_INACTIVE_NOTE);
+  }
+  if (snapshot.credential_missing || !snapshot.api_key_id) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_CREDENTIAL_NOTE);
+  }
+  if (
+    snapshot.credential_type !== "oauth2" &&
+    snapshot.auth_method !== "oauth2" &&
+    snapshot.auth_method !== "oidc"
+  ) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_MODALITY_NOTE);
+  }
+  if (snapshot.auto_connected) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_PLATFORM_NOTE);
+  }
+  if (
+    snapshot.credential_source?.type === "org" &&
+    snapshot.credential_source.role !== "admin"
+  ) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_ORG_NOTE);
+  }
+
+  const catalog = reauthorizationCatalogSchema.parse(
+    await api.get<unknown>("/catalog?include_all=true"),
+  );
+  const catalogSlug = snapshot.catalog_service_slug ?? snapshot.slug;
+  const catalogEntry = catalog.entries.find(
+    (entry) => entry.slug === catalogSlug,
+  );
+  if (!catalogEntry) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_CATALOG_NOTE);
+  }
+  if (
+    (catalogEntry.provider_type !== "oauth2" &&
+      catalogEntry.provider_type !== "device_code") ||
+    !catalogEntry.provider_config_id
+  ) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_MODALITY_NOTE);
+  }
+  if (
+    catalogEntry.provider_type === "device_code" &&
+    catalogEntry.device_code_format === "openai"
+  ) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_SCOPES_UNSUPPORTED_NOTE);
+  }
+
+  // The public KeyInfo type is the full response contract. This read validates
+  // the journey-owned projection above and preserves the remaining fields for
+  // the existing reconnect dialog, which already consumes that full contract.
+  return value as KeyInfo;
+}
 
 function authorizationFailedNote(reason: string | undefined): string {
   const detail = reason?.trim();
@@ -93,6 +264,34 @@ function ParameterSummary({
           <Badge variant="secondary" className="max-w-full truncate font-mono">
             {params.key_id}
           </Badge>
+        </div>
+      </div>
+    );
+  }
+  if (params.variant === "service_reauthorize") {
+    return (
+      <div className="space-y-2.5 border-y border-border bg-muted px-4 py-3">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[1px] text-muted-foreground">
+            Service
+          </span>
+          <Badge variant="secondary" className="max-w-full truncate font-mono">
+            {params.user_service_id}
+          </Badge>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[1px] text-muted-foreground">
+            Requested scopes
+          </span>
+          {params.requested_scopes.map((scope) => (
+            <Badge
+              key={scope}
+              variant="secondary"
+              className="max-w-full truncate font-mono"
+            >
+              <span className="min-w-0 truncate">{scope}</span>
+            </Badge>
+          ))}
         </div>
       </div>
     );
@@ -231,7 +430,9 @@ export function ActionCard({
   onResolve,
 }: ActionCardProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [reauthorizeKey, setReauthorizeKey] = useState<KeyInfo | null>(null);
   const resolvingRef = useRef(false);
+  const journeyStartingRef = useRef(false);
   /**
    * An out-of-band authorization handed to a provider, still settling. Held
    * outside React (keyed by block id) rather than in the dialog or in this
@@ -309,6 +510,19 @@ export function ActionCard({
     // The ref is the synchronous re-entry guard; the state clear rides the
     // microtask so this effect never sets the state it depends on inline.
     if (watch.authorized) {
+      if (
+        block.params.variant === "service_reauthorize" &&
+        keyId !== block.params.user_service_id
+      ) {
+        watchSettledRef.current = attemptId;
+        void Promise.resolve()
+          .then(() => {
+            endPendingAuth(block.block_id);
+            return onBlock(block.block_id, REAUTHORIZE_IDENTITY_NOTE);
+          })
+          .catch(() => undefined);
+        return;
+      }
       watchSettledRef.current = attemptId;
       resolvingRef.current = true;
       void Promise.resolve()
@@ -349,6 +563,7 @@ export function ActionCard({
     watch.authorized,
     watch.timedOut,
     watch.errorMessage,
+    block.params,
     block.block_id,
     block.action_request_id,
     block.origin_turn_id,
@@ -366,23 +581,34 @@ export function ActionCard({
 
   const baseVerdict = settled ? SETTLED[block.status as SettledStatus] : null;
   const verdict =
-    baseVerdict && block.status === "completed" && block.action === "key.create"
+    baseVerdict &&
+    block.status === "completed" &&
+    block.action === "service.reauthorize"
       ? {
           ...baseVerdict,
-          badge: "Created",
+          badge: "Re-authorized",
           footer:
-            "The assistant received only the verified key reference. Key material stayed in NyxID.",
+            "The assistant received only the verified service reference. Your OAuth credential stayed in NyxID.",
         }
       : baseVerdict &&
           block.status === "completed" &&
-          block.action === "key.rotate"
+          block.action === "key.create"
         ? {
             ...baseVerdict,
-            badge: "Rotated",
+            badge: "Created",
             footer:
-              "The assistant received only the verified replacement key reference. Replacement key material stayed in NyxID.",
+              "The assistant received only the verified key reference. Key material stayed in NyxID.",
           }
-        : baseVerdict;
+        : baseVerdict &&
+            block.status === "completed" &&
+            block.action === "key.rotate"
+          ? {
+              ...baseVerdict,
+              badge: "Rotated",
+              footer:
+                "The assistant received only the verified replacement key reference. Replacement key material stayed in NyxID.",
+            }
+          : baseVerdict;
   const VerdictIcon = verdict?.icon;
 
   // Trust the descriptor too: a card whose verb has no journey behind it must
@@ -463,6 +689,38 @@ export function ActionCard({
       });
   }
 
+  async function beginJourney() {
+    if (journeyStartingRef.current) return;
+    journeyStartingRef.current = true;
+    onProgress(block.block_id, true);
+
+    if (params.variant !== "service_reauthorize") {
+      setDialogOpen(true);
+      journeyStartingRef.current = false;
+      return;
+    }
+
+    try {
+      const key = await readReauthorizationKey(params.user_service_id);
+      setReauthorizeKey(key);
+      setDialogOpen(true);
+    } catch (caught) {
+      const note =
+        caught instanceof ReauthorizationBlockedError
+          ? caught.message
+          : caught instanceof ApiError && caught.status === 404
+            ? REAUTHORIZE_NOT_FOUND_NOTE
+            : REAUTHORIZE_UNAVAILABLE_NOTE;
+      try {
+        await onBlock(block.block_id, note);
+      } catch {
+        onProgress(block.block_id, false);
+      }
+    } finally {
+      journeyStartingRef.current = false;
+    }
+  }
+
   return (
     <section className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
       <div className="flex items-start gap-3 px-4 py-3.5">
@@ -479,6 +737,8 @@ export function ActionCard({
             <ServiceIcon slug={params.service_slug} size="sm" />
           ) : params.variant === "custom" ? (
             <Globe className="h-4 w-4 text-muted-foreground" />
+          ) : params.variant === "service_reauthorize" ? (
+            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
           ) : params.variant === "key_create" ||
             params.variant === "key_rotate" ? (
             <KeyRound className="h-4 w-4 text-muted-foreground" />
@@ -547,7 +807,9 @@ export function ActionCard({
               ? "NyxID creates and verifies the key here. The assistant receives only the safe key reference after you finish."
               : params.variant === "key_rotate"
                 ? "NyxID rotates and verifies the exact lineage here. The assistant receives only the replacement key reference after you finish."
-                : "You choose the account, routing, and credential. The assistant receives only brokered access after you finish."}
+                : params.variant === "service_reauthorize"
+                  ? "NyxID opens the provider authorization flow here. The assistant receives only the service reference after fresh authorization finishes."
+                  : "You choose the account, routing, and credential. The assistant receives only brokered access after you finish."}
           </p>
         </div>
       ) : null}
@@ -560,10 +822,7 @@ export function ActionCard({
               variant="primary"
               size="sm"
               disabled={primaryDisabled}
-              onClick={() => {
-                onProgress(block.block_id, true);
-                setDialogOpen(true);
-              }}
+              onClick={() => void beginJourney()}
             >
               {busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
               {awaitingAuthorization
@@ -572,7 +831,9 @@ export function ActionCard({
                   ? params.variant === "key_create" ||
                     params.variant === "key_rotate"
                     ? "Working"
-                    : "Connecting"
+                    : params.variant === "service_reauthorize"
+                      ? "Authorizing"
+                      : "Connecting"
                   : descriptor.cta(params)}
             </Button>
           ) : null}
@@ -682,6 +943,44 @@ export function ActionCard({
           actionRequestId={block.action_request_id}
           params={{ keyId: params.key_id }}
           onComplete={(keyId) => report("completed", { key: { keyId } })}
+        />
+      ) : null}
+      {!verdict &&
+      !unsupported &&
+      params.variant === "service_reauthorize" &&
+      reauthorizeKey ? (
+        <AddKeyDialog
+          open={dialogOpen}
+          onOpenChange={setOpen}
+          prefillIncludeAllCatalog
+          prefillScopes={params.requested_scopes}
+          reconnectKey={reauthorizeKey}
+          launch="popup"
+          flow="cc"
+          onPopupViewResult={() => {
+            setOpen(false);
+            return true;
+          }}
+          onSuccess={({ userServiceId }) => {
+            if (userServiceId !== params.user_service_id) {
+              void onBlock(block.block_id, REAUTHORIZE_IDENTITY_NOTE);
+              return;
+            }
+            report("completed", {
+              userService: { userServiceId: params.user_service_id },
+            });
+          }}
+          onAuthorizationPending={(attempt) => {
+            if (attempt.keyId !== params.user_service_id) {
+              void onBlock(block.block_id, REAUTHORIZE_IDENTITY_NOTE);
+              return;
+            }
+            watchSettledRef.current = null;
+            beginPendingAuth(block.block_id, {
+              ...attempt,
+              startedAt: Date.now(),
+            });
+          }}
         />
       ) : null}
     </section>

--- a/frontend/src/components/dashboard/add-key-dialog.test.tsx
+++ b/frontend/src/components/dashboard/add-key-dialog.test.tsx
@@ -189,6 +189,14 @@ const DEVICE_CODE_ENTRY = {
   device_code_format: "openai",
 } as unknown as CatalogEntry;
 
+const RFC8628_DEVICE_CODE_ENTRY = {
+  ...DEVICE_CODE_ENTRY,
+  slug: "google-device",
+  name: "Google Device",
+  device_code_format: "rfc8628",
+  default_scopes: ["openid"],
+} as unknown as CatalogEntry;
+
 function makeReconnectKey(overrides: Partial<KeyInfo> = {}): KeyInfo {
   return {
     id: "existing-service-1",
@@ -736,6 +744,66 @@ describe("AddKeyDialog — reconnect path", () => {
     expect(screen.getByRole("status")).toHaveTextContent(/Waiting for GitHub/i);
   });
 
+  it("merges granted and assistant-requested scopes for OAuth reconnect", async () => {
+    catalog.entries = [OAUTH_ENTRY];
+    const user = userEvent.setup();
+    render(
+      <AddKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        reconnectKey={makeReconnectKey({
+          granted_scopes: ["repo", "workflow"],
+        })}
+        prefillScopes={["workflow", "custom:assistant-scope"]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Connect with GitHub/i }),
+    );
+
+    await waitFor(() => {
+      expect(initiateOAuthMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(initiateOAuthMutateAsync).toHaveBeenCalledWith({
+      providerId: "provider-oauth",
+      redirectPath: "/keys/existing-service-1",
+      scopeOverride: ["repo", "workflow", "custom:assistant-scope"],
+      keyId: "existing-service-1",
+    });
+  });
+
+  it("merges provider defaults and assistant-requested scopes when no OAuth grant exists", async () => {
+    catalog.entries = [
+      {
+        ...OAUTH_ENTRY,
+        default_scopes: ["read:user"],
+      } as CatalogEntry,
+    ];
+    const user = userEvent.setup();
+    render(
+      <AddKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        reconnectKey={makeReconnectKey({ granted_scopes: null })}
+        prefillScopes={["user:email"]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Connect with GitHub/i }),
+    );
+
+    await waitFor(() => {
+      expect(initiateOAuthMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(initiateOAuthMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeOverride: ["read:user", "user:email"],
+      }),
+    );
+  });
+
   it("reports success in place once the polled placeholder key goes active", async () => {
     catalog.entries = [OAUTH_ENTRY];
     pendingKeyStatus.value = "active";
@@ -949,6 +1017,41 @@ describe("AddKeyDialog — reconnect path", () => {
     expect(createKeyMutate).not.toHaveBeenCalled();
     expect(createKeyMutateAsync).not.toHaveBeenCalled();
     expect(mockApiDelete).not.toHaveBeenCalled();
+  });
+
+  it("merges granted and assistant-requested scopes for RFC 8628 reconnect", async () => {
+    catalog.entries = [RFC8628_DEVICE_CODE_ENTRY];
+    const user = userEvent.setup();
+    render(
+      <AddKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        reconnectKey={makeReconnectKey({
+          catalog_service_slug: "google-device",
+          catalog_service_name: "Google Device",
+          granted_scopes: ["openid", "profile"],
+        })}
+        prefillScopes={[
+          "profile",
+          "https://www.googleapis.com/auth/calendar.readonly",
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(initiateDeviceCodeMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(initiateDeviceCodeMutateAsync).toHaveBeenCalledWith({
+      providerId: "provider-device",
+      scopeOverride: [
+        "openid",
+        "profile",
+        "https://www.googleapis.com/auth/calendar.readonly",
+      ],
+      keyId: "existing-service-1",
+    });
   });
 
   it("does not announce a device-code attempt when initiation fails", async () => {

--- a/frontend/src/components/dashboard/add-key-dialog.tsx
+++ b/frontend/src/components/dashboard/add-key-dialog.tsx
@@ -1460,6 +1460,12 @@ export interface AuthorizationAttempt {
   readonly previousAuthorizationAt: string | null | undefined;
 }
 
+function mergeScopes(
+  ...groups: readonly (readonly string[])[]
+): readonly string[] {
+  return [...new Set(groups.flat())];
+}
+
 function OAuthStep({
   catalogEntry,
   ensureKey,
@@ -1473,6 +1479,7 @@ function OAuthStep({
   reconnectMode,
   lockedScopes = [],
   grantedScopes = [],
+  prefillScopes = [],
   launch,
   flow,
   onPopupViewResult,
@@ -1505,6 +1512,8 @@ function OAuthStep({
    * Drives the change summary + removal warning, and seeds the selection.
    */
   readonly grantedScopes?: readonly string[];
+  /** Additional normalized scopes requested by an assistant action. */
+  readonly prefillScopes?: readonly string[];
   readonly launch?: "popup";
   readonly flow?: OAuthFlowKind;
   readonly onPopupViewResult?: (keyId: string) => boolean;
@@ -1518,9 +1527,12 @@ function OAuthStep({
   // pre-selected) so an unedited add requests today's scopes. The full
   // selection is sent as `scopeOverride`.
   const [selectedScopes, setSelectedScopes] = useState<readonly string[]>(
-    grantedScopes.length > 0
-      ? grantedScopes
-      : (catalogEntry.default_scopes ?? []),
+    mergeScopes(
+      grantedScopes.length > 0
+        ? grantedScopes
+        : (catalogEntry.default_scopes ?? []),
+      prefillScopes,
+    ),
   );
   // In-dialog authorization handoff. The whole-tab `hardRedirect` this
   // replaced destroyed any surface hosting the dialog — fatal for the
@@ -1801,8 +1813,7 @@ function OAuthStep({
             throw new Error("OAuth provider returned an invalid attempt nonce");
           }
           if (
-            validateAuthorizationUrl(response.authorization_url, nonce) ===
-            null
+            validateAuthorizationUrl(response.authorization_url, nonce) === null
           ) {
             throw new Error(
               "OAuth provider returned an invalid authorization URL",
@@ -1840,11 +1851,7 @@ function OAuthStep({
         }
         useOAuthPopupStore.getState().setNonce(popup.launchId, nonce);
         try {
-          await popup.navigate(
-            authorizationHref,
-            nonce,
-            catalogEntry.name,
-          );
+          await popup.navigate(authorizationHref, nonce, catalogEntry.name);
         } catch {
           if (generationRef.current !== generation) return;
           // A cold interstitial or detached popup does not invalidate the
@@ -2033,11 +2040,7 @@ function OAuthStep({
 }
 
 type DeviceFlowStep =
-  | "configure"
-  | "requesting"
-  | "show_code"
-  | "success"
-  | "error";
+  "configure" | "requesting" | "show_code" | "success" | "error";
 
 function DeviceCodeStep({
   catalogEntry,
@@ -2054,6 +2057,7 @@ function DeviceCodeStep({
   reconnectMode,
   lockedScopes = [],
   grantedScopes = [],
+  prefillScopes = [],
 }: {
   readonly catalogEntry: CatalogEntry;
   readonly ensureKey: () => Promise<KeyInfo>;
@@ -2070,6 +2074,8 @@ function DeviceCodeStep({
   readonly lockedScopes?: readonly string[];
   /** The connection's currently-granted scopes when editing (see `OAuthStep`). */
   readonly grantedScopes?: readonly string[];
+  /** Additional normalized scopes requested by an assistant action. */
+  readonly prefillScopes?: readonly string[];
 }) {
   const [flowStep, setFlowStep] = useState<DeviceFlowStep>("configure");
   const [userCode, setUserCode] = useState("");
@@ -2081,9 +2087,12 @@ function DeviceCodeStep({
   // existing connection, else provider defaults. Only used for non-openai
   // device-code providers (openai rejects scopes).
   const [selectedScopes, setSelectedScopes] = useState<readonly string[]>(
-    grantedScopes.length > 0
-      ? grantedScopes
-      : (catalogEntry.default_scopes ?? []),
+    mergeScopes(
+      grantedScopes.length > 0
+        ? grantedScopes
+        : (catalogEntry.default_scopes ?? []),
+      prefillScopes,
+    ),
   );
 
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -2840,6 +2849,7 @@ export function AddKeyDialog({
   prefillNodeId,
   prefillTargetOrgId,
   prefillCustom,
+  prefillScopes,
   reconnectKey,
   onSuccess,
   onAuthorizationPending,
@@ -2865,6 +2875,8 @@ export function AddKeyDialog({
   readonly prefillTargetOrgId?: string;
   /** Opens the existing custom-endpoint route with every mappable field set. */
   readonly prefillCustom?: AddKeyDialogCustomPrefill;
+  /** Additional normalized OAuth scopes supplied by an assistant action. */
+  readonly prefillScopes?: readonly string[];
   readonly reconnectKey?: KeyInfo | null;
   /** Fires only when the user finishes the post-connect success step. */
   readonly onSuccess?: (result: AddKeyDialogCompletion) => void;
@@ -3182,7 +3194,7 @@ export function AddKeyDialog({
           keyId: reconnectKey.id,
           auth_method:
             reconnectKey.auth_method === "none"
-              ? selectedEntry?.auth_method ?? reconnectKey.auth_method
+              ? (selectedEntry?.auth_method ?? reconnectKey.auth_method)
               : reconnectKey.auth_method,
         });
         setAuthKey(repaired);
@@ -3493,6 +3505,7 @@ export function AddKeyDialog({
                 ? (reconnectKey?.granted_scopes ?? [])
                 : []
             }
+            prefillScopes={prefillScopes}
             platformScopeAllowlist={
               // Gate scope pills only when this connection rides the shared
               // platform app: managed path (not switched to BYO), fresh add.
@@ -3537,6 +3550,7 @@ export function AddKeyDialog({
                 ? (reconnectKey?.granted_scopes ?? [])
                 : []
             }
+            prefillScopes={prefillScopes}
             onBack={() => {
               if (isReconnect) {
                 handleOpenChange(false);

--- a/frontend/src/lib/assistant/action-registry.ts
+++ b/frontend/src/lib/assistant/action-registry.ts
@@ -4,6 +4,7 @@ import {
   keyCreateActionParamsSchema,
   keyRotateActionParamsSchema,
   serviceConnectActionParamsSchema,
+  serviceReauthorizeActionParamsSchema,
   type ActionCardParams,
   type AssistantActionRequest,
 } from "@/schemas/assistant-actions";
@@ -12,6 +13,7 @@ export type ActionRisk = "credential_access" | "unsupported";
 export type ActionJourney =
   | "catalog_service"
   | "custom_service"
+  | "service_reauthorize"
   | "key_create"
   | "key_rotate"
   | null;
@@ -87,6 +89,18 @@ const serviceConnectDescriptor: ActionDescriptor = {
   },
 };
 
+const serviceReauthorizeDescriptor: ActionDescriptor = {
+  title: () => "Re-authorize service",
+  body: (params) =>
+    params.variant === "service_reauthorize"
+      ? "NyxID will re-authorize this connected service with the requested permissions. Your credential stays in NyxID and is never shared with the model."
+      : "NyxID will re-authorize one exact connected service.",
+  cta: () => "Re-authorize",
+  risk: "credential_access",
+  journey: (params) =>
+    params.variant === "service_reauthorize" ? "service_reauthorize" : null,
+};
+
 const keyCreateDescriptor: ActionDescriptor = {
   title: () => "Create API key",
   body: (params) =>
@@ -120,6 +134,7 @@ const unsupportedDescriptor: ActionDescriptor = {
 
 export const ACTION_REGISTRY: Readonly<Record<string, ActionDescriptor>> = {
   "service.connect": serviceConnectDescriptor,
+  "service.reauthorize": serviceReauthorizeDescriptor,
   "key.create": keyCreateDescriptor,
   "key.rotate": keyRotateDescriptor,
 };
@@ -163,6 +178,18 @@ function safeAuthKeyName(value: string): string | null {
 }
 
 function normalizeParams(request: AssistantActionRequest): ActionCardParams {
+  if (request.action === "service.reauthorize") {
+    const parsed = serviceReauthorizeActionParamsSchema.safeParse(
+      request.params,
+    );
+    if (!parsed.success) return { variant: "unknown" };
+    return {
+      variant: "service_reauthorize",
+      user_service_id: parsed.data.userServiceId,
+      requested_scopes: parsed.data.requestedScopes,
+    };
+  }
+
   if (request.action === "key.create") {
     const parsed = keyCreateActionParamsSchema.safeParse(request.params);
     if (!parsed.success) return { variant: "unknown" };

--- a/frontend/src/lib/assistant/aevatar-transport.ts
+++ b/frontend/src/lib/assistant/aevatar-transport.ts
@@ -973,6 +973,12 @@ function fingerprintStableRequestInput(
 
 function fingerprintActionRequest(request: AssistantActionRequest): string {
   const params = resolveAssistantAction(request).params;
+  if (params.variant === "service_reauthorize") {
+    return fingerprintStableRequestInput({
+      userServiceId: params.user_service_id,
+      requestedScopes: [...params.requested_scopes].sort(),
+    });
+  }
   if (params.variant === "key_create") {
     return fingerprintStableRequestInput({
       name: params.name,
@@ -1029,6 +1035,12 @@ function sameActionCardParams(
         left.auth_key_name === right.auth_key_name &&
         left.via_node_id === right.via_node_id &&
         left.target_org_id === right.target_org_id
+      );
+    case "service_reauthorize":
+      return (
+        right.variant === "service_reauthorize" &&
+        left.user_service_id === right.user_service_id &&
+        sameStringSet(left.requested_scopes, right.requested_scopes)
       );
     case "key_create":
       return (

--- a/frontend/src/schemas/assistant-actions.test.ts
+++ b/frontend/src/schemas/assistant-actions.test.ts
@@ -85,6 +85,77 @@ describe("assistant action request schema", () => {
     });
   });
 
+  it("parses exact service.reauthorize params including URL-shaped scopes", () => {
+    const request = assistantActionRequestSchema.parse({
+      ...BASE_REQUEST,
+      action: "service.reauthorize",
+      params: {
+        userServiceId: "service-alpha",
+        requestedScopes: [
+          "repo",
+          "https://www.googleapis.com/auth/cloud-platform.read-only",
+        ],
+      },
+    });
+
+    expect(resolveAssistantAction(request)).toMatchObject({
+      supported: true,
+      journey: "service_reauthorize",
+      params: {
+        variant: "service_reauthorize",
+        user_service_id: "service-alpha",
+        requested_scopes: [
+          "repo",
+          "https://www.googleapis.com/auth/cloud-platform.read-only",
+        ],
+      },
+    });
+  });
+
+  it("rejects empty, duplicate, unnormalized, packed, and widened reauthorization scopes", () => {
+    const invalidParams = [
+      { userServiceId: "service-alpha", requestedScopes: [] },
+      {
+        userServiceId: "service-alpha",
+        requestedScopes: ["repo", "repo"],
+      },
+      { userServiceId: "service-alpha", requestedScopes: [" repo"] },
+      { userServiceId: "service-alpha", requestedScopes: ["repo write"] },
+      { userServiceId: "service-alpha", requestedScopes: ["repo,write"] },
+      {
+        userServiceId: "service-alpha",
+        requestedScopes: ["repo"],
+        replacementServiceId: "service-beta",
+      },
+      { userServiceId: "invalid/service", requestedScopes: ["repo"] },
+    ];
+
+    for (const [index, params] of invalidParams.entries()) {
+      expect(
+        assistantActionRequestSchema.safeParse({
+          ...BASE_REQUEST,
+          actionRequestId: `invalid-reauthorize-${String(index)}`,
+          action: "service.reauthorize",
+          params,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("falls back to unsupported when service.reauthorize params are absent", () => {
+    const request = assistantActionRequestSchema.parse({
+      ...BASE_REQUEST,
+      action: "service.reauthorize",
+      params: {},
+    });
+
+    expect(resolveAssistantAction(request)).toMatchObject({
+      supported: false,
+      journey: null,
+      params: { variant: "unknown" },
+    });
+  });
+
   it("parses an exact nonempty key.create service set", () => {
     const request = assistantActionRequestSchema.parse({
       ...BASE_REQUEST,

--- a/frontend/src/schemas/assistant-actions.ts
+++ b/frontend/src/schemas/assistant-actions.ts
@@ -46,6 +46,34 @@ const allowedServiceIdsSchema = z
     }
   });
 
+export const actionScopeTokenSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine((value) => value === value.trim(), "Scope must be normalized")
+  .regex(
+    /^[A-Za-z0-9._:/~+*=-]+$/,
+    "Scope contains characters NyxID cannot request",
+  );
+
+const requestedScopesSchema = z
+  .array(actionScopeTokenSchema)
+  .min(1)
+  .max(64)
+  .superRefine((values, context) => {
+    const seen = new Set<string>();
+    for (const [index, value] of values.entries()) {
+      if (seen.has(value)) {
+        context.addIssue({
+          code: "custom",
+          path: [index],
+          message: "Duplicate requested scope",
+        });
+      }
+      seen.add(value);
+    }
+  });
+
 const SECRET_VALUE =
   /(Bearer\s+)[A-Za-z0-9._~+/-]+|nyx(?:id)?_[A-Za-z0-9_-]{8,}/gi;
 const FORBIDDEN_ACTION_KEY =
@@ -92,6 +120,13 @@ export const serviceConnectActionParamsSchema = z
   })
   .strict();
 
+export const serviceReauthorizeActionParamsSchema = z
+  .object({
+    userServiceId: requiredActionIdentitySchema,
+    requestedScopes: requestedScopesSchema,
+  })
+  .strict();
+
 export const keyCreateActionParamsSchema = z
   .object({
     name: z
@@ -119,6 +154,7 @@ const emptyActionParamsSchema = z.object({}).strict();
 export const assistantActionParamsSchema = z
   .union([
     serviceConnectActionParamsSchema,
+    serviceReauthorizeActionParamsSchema,
     keyCreateActionParamsSchema,
     keyRotateActionParamsSchema,
     emptyActionParamsSchema,
@@ -216,6 +252,11 @@ export type ActionCardParams =
       readonly auth_key_name: string;
       readonly via_node_id: string | null;
       readonly target_org_id: string | null;
+    }
+  | {
+      readonly variant: "service_reauthorize";
+      readonly user_service_id: string;
+      readonly requested_scopes: readonly string[];
     }
   | {
       readonly variant: "key_create";
@@ -332,8 +373,7 @@ export type ActionReport = z.infer<typeof actionReportSchema>;
 export type ActionContinueBody = z.infer<typeof actionContinueBodySchema>;
 export type ActionWakeBody = z.infer<typeof actionWakeBodySchema>;
 export type ActionReportActionLookup =
-  | ReadonlyMap<string, string>
-  | Readonly<Record<string, string | undefined>>;
+  ReadonlyMap<string, string> | Readonly<Record<string, string | undefined>>;
 function matchesSecretValue(value: string): boolean {
   SECRET_VALUE.lastIndex = 0;
   return SECRET_VALUE.test(value);


### PR DESCRIPTION
# DO-NOT-MERGE

**Aevatar has no `nyxid-assistant-actions.v8` consumer today. Aevatar must merge and deploy the matching consumer first. If NyxID publishes v8 first, every Aevatar process started afterward disables the entire assistant-action registry: all NyxID assistant action cards become unavailable, although chat itself remains alive.**

`nyxid-assistant-actions.v8` is a working assumption only. Do not merge or deploy this PR until the Aevatar prerequisite below is complete and verified.

## Summary

- publish the exact `service.reauthorize` assistant action descriptor under the provisional v8 revision;
- make `GET /api/v1/keys/{id}` return the authorization-evidence shape Aevatar actually parses;
- normalize comma/whitespace provider scope echoes with stable, case-sensitive deduplication;
- execute the action through NyxID's existing OAuth/device-code reconnect journey, including exact key/catalog preflight, requested-scope prefill, popup handoff, and freshness-aware completion;
- report only `{ userService: { userServiceId } }` after a real authorization attempt completes;
- keep B3 as no-code-change: the existing assistant facade already round-trips the `userService` safe-resource variant.

The evidence-endpoint correction is important: Aevatar calls `NyxIdApiClient.GetServiceAsync`, which reads **`GET /api/v1/keys/{id}`**, not `/api/v1/user-services`.

## Aevatar prerequisite: complete before NyxID merge

On `aevatarAI/aevatar` (building from `feature/integrate`):

1. Add `nyxid-assistant-actions.v8` to both `PinnedActionsByRevision` and `ExecutableActionsByRevision`/the accepted revision gate.
2. Pin exactly four actions for v8 and make all four executable: `service.connect`, `service.reauthorize`, `key.create`, and `key.rotate`.
3. Pin `service.reauthorize` to the exact NyxID schema and metadata: `{userServiceId, requestedScopes[]}`, `risk=grant`, `tier=v1`, `remember_eligible=false`. `ValidatePinnedContract` uses `JsonNode.DeepEquals`, so the published schema must have no extra refinements. Preserve the least-scope `key.create` schema pin for v8 as well.
4. Add `docs/contracts/nyxid-assistant-conformance/v1/registry-v8.json` containing the byte-structurally exact manifest published here.
5. Update registry/conformance tests, including the `ServiceReauthorize` executable mapping and the existing postcondition verification path.
6. Merge and deploy the additive Aevatar consumer, then restart an Aevatar process while NyxID still serves the live v7 manifest and prove the registry still loads with all current actions. Only after that proof may NyxID merge/deploy this v8 manifest.

After the NyxID deploy, restart another Aevatar process, prove it loads v8, and run one end-to-end `service.reauthorize` action.

## Adversarial review

Verdict: **BUILD-WITH-FIXES**: **1 BLOCKER, 4 MAJOR, 2 MINOR**.

| Finding | Disposition |
| --- | --- |
| BLOCKER: no Aevatar v8 consumer; early publication disables all action cards on newly started Aevatar processes | **Accepted / merge gate.** v8 is provisional; PR is draft and DO-NOT-MERGE. Exact Aevatar-first rollout is above. |
| MAJOR: the plan's starting branch lacked the `connection_status` prerequisite present on newer main | **Fixed.** Work was rebased onto current `origin/main`; the already-landed OAuth-health prerequisite is present without duplicating it in this PR. |
| MAJOR: a currently-active key could make F2 report completed without a new authorization | **Fixed.** Pending attempts carry `previousAuthorizationAt`; the watcher requires `last_authorized_at` to advance for reconnects. Mismatched service IDs block rather than complete. |
| MAJOR: whitespace-only scope parsing makes comma-separated provider echoes unverifiable | **Fixed.** Read-boundary parsing splits on comma or Unicode whitespace, removes empties, and preserves first occurrence under case-sensitive deduplication. Stored provider echoes remain unchanged. |
| MAJOR: the plan's expiry-less health rule would label `pending_auth` active | **Fixed, overriding the plan.** Expiry-less `active` now requires `status == active` and stored access-token material. Terminal states remain expired; placeholders/inconsistent rows serialize null. |
| MINOR: the plan checked secret-bearing names but missed Aevatar's recursive value scan | **Fixed for this boundary.** Added representative `KeyResponse` serialization coverage plus an Aevatar-compatible recursive field/value tripwire. A future minimal evidence projection remains a possible hardening follow-up for arbitrary user-controlled strings. |
| MINOR: the plan cited frontend response helpers/schemas that were not present | **Accepted / corrected.** No broad response-schema churn was added. The journey uses narrow runtime Zod projections and a local recursive secret scan; frontend build/tests and CLI tests are the compatibility gates. |

Review positions that override or amend the original plan:

- use `/keys/{id}` as the evidence source;
- publish the params schema exactly as pinned, while enforcing stricter scope-token grammar only in the browser;
- require fresh `last_authorized_at` advancement before browser completion;
- normalize and stably deduplicate comma/whitespace scope echoes at the read boundary;
- require access-token material before deriving expiry-less active health;
- block OpenAI-format device-code reauthorization when requested scopes cannot be forwarded instead of silently dropping them;
- perform exact service identity, OAuth modality, credential presence, catalog/provider, organization-admin, and recursive secret checks before opening the provider flow.

## Verification

- `npm --prefix frontend run test`: **246 files, 2,847 tests passed; 0 failed**.
- `npm --prefix frontend run lint`: **0 errors, 23 existing warnings** in unrelated files.
- `npm --prefix frontend run build`: passed `tsc -b`, main Vite build (**3,470 modules**), credential-accept build (**107 modules**), and mock-footprint assertion. It emits the existing generated-CSS `text-destructive` pseudo-class warning.
- `cargo test assistant_actions` with low-footprint test settings: **5 passed, 0 failed**.
- `cargo test unified_key_service` with low-footprint test settings: **163 passed, 0 failed**.
- `cargo fmt --check`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed after fixing CI’s `filter_map_bool_then` finding.
- `cargo test -p nyxid-cli`: **1,100 unit tests + 1 wizard freshness test passed; 0 failed**.
- B3 compiled-harness check `completed_action_reports_round_trip_each_safe_resource_variant`: **1 passed, 0 failed**.
- Pre-final-rebase full `cargo test`: backend harness printed **5,189 passed, 129 failed**. Every listed failure requires local MongoDB/replica-set fixtures; `NYXID_TEST_DATABASE_URL` is unset and Docker is unavailable. The failed harness remained in MongoDB cleanup after its summary and was interrupted; this is not reported as a green full-suite run.

## Coordination drafts: do not post from this PR

### Draft Aevatar issue

**Title:** Accept and execute NyxID assistant-actions v8 with `service.reauthorize`

NyxID issue ChronoAIProject/NyxID#1400 item 1 has one residual verb: `service.reauthorize`. Aevatar's action production, parsing, evidence verification, and postcondition machinery already exist on `feature/integrate`, but no revision currently makes the verb executable and no v8 consumer exists.

Please add `nyxid-assistant-actions.v8` to both pinned and executable revision maps; make `service.connect`, `service.reauthorize`, `key.create`, and `key.rotate` executable; pin the exact `service.reauthorize` schema/metadata and v8's least-scope `key.create` contract; add the exact `registry-v8.json` conformance fixture; and update registry/executable tests. The settled params shape for aevatar#3315 item 6 is `{userServiceId, requestedScopes[]}`. This is the consumer prerequisite for aevatar#3312.

Before NyxID publishes v8, merge/deploy this additive consumer and prove a restarted Aevatar process still loads NyxID's live v7 manifest. Publishing v8 first disables the whole action registry on newly started Aevatar processes while chat itself stays alive.

### Draft NyxID #1400 comment

Item 1's residual NyxID scope is `service.reauthorize` only; the other Wave-1 action verbs are already published. The NyxID implementation is in this draft PR and is **DO-NOT-MERGE** until Aevatar accepts and deploys the exact v8 contract. Deployment order is Aevatar consumer first, NyxID manifest second; reversing it disables every assistant action on newly started Aevatar processes, although chat continues running.

Evidence-endpoint correction: Aevatar's reauthorization verifier reads `GET /api/v1/keys/{id}` through `NyxIdApiClient.GetServiceAsync`, not `/api/v1/user-services`. The NyxID response hardening and browser journey in this PR target that actual contract.

Calvin should post both drafts only after confirming the v8 revision string and assigning the Aevatar prerequisite.



