### PR TITLE
fix(assistant): close wave-1 reauthorize evidence gaps

### DIFF
--- a/backend/src/api_docs.rs
+++ b/backend/src/api_docs.rs
@@ -28,6 +28,7 @@
         crate::handlers::keys::create_key,
         crate::handlers::keys::list_keys,
         crate::handlers::keys::get_key,
+        crate::handlers::keys::get_key_authorization,
         crate::handlers::keys::update_key,
         crate::handlers::keys::delete_key,
         // Hosted Connect Links
@@ -59,6 +60,7 @@
         // NyxID API Keys
         crate::handlers::api_keys::list_keys,
         crate::handlers::api_keys::get_key,
+        crate::handlers::api_keys::get_key_authorization,
         crate::handlers::api_keys::plan_key_scope,
         crate::handlers::api_keys::create_key,
         crate::handlers::api_keys::update_key,
@@ -99,6 +101,7 @@
             crate::handlers::keys::CreateKeyRequest,
             crate::handlers::keys::UpdateKeyRequest,
             crate::handlers::keys::KeyResponse,
+            crate::handlers::keys::KeyAuthorizationEvidenceResponse,
             crate::handlers::keys::KeyListResponse,
             crate::handlers::keys::DeleteKeyResponse,
             // Hosted Connect Links
@@ -142,6 +145,7 @@
             crate::handlers::api_keys::AllowedServiceInfo,
             crate::handlers::api_keys::AllowedNodeInfo,
             crate::handlers::api_keys::ApiKeyResponse,
+            crate::handlers::api_keys::ApiKeyAuthorizationEvidenceResponse,
             crate::handlers::api_keys::ApiKeyListResponse,
             crate::handlers::api_keys::DeleteApiKeyResponse,
             crate::handlers::api_keys::DurableGrantReceipt,

--- a/backend/src/handlers/api_keys.rs
+++ b/backend/src/handlers/api_keys.rs
@@ -348,6 +348,78 @@ pub struct ApiKeyResponse {
     pub credential_source: crate::handlers::user_services_handler::CredentialSourceResponse,
 }
 
+/// Authorization evidence for one agent API key — the minimal projection of
+/// `ApiKeyResponse` that an assistant-action postcondition reader consumes,
+/// for the `key.create` and `key.rotate` verbs.
+///
+/// Exists for the same reason as `KeyAuthorizationEvidenceResponse` in
+/// `handlers::keys`: the evidence reader runs a recursive secret-shape scan
+/// over the whole document it receives, and `ApiKeyResponse` carries
+/// user-controlled free text that legitimately matches it — `description`,
+/// `allowed_services[].label` (the user's own service label), and
+/// `allowed_nodes[].name`. None of those three are evidence, so projecting
+/// them away removes the tripwire surface.
+///
+/// `name` is the irreducible remainder: the reader both requires it and scans
+/// it, so a key named e.g. `Bearer Bot` stays unverifiable no matter what
+/// NyxID serves. Closing that needs either a write-time restriction on key
+/// names or a reader that excludes its own required evidence properties from
+/// the scan; it cannot be closed by a projection.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ApiKeyAuthorizationEvidenceResponse {
+    pub id: String,
+    pub name: String,
+    pub scopes: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    pub is_active: bool,
+    pub allowed_service_ids: Vec<String>,
+    pub allow_all_services: bool,
+    pub allowed_node_ids: Vec<String>,
+    pub allow_all_nodes: bool,
+    pub created_at: String,
+    /// Rotation lineage. Emitted as a trio or not at all: the reader treats
+    /// all three absent as "no lineage evidence" but all three present with
+    /// `state_version <= 0` as a malformed document. Pre-lineage rows
+    /// (`state_version` 0) therefore have to omit the trio rather than
+    /// serialize a zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotation_predecessor_id: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_version: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<Option<String>>,
+}
+
+impl ApiKeyAuthorizationEvidenceResponse {
+    /// Project the full detail response down to authorization evidence.
+    ///
+    /// Derived from `ApiKeyResponse` so the two representations report the
+    /// same values for every shared property.
+    fn from_api_key_response(response: ApiKeyResponse) -> Self {
+        // A row written before rotation lineage existed has no lineage to
+        // report. Serializing `state_version: 0` alongside two nulls is worse
+        // than silence: the reader reads it as a present-but-invalid trio and
+        // rejects the whole document.
+        let has_lineage = response.state_version >= 1;
+        Self {
+            id: response.id,
+            name: response.name,
+            scopes: response.scopes,
+            platform: response.platform,
+            is_active: response.is_active,
+            allowed_service_ids: response.allowed_service_ids,
+            allow_all_services: response.allow_all_services,
+            allowed_node_ids: response.allowed_node_ids,
+            allow_all_nodes: response.allow_all_nodes,
+            created_at: response.created_at,
+            rotation_predecessor_id: has_lineage.then_some(response.rotation_predecessor_id),
+            state_version: has_lineage.then_some(response.state_version),
+            updated_at: has_lineage.then_some(response.updated_at),
+        }
+    }
+}
+
 fn is_zero(v: &u64) -> bool {
     *v == 0
 }
@@ -1116,10 +1188,50 @@ pub async fn get_key(
     Path(key_id): Path<String>,
 ) -> AppResult<Json<ApiKeyResponse>> {
     let actor = auth_user.user_id.to_string();
-    let user_id_str = resolve_api_key_read_owner(&state, &actor, &key_id).await?;
-    let key = key_service::get_api_key(&state.db, &user_id_str, &key_id).await?;
-    let enriched = enrich_api_keys_batch(&state, &actor, &[key]).await?;
-    Ok(Json(enriched.into_iter().next().unwrap()))
+    Ok(Json(
+        resolve_api_key_response(&state, &actor, &key_id).await?,
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/api-keys/{key_id}/authorization",
+    params(
+        ("key_id" = String, Path, description = "API key ID or name")
+    ),
+    responses(
+        (status = 200, description = "Authorization evidence", body = ApiKeyAuthorizationEvidenceResponse),
+        (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 404, description = "API key not found", body = crate::errors::ErrorResponse)
+    ),
+    tag = "API Keys"
+)]
+/// GET /api/v1/api-keys/{key_id}/authorization
+///
+/// Same resolution and ACL as `GET /api/v1/api-keys/{key_id}`, projected to
+/// the properties an assistant-action postcondition reader consumes.
+pub async fn get_key_authorization(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(key_id): Path<String>,
+) -> AppResult<Json<ApiKeyAuthorizationEvidenceResponse>> {
+    let actor = auth_user.user_id.to_string();
+    let response = resolve_api_key_response(&state, &actor, &key_id).await?;
+    Ok(Json(
+        ApiKeyAuthorizationEvidenceResponse::from_api_key_response(response),
+    ))
+}
+
+/// Shared body of the two API key detail reads.
+async fn resolve_api_key_response(
+    state: &AppState,
+    actor: &str,
+    key_id: &str,
+) -> AppResult<ApiKeyResponse> {
+    let user_id_str = resolve_api_key_read_owner(state, actor, key_id).await?;
+    let key = key_service::get_api_key(&state.db, &user_id_str, key_id).await?;
+    let enriched = enrich_api_keys_batch(state, actor, &[key]).await?;
+    Ok(enriched.into_iter().next().unwrap())
 }
 
 #[utoipa::path(
@@ -1847,6 +1959,137 @@ mod tests {
         assert!(json.get("full_key").is_none());
         assert!(json.get("key_hash").is_none());
         assert!(json.get("secret").is_none());
+    }
+
+    /// An `ApiKeyResponse` whose owner used three supported free-text fields
+    /// in ways that match the evidence reader's secret-shape tripwire: a
+    /// description mentioning a bearer token, a scoped service whose own
+    /// `UserEndpoint.label` is `Bearer Bot`, and a node display name.
+    fn poisoned_api_key_response(state_version: i64) -> ApiKeyResponse {
+        ApiKeyResponse {
+            id: "key-1".to_string(),
+            name: "release-agent".to_string(),
+            description: Some("rotate when the Bearer sk-live-abc123 header expires".to_string()),
+            key_prefix: "nyxid_ag_public".to_string(),
+            scopes: "proxy".to_string(),
+            last_used_at: None,
+            expires_at: None,
+            is_active: true,
+            created_at: "2026-08-11T00:00:00Z".to_string(),
+            rotation_predecessor_id: (state_version >= 1).then(|| "predecessor-id".to_string()),
+            state_version,
+            updated_at: (state_version >= 1).then(|| "2026-08-11T00:00:00Z".to_string()),
+            allowed_service_ids: vec!["service-1".to_string()],
+            allowed_node_ids: vec!["node-1".to_string()],
+            allow_all_services: false,
+            allow_all_nodes: false,
+            allowed_services: vec![super::AllowedServiceInfo {
+                id: "service-1".to_string(),
+                slug: "example".to_string(),
+                label: "Bearer Bot".to_string(),
+                catalog_service_name: None,
+            }],
+            allowed_nodes: vec![super::AllowedNodeInfo {
+                id: "node-1".to_string(),
+                name: "Bearer Bot node".to_string(),
+                status: "online".to_string(),
+            }],
+            rate_limit_per_second: None,
+            rate_limit_burst: None,
+            platform: Some("codex".to_string()),
+            callback_url: None,
+            purpose: Default::default(),
+            scheduled_write_enabled: false,
+            bindings_count: 0,
+            credential_source:
+                crate::handlers::user_services_handler::CredentialSourceResponse::Personal,
+        }
+    }
+
+    /// The hazard the projection exists for: the full detail response *does*
+    /// trip the evidence reader's scan, so serving it as `key.create` /
+    /// `key.rotate` evidence would make those keys permanently unverifiable.
+    #[test]
+    fn full_api_key_response_trips_the_aevatar_secret_scan() {
+        let json = serde_json::to_value(poisoned_api_key_response(1)).unwrap();
+        assert!(
+            crate::test_utils::aevatar_secret_free_violation(&json).is_some(),
+            "expected the full API key detail response to be rejected by the evidence scan"
+        );
+    }
+
+    #[test]
+    fn api_key_authorization_evidence_is_secret_free_for_a_poisoned_key() {
+        let evidence = serde_json::to_value(
+            super::ApiKeyAuthorizationEvidenceResponse::from_api_key_response(
+                poisoned_api_key_response(1),
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            crate::test_utils::aevatar_secret_free_violation(&evidence),
+            None,
+            "authorization evidence must never carry a secret-shaped value"
+        );
+
+        let properties: std::collections::BTreeSet<&str> = evidence
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            properties,
+            [
+                "allow_all_nodes",
+                "allow_all_services",
+                "allowed_node_ids",
+                "allowed_service_ids",
+                "created_at",
+                "id",
+                "is_active",
+                "name",
+                "platform",
+                "rotation_predecessor_id",
+                "scopes",
+                "state_version",
+                "updated_at",
+            ]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<&str>>()
+        );
+    }
+
+    /// A pre-lineage row must omit the trio entirely. Emitting
+    /// `state_version: 0` alongside two nulls reads to the evidence parser as
+    /// a present-but-invalid lineage and rejects the whole document.
+    #[test]
+    fn api_key_authorization_evidence_omits_the_lineage_trio_for_legacy_rows() {
+        let evidence = serde_json::to_value(
+            super::ApiKeyAuthorizationEvidenceResponse::from_api_key_response(
+                poisoned_api_key_response(0),
+            ),
+        )
+        .unwrap();
+
+        for property in ["rotation_predecessor_id", "state_version", "updated_at"] {
+            assert!(
+                evidence.get(property).is_none(),
+                "legacy rows must omit {property} rather than serialize a zero-version trio"
+            );
+        }
+    }
+
+    /// The same row today, straight off `GET /api/v1/api-keys/{id}`: all three
+    /// present, `state_version` zero. Documented so the projection's reason to
+    /// exist stays visible if anyone changes the detail response.
+    #[test]
+    fn full_api_key_response_still_emits_a_zero_version_lineage_trio() {
+        let json = serde_json::to_value(poisoned_api_key_response(0)).unwrap();
+        assert_eq!(json["state_version"], 0);
+        assert_eq!(json["rotation_predecessor_id"], serde_json::Value::Null);
+        assert_eq!(json["updated_at"], serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/backend/src/handlers/keys.rs
+++ b/backend/src/handlers/keys.rs
@@ -564,6 +564,57 @@ pub struct KeyResponse {
     pub permission_setup_scopes: Option<Vec<String>>,
 }
 
+/// Authorization evidence for one user service — the minimal projection of
+/// `KeyResponse` that an assistant-action postcondition reader consumes.
+///
+/// Why this exists as its own representation rather than reusing the full
+/// `KeyResponse`: evidence readers run a recursive secret-shape scan over the
+/// *whole* document they receive, rejecting any string matching
+/// `Bearer\s+\S+` or a `nyxid_` key prefix. `KeyResponse` carries several
+/// user-controlled free-text carriers — `label` / `name`,
+/// `default_request_headers[].value`, and `ws_frame_injections[].template`,
+/// where `{"headers":{"Authorization":"Bearer ${credential}"}}` is an
+/// explicitly supported template (CLAUDE.md §6) — so a legitimately
+/// configured service could make its own authorization permanently
+/// unverifiable. None of those fields are evidence. Projecting to exactly the
+/// consumed properties removes the tripwire surface instead of asking users
+/// not to configure supported features.
+///
+/// Every property is serialized unconditionally except `api_key_id`, which
+/// mirrors `KeyResponse` (absent and null are equivalent to the reader).
+/// Readers distinguish an explicit null from a missing property, so no
+/// `skip_serializing_if` may be added to the remaining fields.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct KeyAuthorizationEvidenceResponse {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key_id: Option<String>,
+    pub is_active: bool,
+    pub status: String,
+    pub connection_status: Option<String>,
+    pub granted_scopes: Option<Vec<String>>,
+    pub last_authorized_at: Option<String>,
+}
+
+impl KeyAuthorizationEvidenceResponse {
+    /// Project the full detail response down to authorization evidence.
+    ///
+    /// Deriving from `KeyResponse` rather than from `KeyView` keeps the two
+    /// representations from drifting: whatever `/keys/{id}` reports for these
+    /// seven properties is exactly what the evidence read reports.
+    fn from_key_response(response: KeyResponse) -> Self {
+        Self {
+            id: response.id,
+            api_key_id: response.api_key_id,
+            is_active: response.is_active,
+            status: response.status,
+            connection_status: response.connection_status,
+            granted_scopes: response.granted_scopes,
+            last_authorized_at: response.last_authorized_at,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, ToSchema)]
 pub struct KeyRevocationResponse {
     pub revokes_grant: bool,
@@ -1092,7 +1143,58 @@ pub async fn get_key(
     Path(key_id): Path<String>,
 ) -> AppResult<Json<KeyResponse>> {
     let actor = auth_user.user_id.to_string();
-    let access = resolve_key_read_owner(&state, &actor, &key_id).await?;
+    let mut response = resolve_key_response(&state, &actor, &key_id).await?;
+    enrich_key_response(
+        &state.db,
+        &state.node_ws_manager,
+        &actor,
+        state.config.node_heartbeat_timeout_secs,
+        state.config.base_url.trim_end_matches('/'),
+        &mut response,
+    )
+    .await?;
+    Ok(Json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/keys/{key_id}/authorization",
+    params(
+        ("key_id" = String, Path, description = "User service ID or slug")
+    ),
+    responses(
+        (status = 200, description = "Authorization evidence", body = KeyAuthorizationEvidenceResponse),
+        (status = 401, description = "Unauthorized", body = crate::errors::ErrorResponse),
+        (status = 404, description = "Key not found", body = crate::errors::ErrorResponse)
+    ),
+    tag = "AI Services"
+)]
+/// GET /api/v1/keys/{key_id}/authorization
+///
+/// Same resolution, ACL, and lazy `pending_auth` reconciliation as
+/// `GET /api/v1/keys/{key_id}`, projected to authorization evidence. Node and
+/// proxy-URL enrichment is skipped because no evidence property depends on it.
+pub async fn get_key_authorization(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(key_id): Path<String>,
+) -> AppResult<Json<KeyAuthorizationEvidenceResponse>> {
+    let actor = auth_user.user_id.to_string();
+    let response = resolve_key_response(&state, &actor, &key_id).await?;
+    Ok(Json(KeyAuthorizationEvidenceResponse::from_key_response(
+        response,
+    )))
+}
+
+/// Shared body of the two key detail reads: ACL resolution, lazy OAuth
+/// placeholder reconciliation, and the view→response mapping. Returns the
+/// un-enriched response; callers add whatever their representation needs.
+async fn resolve_key_response(
+    state: &AppState,
+    actor: &str,
+    key_id: &str,
+) -> AppResult<KeyResponse> {
+    let access = resolve_key_read_owner(state, actor, key_id).await?;
 
     // Lazy reconciliation of pending_auth OAuth placeholders (issue #653).
     // Wizard polling hits this handler every ~2s; treating each poll as a
@@ -1138,7 +1240,7 @@ pub async fn get_key(
     let api_key_id = view.api_key_id.clone();
     let mut response = key_response_from_view(view);
     let (permission_url, permission_scopes) = derive_lark_permission_for_key(
-        &state,
+        state,
         &owner_id,
         catalog_id.as_deref(),
         catalog_slug.as_deref(),
@@ -1147,16 +1249,7 @@ pub async fn get_key(
     .await;
     response.permission_setup_url = permission_url;
     response.permission_setup_scopes = permission_scopes;
-    enrich_key_response(
-        &state.db,
-        &state.node_ws_manager,
-        &actor,
-        state.config.node_heartbeat_timeout_secs,
-        state.config.base_url.trim_end_matches('/'),
-        &mut response,
-    )
-    .await?;
-    Ok(Json(response))
+    Ok(response)
 }
 
 #[utoipa::path(
@@ -2689,62 +2782,148 @@ mod tests {
         assert_aevatar_secret_free(&response);
     }
 
-    fn assert_aevatar_secret_free(value: &serde_json::Value) {
-        const FORBIDDEN_NAMES: &[&str] = &[
-            "apikey",
-            "fullkey",
-            "keyhash",
-            "credential",
-            "credentials",
-            "accesstoken",
-            "refreshtoken",
-            "authorization",
-            "cookie",
-            "cookies",
-            "secret",
-            "secrets",
-            "clientsecret",
-            "password",
-            "token",
-            "passphrase",
-            "usercode",
-            "devicecode",
-            "rawbody",
-            "rawupstreambody",
-        ];
-        let secret_value =
-            regex::Regex::new(r"(?i)(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})").unwrap();
+    /// A `KeyResponse` for a service whose owner used three supported
+    /// features whose free text happens to match the evidence reader's
+    /// secret-shape tripwire: a `Bearer …` service label, a custom request
+    /// header carrying a bearer value, and the `${credential}` WS auth
+    /// template that `ws_frame_injector::validate_template_does_not_embed_credentials`
+    /// explicitly permits (CLAUDE.md §6).
+    fn poisoned_key_response() -> super::KeyResponse {
+        use crate::models::default_request_header::DefaultRequestHeader;
+        use crate::models::ws_frame_injection::{
+            WsFrameDirection, WsFrameInjection, WsFrameKind, WsFrameTrigger,
+        };
 
-        fn visit(value: &serde_json::Value, secret_value: &regex::Regex) {
-            match value {
-                serde_json::Value::Object(properties) => {
-                    for (name, nested) in properties {
-                        let normalized: String = name
-                            .chars()
-                            .filter(char::is_ascii_alphanumeric)
-                            .map(|character| character.to_ascii_lowercase())
-                            .collect();
-                        assert!(
-                            !FORBIDDEN_NAMES.contains(&normalized.as_str()),
-                            "secret-bearing response property: {name}"
-                        );
-                        visit(nested, secret_value);
-                    }
-                }
-                serde_json::Value::Array(items) => {
-                    for item in items {
-                        visit(item, secret_value);
-                    }
-                }
-                serde_json::Value::String(text) => assert!(
-                    !secret_value.is_match(text),
-                    "secret-shaped response value at serialization boundary"
-                ),
-                _ => {}
-            }
+        let result = crate::services::unified_key_service::CreateKeyResult {
+            endpoint: test_user_endpoint(
+                "endpoint-1",
+                "user-1",
+                "Example",
+                "https://api.example.com",
+                None,
+                None,
+            ),
+            api_key: None,
+            service: test_user_service("service-1", "user-1", "example", "endpoint-1", None, None),
+            ssh_host: None,
+            ssh_port: None,
+            ssh_ca_public_key: None,
+            ssh_allowed_principals: None,
+            ssh_certificate_ttl_minutes: None,
+        };
+        let mut response = super::key_response_from_result(&result);
+        response.label = "Bearer Bot".to_string();
+        response.name = "Bearer Bot".to_string();
+        response.default_request_headers = Some(vec![DefaultRequestHeader {
+            name: "X-Upstream-Auth".to_string(),
+            value: "Bearer sk-live-abc123".to_string(),
+            overridable: false,
+            sensitive: false,
+        }]);
+        response.ws_frame_injections = vec![WsFrameInjection {
+            trigger: WsFrameTrigger::FirstFrameFromDownstream,
+            template: r#"{"headers":{"Authorization":"Bearer ${credential}"}}"#.to_string(),
+            frame_kind: WsFrameKind::Text,
+            consume_trigger: true,
+            direction: WsFrameDirection::Downstream,
+        }];
+        response.granted_scopes = Some(vec!["repo".to_string(), "read:user".to_string()]);
+        response.last_authorized_at = Some("2026-08-19T00:00:00+00:00".to_string());
+        response.api_key_id = Some("api-key-1".to_string());
+        response.connection_status = Some("connected".to_string());
+        response
+    }
+
+    /// The hazard this projection exists for. A fully populated detail
+    /// response *does* trip the evidence reader's scan, through three
+    /// separate user-controlled carriers — so serving the detail document as
+    /// authorization evidence would make those services permanently
+    /// unverifiable. If this assertion ever stops holding, the projection has
+    /// stopped being load-bearing and the reason for it should be re-checked,
+    /// not the assertion deleted.
+    #[test]
+    fn full_key_response_trips_the_aevatar_secret_scan() {
+        let response = serde_json::to_value(poisoned_key_response()).unwrap();
+        assert!(
+            crate::test_utils::aevatar_secret_free_violation(&response).is_some(),
+            "expected the full detail response to be rejected by the evidence scan"
+        );
+    }
+
+    #[test]
+    fn authorization_evidence_is_secret_free_for_a_poisoned_service() {
+        let evidence = serde_json::to_value(
+            super::KeyAuthorizationEvidenceResponse::from_key_response(poisoned_key_response()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            crate::test_utils::aevatar_secret_free_violation(&evidence),
+            None,
+            "authorization evidence must never carry a secret-shaped value"
+        );
+
+        // Exactly the consumed properties, nothing more: every additional
+        // property is new tripwire surface on a read that cannot afford it.
+        let properties: std::collections::BTreeSet<&str> = evidence
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            properties,
+            [
+                "api_key_id",
+                "connection_status",
+                "granted_scopes",
+                "id",
+                "is_active",
+                "last_authorized_at",
+                "status",
+            ]
+            .into_iter()
+            .collect::<std::collections::BTreeSet<&str>>()
+        );
+    }
+
+    #[test]
+    fn authorization_evidence_always_serializes_nullable_properties() {
+        let result = crate::services::unified_key_service::CreateKeyResult {
+            endpoint: test_user_endpoint(
+                "endpoint-1",
+                "user-1",
+                "Example",
+                "https://api.example.com",
+                None,
+                None,
+            ),
+            api_key: None,
+            service: test_user_service("service-1", "user-1", "example", "endpoint-1", None, None),
+            ssh_host: None,
+            ssh_port: None,
+            ssh_ca_public_key: None,
+            ssh_allowed_principals: None,
+            ssh_certificate_ttl_minutes: None,
+        };
+        let evidence =
+            serde_json::to_value(super::KeyAuthorizationEvidenceResponse::from_key_response(
+                super::key_response_from_result(&result),
+            ))
+            .unwrap();
+
+        // The reader distinguishes an explicit null from a missing property
+        // and treats a missing one as a malformed response.
+        for property in ["connection_status", "granted_scopes", "last_authorized_at"] {
+            assert_eq!(evidence.get(property), Some(&serde_json::Value::Null));
         }
+    }
 
-        visit(value, &secret_value);
+    fn assert_aevatar_secret_free(value: &serde_json::Value) {
+        assert_eq!(
+            crate::test_utils::aevatar_secret_free_violation(value),
+            None
+        );
     }
 
     async fn insert_user(db: &mongodb::Database, user_id: &str, user_type: UserType) {

--- a/backend/src/mw/auth.rs
+++ b/backend/src/mw/auth.rs
@@ -1372,7 +1372,12 @@ mod tests {
         "/api/v1/users/me",
         "/api/v1/users/me/consents",
         "/api/v1/keys",
+        // Assistant-action authorization evidence. Strictly fewer properties
+        // than the detail read directly above it, and no secret material, so
+        // it belongs in the same allowed family.
+        "/api/v1/keys/key-id/authorization",
         "/api/v1/api-keys",
+        "/api/v1/api-keys/key-id/authorization",
         "/api/v1/api-keys/key-id/usage",
         "/api/v1/api-keys/key-id/bindings",
         "/api/v1/nodes",

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -494,6 +494,12 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
                 .put(handlers::api_keys::update_key)
                 .delete(handlers::api_keys::delete_key),
         )
+        // Authorization-evidence projection of `/{key_id}`; see the note on
+        // the equivalent unified-key route.
+        .route(
+            "/{key_id}/authorization",
+            get(handlers::api_keys::get_key_authorization),
+        )
         .route("/{key_id}/usage", get(handlers::api_keys::get_key_usage))
         .route("/{key_id}/rotate", post(handlers::api_keys::rotate_key))
         .route(
@@ -1070,6 +1076,13 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
             get(handlers::keys::get_key)
                 .put(handlers::keys::update_key)
                 .delete(handlers::keys::delete_key),
+        )
+        // Authorization-evidence projection of `/{key_id}`. Same ACL, strictly
+        // fewer properties: an evidence reader must not be handed the
+        // free-text carriers that its own secret-shape tripwire rejects.
+        .route(
+            "/{key_id}/authorization",
+            get(handlers::keys::get_key_authorization),
         );
 
     let connect_link_routes = Router::new()

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -1038,6 +1038,70 @@ pub(crate) fn test_user_service(
     }
 }
 
+/// Mirror of the Aevatar assistant-action evidence reader's recursive
+/// secret-shape scan (`RejectSecretBearingRead`): forbidden property names,
+/// plus any string value matching `Bearer\s+\S+` or a long `nyxid_` prefix.
+///
+/// Returns the offending property or value instead of panicking so tests can
+/// assert both directions — that an evidence projection is clean, and that
+/// the full detail document it projects from is not.
+pub(crate) fn aevatar_secret_free_violation(value: &serde_json::Value) -> Option<String> {
+    const FORBIDDEN_NAMES: &[&str] = &[
+        "apikey",
+        "fullkey",
+        "keyhash",
+        "credential",
+        "credentials",
+        "accesstoken",
+        "refreshtoken",
+        "authorization",
+        "cookie",
+        "cookies",
+        "secret",
+        "secrets",
+        "clientsecret",
+        "password",
+        "token",
+        "passphrase",
+        "usercode",
+        "devicecode",
+        "rawbody",
+        "rawupstreambody",
+    ];
+    let secret_value =
+        regex::Regex::new(r"(?i)(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})").unwrap();
+
+    fn visit(value: &serde_json::Value, secret_value: &regex::Regex) -> Option<String> {
+        match value {
+            serde_json::Value::Object(properties) => {
+                for (name, nested) in properties {
+                    let normalized: String = name
+                        .chars()
+                        .filter(char::is_ascii_alphanumeric)
+                        .map(|character| character.to_ascii_lowercase())
+                        .collect();
+                    if FORBIDDEN_NAMES.contains(&normalized.as_str()) {
+                        return Some(format!("secret-bearing response property: {name}"));
+                    }
+                    if let Some(violation) = visit(nested, secret_value) {
+                        return Some(violation);
+                    }
+                }
+                None
+            }
+            serde_json::Value::Array(items) => {
+                items.iter().find_map(|item| visit(item, secret_value))
+            }
+            serde_json::Value::String(text) => secret_value
+                .is_match(text)
+                .then(|| "secret-shaped response value at serialization boundary".to_string()),
+            _ => None,
+        }
+    }
+
+    visit(value, &secret_value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/chat/06-actions-registry.md
+++ b/docs/chat/06-actions-registry.md
@@ -160,6 +160,51 @@ The description is composition guidance. It states the trust boundary: NyxID own
 
 The manifest schema defines structure. Aevatar and the browser apply additional semantic bounds, URL normalization, control-identity checks, exact-one-variant rules, secret rejection, and supported-auth-method checks before a request can execute. Those rules are specified in [Action cards](04-action-cards.md).
 
+### Where the browser is stricter than the published schema
+
+The manifest is the contract, and it is pinned byte-for-byte: Aevatar compares
+each published `params_schema` with `JsonNode.DeepEquals`, so a refinement
+added to the manifest to describe a browser-side rule would fail the pin and
+disable the whole registry. The rules below therefore live only in the browser
+and are invisible from the manifest. They are recorded here because a request
+that satisfies the published schema can still be refused.
+
+| Parameter | Published schema | Browser rule (`frontend/src/schemas/assistant-actions.ts`) |
+| --- | --- | --- |
+| `requestedScopes[]` | `{"type": "string"}`, and the array may be empty | non-empty, `<= 256` chars, already trimmed, and matching `/^[A-Za-z0-9._:\/~+*=-]+$/` |
+| `requestedScopes` | array of strings | 1-64 entries, no duplicates |
+
+RFC 6749 §3.3 permits every printable ASCII character except space, `"` and
+`\` in a scope token, so the character class is narrower than the standard
+allows. No provider in the current catalog trips it -- Google, GitHub, Slack,
+Lark, Microsoft, Zoom, HubSpot and Atlassian scopes all pass -- but a
+conforming scope outside it parses at Aevatar and then degrades to
+`{variant: "unknown"}` in the browser, which renders "Unsupported action
+request" without saying which scope was rejected.
+
+If a provider ever needs a character outside that class, widen the browser
+regex; do not widen the manifest.
+
+### Authorization evidence reads
+
+Postcondition verification reads evidence from dedicated projections rather
+than from the full detail responses:
+
+| Verb | Evidence read |
+| --- | --- |
+| `service.reauthorize` | `GET /api/v1/keys/{id}/authorization` |
+| `key.create`, `key.rotate` | `GET /api/v1/api-keys/{id}/authorization` |
+
+Both return exactly the properties the reader consumes and nothing else. The
+full `/keys/{id}` and `/api-keys/{id}` responses remain unchanged and are still
+the documented detail contract for the dashboard, the CLI and external
+consumers; they are simply not safe to use as evidence, because they carry
+user-controlled free text (a service label, a custom header value, the
+supported `Bearer ${credential}` WS auth template, a key description) that the
+reader's secret-shape scan cannot distinguish from a real credential. A
+consumer still reading evidence from the detail routes will reject any service
+or key configured that way, permanently and silently.
+
 `key.create` executes through `POST /api/v1/assistant/actions/key-create`.
 The effect reserves one key UUID in a durable, secret-free action receipt,
 validates the exact personal service set, and makes exact retries return only

--- a/docs/chat/wave1-service-reauthorize-actions.md
+++ b/docs/chat/wave1-service-reauthorize-actions.md
@@ -258,7 +258,7 @@ either direction and is superseded rather than confirmed.
 
 | Command | Result |
 | --- | --- |
-| `cargo test -p nyxid` (replica set connected) | **5,342 passed, 0 failed, 0 ignored** — 301s |
+| `cargo test -p nyxid` (replica set connected) | **5,342 passed, 0 failed, 0 ignored** — 301s, and again at the final commit in 261s |
 | `cargo fmt --check` | clean |
 | `cargo clippy --workspace --all-targets -- -D warnings` | clean |
 | `npm --prefix frontend run test` | 246 files / **2,853 passed, 0 failed** |
@@ -279,6 +279,13 @@ Note the crate is `nyxid` and has no lib target: `cargo test --lib` silently
 matches zero tests in this package. Use `cargo test -p nyxid`.
 
 No wizard-bundle rebuild was needed — no frontend dependency or lockfile change.
+
+One caveat worth recording for whoever repeats this: an intermediate run
+appeared to hang in an unrelated org test. It was not a flaky test — `mongod`
+had crashed in its FTDC thread with the volume at 99% full, and every DB-backed
+test was blocked on server selection. If the suite stops making progress, check
+`mongod` is alive and check free disk before suspecting the tests. Restarting
+with `--setParameter diagnosticDataCollectionEnabled=false` avoided a repeat.
 
 ### C1a · wire-visible changes on the existing detail routes
 

--- a/docs/chat/wave1-service-reauthorize-actions.md
+++ b/docs/chat/wave1-service-reauthorize-actions.md
@@ -9,6 +9,7 @@ consolidates are evidence, not instructions:
 | `wave1-service-reauthorize-plan.md` | planner | Contract reference (§1 target contract, §5 rollout). Task breakdown is **superseded by this file**. |
 | `wave1-service-reauthorize-review-sol.md` | implementer's pre-build review | Evidence for the plan corrections that shaped the build. |
 | `wave1-service-reauthorize-review-opus.md` | independent adversarial review | Evidence for every A-item below; full reproductions live there. |
+| `wave1-relook-fable.md` (branch `review/2026-08-19_wave1-relook`, `d6c57a00`) | fourth-pass relook | Evidence for F1-F4. Found no errors in the other three documents. |
 
 Where any source document disagrees with this file, this file wins. Where a
 finding was overturned by a later pass, it is recorded in §5 so it is not
@@ -21,16 +22,25 @@ out of scope (item 3 shipped separately in #1404).
 
 ## 1. Status at a glance
 
-| | Count | Blocking merge? |
+| | Count | Status |
 | --- | --- | --- |
-| Shipped and verified | 4 workstreams | — |
-| **A. NyxID actions outstanding** | 3 major, 5 minor | 3 major: yes |
-| **B. Aevatar prerequisites** | 4 code sites | **yes — hard gate** |
-| **C. Verification gaps** | 2 | 1 should clear before merge |
-| **D. Coordination (Calvin)** | 2 posts | not code-blocking |
+| **A. NyxID actions** | 3 major, 5 minor | A2-A8 closed; A1 partly closed (see below) |
+| **B. Aevatar prerequisites** | 4 code sites + 2 evidence reads | **outstanding — hard gate** |
+| **C. Verification gaps** | 2 | C1 closed; C2 open |
+| **D. Coordination (Calvin)** | 2 posts | not posted |
+| **F. Fourth-pass findings** | 1 major, 3 minor | F1 partly closed, F2 closed, F3/F4 recorded |
 
-**Overall: BLOCKED.** PR #1462 stays draft. Two independent gates — the Aevatar
-consumer (§3) and the three MAJOR defects (§2) — must both clear.
+> **PR #1462 was merged into `main` at 2026-08-19T04:08:46Z** (merge commit
+> `67c9bc1f`, by `ctkm-aelf`), against the DO-NOT-MERGE instruction that was in
+> force. `main` now publishes `nyxid-assistant-actions.v8` while the Aevatar
+> consumer is still pinned at v7 with no `registry-v8.json`. If `main` is
+> deployed, every NyxID action card goes dark on Aevatar processes started
+> afterwards — chat itself survives. Whether it has been deployed is
+> **unverified**; it could not be checked from the implementation environment.
+> The rollout order in §3 is now out of sequence and needs Calvin's decision.
+
+The fixes below therefore live on `feat/2026-08-17_wave1-reauthorize-impl` past
+the merge point, with no PR tracking them yet.
 
 ---
 
@@ -39,155 +49,151 @@ consumer (§3) and the three MAJOR defects (§2) — must both clear.
 Severity, owner, and status per item. File references are on this branch unless
 marked otherwise.
 
-### A1 · MAJOR · open — user-controlled `Bearer …` strings permanently break the journey
+### A1 · MAJOR · partly closed — user-controlled `Bearer …` strings break the evidence read
 
-**Where** (line numbers re-verified on `5b1189ee` for this document).
-`backend/src/handlers/keys.rs:514` (`ws_frame_injections: Vec<WsFrameInjection>` —
-a bare `Vec`, always serialized), `:509` (`default_request_headers`), `:417-418`
-(`name` / `label`); `services/ws_frame_injector.rs:189-197` (the validator that
-permits the offending template);
-`frontend/src/components/assistant/blocks/action-card.tsx:110-128`
-(`assertSecretFreeReadBack`).
+**Status.** The NyxID side that can be closed unilaterally is closed. The half
+that requires Aevatar is not, and cannot be.
 
-**What.** Two recursive scanners run over the whole `/keys/{id}` body — Aevatar's
-`RejectSecretBearingRead` and this PR's `assertSecretFreeReadBack` — both matching
-`(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})`. NyxID's own WS-template
-validator explicitly permits `{"headers":{"Authorization":"Bearer ${credential}"}}`
-(it strips `${credential}` before checking, leaving `Bearer ` — no `nyxid_`, no JWT
-segment). So NyxID stores a value it then refuses to read back. The service can
-never be re-authorized through the assistant; the user sees only the generic
-"NyxID could not verify this service for re-authorization" and is pointed at AI
-Services, where nothing is visibly wrong.
+**What was wrong.** Two recursive scanners run over the whole `/keys/{id}`
+body — Aevatar's `RejectSecretBearingRead` and the browser's
+`assertSecretFreeReadBack` — both matching
+`(?:Bearer\s+\S+|nyxid_(?:ag_)?[A-Za-z0-9_-]{16,})`. `KeyResponse` carries at
+least three user-controlled free-text carriers that reach them:
+`ws_frame_injections[].template` (NyxID's own validator explicitly permits
+`{"headers":{"Authorization":"Bearer ${credential}"}}`),
+`default_request_headers[].value`, and `label` / `name`. NyxID stores a value
+it then refuses to read back.
 
-Fail mode is closed, not leaky — no secret escapes. But this is reachable through a
-documented, supported feature (CLAUDE.md §6), not a hypothetical.
+**Why the two fixes the reviews proposed are both unavailable as written.**
 
-**Fix — preferred.** Serve a minimal evidence projection for this read. Aevatar
-consumes only `id`, `api_key_id`, `is_active`, `status`, `connection_status`,
-`granted_scopes`, `last_authorized_at`; every other field on that response is pure
-tripwire surface. Alternatives (reject `Bearer\s` at write time; browser-side error
-differentiation) are documented in the Opus review §M1 and are strictly worse — the
-write-time option does not repair rows already stored.
+- *Drop the carriers from `/keys/{id}`* — not possible. They have live
+  consumers: `frontend/src/pages/key-detail.tsx`, `schemas/keys.ts`,
+  `pages/service-detail.tsx`, `service-edit.tsx`, `cli/src/commands/service.rs`,
+  and the route is a documented public API (`backend/src/api_docs.rs`).
+  Dropping them is a breaking change to a published contract.
+- *Sanitize the values in place* — not possible either, and worse than it
+  looks. `key-detail.tsx:2635-2641` seeds the WS-template editor directly from
+  this response and `:2081` PUTs the edited value back, so a redacted template
+  would be written over the user's real configuration the next time they touch
+  that section. Same round trip for `default_request_headers`. This destroys
+  data rather than protecting it.
+- *Reject at write time* — does not repair rows already stored, and would
+  reject a feature CLAUDE.md §6 documents as supported.
 
-**Also required.** Extend `assert_aevatar_secret_free`
-(`backend/src/handlers/keys.rs:2692`, called from
-`key_response_always_serializes_authorization_evidence_properties` at `:2665`) to
-run over a *fully populated* `KeyResponse` including a `Bearer ${credential}` WS
-template. Today it runs over a near-empty response — no `ws_frame_injections`, no
-`default_request_headers`, fixed test label — so it cannot fail. Written correctly
-it would fail today, which is the point.
+**What landed.** `GET /api/v1/keys/{id}/authorization`: same resolution, ACL and
+lazy `pending_auth` reconciliation as the detail read, projected to exactly the
+seven properties the evidence reader consumes (`id`, `api_key_id`, `is_active`,
+`status`, `connection_status`, `granted_scopes`, `last_authorized_at`). The
+detail response is untouched. Tests assert both directions — that a fully
+populated `KeyResponse` carrying a `Bearer ${credential}` WS template, a
+`Bearer …` header value and a `Bearer Bot` label *does* trip the scan, and that
+the projection does not — so the projection cannot quietly stop being
+load-bearing.
 
-### A2 · MAJOR · open — `completed` is reported without checking scopes were granted
+The browser half is fully closed: the eligibility preflight no longer scans the
+detail response (it reports nothing to the assistant), the assertion moved to
+the evidence read, and a scan hit there now produces a specific note instead of
+the generic "could not verify this service".
 
-**Where.** `frontend/src/components/assistant/blocks/action-card.tsx:513-541`
-(watch path), `:965-973` (dialog path).
+**What remains open, and why it cannot be closed here.** Aevatar hardcodes
+`GET /api/v1/keys/{Uri.EscapeDataString(id)}` in `NyxIdApiClient.GetServiceAsync`
+and sends no header or query parameter NyxID could content-negotiate on. The
+same client method also serves `NyxIdServicesTool`, `NyxIdSshCommandExecutor`
+and `NyxIdAssistantToolSource`, which legitimately need the full document — so
+NyxID cannot narrow that response by caller either. Until Aevatar points its
+evidence read at the projection (**B5**), a service configured with any of the
+three carriers stays unverifiable on the Aevatar side.
 
-**What.** Both completion paths report `completed` on identity match + `status ==
-active` + `last_authorized_at` advancement. Neither reads `granted_scopes`. Aevatar
-*does* check (`NyxIdActionPostconditionPort.cs:294-296`), so the model is not
-misled — it receives `MismatchCode`. **The user is**: the card renders the
-`Re-authorized` badge while the conversation proceeds as though nothing happened.
+### A2 · MAJOR · closed — `completed` was reported without checking scopes
 
-Three reachable paths: the user deselects a prefilled scope before clicking Connect
-(`prefillScopes` only seeds the `useState` initializer,
-`add-key-dialog.tsx:1530-1536`, nothing pins it after); the provider grants a subset
-(unapproved GitHub org access, unchecked Google consent scopes, pending Lark review);
-or the provider omits `scope` from the token response, in which case the backend
-deliberately preserves the previous `token_scopes`
-(`services/user_api_key_service.rs:568-580`, per NyxID#917) while still stamping
-`last_authorized_at` — so the freshness gate passes on a completely unchanged grant.
+Both completion paths now read `/keys/{id}/authorization` and require
+`requested_scopes` to be an ordinal subset of `granted_scopes` before
+`report("completed", …)`, matching Aevatar's `StringComparer.Ordinal`. On a
+shortfall the card calls `onBlock` naming the missing scopes; an unreadable or
+secret-bearing evidence response blocks with its own distinct note rather than
+settling. Covered by three tests in `action-card.test.tsx` (shortfall, read
+failure, and the unchanged happy path).
 
-**Fix.** In both completion paths, re-read `/keys/{id}` and require
-`requested_scopes ⊆ granted_scopes` (case-sensitive, matching Aevatar's
-`StringComparer.Ordinal`) before `report("completed", …)`. On shortfall call
-`onBlock` naming the missing scopes.
+### A3 · MAJOR · partly closed — the freshness gate proved "some authorization advanced"
 
-### A3 · MAJOR · open — the freshness gate proves "some authorization advanced", not "this one"
+**Decision taken: the fresh-baseline option, not full server-side attempt
+correlation.** Stated plainly because the brief asked for that choice to be
+explicit.
 
-**Where.** `frontend/src/hooks/use-keys.ts:213-216`;
-`frontend/src/components/dashboard/add-key-dialog.tsx:1764, 1792-1794, 3191-3203`.
+**What landed.** `ensureAuthKey` re-reads the row when Connect is clicked
+instead of returning the `reconnectKey` prop, so the baseline is current as of
+the authorization it is about to start rather than as of when the card was
+clicked — a window that is minutes wide in the assistant flow. The read is
+deliberately not caught: falling back to a stale baseline can settle the card
+on someone else's authorization, so failing the click is the safer outcome.
+Two tests in `add-key-dialog.test.tsx` cover both directions.
 
-**What.** The predicate is a bare timestamp inequality with no server-side
-correlation to the attempt. `attemptId` is a client-side `crypto.randomUUID()` used
-only as a TanStack Query cache generation (`use-keys.ts:154`); it never reaches the
-server. The baseline comes from a **stale snapshot** — `ensureAuthKey` returns the
-`reconnectKey` prop verbatim, i.e. the object fetched at *card-click* time, which
-may be minutes old by the time the user presses Connect.
+**What remains open.** The gate still proves "an authorization landed on this
+row after Connect was pressed", not "*this* attempt landed". A concurrent
+authorization of the same service from another surface — the AI Services page,
+a second tab, `nyxid service scopes`, a second card — inside the window between
+Connect and settlement still satisfies it.
 
-Consequence: any unrelated fresh authorization of the same key inside that window —
-the AI Services page, a second tab, `nyxid service scopes`, the CLI wizard, a second
-assistant card for the same service — satisfies the gate and settles the card as
-`completed`. Two concurrent cards for one service share a baseline; completing
-either settles both.
+**Why full correlation was not attempted here.** The server does hold a
+correlation primitive, `UserApiKey.oauth_attempt_nonce` ("current chat-popup
+OAuth attempt allowed to mutate this connection"), but it is *consumed*:
+`user_api_key_service.rs` unsets it on completion, so it cannot witness after
+the fact which attempt won. Making it witness would mean a new stored field
+written on the OAuth token-write path, surfaced through the evidence contract,
+and required by the browser before settling. If any fresh-authorization path
+failed to stamp it — device-code reauthorization is the obvious candidate —
+cards would hang to the timeout instead of completing, which is a worse failure
+than the one being fixed. That is a change worth making deliberately, with its
+own coverage of every authorization path, not as a rider here.
 
-Combined with A2 this is the real false-`completed` surface: not a background
-refresh (that path is genuinely closed — see §5), but *someone else's*
-authorization being claimed as this attempt's.
+Note also that the residual is bounded by what the assistant is actually told:
+with A2 in place the report is only issued when the service genuinely holds the
+requested scopes and was genuinely authorized within the window. The remaining
+inaccuracy is about *causation*, not about state — and Aevatar re-verifies
+independently against its own recorded baseline.
 
-**Fix.** Correlate to the server-side attempt. `initiateOAuthAsync` already returns
-an `attempt_nonce` and the flow threads a `connection_id`; settle on evidence that
-*this* attempt landed. If that is too large for this wave, at minimum re-read
-`/keys/{id}` inside `handleConnect` and derive the baseline from that fresh read —
-closes the card-click→Connect-click window, does not close the concurrent-flow case.
+### A4 · MINOR · closed here, still wrong on the PR
 
-### A4 · MINOR · open — PR body misattributes the freshness fix
+The disposition table in PR #1462's body claims the freshness mechanism was
+delivered in that PR. It was not: all three parts pre-exist on `origin/main`
+(`stores/pending-connect-store.ts:12`, `action-card.tsx:285`, `hooks/use-keys.ts`
+×11), and neither `use-keys.ts` nor `pending-connect-store.ts` appears in its
+diffstat. What that PR added on this axis is the exact-service **identity**
+guard — real and correct, but a different control.
 
-The disposition table claims the freshness mechanism was delivered here. All three
-parts pre-exist on `origin/main` (`stores/pending-connect-store.ts:12`,
-`action-card.tsx:285`, `hooks/use-keys.ts` ×11); neither `use-keys.ts` nor
-`pending-connect-store.ts` is in this PR's diffstat. What this PR actually adds on
-that axis is the exact-service **identity** guard (`action-card.tsx:513-525`) —
-real and correct, but a different control.
+Corrected here, which is the authoritative record. The PR body itself still
+carries the error; #1462 is now merged, so editing it is Calvin's call rather
+than something to do unprompted.
 
-Sol's review was accurate about its pre-rebase branch point; the PR body carried
-"Fixed" forward without re-checking what the rebase brought in.
+### A5 · MINOR · closed — the freshness test now tests freshness
 
-**Fix.** Correct the table entry to "already present on `main`; this PR adds the
-exact-service identity guard and relies on the inherited baseline gate."
+Two cases added to `action-card.test.tsx`: one where the key read always
+returns the original `last_authorized_at`, asserting `onResolve` is never
+called across repeated polls; and one that drives the watch past its deadline
+and asserts the card reports the timeout note. Deleting the freshness gate from
+`use-keys.ts` now fails the first.
 
-### A5 · MINOR · open — the freshness test does not test freshness
+### A6 · MINOR · closed — scope-grammar divergence documented
 
-`action-card.test.tsx`, "waits for a fresh authorization timestamp before
-auto-completing reauthorization". Delete the entire freshness gate from
-`use-keys.ts` and this test still passes — the assertion its name promises (an
-unchanged `last_authorized_at` must **not** settle the card) is absent.
+`docs/chat/06-actions-registry.md` gains a "Where the browser is stricter than
+the published schema" section: the character class, the length and count
+bounds, the RFC 6749 §3.3 comparison, the degradation path
+(`{variant: "unknown"}` → "Unsupported action request"), and the instruction to
+widen the browser regex rather than the manifest if a provider ever needs it.
+The `params_schema` is unchanged — it is pinned by `JsonNode.DeepEquals`.
 
-**Fix.** Add a case whose key read always returns the original
-`last_authorized_at`; assert `onResolve` is never called and the card reports the
-timeout note.
+### A7 · MINOR · closed — `credential_source` is required
 
-### A6 · MINOR · open — browser scope grammar is stricter than the published contract
+The reauthorization key schema now requires `credential_source` instead of
+declaring it `.optional()`, so the org-admin guard fails loudly rather than
+silently vanishing if the response shape changes. The backend remains the real
+gate.
 
-`frontend/src/schemas/assistant-actions.ts:49-56` enforces
-`/^[A-Za-z0-9._:/~+*=-]+$/` and `.min(1)`. The published `params_schema` says
-`{"type": "string"}` and permits an empty array; RFC 6749 §3.3 allows every
-printable ASCII except space, `"` and `\`. A conforming scope outside that regex
-parses at Aevatar, then degrades to `{variant: "unknown"}` → "Unsupported action
-request" with no indication which scope was rejected.
+### A8 · MINOR · closed — one catalog entry, not the whole catalog
 
-No real catalog provider trips it (Google, GitHub, Slack, Lark, Microsoft, Zoom,
-HubSpot, Atlassian all pass), so likelihood is low.
-
-**Fix.** Document the divergence in `docs/chat/06-actions-registry.md` — the
-published schema is the contract and this restriction is invisible from it.
-
-### A7 · MINOR · open — org-admin preflight guard fails open
-
-`action-card.tsx:79-88, 158-163` declares `credential_source` `.optional()`, but
-`KeyResponse.credential_source` is mandatory (`keys.rs:544-546`), so the guard is
-currently unreachable. An `.optional()` schema means it silently vanishes if the
-response shape changes — the opposite of defence in depth.
-
-**Fix.** Make it required so a shape change fails loudly. (The backend remains the
-real gate.)
-
-### A8 · MINOR · open — preflight fetches the whole catalog for one entry
-
-`action-card.tsx:167-169` does `GET /catalog?include_all=true` then finds one slug.
-`GET /api/v1/catalog/{slug}` returns the same `provider_type` /
-`provider_config_id` / `device_code_format`. One full-catalog fetch per card click.
-
----
+The preflight fetches `GET /api/v1/catalog/{slug}` and maps a 404 to the
+existing catalog-unresolvable note, replacing a full `?include_all=true` fetch
+per card click.
 
 ## 3. Section B — Aevatar prerequisites (hard merge gate)
 
@@ -206,11 +212,21 @@ its own revision-map tests and still kills the registry.
 | B2 | `ExecutableActionsByRevision` (~line 234) | add `v8` → all four actions |
 | B3 | `IsActionExecutable` wire-action switch (~line 293) | **`ServiceReauthorize` currently falls through to `null`** — map it to `"service.reauthorize"` or the verb stays non-executable regardless of B1/B2 |
 | B4 | `ValidatePinnedContract` revision ternary (~line 886) | v8 is in neither branch, so `key.create` would be compared against the *unconstrained* schema while NyxID publishes the least-scope variant → `DeepEquals` fails → `RegistryInvalid` |
+| B5 | `NyxIdActionEvidenceReadPort.GetUserServiceAuthorizationAsync` | point the evidence read at `GET /api/v1/keys/{id}/authorization` instead of `GET /api/v1/keys/{id}`. Without this, A1 stays live: the shared `GetServiceAsync` also serves the services tool and the SSH executor, which need the full document, so NyxID cannot narrow the detail response by caller. |
+| B6 | `NyxIdActionEvidenceReadPort.GetAgentApiKeyAsync` | same, for `GET /api/v1/api-keys/{id}/authorization`. Closes F1's non-`name` carriers and F2. |
 
 Plus: `docs/contracts/nyxid-assistant-conformance/v1/registry-v8.json` matching the
 published manifest, and registry/conformance test updates.
 
-**Rollout order (binding).**
+**B4 rollout trap (F3).** B4's ternary is written over named constants
+(`revision is LeastScopeRegistryRevision or SupportedRegistryRevision`). The
+natural v8 implementation — repointing `SupportedRegistryRevision` from v7 to
+v8 — silently drops v7 from the least-scope branch, so the new consumer rejects
+the **live v7 manifest** during exactly the rollout step (2, below) that exists
+to catch this. Add a v8 constant and extend the pattern list; do not repoint
+`SupportedRegistryRevision`.
+
+**Rollout order (was binding; step 3 has already happened).**
 1. Aevatar merges + deploys the additive v8 consumer.
 2. Restart an Aevatar process while NyxID still serves **v7**; prove the registry
    still loads with all current actions.
@@ -218,34 +234,52 @@ published manifest, and registry/conformance test updates.
 4. Restart another Aevatar process, prove it loads v8, run one end-to-end
    `service.reauthorize`.
 
+⚠ **Step 3 has been performed out of order**: PR #1462 merged to `main` on
+2026-08-19, so NyxID's `main` publishes v8 before step 1. Step 2 can no longer
+be run against `main`. Either hold the NyxID deploy until the Aevatar consumer
+ships, or run step 2 against a NyxID build pinned to v7.
+
 ---
 
 ## 4. Section C — verification gaps
 
-### C1 · open · should clear before merge — nobody has run the full backend suite
+### C1 · closed — the full backend suite has now been run
 
-The implementer reported 5,189 passed / 129 failed with all failures attributed to
-a missing MongoDB replica set (`NYXID_TEST_DATABASE_URL` unset, Docker unavailable),
-and explicitly did **not** claim green — the correct posture. The reviewer could not
-reproduce it for the same reason. So the split and its attribution are unverified in
-both directions, and **no full backend run exists for this change**.
+Docker is unavailable in the implementation environment, so the replica set was
+stood up directly: `mongod` (Homebrew `mongodb-community@7.0`) as a single-node
+`rs0` on `127.0.0.1:27019`, with
+`NYXID_TEST_DATABASE_URL=mongodb://127.0.0.1:27019/?replicaSet=rs0`.
 
-**Action.** Someone with a replica set runs `cargo test` before merge.
+Numbers are in §4a below. The earlier 5,189/129 split was never reproducible in
+either direction and is superseded rather than confirmed.
 
-Everything else reproduced exactly on an independent re-run:
+### C1a · wire-visible changes on the existing detail routes
 
-| Command | Result |
-| --- | --- |
-| `npm --prefix frontend run test` | 246 files / 2,847 passed, 0 failed |
-| `npm --prefix frontend run lint` | 0 errors, 23 pre-existing warnings |
-| `npm --prefix frontend run build` (CI parity: `tsc -b`) | passed — 3,470 + 107 modules |
-| `cargo test assistant_actions` | 5 passed, 0 failed |
-| `cargo test unified_key_service` | 163 passed, 0 failed |
-| `cargo fmt --check` / `clippy -D warnings` | passed |
-| `cargo test -p nyxid-cli` | 1,100 + 1 wizard-freshness passed |
+Asked for explicitly. "Merged" below means already on `main` via #1462;
+"pending" means on the fix branch.
 
-No wizard-bundle rebuild is required: `add-key-dialog.tsx` is not in
-`cli/src/wizard/bundle-meta/index.manifest`.
+**`GET /api/v1/keys/{id}` and `GET /api/v1/keys` — three changes, all merged.**
+
+| # | Change | Shape |
+| --- | --- | --- |
+| 1 | `connection_status`, `granted_scopes` and `last_authorized_at` lost their `skip_serializing_if`. They were omitted when null; they are now always present, as explicit `null`. | Additive for a tolerant parser. **Breaking** for any consumer that treats *absence* as meaningful — `"granted_scopes" in response` flips from `false` to `true` for every non-OAuth key. |
+| 2 | `granted_scopes` values changed. The old code split `token_scopes` on whitespace only; it now splits on commas **and** whitespace and de-duplicates, preserving first-occurrence order. | **Value-breaking, and a fix.** A provider echoing `repo,read:user` previously produced the single garbage token `"repo,read:user"` (which was then re-submitted verbatim as a scope); it now produces `["repo", "read:user"]`. Repeated scopes now collapse to one entry. |
+| 3 | `connection_status` derivation changed in both directions. | **Value-breaking.** It now returns `null` when the credential's `status != "active"` or it has no stored access token — so a `pending_auth` row that used to report `"expired"`/`"active"` now reports `null`. Conversely an active row with no `expires_at` used to report `null` and now reports `"active"`. |
+
+Known consumers were checked: no Rust or TypeScript consumer of these three
+fields exists in `cli/src`, `sdk/` or `mobile/src`, no frontend Zod schema
+parses the key response, and `frontend/src/pages/keys.tsx` reads
+`connection_status ?? status`, so change 3 gives a `pending_auth` row a
+Reconnect affordance it did not have. External consumers were not enumerable.
+
+**`GET /api/v1/api-keys/{id}` — no change.** F2's lineage-trio fix lives only on
+the new projection; the detail response still emits
+`state_version: 0` with two nulls for legacy rows, as it always has.
+
+**Pending changes are additive only.** Two new routes,
+`GET /api/v1/keys/{id}/authorization` and
+`GET /api/v1/api-keys/{id}/authorization`. No existing response body is
+modified by the fix branch.
 
 ### C2 · open · low — one unreachability claim is inferred, not proven
 
@@ -296,6 +330,67 @@ Each was checked against code by the independent pass.
 
 ---
 
+## 5a. Section F — fourth-pass findings (Fable, 2026-08-19)
+
+Evidence: `wave1-relook-fable.md` on `review/2026-08-19_wave1-relook`
+(`d6c57a00`). That pass found **no errors** in the other three documents.
+
+### F1 · MAJOR · partly closed — the A1 tripwire class also hits `key.create` and `key.rotate`
+
+#1400 item 1 is a three-verb requirement, and the two key verbs were never
+audited to the standard applied to `service.reauthorize`. Aevatar verifies both
+through `GET /api/v1/api-keys/{id}` (`GetAgentApiKeyAsync`), and
+`ParseAgentApiKeyDocument` runs the same `RejectSecretBearingRead` scan.
+`ApiKeyResponse` reaches it with four user-controlled carriers: `name`,
+`description`, `allowed_services[].label` (the same `UserEndpoint.label` A1
+flags), and `allowed_nodes[].name`. `key.rotate` inherits the problem because
+the successor clones `name` and `description` from the predecessor.
+
+**Closed:** `GET /api/v1/api-keys/{id}/authorization` projects to the thirteen
+properties the reader consumes, removing `description`, `allowed_services`,
+`allowed_nodes` and everything else. Symmetric tests to A1's, both directions.
+
+**Irreducible remainder:** `name` is itself required evidence — the reader both
+demands it (`RequireNormalizedString(root, "name")`) and scans it, and the
+postcondition pins `evidence.Name == params.name`. A key named `Bearer Bot`
+stays unverifiable no matter what NyxID serves. No projection can fix that; it
+needs either a write-time restriction on key names (which would also have to
+handle rotation inheritance and existing rows) or an Aevatar-side change to
+exclude its own required evidence properties from the scan. Recommended: the
+latter — the scan exists to catch *unexpected* secret-bearing fields, not to
+reject the fields it deliberately reads.
+
+Also depends on **B6** to take effect at all.
+
+### F2 · MINOR · closed — legacy pre-lineage key rows were structurally unparseable
+
+`ApiKeyResponse` always serializes the lineage trio, so a pre-#1406 row emits
+`rotation_predecessor_id: null`, `state_version: 0`, `updated_at: null`.
+Aevatar's `ParseOptionalVersionEvidence` sees all three present, skips its
+absent-trio exit, then throws on `state_version <= 0` — the whole document is
+malformed. Zero impact today because create/rotate only read freshly written
+rows, but every legacy key violates the published evidence contract.
+
+The projection emits the trio as a trio or not at all: `state_version >= 1` or
+all three omitted. The detail response is unchanged, so this is not a wire
+change to `/api-keys/{id}`. Two tests pin both shapes.
+
+### F3 · MINOR · recorded — B4 rollout trap
+
+Folded into §3 above, and it belongs in the Aevatar issue text (D1).
+
+### F4 · MINOR · recorded — no clock-skew allowance
+
+All three verbs reject evidence timestamps a single tick ahead of Aevatar's
+clock (`LastAuthorizedAtUtc > now`, `NyxIdActionPostconditionPort.cs:306-308`;
+create `:381-382`; rotate `:460-464`). NyxID stamps, Aevatar compares, tolerance
+is zero, and verification runs immediately after the journey — the worst case
+for small positive NyxID skew. The failure is a retryable `StaleCode`, so this
+is a robustness note, not a bug. Deliberately **not** fixed here: any tolerance
+is Aevatar-side and should not be introduced unilaterally.
+
+---
+
 ## 6. Section D — coordination, owner: Calvin
 
 | # | Action | Status |
@@ -319,9 +414,15 @@ Verified against the issue text and this branch on 2026-08-18.
 | Param-shape confirmation: `{keyId, requestedScopes}` vs `{userServiceId, requestedScopes[]}` (aevatar#3315 item 6) | **Settled: `{userServiceId, requestedScopes[]}`.** Aevatar already implemented this shape on `feature/integrate`; NyxID now publishes it byte-identically. No decision outstanding. |
 | Wave 1 hardening follow-ups #1405, #1406 | **Both closed.** |
 
-**Conclusion.** Item 1 is fully addressed in scope and contract. It is not yet
-*complete* — completion requires §2 A1–A3 fixed and §3 B1–B4 shipped and deployed
-by Aevatar. The issue's framing that this "extends verb coverage beyond
+**Conclusion.** Item 1 is fully addressed in scope and contract **for
+`service.reauthorize`**. It is not fully addressed for the three verbs
+together: `key.create` and `key.rotate` shipped earlier (v6/v7) and were never
+audited to the same standard — see F1, which found the identical evidence-read
+tripwire on `GET /api/v1/api-keys/{id}` and one carrier (`name`) that no NyxID
+change can close.
+
+It is not yet *complete* either — completion requires A1's Aevatar half plus
+§3 B1–B6 shipped and deployed by Aevatar. The issue's framing that this "extends verb coverage beyond
 `service.connect`" is now accurate for all three Wave-1 verbs.
 
 Items 2 (exact-service non-blocking approval) and 3 (facade v4 conformance) of

--- a/docs/chat/wave1-service-reauthorize-actions.md
+++ b/docs/chat/wave1-service-reauthorize-actions.md
@@ -254,6 +254,32 @@ stood up directly: `mongod` (Homebrew `mongodb-community@7.0`) as a single-node
 Numbers are in §4a below. The earlier 5,189/129 split was never reproducible in
 either direction and is superseded rather than confirmed.
 
+### C1 numbers
+
+| Command | Result |
+| --- | --- |
+| `cargo test -p nyxid` (replica set connected) | **5,342 passed, 0 failed, 0 ignored** — 301s |
+| `cargo fmt --check` | clean |
+| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
+| `npm --prefix frontend run test` | 246 files / **2,853 passed, 0 failed** |
+| `npm --prefix frontend run lint` | 0 errors, 23 pre-existing warnings |
+| `npm --prefix frontend run build` (CI parity: `tsc -b`) | passed |
+
+Harness, for whoever needs to reproduce it: Docker was unavailable, so
+`mongod` (Homebrew `mongodb-community@7.0`) was run directly as a single-node
+replica set —
+
+```
+mongod --replSet rs0 --port 27019 --dbpath <dir> --bind_ip 127.0.0.1 --fork --logpath <log>
+mongosh --port 27019 --eval 'rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27019"}]})'
+export NYXID_TEST_DATABASE_URL="mongodb://127.0.0.1:27019/?replicaSet=rs0"
+```
+
+Note the crate is `nyxid` and has no lib target: `cargo test --lib` silently
+matches zero tests in this package. Use `cargo test -p nyxid`.
+
+No wizard-bundle rebuild was needed — no frontend dependency or lockfile change.
+
 ### C1a · wire-visible changes on the existing detail routes
 
 Asked for explicitly. "Merged" below means already on `main` via #1462;

--- a/docs/chat/wave1-service-reauthorize-actions.md
+++ b/docs/chat/wave1-service-reauthorize-actions.md
@@ -1,8 +1,9 @@
 # Wave 1 `service.reauthorize` — consolidated action list
 
-**This is the working document for PR #1462.** It is the single place that says what
-is done, what is outstanding, and who owns each item. The three documents it
-consolidates are evidence, not instructions:
+**This is the working document for the wave-1 `service.reauthorize` work**,
+originally PR #1462 (now merged — see the note in §1). It is the single place
+that says what is done, what is outstanding, and who owns each item. The four
+documents it consolidates are evidence, not instructions:
 
 | Document | Author | Role now |
 | --- | --- | --- |
@@ -44,7 +45,7 @@ the merge point, with no PR tracking them yet.
 
 ---
 
-## 2. Section A — NyxID actions outstanding
+## 2. Section A — NyxID actions
 
 Severity, owner, and status per item. File references are on this branch unless
 marked otherwise.

--- a/frontend/src/components/assistant/blocks/action-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.test.tsx
@@ -24,13 +24,31 @@ import { usePendingConnectStore } from "@/stores/pending-connect-store";
 import type { ActionCardContentBlock } from "@/types/assistant";
 import { ActionCard } from "./action-card";
 
-const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+const { mockGet, watchDeadline } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  // Lets one test drive the watch past its give-up point without waiting out
+  // the real ten-minute window.
+  watchDeadline: { override: null as number | null },
+}));
 
 // The pending-authorization store outlives any one card by design, so it also
 // outlives any one test. Reset it or a stranded attempt leaks forward.
 beforeEach(() => {
   mockGet.mockReset();
+  watchDeadline.override = null;
   usePendingConnectStore.setState({ attempts: {} });
+});
+
+vi.mock("@/lib/assistant/connect-watch", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/assistant/connect-watch")
+  >("@/lib/assistant/connect-watch");
+  return {
+    ...actual,
+    connectWatchDeadline: (startedAt: number, lastActivityAt: number) =>
+      watchDeadline.override ??
+      actual.connectWatchDeadline(startedAt, lastActivityAt),
+  };
 });
 
 vi.mock("@/lib/api-client", () => ({
@@ -309,31 +327,47 @@ function reauthorizationCatalog(
   overrides: Readonly<Record<string, unknown>> = {},
 ) {
   return {
-    entries: [
-      {
-        slug: "github",
-        provider_type: "oauth2",
-        provider_config_id: "provider-github",
-        device_code_format: null,
-        ...overrides,
-      },
-      {
-        slug: "plain-api",
-        provider_type: "api_key",
-        provider_config_id: null,
-        device_code_format: null,
-      },
-    ],
+    slug: "github",
+    provider_type: "oauth2",
+    provider_config_id: "provider-github",
+    device_code_format: null,
+    ...overrides,
+  };
+}
+
+/**
+ * The authorization-evidence projection served by
+ * `GET /keys/{id}/authorization`. Defaults grant every scope the fixtures
+ * request, so a test that does not care about scopes settles as before.
+ */
+function reauthorizationEvidence(
+  overrides: Readonly<Record<string, unknown>> = {},
+): Readonly<Record<string, unknown>> {
+  return {
+    id: "service-existing",
+    api_key_id: "credential-existing",
+    is_active: true,
+    status: "active",
+    connection_status: "connected",
+    granted_scopes: ["repo", "workflow"],
+    last_authorized_at: "2026-08-17T00:00:00Z",
+    ...overrides,
   };
 }
 
 function mockReauthorizationReads(
   key: Readonly<Record<string, unknown>> = reauthorizationKey(),
   catalog = reauthorizationCatalog(),
+  evidence: Readonly<Record<string, unknown>> | null = reauthorizationEvidence(),
 ) {
   mockGet.mockImplementation((path: string) => {
     if (path === "/keys/service-existing") return Promise.resolve(key);
-    if (path === "/catalog?include_all=true") {
+    if (path === "/keys/service-existing/authorization") {
+      return evidence === null
+        ? Promise.reject(new Error("evidence unavailable"))
+        : Promise.resolve(evidence);
+    }
+    if (path === `/catalog/${String(catalog.slug)}`) {
       return Promise.resolve(catalog);
     }
     return Promise.reject(new Error(`Unexpected read: ${path}`));
@@ -399,7 +433,7 @@ describe("ActionCard", () => {
     expect(dialog).toHaveAttribute("data-launch", "popup");
     expect(dialog).toHaveAttribute("data-flow", "cc");
     expect(mockGet).toHaveBeenCalledWith("/keys/service-existing");
-    expect(mockGet).toHaveBeenCalledWith("/catalog?include_all=true");
+    expect(mockGet).toHaveBeenCalledWith("/catalog/github");
 
     await userEvent.click(
       screen.getByRole("button", { name: "Finish mock connection" }),
@@ -439,7 +473,7 @@ describe("ActionCard", () => {
     });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(onResolve).not.toHaveBeenCalled();
-    expect(mockGet).not.toHaveBeenCalledWith("/catalog?include_all=true");
+    expect(mockGet).not.toHaveBeenCalledWith("/catalog/github");
   });
 
   it("blocks OpenAI-format device authorization instead of dropping requested scopes", async () => {
@@ -477,6 +511,8 @@ describe("ActionCard", () => {
     mockGet.mockImplementation((path: string) => {
       if (path === "/keys/service-existing") {
         keyReads += 1;
+        // Read 1 is the eligibility preflight. `AddKeyDialog` is mocked in
+        // this file, so the watch polls are everything after it.
         return Promise.resolve(
           keyReads === 1
             ? reauthorizationKey()
@@ -485,7 +521,10 @@ describe("ActionCard", () => {
               }),
         );
       }
-      if (path === "/catalog?include_all=true") {
+      if (path === "/keys/service-existing/authorization") {
+        return Promise.resolve(reauthorizationEvidence());
+      }
+      if (path === "/catalog/github") {
         return Promise.resolve(reauthorizationCatalog());
       }
       return Promise.reject(new Error(`Unexpected read: ${path}`));
@@ -514,6 +553,168 @@ describe("ActionCard", () => {
       });
     });
     expect(onResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("never auto-completes reauthorization while the authorization timestamp is unchanged", async () => {
+    // The counterpart to the test above: same flow, but the row never records
+    // a fresh authorization. Deleting the freshness gate makes this fail.
+    mockReauthorizationReads();
+    const onResolve = vi.fn();
+    const onBlock = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={onResolve}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Hand off to provider" }),
+    );
+
+    // Let the watch poll the unchanged row several times over. The fast
+    // cadence is 2s, so this needs more than waitFor's default second.
+    await waitFor(
+      () => {
+        expect(
+          mockGet.mock.calls.filter(
+            ([path]) => path === "/keys/service-existing",
+          ).length,
+        ).toBeGreaterThanOrEqual(3);
+      },
+      { timeout: 8_000 },
+    );
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it("reports the authorization timeout when no fresh authorization ever lands", async () => {
+    mockReauthorizationReads();
+    const onResolve = vi.fn();
+    const onBlock = vi.fn();
+    // Give up immediately instead of waiting out the real window.
+    watchDeadline.override = Date.now() - 1;
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={onResolve}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Hand off to provider" }),
+    );
+
+    await waitFor(() => {
+      expect(onBlock).toHaveBeenCalledWith(
+        "action-card-reauthorize",
+        expect.stringContaining("stopped waiting"),
+      );
+    });
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it("blocks instead of reporting completed when the provider withheld a requested scope", async () => {
+    let keyReads = 0;
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/keys/service-existing") {
+        keyReads += 1;
+        return Promise.resolve(
+          keyReads === 1
+            ? reauthorizationKey()
+            : reauthorizationKey({
+                last_authorized_at: "2026-08-17T00:01:00Z",
+              }),
+        );
+      }
+      if (path === "/keys/service-existing/authorization") {
+        // Fresh authorization, but `workflow` was never granted.
+        return Promise.resolve(
+          reauthorizationEvidence({
+            granted_scopes: ["repo"],
+            last_authorized_at: "2026-08-17T00:01:00Z",
+          }),
+        );
+      }
+      if (path === "/catalog/github") {
+        return Promise.resolve(reauthorizationCatalog());
+      }
+      return Promise.reject(new Error(`Unexpected read: ${path}`));
+    });
+    const onResolve = vi.fn();
+    const onBlock = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={onResolve}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Hand off to provider" }),
+    );
+
+    await waitFor(() => {
+      expect(onBlock).toHaveBeenCalledWith(
+        "action-card-reauthorize",
+        expect.stringContaining("did not grant workflow"),
+      );
+    });
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it("blocks when the authorization evidence read fails", async () => {
+    let keyReads = 0;
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/keys/service-existing") {
+        keyReads += 1;
+        return Promise.resolve(
+          keyReads === 1
+            ? reauthorizationKey()
+            : reauthorizationKey({
+                last_authorized_at: "2026-08-17T00:01:00Z",
+              }),
+        );
+      }
+      if (path === "/keys/service-existing/authorization") {
+        return Promise.reject(new Error("evidence unavailable"));
+      }
+      if (path === "/catalog/github") {
+        return Promise.resolve(reauthorizationCatalog());
+      }
+      return Promise.reject(new Error(`Unexpected read: ${path}`));
+    });
+    const onResolve = vi.fn();
+    const onBlock = vi.fn();
+    renderCard(
+      <ActionCard
+        block={reauthorizeBlock()}
+        onProgress={vi.fn()}
+        onBlock={onBlock}
+        onResolve={onResolve}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Re-authorize" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Hand off to provider" }),
+    );
+
+    await waitFor(() => {
+      expect(onBlock).toHaveBeenCalledWith(
+        "action-card-reauthorize",
+        expect.stringContaining("could not read this service's authorization"),
+      );
+    });
+    expect(onResolve).not.toHaveBeenCalled();
   });
 
   it("opens the key.create journey and reports only the safe key identity", async () => {

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -61,6 +61,24 @@ const REAUTHORIZE_CATALOG_NOTE =
   "NyxID could not resolve this service's OAuth provider. Manage it in AI Services, then ask the assistant to try again.";
 const REAUTHORIZE_SCOPES_UNSUPPORTED_NOTE =
   "This provider does not accept requested scope changes during device authorization, so NyxID did not start a re-authorization that could drop the request.";
+const REAUTHORIZE_EVIDENCE_UNREADABLE_NOTE =
+  "NyxID could not read this service's authorization state, so the re-authorization was not confirmed. Check it in AI Services, then ask the assistant to request it again.";
+const REAUTHORIZE_SECRET_EVIDENCE_NOTE =
+  "NyxID returned credential-shaped data where it should have returned only authorization state, so the re-authorization was not confirmed. This is a NyxID bug — report it rather than retrying.";
+
+/** Ordinal, matching the postcondition reader's `StringComparer.Ordinal`. */
+function missingScopes(
+  requested: readonly string[],
+  granted: readonly string[] | null,
+): readonly string[] {
+  if (granted === null) return [...requested];
+  const held = new Set(granted);
+  return requested.filter((scope) => !held.has(scope));
+}
+
+function scopeShortfallNote(missing: readonly string[]): string {
+  return `The provider did not grant ${missing.join(", ")}. NyxID did not report this as re-authorized — ask the assistant to request it again, or grant the missing access at the provider first.`;
+}
 
 const reauthorizationCredentialSourceSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("personal") }).passthrough(),
@@ -82,23 +100,40 @@ const reauthorizationKeySchema = z
     is_active: z.boolean(),
     auto_connected: z.boolean(),
     catalog_service_slug: z.string().nullish(),
-    credential_source: reauthorizationCredentialSourceSchema.optional(),
+    // Required, not optional. `KeyResponse.credential_source` is mandatory on
+    // the wire, and an `.optional()` schema would let the org-admin guard
+    // below silently vanish if that ever changed — the opposite of what a
+    // defence-in-depth check is for. The backend remains the real gate.
+    credential_source: reauthorizationCredentialSourceSchema,
   })
   .passthrough();
-const reauthorizationCatalogSchema = z
+const reauthorizationCatalogEntrySchema = z
   .object({
-    entries: z.array(
-      z
-        .object({
-          slug: z.string().min(1),
-          provider_type: z.string().nullish(),
-          provider_config_id: z.string().nullish(),
-          device_code_format: z.string().nullish(),
-        })
-        .passthrough(),
-    ),
+    slug: z.string().min(1),
+    provider_type: z.string().nullish(),
+    provider_config_id: z.string().nullish(),
+    device_code_format: z.string().nullish(),
   })
   .passthrough();
+
+/**
+ * The authorization-evidence projection of a user service
+ * (`GET /keys/{id}/authorization`) — the same seven properties the
+ * assistant-side postcondition reader consumes.
+ */
+const authorizationEvidenceSchema = z
+  .object({
+    id: z.string().min(1),
+    api_key_id: z.string().min(1).nullish(),
+    is_active: z.boolean(),
+    status: z.string().min(1),
+    connection_status: z.string().nullable(),
+    granted_scopes: z.array(z.string()).nullable(),
+    last_authorized_at: z.string().nullable(),
+  })
+  .strict();
+
+type AuthorizationEvidence = z.infer<typeof authorizationEvidenceSchema>;
 
 const FORBIDDEN_READ_BACK_FIELDS = new Set([
   "apikey",
@@ -147,11 +182,80 @@ function assertSecretFreeReadBack(value: unknown): void {
 
 class ReauthorizationBlockedError extends Error {}
 
+/** A secret-shaped value reached a read that reports to the assistant. */
+class SecretBearingEvidenceError extends Error {}
+
+/**
+ * Read the authorization evidence for one user service.
+ *
+ * This is the read that decides whether the assistant is told the
+ * re-authorization happened, so it is the read the secret-shape assertion
+ * belongs on — and it is served as a minimal projection precisely so a
+ * legitimately configured service (a `Bearer ${credential}` WS auth template,
+ * a `Bearer …` service label) cannot make its own authorization permanently
+ * unverifiable. The equivalent backend assertion over a fully populated
+ * detail response is the canary for the projection itself.
+ */
+async function readAuthorizationEvidence(
+  userServiceId: string,
+): Promise<AuthorizationEvidence> {
+  const value = await api.get<unknown>(
+    `/keys/${encodeURIComponent(userServiceId)}/authorization`,
+  );
+  try {
+    assertSecretFreeReadBack(value);
+  } catch {
+    throw new SecretBearingEvidenceError(REAUTHORIZE_SECRET_EVIDENCE_NOTE);
+  }
+  const evidence = authorizationEvidenceSchema.parse(value);
+  if (evidence.id !== userServiceId) {
+    throw new ReauthorizationBlockedError(REAUTHORIZE_IDENTITY_NOTE);
+  }
+  return evidence;
+}
+
+/**
+ * Verify that the provider actually granted every requested scope before the
+ * card reports `completed`.
+ *
+ * `last_authorized_at` advancing proves an authorization landed, not that it
+ * granted anything new: the token endpoint may omit `scope`, in which case the
+ * backend deliberately preserves the previous `token_scopes` while still
+ * stamping the timestamp. Returns the note to block with, or `null` to
+ * proceed.
+ */
+async function scopeGrantShortfall(
+  userServiceId: string,
+  requestedScopes: readonly string[],
+): Promise<string | null> {
+  if (requestedScopes.length === 0) return null;
+  let evidence: AuthorizationEvidence;
+  try {
+    evidence = await readAuthorizationEvidence(userServiceId);
+  } catch (caught) {
+    if (
+      caught instanceof SecretBearingEvidenceError ||
+      caught instanceof ReauthorizationBlockedError
+    ) {
+      return caught.message;
+    }
+    return REAUTHORIZE_EVIDENCE_UNREADABLE_NOTE;
+  }
+  const missing = missingScopes(requestedScopes, evidence.granted_scopes);
+  return missing.length > 0 ? scopeShortfallNote(missing) : null;
+}
+
 async function readReauthorizationKey(userServiceId: string): Promise<KeyInfo> {
   const value = await api.get<unknown>(
     `/keys/${encodeURIComponent(userServiceId)}`,
   );
-  assertSecretFreeReadBack(value);
+  // Deliberately not secret-scanned. This is the eligibility read: nothing
+  // from it is reported to the assistant, and the full detail response
+  // legitimately carries user free text (service label, custom header values,
+  // the supported `Bearer ${credential}` WS template) that a secret-shape
+  // scan cannot tell from a real credential. Scanning it here would refuse to
+  // start the journey for services that are configured perfectly correctly.
+  // The assertion lives on `readAuthorizationEvidence` instead.
   const snapshot = reauthorizationKeySchema.parse(value);
   if (snapshot.id !== userServiceId) {
     throw new ReauthorizationBlockedError(REAUTHORIZE_IDENTITY_NOTE);
@@ -173,21 +277,26 @@ async function readReauthorizationKey(userServiceId: string): Promise<KeyInfo> {
     throw new ReauthorizationBlockedError(REAUTHORIZE_PLATFORM_NOTE);
   }
   if (
-    snapshot.credential_source?.type === "org" &&
+    snapshot.credential_source.type === "org" &&
     snapshot.credential_source.role !== "admin"
   ) {
     throw new ReauthorizationBlockedError(REAUTHORIZE_ORG_NOTE);
   }
 
-  const catalog = reauthorizationCatalogSchema.parse(
-    await api.get<unknown>("/catalog?include_all=true"),
-  );
+  // One entry, not the whole catalog: `/catalog/{slug}` returns the same
+  // `provider_type` / `provider_config_id` / `device_code_format` this needs,
+  // and also resolves rows the list endpoint filters out.
   const catalogSlug = snapshot.catalog_service_slug ?? snapshot.slug;
-  const catalogEntry = catalog.entries.find(
-    (entry) => entry.slug === catalogSlug,
-  );
-  if (!catalogEntry) {
-    throw new ReauthorizationBlockedError(REAUTHORIZE_CATALOG_NOTE);
+  let catalogEntry: z.infer<typeof reauthorizationCatalogEntrySchema>;
+  try {
+    catalogEntry = reauthorizationCatalogEntrySchema.parse(
+      await api.get<unknown>(`/catalog/${encodeURIComponent(catalogSlug)}`),
+    );
+  } catch (caught) {
+    if (caught instanceof ApiError && caught.status === 404) {
+      throw new ReauthorizationBlockedError(REAUTHORIZE_CATALOG_NOTE);
+    }
+    throw caught;
   }
   if (
     (catalogEntry.provider_type !== "oauth2" &&
@@ -525,9 +634,21 @@ export function ActionCard({
       }
       watchSettledRef.current = attemptId;
       resolvingRef.current = true;
+      const requestedScopes =
+        block.params.variant === "service_reauthorize"
+          ? block.params.requested_scopes
+          : [];
       void Promise.resolve()
-        .then(() => {
+        .then(async () => {
           endPendingAuth(block.block_id);
+          // A fresh authorization is not the same as a granted one. Confirm
+          // the provider actually issued every requested scope before telling
+          // the assistant this succeeded.
+          const shortfall = await scopeGrantShortfall(keyId, requestedScopes);
+          if (shortfall) {
+            resolvingRef.current = false;
+            return onBlock(block.block_id, shortfall);
+          }
           return onResolve({
             actionRequestId: block.action_request_id,
             originTurnId: block.origin_turn_id,
@@ -966,9 +1087,27 @@ export function ActionCard({
               void onBlock(block.block_id, REAUTHORIZE_IDENTITY_NOTE);
               return;
             }
-            report("completed", {
-              userService: { userServiceId: params.user_service_id },
-            });
+            // Same scope confirmation as the watch path: the dialog reporting
+            // success only means the handshake finished.
+            void scopeGrantShortfall(
+              params.user_service_id,
+              params.requested_scopes,
+            )
+              .then((shortfall) => {
+                if (shortfall) {
+                  return onBlock(block.block_id, shortfall);
+                }
+                report("completed", {
+                  userService: { userServiceId: params.user_service_id },
+                });
+                return undefined;
+              })
+              .catch(() => {
+                void onBlock(
+                  block.block_id,
+                  REAUTHORIZE_EVIDENCE_UNREADABLE_NOTE,
+                );
+              });
           }}
           onAuthorizationPending={(attempt) => {
             if (attempt.keyId !== params.user_service_id) {

--- a/frontend/src/components/assistant/blocks/action-card.tsx
+++ b/frontend/src/components/assistant/blocks/action-card.tsx
@@ -1087,6 +1087,12 @@ export function ActionCard({
               void onBlock(block.block_id, REAUTHORIZE_IDENTITY_NOTE);
               return;
             }
+            // Claim the card before awaiting. `report` used to run
+            // synchronously here, which is what stopped the watch from
+            // settling the same attempt; the scope read opens a gap the watch
+            // could otherwise resolve into a second report.
+            watchSettledRef.current = authorizationAttemptId;
+            resolvingRef.current = true;
             // Same scope confirmation as the watch path: the dialog reporting
             // success only means the handshake finished.
             void scopeGrantShortfall(
@@ -1095,6 +1101,7 @@ export function ActionCard({
             )
               .then((shortfall) => {
                 if (shortfall) {
+                  resolvingRef.current = false;
                   return onBlock(block.block_id, shortfall);
                 }
                 report("completed", {
@@ -1103,6 +1110,7 @@ export function ActionCard({
                 return undefined;
               })
               .catch(() => {
+                resolvingRef.current = false;
                 void onBlock(
                   block.block_id,
                   REAUTHORIZE_EVIDENCE_UNREADABLE_NOTE,

--- a/frontend/src/components/dashboard/add-key-dialog.test.tsx
+++ b/frontend/src/components/dashboard/add-key-dialog.test.tsx
@@ -17,6 +17,9 @@ const {
   initiateDeviceCodeMutateAsync,
   pollDeviceCodeMutate,
   mockApiDelete,
+  mockApiGet,
+  lastReconnectKey,
+  freshReconnectRead,
   mockHardRedirect,
   mockNavigate,
   pendingKeyStatus,
@@ -48,6 +51,13 @@ const {
   initiateDeviceCodeMutateAsync: vi.fn(),
   pollDeviceCodeMutate: vi.fn(),
   mockApiDelete: vi.fn(),
+  mockApiGet: vi.fn(),
+  // `ensureAuthKey` re-reads the key when Connect is clicked so the reconnect
+  // freshness baseline is current rather than as-of-dialog-open. These hold
+  // what that read returns: the reconnect key the test rendered, plus any
+  // per-test override simulating the row moving underneath the dialog.
+  lastReconnectKey: { value: null as Record<string, unknown> | null },
+  freshReconnectRead: { value: null as Record<string, unknown> | null },
   mockHardRedirect: vi.fn(),
   mockNavigate: vi.fn(),
   toastFns: { success: vi.fn(), error: vi.fn() },
@@ -127,6 +137,7 @@ vi.mock("@/lib/api-client", async () => {
     api: {
       ...actual.api,
       delete: mockApiDelete,
+      get: mockApiGet,
     },
   };
 });
@@ -198,6 +209,12 @@ const RFC8628_DEVICE_CODE_ENTRY = {
 } as unknown as CatalogEntry;
 
 function makeReconnectKey(overrides: Partial<KeyInfo> = {}): KeyInfo {
+  const key = buildReconnectKey(overrides);
+  lastReconnectKey.value = key as unknown as Record<string, unknown>;
+  return key;
+}
+
+function buildReconnectKey(overrides: Partial<KeyInfo> = {}): KeyInfo {
   return {
     id: "existing-service-1",
     label: "Existing GitHub",
@@ -241,6 +258,17 @@ beforeEach(() => {
   pendingKeyStatus.value = null;
   pendingLastAuthorizedAt.value = null;
   popupReceiverOptions.current = null;
+  lastReconnectKey.value = null;
+  freshReconnectRead.value = null;
+  // Default: the row is unchanged since the dialog opened, so the re-read
+  // returns the same key the test rendered.
+  mockApiGet.mockImplementation((path: string) => {
+    if (typeof path === "string" && path.startsWith("/keys/")) {
+      const base = lastReconnectKey.value ?? {};
+      return Promise.resolve({ ...base, ...(freshReconnectRead.value ?? {}) });
+    }
+    return Promise.reject(new Error(`Unexpected read: ${String(path)}`));
+  });
   createKeyMutateAsync.mockResolvedValue({ id: "created-service-1" });
   updateKeyMutateAsync.mockResolvedValue(makeReconnectKey());
   initiateOAuthMutateAsync.mockResolvedValue({
@@ -857,6 +885,74 @@ describe("AddKeyDialog — reconnect path", () => {
     expect(
       screen.queryByRole("button", { name: "Continue" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("takes the freshness baseline from a read at Connect time, not from the prop", async () => {
+    catalog.entries = [OAUTH_ENTRY];
+    // The row was re-authorized somewhere else between the card being clicked
+    // and Connect being pressed. The stale prop still says 00:00:00; the
+    // server now says 00:05:00.
+    freshReconnectRead.value = {
+      last_authorized_at: "2026-01-01T00:05:00Z",
+    };
+    pendingKeyStatus.value = "active";
+    pendingLastAuthorizedAt.value = "2026-01-01T00:05:00Z";
+    const onAuthorizationPending = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AddKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        reconnectKey={makeReconnectKey({ status: "active" })}
+        onAuthorizationPending={onAuthorizationPending}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Connect with GitHub/i }),
+    );
+
+    await waitFor(() => expect(onAuthorizationPending).toHaveBeenCalled());
+    expect(onAuthorizationPending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousAuthorizationAt: "2026-01-01T00:05:00Z",
+      }),
+    );
+    expect(mockApiGet).toHaveBeenCalledWith("/keys/existing-service-1");
+    // With the stale prop as the baseline this would have settled as freshly
+    // authorized on somebody else's authorization.
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /Waiting for GitHub/i,
+      );
+    });
+    expect(
+      screen.queryByRole("button", { name: "Continue" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("fails the Connect click rather than falling back to a stale baseline", async () => {
+    catalog.entries = [OAUTH_ENTRY];
+    mockApiGet.mockRejectedValue(new Error("network down"));
+    const onAuthorizationPending = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AddKeyDialog
+        open
+        onOpenChange={vi.fn()}
+        reconnectKey={makeReconnectKey()}
+        onAuthorizationPending={onAuthorizationPending}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Connect with GitHub/i }),
+    );
+
+    await waitFor(() =>
+      expect(initiateOAuthMutateAsync).not.toHaveBeenCalled(),
+    );
+    expect(onAuthorizationPending).not.toHaveBeenCalled();
   });
 
   it("offers a retry when the provider denies authorization", async () => {

--- a/frontend/src/components/dashboard/add-key-dialog.tsx
+++ b/frontend/src/components/dashboard/add-key-dialog.tsx
@@ -3200,7 +3200,22 @@ export function AddKeyDialog({
         setAuthKey(repaired);
         return repaired;
       }
-      return reconnectKey;
+      // Re-read rather than returning the prop. The caller derives the
+      // reconnect freshness baseline (`last_authorized_at`) from whatever
+      // this returns, and `reconnectKey` was fetched when the dialog was
+      // opened — minutes earlier, in the assistant-card flow. A baseline that
+      // old lets an authorization completed in the meantime satisfy the gate.
+      // Deliberately not caught: a stale baseline can settle the card as
+      // re-authorized on someone else's authorization, so failing the Connect
+      // click is the safer outcome.
+      const fresh = await api.get<KeyInfo>(
+        `/keys/${encodeURIComponent(reconnectKey.id)}`,
+      );
+      if (fresh.id !== reconnectKey.id) {
+        throw new Error("NyxID returned a different service than requested");
+      }
+      setAuthKey(fresh);
+      return fresh;
     }
     if (authKey) {
       return authKey;


### PR DESCRIPTION
Follow-up hardening on the wave-1 `service.reauthorize` journey that shipped in #1462. Refs #1400 (item 1).

## What

- `feat(keys)`: serve authorization-evidence projections for assistant actions — new read endpoints so a postcondition reader can verify effect rather than trust a browser completion report
- `fix(assistant)`: verify granted scopes and a current baseline before completing — previously success could be reported without checking `requestedScopes ⊆ granted_scopes`, and against a stale freshness baseline
- `fix(assistant)`: claim the card before awaiting the scope check — closes a settle race
- 3 docs commits recording outcomes and reproduction

## Aevatar impact: none

Does **not** touch `backend/src/handlers/assistant_actions.rs`. The manifest revision stays `nyxid-assistant-actions.v8`, unchanged from what production already serves. No re-pin or deploy coordination needed on the Aevatar side.

## Verification

CI green on the merged tree. `Backend Test` 5359/5359, `Coverage (Backend)`, `Coverage (Frontend)`, `Frontend`, `Rust Clippy`, `Rust Format`, all three KMS feature matrices, CodeQL, and Wizard Bundle Freshness all pass.

This branch was 9 commits behind `main` when opened, so the suite result recorded in the docs commits predated `ce63508e fix(approvals): enforce delegated exact authority` and the #1460 delegation exact-view work. The merge is textually clean and the combined tree is now verified green, closing that gap.

**One transient failure, not a regression.** The first run failed `billing_integration_tests::billing_route_coverage_smoke` ("expected 5 finalized Requests rows") in `Coverage (Backend)` only — while `Backend Test`, running the same tests without llvm-cov instrumentation, passed on that same commit. This test has a documented history of flaking in the coverage job (`d760208f test: widen billing settlement poll budget to stop coverage-job flake`), and its poll budget was already at the widened 500 attempts / 10s. Re-running the job passes. Nothing in these commits touches billing, proxy, or usage-meter, and the two new routes are outside every billing route macro group, so `mounted_billing_route_inventory()` is unaffected.

Worth noting separately: widening the budget has now failed to hold once. A durable fix would make the settlement assertion deterministic rather than wall-clock polled — out of scope here, but it will keep costing re-runs across all branches.

## Open question

Whether pre-lineage API-key rows need a data backfill, or whether the projection's trio-or-nothing handling is sufficient on its own. No backfill was found; `state_version: 0` alongside two nulls currently reads as present-but-invalid lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)