### PR TITLE
feat(auth): device-login deny endpoint, requester-IP preview, and mobile QR approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ NyxID is an Auth/SSO platform (similar to Supabase Auth) with a Rust backend, Re
 **Tech Stack:**
 - **Backend:** Rust, Axum 0.8, MongoDB 8.0 (`mongodb` 3.5, `bson` 2.15)
 - **Frontend:** React 19, TypeScript, Vite 7, TanStack Router + Query, Tailwind CSS 4, Zod 4, Zustand
-- **Mobile:** React Native 0.79, Expo 53, TypeScript (iOS + Android approval app)
+- **Mobile:** React Native 0.83, Expo 55, TypeScript (iOS + Android approval app)
 - **SDK:** TypeScript OAuth 2.0 client (`@nyxids/oauth-core`, `@nyxids/oauth-react`)
 - **Dev tools:** Docker Compose (MongoDB + Mailpit), RSA keys for JWT signing
 
@@ -158,16 +158,16 @@ Key files: `models/oracle_{pool,task,session,worker}.rs`, `services/oracle_{pool
 
 ### 12. Auth Device-Code Login
 
-First-party RFC 8628-style login for headless CLI environments: `nyxid login --device` displays a short `user_code`; an already logged-in human approves it in the web UI; the waiting CLI receives normal first-party access + refresh tokens without a password in the terminal.
+First-party RFC 8628-style login for headless CLI environments: `nyxid login --device` displays a short `user_code`; an already logged-in human approves or rejects it in the web UI or mobile app; the waiting CLI receives normal first-party access + refresh tokens without a password in the terminal.
 
-- **Storage**: `auth_device_codes` collection -- HMACs of both the opaque `device_code` and display `user_code` (raw codes and token plaintext never persisted), `pending`/`approved`/`denied`/`expired`/`delivered` status state machine, sanitized client context, encrypted delivery tokens. The CLI polls with an opaque `nyx_adc_`-prefixed `device_code` secret (not a worker-pool flow).
-- **Routes**: `POST /auth/device/request` and `POST /auth/device/poll` are public (no auth). `POST /auth/device/approve` is human-only: JWT session user; API keys, service accounts, and delegated tokens are rejected before handler execution. `POST /auth/device/preview` is public and returns non-sensitive anti-phishing context (`client_label`, `client_user_agent`, timestamps, status) for a `user_code` without changing state -- all fields are device-supplied at `/request` time so there is nothing to leak; the verification page only calls it after login (GitHub-style flow), but it stays public as defense-in-depth simplification and for future anonymous-preview surfaces. Rate-limited per IP.
+- **Storage**: `auth_device_codes` collection -- HMACs of both the opaque `device_code` and display `user_code` (raw codes and token plaintext never persisted), `pending`/`approved`/`denied`/`expired`/`delivered` status state machine, sanitized client context, short-lived server-observed `client_ip` plus its HMAC, encrypted delivery tokens. Denials record `denied_at` and `denied_by_user_id`. The CLI polls with an opaque `nyx_adc_`-prefixed `device_code` secret (not a worker-pool flow).
+- **Routes**: `POST /auth/device/request`, `/poll`, and `/preview` are public (no auth). Preview is non-mutating and returns untrusted `client_label`/`client_user_agent` plus server-observed `client_ip`, Z-suffix timestamps, and status. `POST /auth/device/approve` and `/deny` are human-only: JWT session user; API keys, service accounts, delegated tokens, and relay tokens are rejected before handler execution. Approve and deny race atomically on `status = pending`; deny mints no tokens and the next poll returns 11204. All routes are rate-limited per IP; decisions also share a per-user limit.
 - **Atomic delivery**: poll claims `approved` -> `delivered` via `find_one_and_update(...).return_document(Before)`; the pre-update document carries the encrypted delivery tokens for exactly one poller; later pollers get `AuthDeviceCodeAlreadyDelivered` (11205).
 - **Rate limiters**: `auth_device_{request,poll,approve,approve_per_user,preview}_limiter`
 - **CLI output**: prints `user_code` plus the bare `verification_uri` -- never `verification_uri_complete`, which would put the code in the URL and defeat manual-entry anti-phishing. On stdin+stderr TTYs: prompts `Open in your browser? [Y/n]` and opens via `crate::browser::open_browser`, falling through with a "paste it manually" hint on failure. Non-TTY (CI/piped) skips the prompt and polls immediately.
 - **CLI dispatch**: `nyxid login --device` forces device-code login; plain `nyxid login` auto-falls back to it when browser launch is unavailable unless `NYXID_LOGIN_NO_DEVICE_FALLBACK=1`.
-- **Verification page** (`/login/device`): auth-gated at entry (redirect to `/login?return_to=/login/device`). Code input starts empty; the `?user_code=` query param is stripped by the router's `validateSearch` and ignored. Two explicit clicks: Continue calls `/preview` (anti-phishing block renders), then Approve calls `/approve`. No API call fires on typing, focus, mount, or reconnect; both buttons are throttled to >= 750 ms between clicks and disabled while pending (input disabled too).
-- **Out of scope for v1**: mobile approval deep-link to the approval app (follow-up issue if needed).
+- **Verification page** (`/login/device`): auth-gated at entry (redirect to `/login?return_to=/login/device`). Code input starts empty; the `?user_code=` query param is stripped by the router's `validateSearch` and ignored. Two explicit clicks: Continue calls `/preview` (anti-phishing block renders), then Approve or Reject calls `/approve` or `/deny`. No API call fires on typing, focus, mount, or reconnect; actions are throttled to >= 750 ms between clicks and disabled while pending (input disabled too).
+- **Mobile approval**: `CameraView` scans only QR codes whose shape is `https://<frontend>/login/device?user_code=...` or `nyxid://login/device?user_code=...`. The app extracts and normalizes only `user_code`; every request uses its configured API base URL. Deep links prefill without making a request. Preview and approve/reject remain separate explicit actions, share the >= 750 ms throttle, and never auto-approve.
 
 ### 13. Hosted Connect Links
 
@@ -222,7 +222,7 @@ frontend/src/
 |-- types/               # TypeScript type definitions
 |-- router.tsx           # TanStack Router config
 
-mobile/src/              # React Native + Expo app (Expo 53, RN 0.79): app/ (shell, navigator,
+mobile/src/              # React Native + Expo app (Expo 55, RN 0.83): app/ (shell, navigator,
                          # deep linking nyxid://challenge/{id}), features/ (auth, challenges,
                          # approvals, account, legal), components/, lib/ (API client, SecureStore
                          # session, push registration), theme/
@@ -236,7 +236,7 @@ sdk/                     # OAuth SDK monorepo (@nyxids/* npm namespace): oauth-c
 
 All API routes under `/api/v1`:
 - `/auth` -- register, login, logout, refresh, verify-email, forgot/reset-password
-- `/auth/device/{request,poll,approve,preview}` -- auth device-code login (see Critical Rule 12 for auth posture per route)
+- `/auth/device/{request,poll,preview,approve,deny}` -- auth device-code login (see Critical Rule 12 for auth posture per route)
 - `/connect-links` -- create, poll, creator cancel, public preview, human decline, and human-only completion for hosted service connections (see Critical Rule 13)
 - `/developer/oauth-clients/{client_id}/connection-webhook` -- human-only developer-app lifecycle webhook configure/disable; `/connection-webhook/rotate-secret` returns a new signing secret and key ID once
 - `/triggers` -- trigger CRUD; `/{id}/rotate-secret`, `/{id}/rotate-delivery-secret`, `/{id}/deliveries`, and `/{id}/deliveries/{event_id}/redeliver` cover inbound/outbound secret rotation, delivery history, and retained-envelope replay (JWT or agent API key; delegated, relay, and service-account tokens rejected)

--- a/backend/src/api_docs.rs
+++ b/backend/src/api_docs.rs
@@ -39,7 +39,10 @@
         crate::handlers::connect_links::cancel_hosted_connect_link,
         crate::handlers::connect_links::complete_connect_link,
         // Auth Device Login
+        crate::handlers::auth_device::request_auth_device,
+        crate::handlers::auth_device::poll_auth_device,
         crate::handlers::auth_device::preview_auth_device,
+        crate::handlers::auth_device::approve_auth_device,
         crate::handlers::auth_device::deny_auth_device,
         // Catalog
         crate::handlers::catalog::list_catalog,
@@ -118,8 +121,13 @@
             crate::handlers::connect_links::CompleteConnectLinkRequest,
             crate::handlers::connect_links::CompleteConnectLinkResponse,
             // Auth Device Login
+            crate::handlers::auth_device::AuthDeviceRequestBody,
+            crate::handlers::auth_device::AuthDeviceRequestResponse,
+            crate::handlers::auth_device::AuthDevicePollBody,
+            crate::handlers::auth_device::AuthDevicePollResponse,
             crate::handlers::auth_device::AuthDevicePreviewBody,
             crate::handlers::auth_device::AuthDevicePreviewResponse,
+            crate::handlers::auth_device::AuthDeviceApproveBody,
             crate::handlers::auth_device::AuthDeviceDenyBody,
             crate::handlers::auth_device::AuthDeviceDecisionResponse,
             // Catalog

--- a/backend/src/api_docs.rs
+++ b/backend/src/api_docs.rs
@@ -38,6 +38,9 @@
         crate::handlers::connect_links::preview_connect_link,
         crate::handlers::connect_links::cancel_hosted_connect_link,
         crate::handlers::connect_links::complete_connect_link,
+        // Auth Device Login
+        crate::handlers::auth_device::preview_auth_device,
+        crate::handlers::auth_device::deny_auth_device,
         // Catalog
         crate::handlers::catalog::list_catalog,
         crate::handlers::catalog::get_catalog_entry,
@@ -114,6 +117,11 @@
             crate::handlers::connect_links::CancelHostedConnectLinkRequest,
             crate::handlers::connect_links::CompleteConnectLinkRequest,
             crate::handlers::connect_links::CompleteConnectLinkResponse,
+            // Auth Device Login
+            crate::handlers::auth_device::AuthDevicePreviewBody,
+            crate::handlers::auth_device::AuthDevicePreviewResponse,
+            crate::handlers::auth_device::AuthDeviceDenyBody,
+            crate::handlers::auth_device::AuthDeviceDecisionResponse,
             // Catalog
             crate::handlers::catalog::CatalogEntryResponse,
             crate::handlers::catalog::CatalogListResponse,
@@ -196,6 +204,7 @@
         (name = "SSH", description = "SSH certificate issuance and WebSocket tunnel endpoints"),
         (name = "AI Services", description = "Unified key management: auto-provisions endpoint, credential, and proxy routing from catalog or custom input"),
         (name = "Connect Links", description = "Hosted single-use service credential connection flows"),
+        (name = "Auth Device Login", description = "First-party device-code login review and decisions"),
         (name = "Catalog", description = "Read-only service catalog for users (admin-created services and providers)"),
         (name = "Endpoints", description = "User-managed target URLs"),
         (name = "External API Keys", description = "User's external API keys and credentials"),

--- a/backend/src/handlers/auth_device.rs
+++ b/backend/src/handlers/auth_device.rs
@@ -80,6 +80,16 @@ pub struct AuthDevicePreviewResponse {
     pub status: String,
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/device/request",
+    request_body = AuthDeviceRequestBody,
+    responses(
+        (status = 200, body = AuthDeviceRequestResponse),
+        (status = 429, body = crate::errors::ErrorResponse)
+    ),
+    tag = "Auth Device Login"
+)]
 #[tracing::instrument(skip_all, fields(client_ip_hash, route = "request"))]
 pub async fn request_auth_device(
     State(state): State<AppState>,
@@ -126,6 +136,20 @@ pub async fn request_auth_device(
     }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/device/poll",
+    request_body = AuthDevicePollBody,
+    responses(
+        (status = 200, body = AuthDevicePollResponse),
+        (status = 400, body = crate::errors::ErrorResponse),
+        (status = 403, body = crate::errors::ErrorResponse),
+        (status = 404, body = crate::errors::ErrorResponse),
+        (status = 410, body = crate::errors::ErrorResponse),
+        (status = 429, body = crate::errors::ErrorResponse)
+    ),
+    tag = "Auth Device Login"
+)]
 #[tracing::instrument(skip_all, fields(client_ip_hash, route = "poll"))]
 pub async fn poll_auth_device(
     State(state): State<AppState>,
@@ -198,6 +222,21 @@ pub async fn poll_auth_device(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/device/approve",
+    request_body = AuthDeviceApproveBody,
+    responses(
+        (status = 200, body = AuthDeviceDecisionResponse),
+        (status = 400, body = crate::errors::ErrorResponse),
+        (status = 401, body = crate::errors::ErrorResponse),
+        (status = 403, body = crate::errors::ErrorResponse),
+        (status = 410, body = crate::errors::ErrorResponse),
+        (status = 429, body = crate::errors::ErrorResponse)
+    ),
+    security(("bearer_auth" = [])),
+    tag = "Auth Device Login"
+)]
 #[tracing::instrument(skip_all, fields(client_ip_hash, route = "approve"))]
 pub async fn approve_auth_device(
     State(state): State<AppState>,

--- a/backend/src/handlers/auth_device.rs
+++ b/backend/src/handlers/auth_device.rs
@@ -14,7 +14,7 @@ use crate::AppState;
 use crate::errors::{AppError, AppResult};
 use crate::mw::auth::AuthUser;
 use crate::services::auth_device_service::{
-    self, ApproveInput, InitiateInput, PollClaim, PreviewOutput,
+    self, ApproveInput, DenyInput, InitiateInput, PollClaim, PreviewOutput,
 };
 
 type HmacSha256 = Hmac<Sha256>;
@@ -56,6 +56,16 @@ pub struct AuthDeviceApproveBody {
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
+pub struct AuthDeviceDenyBody {
+    pub user_code: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthDeviceDecisionResponse {
+    pub ok: bool,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct AuthDevicePreviewBody {
     pub user_code: String,
 }
@@ -64,6 +74,7 @@ pub struct AuthDevicePreviewBody {
 pub struct AuthDevicePreviewResponse {
     pub client_label: Option<String>,
     pub client_user_agent: Option<String>,
+    pub client_ip: Option<String>,
     pub initiated_at: String,
     pub expires_at: String,
     pub status: String,
@@ -194,7 +205,7 @@ pub async fn approve_auth_device(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<AuthDeviceApproveBody>,
-) -> AppResult<Json<serde_json::Value>> {
+) -> AppResult<Json<AuthDeviceDecisionResponse>> {
     let client_ip = resolve_client_ip(&headers, addr, &state)?;
     let client_ip_hash = client_ip_hash(&state, client_ip);
     tracing::Span::current().record("client_ip_hash", client_ip_hash.as_str());
@@ -232,9 +243,80 @@ pub async fn approve_auth_device(
         "auth_device.handler.approve"
     );
 
-    Ok(Json(serde_json::json!({ "ok": true })))
+    Ok(Json(AuthDeviceDecisionResponse { ok: true }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/device/deny",
+    request_body = AuthDeviceDenyBody,
+    responses(
+        (status = 200, body = AuthDeviceDecisionResponse),
+        (status = 400, body = crate::errors::ErrorResponse),
+        (status = 401, body = crate::errors::ErrorResponse),
+        (status = 403, body = crate::errors::ErrorResponse),
+        (status = 410, body = crate::errors::ErrorResponse),
+        (status = 429, body = crate::errors::ErrorResponse)
+    ),
+    security(("bearer_auth" = [])),
+    tag = "Auth Device Login"
+)]
+#[tracing::instrument(skip_all, fields(client_ip_hash, route = "deny"))]
+pub async fn deny_auth_device(
+    State(state): State<AppState>,
+    user: AuthUser,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<AuthDeviceDenyBody>,
+) -> AppResult<Json<AuthDeviceDecisionResponse>> {
+    let client_ip = resolve_client_ip(&headers, addr, &state)?;
+    let client_ip_hash = client_ip_hash(&state, client_ip);
+    tracing::Span::current().record("client_ip_hash", client_ip_hash.as_str());
+
+    if !state.auth_device_approve_limiter.check(client_ip) {
+        rate_limit_hit("deny", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    let user_key = format!("user:{}", user.user_id);
+    if !state.auth_device_approve_per_user_limiter.check(&user_key) {
+        rate_limit_hit("deny", &client_ip_hash);
+        return Err(AppError::AuthDeviceCodeRateLimited);
+    }
+
+    auth_device_service::deny(
+        &state.db,
+        state.auth_device_hmac_key.as_slice(),
+        DenyInput {
+            user_id: user.user_id.to_string(),
+            user_code: body.user_code,
+            denier_ip: Some(client_ip.to_string()),
+            denier_user_agent: user_agent(&headers),
+        },
+    )
+    .await?;
+
+    tracing::info!(
+        client_ip_hash = %client_ip_hash,
+        user_id = %user.user_id,
+        audit_logged = true,
+        "auth_device.handler.deny"
+    );
+
+    Ok(Json(AuthDeviceDecisionResponse { ok: true }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/device/preview",
+    request_body = AuthDevicePreviewBody,
+    responses(
+        (status = 200, body = AuthDevicePreviewResponse),
+        (status = 400, body = crate::errors::ErrorResponse),
+        (status = 429, body = crate::errors::ErrorResponse)
+    ),
+    tag = "Auth Device Login"
+)]
 #[tracing::instrument(skip_all, fields(client_ip_hash, route = "preview"))]
 pub async fn preview_auth_device(
     State(state): State<AppState>,
@@ -320,6 +402,7 @@ fn preview_response(preview: PreviewOutput) -> AuthDevicePreviewResponse {
     AuthDevicePreviewResponse {
         client_label: preview.client_label,
         client_user_agent: preview.client_user_agent,
+        client_ip: preview.client_ip,
         initiated_at: preview
             .initiated_at
             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
@@ -352,6 +435,9 @@ mod tests {
     use uuid::Uuid;
 
     use crate::models::audit_log::{AuditLog, COLLECTION_NAME as AUDIT_LOG};
+    use crate::models::auth_device_code::{
+        AuthDeviceCode, AuthDeviceCodeStatus, COLLECTION_NAME as AUTH_DEVICE_CODES,
+    };
     use crate::models::user::{COLLECTION_NAME as USERS, UserType};
     use crate::services::auth_device_service::InitiateInput;
     use crate::test_utils::{connect_test_database, test_app_config, test_app_state, test_user};
@@ -599,6 +685,30 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn auth_device_deny_rejects_api_key_auth() {
+        let Some(state) = setup_state("auth_device_api_key_deny").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let api_key = create_api_key(&state, &user_id).await;
+        let server = spawn_test_server(state).await;
+
+        let (status, _) = post_json(
+            &server,
+            "/api/v1/auth/device/deny",
+            Some(&api_key),
+            serde_json::json!({ "user_code": "ABCD-EFGH" }),
+        )
+        .await;
+
+        assert!(matches!(
+            status,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ));
+    }
+
     // Covers the public mount of /auth/device/preview: an anonymous caller must
     // succeed and receive the sanitized anti-phishing payload (client_label,
     // UA, timestamps, status). Approve stays human-only — see the test above.
@@ -631,9 +741,105 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["client_label"], "kitchen-rpi");
         assert_eq!(json["client_user_agent"], "nyxid-cli/0.7.1");
+        assert_eq!(json["client_ip"], "127.0.0.1");
         assert_eq!(json["status"], "pending");
-        assert!(json["initiated_at"].is_string());
-        assert!(json["expires_at"].is_string());
+        assert!(
+            json["initiated_at"]
+                .as_str()
+                .is_some_and(|value| value.ends_with('Z'))
+        );
+        assert!(
+            json["expires_at"]
+                .as_str()
+                .is_some_and(|value| value.ends_with('Z'))
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_device_preview_legacy_row_without_client_ip_returns_null() {
+        let Some(state) = setup_state("auth_device_preview_legacy_ip_http").await else {
+            return;
+        };
+        let initiated = auth_device_service::initiate(
+            &state.db,
+            state.auth_device_hmac_key.as_slice(),
+            InitiateInput {
+                client_label: None,
+                client_user_agent: None,
+                client_ip: Some("127.0.0.1".to_string()),
+            },
+        )
+        .await
+        .expect("initiate");
+        state
+            .db
+            .collection::<mongodb::bson::Document>(AUTH_DEVICE_CODES)
+            .update_many(doc! {}, doc! { "$unset": { "client_ip": "" } })
+            .await
+            .expect("remove client_ip");
+        let server = spawn_test_server(state).await;
+
+        let (status, json) = post_json(
+            &server,
+            "/api/v1/auth/device/preview",
+            None,
+            serde_json::json!({ "user_code": initiated.user_code }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(json["client_ip"].is_null());
+    }
+
+    #[tokio::test]
+    async fn auth_device_deny_terminates_next_poll_with_11204() {
+        let Some(state) = setup_state("auth_device_deny_poll").await else {
+            return;
+        };
+        let user_id = Uuid::new_v4().to_string();
+        insert_user(&state, &user_id).await;
+        let token = access_token(&state, &user_id);
+        let server = spawn_test_server(state.clone()).await;
+
+        let (status, request_json) = post_json(
+            &server,
+            "/api/v1/auth/device/request",
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, deny_json) = post_json(
+            &server,
+            "/api/v1/auth/device/deny",
+            Some(&token),
+            serde_json::json!({ "user_code": request_json["user_code"] }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(deny_json, serde_json::json!({ "ok": true }));
+
+        let row = state
+            .db
+            .collection::<AuthDeviceCode>(AUTH_DEVICE_CODES)
+            .find_one(doc! {})
+            .await
+            .expect("query auth device row")
+            .expect("auth device row");
+        assert_eq!(row.status, AuthDeviceCodeStatus::Denied);
+        assert!(row.denied_at.is_some());
+        assert_eq!(row.denied_by_user_id.as_deref(), Some(user_id.as_str()));
+
+        let (status, poll_json) = post_json(
+            &server,
+            "/api/v1/auth/device/poll",
+            None,
+            serde_json::json!({ "device_code": request_json["device_code"] }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_error(&poll_json, "auth_device_access_denied", 11204);
     }
 
     #[tokio::test]

--- a/backend/src/models/auth_device_code.rs
+++ b/backend/src/models/auth_device_code.rs
@@ -28,6 +28,8 @@ pub struct AuthDeviceCode {
     pub slow_down_increments: u32,
     pub client_label: Option<String>,
     pub client_user_agent: Option<String>,
+    #[serde(default)]
+    pub client_ip: Option<String>,
     pub client_ip_hmac: Option<String>,
     #[serde(default, with = "bson_datetime::optional")]
     pub last_polled_at: Option<DateTime<Utc>>,
@@ -47,6 +49,8 @@ pub struct AuthDeviceCode {
     pub delivered_at: Option<DateTime<Utc>>,
     #[serde(default, with = "bson_datetime::optional")]
     pub denied_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub denied_by_user_id: Option<String>,
     #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
     pub expires_at: DateTime<Utc>,
 }
@@ -77,6 +81,10 @@ impl fmt::Debug for AuthDeviceCode {
             .field("slow_down_increments", &self.slow_down_increments)
             .field("client_label", &self.client_label)
             .field("client_user_agent", &self.client_user_agent)
+            .field(
+                "client_ip",
+                &self.client_ip.as_ref().map(|ip| RedactedLen(ip.len())),
+            )
             .field(
                 "client_ip_hmac",
                 &self
@@ -116,6 +124,7 @@ impl fmt::Debug for AuthDeviceCode {
             .field("approved_at", &self.approved_at)
             .field("delivered_at", &self.delivered_at)
             .field("denied_at", &self.denied_at)
+            .field("denied_by_user_id", &self.denied_by_user_id)
             .field("expires_at", &self.expires_at)
             .finish()
     }
@@ -136,6 +145,7 @@ mod tests {
             slow_down_increments: 0,
             client_label: Some("wsl-calvin".to_string()),
             client_user_agent: Some("nyxid-cli/0.8.0".to_string()),
+            client_ip: Some("203.0.113.10".to_string()),
             client_ip_hmac: Some("11112222".repeat(8)),
             last_polled_at: Some(now + chrono::Duration::seconds(5)),
             approved_user_id: Some(uuid::Uuid::new_v4().to_string()),
@@ -148,6 +158,7 @@ mod tests {
             approved_at: Some(now + chrono::Duration::seconds(10)),
             delivered_at: Some(now + chrono::Duration::seconds(20)),
             denied_at: None,
+            denied_by_user_id: None,
             expires_at: now + chrono::Duration::minutes(10),
         }
     }
@@ -177,6 +188,7 @@ mod tests {
         assert_eq!(row.slow_down_increments, restored.slow_down_increments);
         assert_eq!(row.client_label, restored.client_label);
         assert_eq!(row.client_user_agent, restored.client_user_agent);
+        assert_eq!(row.client_ip, restored.client_ip);
         assert_eq!(row.client_ip_hmac, restored.client_ip_hmac);
         assert_eq!(row.approved_user_id, restored.approved_user_id);
         assert_eq!(row.approved_session_id, restored.approved_session_id);
@@ -210,6 +222,7 @@ mod tests {
             restored.delivered_at.unwrap().timestamp_millis()
         );
         assert_eq!(row.denied_at, restored.denied_at);
+        assert_eq!(row.denied_by_user_id, restored.denied_by_user_id);
         assert_eq!(
             row.expires_at.timestamp_millis(),
             restored.expires_at.timestamp_millis()
@@ -225,6 +238,7 @@ mod tests {
             row.device_code_hmac.as_str(),
             row.user_code_hmac.as_str(),
             row.client_ip_hmac.as_deref().unwrap(),
+            row.client_ip.as_deref().unwrap(),
             row.approver_ip_hmac.as_deref().unwrap(),
             "abcdef",
             "123456",
@@ -237,5 +251,18 @@ mod tests {
         assert!(debug.contains("expires_at"));
         assert!(debug.contains("wsl-calvin"));
         assert!(debug.contains("nyxid-cli/0.8.0"));
+    }
+
+    #[test]
+    fn legacy_bson_without_new_optional_fields_deserializes() {
+        let row = make_auth_device_code();
+        let mut doc = bson::to_document(&row).expect("serialize");
+        doc.remove("client_ip");
+        doc.remove("denied_by_user_id");
+
+        let restored: AuthDeviceCode = bson::from_document(doc).expect("deserialize legacy row");
+
+        assert!(restored.client_ip.is_none());
+        assert!(restored.denied_by_user_id.is_none());
     }
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1525,6 +1525,10 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
             post(handlers::auth_device::approve_auth_device),
         )
         .route(
+            "/auth/device/deny",
+            post(handlers::auth_device::deny_auth_device),
+        )
+        .route(
             "/connect-links/complete",
             post(handlers::connect_links::complete_connect_link),
         )

--- a/backend/src/services/auth_device_service.rs
+++ b/backend/src/services/auth_device_service.rs
@@ -63,6 +63,7 @@ pub enum PollClaim {
 pub struct PreviewOutput {
     pub client_label: Option<String>,
     pub client_user_agent: Option<String>,
+    pub client_ip: Option<String>,
     pub initiated_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
     pub status: AuthDeviceCodeStatus,
@@ -74,6 +75,14 @@ pub struct ApproveInput {
     pub user_code: String,
     pub approver_ip: Option<String>,
     pub approver_user_agent: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DenyInput {
+    pub user_id: String,
+    pub user_code: String,
+    pub denier_ip: Option<String>,
+    pub denier_user_agent: Option<String>,
 }
 
 #[tracing::instrument(
@@ -130,6 +139,7 @@ where
             slow_down_increments: 0,
             client_label: client_label.clone(),
             client_user_agent: client_user_agent.clone(),
+            client_ip: client_ip.clone(),
             client_ip_hmac: client_ip
                 .as_deref()
                 .map(|client_ip| hmac_hex(hmac_key, client_ip.as_bytes())),
@@ -144,6 +154,7 @@ where
             approved_at: None,
             delivered_at: None,
             denied_at: None,
+            denied_by_user_id: None,
             expires_at: now + Duration::seconds(AUTH_DEVICE_EXPIRES_IN_SECS),
         };
 
@@ -242,6 +253,7 @@ pub async fn preview(db: &Database, hmac_key: &[u8], user_code: &str) -> AppResu
     Ok(PreviewOutput {
         client_label: row.client_label,
         client_user_agent: row.client_user_agent,
+        client_ip: row.client_ip,
         initiated_at: row.created_at,
         expires_at: row.expires_at,
         status: row.status,
@@ -356,7 +368,7 @@ pub async fn approve(
 
     if updated.is_none() {
         cleanup_issued_session(db, &session_id).await;
-        return Err(AppError::AuthDeviceCodeAlreadyDelivered);
+        return Err(current_decision_error(&collection, &row.id).await?);
     }
 
     audit_service::log_async(
@@ -380,6 +392,75 @@ pub async fn approve(
         latency_ms = started_at.elapsed().as_millis() as u64,
         audit_logged = true,
         "auth_device.approve"
+    );
+
+    Ok(())
+}
+
+#[tracing::instrument(
+    name = "auth_device.deny",
+    skip_all,
+    fields(row_id, user_id = %input.user_id)
+)]
+pub async fn deny(db: &Database, hmac_key: &[u8], input: DenyInput) -> AppResult<()> {
+    let normalized = normalize_user_code(&input.user_code)?;
+    let user_code_hmac = hmac_hex(hmac_key, normalized.as_bytes());
+    let collection = collection(db);
+    let now = Utc::now();
+
+    let row = collection
+        .find_one(doc! { "user_code_hmac": user_code_hmac })
+        .await?
+        .ok_or(AppError::AuthDeviceUserCodeInvalid)?;
+
+    tracing::Span::current().record("row_id", row.id.as_str());
+
+    if row.expires_at < now {
+        return Err(AppError::AuthDeviceCodeExpired);
+    }
+
+    if row.status != AuthDeviceCodeStatus::Pending {
+        return Err(non_pending_approve_error(row.status));
+    }
+
+    let denied_status = bson::to_bson(&AuthDeviceCodeStatus::Denied)
+        .map_err(|e| AppError::Internal(format!("serialize auth device status: {e}")))?;
+    let updated = collection
+        .find_one_and_update(
+            doc! { "_id": &row.id, "status": "pending" },
+            doc! {
+                "$set": {
+                    "status": denied_status,
+                    "denied_at": bson::DateTime::from_chrono(now),
+                    "denied_by_user_id": &input.user_id,
+                }
+            },
+        )
+        .return_document(ReturnDocument::After)
+        .await?;
+
+    if updated.is_none() {
+        return Err(current_decision_error(&collection, &row.id).await?);
+    }
+
+    audit_service::log_async(
+        db.clone(),
+        Some(input.user_id.clone()),
+        "auth_device_code_denied".to_string(),
+        Some(serde_json::json!({
+            "user_code_redacted": redact_user_code(&normalized),
+        })),
+        input.denier_ip,
+        input.denier_user_agent,
+        None,
+        None,
+    );
+
+    tracing::info!(
+        row_id = %row.id,
+        user_id = %input.user_id,
+        audit_logged = true,
+        "auth_device.deny"
     );
 
     Ok(())
@@ -503,6 +584,20 @@ fn non_pending_approve_error(status: AuthDeviceCodeStatus) -> AppError {
             AppError::AuthDeviceCodeAlreadyDelivered
         }
     }
+}
+
+async fn current_decision_error(
+    collection: &Collection<AuthDeviceCode>,
+    row_id: &str,
+) -> AppResult<AppError> {
+    let row = collection
+        .find_one(doc! { "_id": row_id })
+        .await?
+        .ok_or(AppError::AuthDeviceCodeAlreadyDelivered)?;
+    if row.expires_at < Utc::now() {
+        return Ok(AppError::AuthDeviceCodeExpired);
+    }
+    Ok(non_pending_approve_error(row.status))
 }
 
 fn redact_user_code(normalized: &str) -> String {
@@ -734,6 +829,7 @@ mod tests {
         assert_eq!(row.status, AuthDeviceCodeStatus::Pending);
         assert_eq!(row.client_label.as_deref(), Some("labelwith-control"));
         assert_eq!(row.client_user_agent.as_ref().unwrap().len(), 256);
+        assert_eq!(row.client_ip.as_deref(), Some("203.0.113.10"));
         assert_eq!(
             row.client_ip_hmac.as_deref(),
             Some(hmac_hex(TEST_HMAC_KEY, b"203.0.113.10").as_str())
@@ -753,7 +849,7 @@ mod tests {
             TEST_HMAC_KEY,
             Some("workstation".to_string()),
             Some("nyxid-cli/0.8.0".to_string()),
-            None,
+            Some("203.0.113.10".to_string()),
             || "ABCD1234".to_string(),
         )
         .await
@@ -768,7 +864,292 @@ mod tests {
             preview.client_user_agent.as_deref(),
             Some("nyxid-cli/0.8.0")
         );
+        assert_eq!(preview.client_ip.as_deref(), Some("203.0.113.10"));
         assert_eq!(preview.status, AuthDeviceCodeStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn preview_legacy_row_without_client_ip_returns_none() {
+        let Some(db) = connect_test_database("auth_device_preview_legacy_ip").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+        db.collection::<bson::Document>(AUTH_DEVICE_CODES)
+            .update_one(
+                doc! { "_id": &row.id },
+                doc! { "$unset": { "client_ip": "" } },
+            )
+            .await
+            .expect("remove legacy field");
+
+        let output = preview(&db, TEST_HMAC_KEY, "ABCD-1234")
+            .await
+            .expect("preview legacy row");
+
+        assert!(output.client_ip.is_none());
+    }
+
+    #[tokio::test]
+    async fn deny_pending_row_sets_terminal_fields_and_audits() {
+        let Some(db) = connect_test_database("auth_device_deny_happy").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+        let audit_written =
+            audit_service::notify_on_audit_write_for_user("auth_device_code_denied", &user_id);
+
+        deny(
+            &db,
+            TEST_HMAC_KEY,
+            DenyInput {
+                user_id: user_id.clone(),
+                user_code: "ABCD-1234".to_string(),
+                denier_ip: Some("203.0.113.88".to_string()),
+                denier_user_agent: Some("nyxid-mobile/1.0".to_string()),
+            },
+        )
+        .await
+        .expect("deny");
+
+        let denied = row_by_id(&db, &row.id).await;
+        assert_eq!(denied.status, AuthDeviceCodeStatus::Denied);
+        assert!(denied.denied_at.is_some());
+        assert_eq!(denied.denied_by_user_id.as_deref(), Some(user_id.as_str()));
+        assert!(denied.approved_user_id.is_none());
+        assert!(denied.approved_session_id.is_none());
+
+        let audit_id = tokio::time::timeout(Duration::seconds(2).to_std().unwrap(), audit_written)
+            .await
+            .expect("audit write timed out")
+            .expect("audit watcher");
+        let audit = db
+            .collection::<AuditLog>(AUDIT_LOG)
+            .find_one(doc! { "_id": audit_id })
+            .await
+            .expect("audit query")
+            .expect("audit row");
+        assert_eq!(audit.event_type, "auth_device_code_denied");
+        assert_eq!(audit.user_id.as_deref(), Some(user_id.as_str()));
+        assert_eq!(
+            audit
+                .event_data
+                .as_ref()
+                .and_then(|data| data.get("user_code_redacted"))
+                .and_then(serde_json::Value::as_str),
+            Some("AB****34")
+        );
+        assert!(
+            !audit
+                .event_data
+                .as_ref()
+                .is_some_and(|data| data.to_string().contains("ABCD1234"))
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_wrong_user_code_returns_invalid_without_mutation() {
+        let Some(db) = connect_test_database("auth_device_deny_wrong_code").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let result = deny(
+            &db,
+            TEST_HMAC_KEY,
+            DenyInput {
+                user_id: Uuid::new_v4().to_string(),
+                user_code: "WXYZ-9999".to_string(),
+                denier_ip: None,
+                denier_user_agent: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AppError::AuthDeviceUserCodeInvalid)));
+        assert_eq!(
+            row_by_id(&db, &row.id).await.status,
+            AuthDeviceCodeStatus::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_non_pending_rows_use_approve_error_mapping() {
+        let Some(db) = connect_test_database("auth_device_deny_non_pending").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+
+        for (status, expected_error_code) in [
+            (AuthDeviceCodeStatus::Approved, 11205),
+            (AuthDeviceCodeStatus::Denied, 11204),
+            (AuthDeviceCodeStatus::Expired, 11201),
+        ] {
+            collection(&db)
+                .delete_many(doc! {})
+                .await
+                .expect("clear rows");
+            seed_row(&db, status, Utc::now() + Duration::minutes(10)).await;
+
+            let error = deny(
+                &db,
+                TEST_HMAC_KEY,
+                DenyInput {
+                    user_id: Uuid::new_v4().to_string(),
+                    user_code: "ABCD-1234".to_string(),
+                    denier_ip: None,
+                    denier_user_agent: None,
+                },
+            )
+            .await
+            .expect_err("non-pending deny must fail");
+
+            assert_eq!(error.error_code(), expected_error_code);
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_after_expiry_returns_expired_without_transition() {
+        let Some(db) = connect_test_database("auth_device_deny_expired_at").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() - Duration::seconds(1),
+        )
+        .await;
+
+        let result = deny(
+            &db,
+            TEST_HMAC_KEY,
+            DenyInput {
+                user_id: Uuid::new_v4().to_string(),
+                user_code: "ABCD-1234".to_string(),
+                denier_ip: None,
+                denier_user_agent: None,
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AppError::AuthDeviceCodeExpired)));
+        assert_eq!(
+            row_by_id(&db, &row.id).await.status,
+            AuthDeviceCodeStatus::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_approve_and_deny_have_one_winner_and_no_orphan_session() {
+        let Some(db) = connect_test_database("auth_device_approve_deny_race").await else {
+            return;
+        };
+        crate::db::ensure_indexes(&db)
+            .await
+            .expect("ensure indexes");
+        let config = test_app_config();
+        let jwt_keys = cached_test_jwt_keys();
+        let encryption_keys = test_encryption_keys();
+        let user_id = Uuid::new_v4().to_string();
+        seed_user(&db, &user_id).await;
+        let row = seed_row(
+            &db,
+            AuthDeviceCodeStatus::Pending,
+            Utc::now() + Duration::minutes(10),
+        )
+        .await;
+
+        let (approve_result, deny_result) = tokio::join!(
+            approve(
+                &db,
+                &config,
+                &jwt_keys,
+                &encryption_keys,
+                TEST_HMAC_KEY,
+                ApproveInput {
+                    user_id: user_id.clone(),
+                    user_code: "ABCD-1234".to_string(),
+                    approver_ip: None,
+                    approver_user_agent: None,
+                },
+            ),
+            deny(
+                &db,
+                TEST_HMAC_KEY,
+                DenyInput {
+                    user_id: user_id.clone(),
+                    user_code: "ABCD-1234".to_string(),
+                    denier_ip: None,
+                    denier_user_agent: None,
+                },
+            )
+        );
+
+        assert_eq!(
+            [approve_result.is_ok(), deny_result.is_ok()]
+                .into_iter()
+                .filter(|won| *won)
+                .count(),
+            1,
+            "approve={approve_result:?} deny={deny_result:?}"
+        );
+
+        let decided = row_by_id(&db, &row.id).await;
+        let live_sessions = db
+            .collection::<bson::Document>(SESSIONS)
+            .count_documents(doc! { "revoked": false })
+            .await
+            .expect("live session count");
+        match decided.status {
+            AuthDeviceCodeStatus::Approved => {
+                assert!(approve_result.is_ok());
+                assert!(matches!(
+                    deny_result,
+                    Err(AppError::AuthDeviceCodeAlreadyDelivered)
+                ));
+                assert_eq!(live_sessions, 1);
+            }
+            AuthDeviceCodeStatus::Denied => {
+                assert!(deny_result.is_ok());
+                assert!(matches!(
+                    approve_result,
+                    Err(AppError::AuthDeviceCodeDenied)
+                ));
+                assert_eq!(live_sessions, 0);
+                assert!(decided.approved_session_id.is_none());
+            }
+            status => panic!("unexpected race terminal status: {status:?}"),
+        }
     }
 
     #[tokio::test]
@@ -1298,6 +1679,7 @@ mod tests {
             slow_down_increments: 0,
             client_label: None,
             client_user_agent: None,
+            client_ip: None,
             client_ip_hmac: None,
             last_polled_at: None,
             approved_user_id: None,
@@ -1310,6 +1692,7 @@ mod tests {
             approved_at: None,
             delivered_at: None,
             denied_at: None,
+            denied_by_user_id: None,
             expires_at,
         };
         collection(db).insert_one(&row).await.expect("seed row");
@@ -1360,6 +1743,7 @@ mod tests {
             slow_down_increments: 0,
             client_label: Some("wsl-calvin".to_string()),
             client_user_agent: Some("nyxid-cli/0.8.0".to_string()),
+            client_ip: Some("203.0.113.10".to_string()),
             client_ip_hmac: Some("11112222".repeat(8)),
             last_polled_at: Some(now),
             approved_user_id: Some(Uuid::new_v4().to_string()),
@@ -1372,6 +1756,7 @@ mod tests {
             approved_at: Some(now),
             delivered_at: Some(now),
             denied_at: None,
+            denied_by_user_id: None,
             expires_at: now + Duration::minutes(10),
         }
     }

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -1136,7 +1136,7 @@ fn handle_device_poll_error(error_code: i64, message: &str, interval: u64) -> Re
         AUTH_DEVICE_CODE_PENDING => Ok(interval),
         AUTH_DEVICE_CODE_SLOW_DOWN => Ok(interval + 5),
         AUTH_DEVICE_CODE_EXPIRED => bail!("Login timed out - run `nyxid login --device` again."),
-        AUTH_DEVICE_CODE_DENIED => bail!("Login denied."),
+        AUTH_DEVICE_CODE_DENIED => bail!("Login was denied."),
         AUTH_DEVICE_CODE_ALREADY_DELIVERED => {
             bail!("This code was already used. Run `nyxid login --device` again.")
         }
@@ -1447,7 +1447,7 @@ mod tests {
             "unexpected: {expired}"
         );
         let denied = handle_device_poll_error(AUTH_DEVICE_CODE_DENIED, "denied", 5).unwrap_err();
-        assert_eq!(denied.to_string(), "Login denied.");
+        assert_eq!(denied.to_string(), "Login was denied.");
         let used =
             handle_device_poll_error(AUTH_DEVICE_CODE_ALREADY_DELIVERED, "used", 5).unwrap_err();
         assert!(

--- a/docs/AI_AGENT_PLAYBOOK.md
+++ b/docs/AI_AGENT_PLAYBOOK.md
@@ -115,7 +115,8 @@ nyxid login --base-url http://localhost:3001
 
 # Headless / SSH / no $DISPLAY: bare `nyxid login` auto-falls-back to
 # device-code, or force it explicitly. The CLI prints a one-time code +
-# verification URL; you approve in any signed-in browser (phone, laptop).
+# verification URL; you review the requester IP/time and approve or reject
+# in any signed-in browser (phone, laptop). Rejection stops the CLI poll.
 nyxid login --base-url http://localhost:3001 --device
 
 # Sanity check the session.
@@ -1129,7 +1130,7 @@ Users add services and manage credentials from the AI Services page: http://loca
 
 > Three distinct "device-code" features exist in NyxID — pick the right one:
 > 1. **Provider device-code OAuth** (section 10) — connect a user's downstream OAuth provider credential.
-> 2. **Auth device-code login** (`nyxid login --device`, endpoints under `/api/v1/auth/device/*`) — RFC 8628 flow that lets the CLI authenticate a user on a headless box (WSL / SSH / no `$DISPLAY`).
+> 2. **Auth device-code login** (`nyxid login --device`, endpoints under `/api/v1/auth/device/*`) -- RFC 8628 flow that lets the CLI authenticate a user on a headless box after an explicit browser or mobile approve/reject decision.
 > 3. **Device-code grant** (this section, endpoints under `/api/v1/devices/code/*`) — provision a headless IoT device with its own scoped NyxID API key, node id, and one-time refresh token.
 
 This is not the provider device-code OAuth flow above. Provider device-code connects a user's downstream OAuth provider credential. Device-code grant gives the device its own NyxID API key, node id, and one-time refresh token.

--- a/docs/API.md
+++ b/docs/API.md
@@ -522,7 +522,62 @@ Poll no faster than the `interval` returned by `/request`. A `11202` response me
 | `11206` | `auth_device_rate_limited` | 429 | Endpoint rate limit was exceeded |
 | `11207` | `auth_device_user_code_invalid` | 400 | The first-party review UI supplied an invalid user code |
 
-`POST /api/v1/auth/device/preview` and `POST /api/v1/auth/device/approve` support the first-party browser review surface. Integrators should direct users to `verification_uri`; they should not call those UI endpoints. Approval requires a human session and rejects API-key, service-account, delegated, and relay credentials.
+#### POST /api/v1/auth/device/preview
+
+Fetch the non-mutating anti-phishing context shown by first-party review surfaces.
+
+**Auth:** None
+
+```json
+{
+  "user_code": "7KM2-RQ9D"
+}
+```
+
+**Response (200):**
+
+```json
+{
+  "client_label": "Desktop workstation",
+  "client_user_agent": "desktop-app/1.4",
+  "client_ip": "203.0.113.24",
+  "initiated_at": "2026-08-20T08:15:00Z",
+  "expires_at": "2026-08-20T08:25:00Z",
+  "status": "pending"
+}
+```
+
+`client_label` and `client_user_agent` are requester-supplied free text. `client_ip` is the server-resolved request address observed at `/request`; legacy rows return `null`. All auth-device rows expire after 10 minutes.
+
+#### POST /api/v1/auth/device/approve
+
+Atomically approve a pending request and prepare a first-party token pair for one poller.
+
+**Auth:** Human JWT session only
+
+```json
+{
+  "user_code": "7KM2-RQ9D"
+}
+```
+
+**Response (200):** `{ "ok": true }`
+
+#### POST /api/v1/auth/device/deny
+
+Atomically reject a pending request. No tokens are minted, and the requester's next poll returns `11204` immediately.
+
+**Auth:** Human JWT session only
+
+```json
+{
+  "user_code": "7KM2-RQ9D"
+}
+```
+
+**Response (200):** `{ "ok": true }`
+
+Approve and deny use the same pending-status guard, so exactly one wins a concurrent decision. API-key, service-account, delegated, and relay credentials are rejected before either decision handler runs. Integrators should direct users to `verification_uri`; these are first-party review endpoints.
 
 ---
 

--- a/docs/SSH_TUNNELING.md
+++ b/docs/SSH_TUNNELING.md
@@ -59,7 +59,7 @@ For headless interactive environments (SSH, Docker shell, WSL with no `$DISPLAY`
 nyxid login --base-url https://auth.example.com --device
 ```
 
-The CLI prints a one-time code and a URL — open the URL on any signed-in browser (phone, another machine), type the code, approve, and the CLI completes. For unattended CI/CD use an API key (Option B below) instead — `nyxid login` short-circuits in CI environments with a hint to do exactly that. `--password` is still available for legacy scripted setups where neither device-code nor an API key fits.
+The CLI prints a one-time code and a URL -- open the URL on any signed-in browser (phone, another machine), type the code, review the requester IP and time, then approve or reject. Approval completes the CLI login; rejection stops its poll immediately. For unattended CI/CD use an API key (Option B below) instead -- `nyxid login` short-circuits in CI environments with a hint to do exactly that. `--password` is still available for legacy scripted setups where neither device-code nor an API key fits.
 
 ### Option B: API Key
 

--- a/docs/site/ai/getting-started/connect-your-agent.md
+++ b/docs/site/ai/getting-started/connect-your-agent.md
@@ -57,7 +57,7 @@ For headless environments (SSH, container, WSL with no `$DISPLAY`), `nyxid login
 nyxid login --device --base-url https://nyx-api.chrono-ai.fun
 ```
 
-The CLI prints a one-time code and a URL; open the URL on any signed-in browser (phone, another machine), paste the code, approve, and the CLI completes.
+The CLI prints a one-time code and a URL; open the URL on any signed-in browser (phone, another machine), paste the code, review the requester IP and time, then approve or reject. Approval completes the CLI login; rejection stops it immediately.
 
 For non-interactive CI use a pre-issued API key (`nyxid api-key create --platform <agent>`) instead of an interactive login — `nyxid login` short-circuits in CI environments with a hint to do exactly that.
 

--- a/docs/site/cli/getting-started/authenticate.md
+++ b/docs/site/cli/getting-started/authenticate.md
@@ -18,7 +18,7 @@ nyxid login --base-url <BASE_URL>
 
 ### Headless / SSH / no browser
 
-If `nyxid login` can't open a browser (SSH session, container, WSL without `$DISPLAY`), it auto-falls back to the **device-code flow**: the CLI prints a one-time code + a URL, you open the URL on any signed-in browser (phone, laptop), type the code, approve, and the CLI completes. You can also force the flow explicitly:
+If `nyxid login` can't open a browser (SSH session, container, WSL without `$DISPLAY`), it auto-falls back to the **device-code flow**: the CLI prints a one-time code + a URL, you open the URL on any signed-in browser (phone, laptop), type the code, review the requester IP and time, then approve or reject. Approval completes the CLI login; rejection stops it immediately. You can also force the flow explicitly:
 
 ```bash
 nyxid login --device --base-url <BASE_URL>

--- a/frontend/src/hooks/use-auth-device.test.tsx
+++ b/frontend/src/hooks/use-auth-device.test.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useApproveAuthDevice,
+  useDenyAuthDevice,
   usePreviewAuthDevice,
 } from "./use-auth-device";
 
@@ -38,6 +39,7 @@ describe("usePreviewAuthDevice", () => {
     mockPost.mockResolvedValue({
       client_label: "kitchen-rpi",
       client_user_agent: "nyxid-cli/0.7.1",
+      client_ip: "203.0.113.10",
       initiated_at: "2026-06-18T10:00:00Z",
       expires_at: "2026-06-18T10:10:00Z",
       status: "pending",
@@ -57,6 +59,7 @@ describe("usePreviewAuthDevice", () => {
     mockPost.mockResolvedValue({
       client_label: "ok",
       client_user_agent: "ok",
+      client_ip: "203.0.113.10",
       initiated_at: "not-a-datetime",
       expires_at: "2026-06-18T10:10:00Z",
       status: "pending",
@@ -70,6 +73,7 @@ describe("usePreviewAuthDevice", () => {
     mockPost.mockResolvedValue({
       client_label: null,
       client_user_agent: null,
+      client_ip: null,
       initiated_at: "2026-06-18T10:00:00Z",
       expires_at: "2026-06-18T10:10:00Z",
       status: "weird-state",
@@ -84,6 +88,7 @@ describe("usePreviewAuthDevice", () => {
       .mockResolvedValueOnce({
         client_label: "device-1",
         client_user_agent: null,
+        client_ip: "203.0.113.11",
         initiated_at: "2026-06-18T10:00:00Z",
         expires_at: "2026-06-18T10:10:00Z",
         status: "pending",
@@ -91,6 +96,7 @@ describe("usePreviewAuthDevice", () => {
       .mockResolvedValueOnce({
         client_label: "device-2",
         client_user_agent: null,
+        client_ip: "203.0.113.12",
         initiated_at: "2026-06-18T10:05:00Z",
         expires_at: "2026-06-18T10:15:00Z",
         status: "pending",
@@ -139,5 +145,24 @@ describe("useApproveAuthDevice", () => {
     const { result } = renderHook(() => useApproveAuthDevice(), { wrapper });
 
     await expect(result.current.mutateAsync("ABCDEFGH")).rejects.toThrow();
+  });
+});
+
+describe("useDenyAuthDevice", () => {
+  it("is idle on mount and only fires when mutateAsync is called", () => {
+    const { result } = renderHook(() => useDenyAuthDevice(), { wrapper });
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("normalizes the user_code before posting to the deny endpoint", async () => {
+    mockPost.mockResolvedValue({ ok: true });
+    const { result } = renderHook(() => useDenyAuthDevice(), { wrapper });
+
+    await result.current.mutateAsync("abcd-efgh");
+
+    expect(mockPost).toHaveBeenCalledWith("/auth/device/deny", {
+      user_code: "ABCDEFGH",
+    });
   });
 });

--- a/frontend/src/hooks/use-auth-device.ts
+++ b/frontend/src/hooks/use-auth-device.ts
@@ -3,6 +3,7 @@ import { api } from "@/lib/api-client";
 import {
   approveBodySchema,
   approveResponseSchema,
+  denyBodySchema,
   previewResponseSchema,
   type ApproveAuthDeviceResponse,
   type PreviewAuthDeviceResponse,
@@ -30,6 +31,21 @@ export function useApproveAuthDevice() {
       const body = approveBodySchema.parse({ user_code: userCode });
       const response = await api.post<ApproveAuthDeviceResponse>(
         "/auth/device/approve",
+        body,
+      );
+      return approveResponseSchema.parse(response);
+    },
+  });
+}
+
+export function useDenyAuthDevice() {
+  return useMutation({
+    mutationFn: async (
+      userCode: string,
+    ): Promise<ApproveAuthDeviceResponse> => {
+      const body = denyBodySchema.parse({ user_code: userCode });
+      const response = await api.post<ApproveAuthDeviceResponse>(
+        "/auth/device/deny",
         body,
       );
       return approveResponseSchema.parse(response);

--- a/frontend/src/pages/login-device.test.tsx
+++ b/frontend/src/pages/login-device.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PreviewAuthDeviceResponse } from "@/schemas/auth-device";
+import { LoginDevicePage } from "./login-device";
+
+const { navigate, previewState } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  previewState: {
+    data: undefined as PreviewAuthDeviceResponse | undefined,
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { readonly children: React.ReactNode }) => (
+    <a href="/">{children}</a>
+  ),
+  useNavigate: () => navigate,
+}));
+
+vi.mock("@/stores/auth-store", () => ({
+  useAuthStore: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/use-auth-device", () => ({
+  usePreviewAuthDevice: () => ({
+    data: previewState.data,
+    error: null,
+    isError: false,
+    isPending: false,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+  }),
+  useApproveAuthDevice: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+  }),
+  useDenyAuthDevice: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  previewState.data = undefined;
+});
+
+describe("LoginDevicePage", () => {
+  it("offers decisions for a pending preview", () => {
+    previewState.data = {
+      client_label: "workstation",
+      client_user_agent: "nyxid-cli",
+      client_ip: null,
+      initiated_at: "2026-08-20T10:00:00Z",
+      expires_at: "2026-08-20T10:10:00Z",
+      status: "pending",
+    };
+
+    render(<LoginDevicePage />);
+
+    expect(
+      screen.getByRole("button", { name: "Approve" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reject" }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["denied", "This login request was already denied."],
+    ["expired", "This code has expired."],
+    ["approved", "This code was already used."],
+    ["delivered", "This code was already used."],
+  ] as const)(
+    "does not offer decisions for a %s preview",
+    (status, expectedMessage) => {
+      previewState.data = {
+        client_label: "workstation",
+        client_user_agent: "nyxid-cli",
+        client_ip: null,
+        initiated_at: "2026-08-20T10:00:00Z",
+        expires_at: "2026-08-20T10:10:00Z",
+        status,
+      };
+
+      render(<LoginDevicePage />);
+
+      expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Approve" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Reject" }),
+      ).not.toBeInTheDocument();
+    },
+  );
+});

--- a/frontend/src/pages/login-device.tsx
+++ b/frontend/src/pages/login-device.tsx
@@ -1,19 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { AlertTriangle, CheckCircle2, ShieldCheck } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleX,
+  ShieldCheck,
+  ShieldX,
+} from "lucide-react";
 import { NyxidIcon } from "@/components/brand/nyxid-icon";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import { Button, ButtonIcon } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   useApproveAuthDevice,
+  useDenyAuthDevice,
   usePreviewAuthDevice,
 } from "@/hooks/use-auth-device";
 import {
@@ -30,7 +32,7 @@ export function LoginDevicePage() {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading } = useAuthStore();
   const [userCode, setUserCode] = useState("");
-  const [approved, setApproved] = useState(false);
+  const [decision, setDecision] = useState<"approved" | "denied" | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const lastClickAtRef = useRef(0);
   const normalizedCode = useMemo(() => {
@@ -39,8 +41,10 @@ export function LoginDevicePage() {
   }, [userCode]);
   const preview = usePreviewAuthDevice();
   const approve = useApproveAuthDevice();
-  const step: "enter-code" | "review" | "approved" = approved
-    ? "approved"
+  const deny = useDenyAuthDevice();
+  const isDecisionPending = approve.isPending || deny.isPending;
+  const step: "enter-code" | "review" | "terminal" = decision
+    ? "terminal"
     : preview.data
       ? "review"
       : "enter-code";
@@ -60,6 +64,7 @@ export function LoginDevicePage() {
   function resetToEnterCode() {
     preview.reset();
     approve.reset();
+    deny.reset();
     setSubmitError(null);
   }
 
@@ -74,11 +79,22 @@ export function LoginDevicePage() {
   }
 
   async function handleApprove() {
-    if (!normalizedCode || approve.isPending || withinCooldown()) return;
+    if (!normalizedCode || isDecisionPending || withinCooldown()) return;
     setSubmitError(null);
     try {
       await approve.mutateAsync(normalizedCode);
-      setApproved(true);
+      setDecision("approved");
+    } catch (error) {
+      setSubmitError(friendlyAuthDeviceErrorMessage(error));
+    }
+  }
+
+  async function handleReject() {
+    if (!normalizedCode || isDecisionPending || withinCooldown()) return;
+    setSubmitError(null);
+    try {
+      await deny.mutateAsync(normalizedCode);
+      setDecision("denied");
     } catch (error) {
       setSubmitError(friendlyAuthDeviceErrorMessage(error));
     }
@@ -116,8 +132,8 @@ export function LoginDevicePage() {
         </div>
       </header>
 
-      {approved ? (
-        <SuccessPanel />
+      {decision ? (
+        <TerminalPanel decision={decision} />
       ) : (
         <Card className="border-border/50">
           <CardHeader>
@@ -140,11 +156,11 @@ export function LoginDevicePage() {
                 placeholder="ABCD-EFGH"
                 value={userCode}
                 disabled={
-                  step === "review" || preview.isPending || approve.isPending
+                  step === "review" || preview.isPending || isDecisionPending
                 }
                 onChange={(event) => {
                   setSubmitError(null);
-                  setApproved(false);
+                  setDecision(null);
                   resetToEnterCode();
                   setUserCode(
                     formatAuthDeviceUserCodeInput(event.target.value),
@@ -169,6 +185,7 @@ export function LoginDevicePage() {
               <PreviewPanel
                 clientLabel={preview.data.client_label}
                 clientUserAgent={preview.data.client_user_agent}
+                clientIp={preview.data.client_ip}
                 initiatedAt={preview.data.initiated_at}
                 expiresAt={preview.data.expires_at}
                 status={preview.data.status}
@@ -179,6 +196,7 @@ export function LoginDevicePage() {
               <Button
                 type="button"
                 variant="outline"
+                disabled={preview.isPending || isDecisionPending}
                 onClick={() => void navigate({ to: "/dashboard" })}
               >
                 Cancel
@@ -196,20 +214,34 @@ export function LoginDevicePage() {
                   </ButtonIcon>
                   Continue
                 </Button>
-              ) : (
-                <Button
-                  type="button"
-                  variant="primary"
-                  disabled={approve.isPending}
-                  isLoading={approve.isPending}
-                  onClick={() => void handleApprove()}
-                >
-                  <ButtonIcon variant="primary">
-                    <ShieldCheck />
-                  </ButtonIcon>
-                  Approve
-                </Button>
-              )}
+              ) : step === "review" ? (
+                <>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={isDecisionPending}
+                    isLoading={deny.isPending}
+                    onClick={() => void handleReject()}
+                  >
+                    <ButtonIcon variant="destructive">
+                      <ShieldX />
+                    </ButtonIcon>
+                    Reject
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    disabled={isDecisionPending}
+                    isLoading={approve.isPending}
+                    onClick={() => void handleApprove()}
+                  >
+                    <ButtonIcon variant="primary">
+                      <ShieldCheck />
+                    </ButtonIcon>
+                    Approve
+                  </Button>
+                </>
+              ) : null}
             </div>
           </CardContent>
         </Card>
@@ -218,7 +250,11 @@ export function LoginDevicePage() {
   );
 }
 
-function LoginDeviceShell({ children }: { readonly children: React.ReactNode }) {
+function LoginDeviceShell({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
   return (
     <main className="flex min-h-dvh items-start justify-center bg-background px-4 py-8 text-foreground sm:items-center sm:py-10">
       <div className="flex w-full max-w-xl flex-col gap-5">{children}</div>
@@ -233,8 +269,8 @@ function WarningBanner() {
         <AlertTriangle className="h-4 w-4 text-warning" />
       </div>
       <p className="text-[12px] leading-relaxed text-warning">
-        Only enter a code you generated yourself. If someone sent you this
-        code, cancel and start a fresh login from your own terminal.
+        Only enter a code you generated yourself. If someone sent you this code,
+        cancel and start a fresh login from your own terminal.
       </p>
     </div>
   );
@@ -243,12 +279,14 @@ function WarningBanner() {
 function PreviewPanel({
   clientLabel,
   clientUserAgent,
+  clientIp,
   initiatedAt,
   expiresAt,
   status,
 }: {
   readonly clientLabel: string | null;
   readonly clientUserAgent: string | null;
+  readonly clientIp: string | null;
   readonly initiatedAt: string | null;
   readonly expiresAt: string | null;
   readonly status: string;
@@ -266,15 +304,22 @@ function PreviewPanel({
         </div>
       </div>
       <div className="divide-y divide-border/30">
+        <div className="px-4 py-3 text-[12px] leading-relaxed text-warning">
+          Requested from{" "}
+          <span className="font-mono text-foreground">
+            {clientIp ?? "an unknown IP"}
+          </span>{" "}
+          at{" "}
+          <span className="font-medium text-foreground">
+            {initiatedAt ? formatRequestedAt(initiatedAt) : "an unknown time"}
+          </span>
+          . Reject this request if you do not recognize it.
+        </div>
         <PreviewRow label="Client" value={clientLabel ?? "Unknown device"} />
         <PreviewRow
           label="User agent"
           value={clientUserAgent ?? "Not provided"}
           mono
-        />
-        <PreviewRow
-          label="Started"
-          value={initiatedAt ? formatStartedAt(initiatedAt) : "Unknown"}
         />
         <PreviewRow
           label="Expires"
@@ -310,46 +355,67 @@ function PreviewRow({
   );
 }
 
-function SuccessPanel() {
+function TerminalPanel({
+  decision,
+}: {
+  readonly decision: "approved" | "denied";
+}) {
+  const approved = decision === "approved";
   return (
-    <Card className="border-success/25 bg-success/[0.03]">
+    <Card
+      className={
+        approved
+          ? "border-success/25 bg-success/[0.03]"
+          : "border-destructive/25 bg-destructive/[0.03]"
+      }
+    >
       <CardContent className="flex flex-col items-center gap-4 p-5 text-center">
-        <div className="flex h-11 w-11 items-center justify-center rounded-xl border border-success/30 bg-success/10">
-          <CheckCircle2 className="h-5 w-5 text-success" />
+        <div
+          className={
+            approved
+              ? "flex h-11 w-11 items-center justify-center rounded-xl border border-success/30 bg-success/10"
+              : "flex h-11 w-11 items-center justify-center rounded-xl border border-destructive/30 bg-destructive/10"
+          }
+        >
+          {approved ? (
+            <CheckCircle2 className="h-5 w-5 text-success" />
+          ) : (
+            <CircleX className="h-5 w-5 text-destructive" />
+          )}
         </div>
         <div className="space-y-1">
           <h2 className="text-[15px] font-semibold text-foreground">
-            Signed in
+            {approved ? "Signed in" : "Request denied"}
           </h2>
           <p className="text-[12px] text-muted-foreground">
-            Return to your terminal. The CLI should finish automatically.
+            {approved
+              ? "Return to your terminal. The CLI should finish automatically."
+              : "The requesting device cannot complete this login."}
           </p>
         </div>
-        <Button asChild variant="outline">
-          <Link to="/settings" search={{ tab: "sessions" }}>
-            Manage sessions
-          </Link>
-        </Button>
+        {approved ? (
+          <Button asChild variant="outline">
+            <Link to="/settings" search={{ tab: "sessions" }}>
+              Manage sessions
+            </Link>
+          </Button>
+        ) : (
+          <Button asChild variant="outline">
+            <Link to="/dashboard">Back to dashboard</Link>
+          </Button>
+        )}
       </CardContent>
     </Card>
   );
 }
 
-function formatRelativeAge(value: string): string {
+function formatRequestedAt(value: string): string {
   const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) return "just now";
-  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds} seconds`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours} hour${hours === 1 ? "" : "s"}`;
-}
-
-function formatStartedAt(value: string): string {
-  const relativeAge = formatRelativeAge(value);
-  return relativeAge === "just now" ? relativeAge : `${relativeAge} ago`;
+  if (!Number.isFinite(timestamp)) return "an unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
 }
 
 function formatAbsoluteTime(value: string): string {

--- a/frontend/src/pages/login-device.tsx
+++ b/frontend/src/pages/login-device.tsx
@@ -21,6 +21,7 @@ import {
 import {
   formatAuthDeviceUserCodeInput,
   friendlyAuthDeviceErrorMessage,
+  friendlyAuthDeviceStatusMessage,
   userCodeSchema,
 } from "@/schemas/auth-device";
 import { useAuthStore } from "@/stores/auth-store";
@@ -43,6 +44,9 @@ export function LoginDevicePage() {
   const approve = useApproveAuthDevice();
   const deny = useDenyAuthDevice();
   const isDecisionPending = approve.isPending || deny.isPending;
+  const previewStatusMessage = preview.data
+    ? friendlyAuthDeviceStatusMessage(preview.data.status)
+    : null;
   const step: "enter-code" | "review" | "terminal" = decision
     ? "terminal"
     : preview.data
@@ -191,6 +195,9 @@ export function LoginDevicePage() {
                 status={preview.data.status}
               />
             ) : null}
+            {previewStatusMessage ? (
+              <ErrorBanner message={previewStatusMessage} />
+            ) : null}
 
             <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
               <Button
@@ -214,7 +221,7 @@ export function LoginDevicePage() {
                   </ButtonIcon>
                   Continue
                 </Button>
-              ) : step === "review" ? (
+              ) : step === "review" && preview.data?.status === "pending" ? (
                 <>
                   <Button
                     type="button"

--- a/frontend/src/schemas/auth-device.test.ts
+++ b/frontend/src/schemas/auth-device.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   approveBodySchema,
+  denyBodySchema,
   errorEnvelopeSchema,
   formatAuthDeviceUserCodeInput,
   friendlyAuthDeviceErrorMessage,
@@ -34,6 +35,14 @@ describe("approveBodySchema", () => {
   });
 });
 
+describe("denyBodySchema", () => {
+  it("normalizes the request payload", () => {
+    expect(denyBodySchema.parse({ user_code: "abcd-efgh" })).toEqual({
+      user_code: "ABCDEFGH",
+    });
+  });
+});
+
 describe("formatAuthDeviceUserCodeInput", () => {
   it("keeps an editable XXXX-XXXX shape while typing", () => {
     expect(formatAuthDeviceUserCodeInput("ab")).toBe("AB");
@@ -60,6 +69,12 @@ describe("errorEnvelopeSchema", () => {
 
 describe("friendlyAuthDeviceErrorMessage", () => {
   it("maps auth-device error codes to friendly messages", () => {
+    expect(
+      friendlyAuthDeviceErrorMessage({
+        errorCode: 11204,
+      }),
+    ).toBe("This login request was already denied.");
+
     expect(
       friendlyAuthDeviceErrorMessage({
         errorCode: 11200,

--- a/frontend/src/schemas/auth-device.test.ts
+++ b/frontend/src/schemas/auth-device.test.ts
@@ -5,6 +5,7 @@ import {
   errorEnvelopeSchema,
   formatAuthDeviceUserCodeInput,
   friendlyAuthDeviceErrorMessage,
+  friendlyAuthDeviceStatusMessage,
   previewResponseSchema,
   userCodeSchema,
 } from "./auth-device";
@@ -128,5 +129,20 @@ describe("friendlyAuthDeviceErrorMessage", () => {
         errorCode: 11207,
       }),
     ).toBe("That code is no longer valid. Run `nyxid login --device` again.");
+  });
+});
+
+describe("friendlyAuthDeviceStatusMessage", () => {
+  it.each([
+    ["denied", "This login request was already denied."],
+    ["expired", "This code has expired."],
+    ["approved", "This code was already used."],
+    ["delivered", "This code was already used."],
+  ] as const)("maps %s previews to terminal copy", (status, message) => {
+    expect(friendlyAuthDeviceStatusMessage(status)).toBe(message);
+  });
+
+  it("returns no message for a pending preview", () => {
+    expect(friendlyAuthDeviceStatusMessage("pending")).toBeNull();
   });
 });

--- a/frontend/src/schemas/auth-device.test.ts
+++ b/frontend/src/schemas/auth-device.test.ts
@@ -5,6 +5,7 @@ import {
   errorEnvelopeSchema,
   formatAuthDeviceUserCodeInput,
   friendlyAuthDeviceErrorMessage,
+  previewResponseSchema,
   userCodeSchema,
 } from "./auth-device";
 
@@ -40,6 +41,20 @@ describe("denyBodySchema", () => {
     expect(denyBodySchema.parse({ user_code: "abcd-efgh" })).toEqual({
       user_code: "ABCDEFGH",
     });
+  });
+});
+
+describe("previewResponseSchema", () => {
+  it("normalizes a missing client_ip from an older backend to null", () => {
+    expect(
+      previewResponseSchema.parse({
+        client_label: "workstation",
+        client_user_agent: "nyxid-cli",
+        initiated_at: "2026-08-20T10:00:00Z",
+        expires_at: "2026-08-20T10:10:00Z",
+        status: "pending",
+      }).client_ip,
+    ).toBeNull();
   });
 });
 

--- a/frontend/src/schemas/auth-device.ts
+++ b/frontend/src/schemas/auth-device.ts
@@ -29,7 +29,11 @@ export const approveResponseSchema = z.object({
 export const previewResponseSchema = z.object({
   client_label: z.string().nullable(),
   client_user_agent: z.string().nullable(),
-  client_ip: z.string().nullable(),
+  client_ip: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null),
   initiated_at: z.string().datetime(),
   expires_at: z.string().datetime(),
   status: z.enum(["pending", "approved", "denied", "expired", "delivered"]),

--- a/frontend/src/schemas/auth-device.ts
+++ b/frontend/src/schemas/auth-device.ts
@@ -91,3 +91,19 @@ export function friendlyAuthDeviceErrorMessage(error: unknown): string {
     ? maybeApiError.message
     : "Device login failed.";
 }
+
+export function friendlyAuthDeviceStatusMessage(
+  status: PreviewAuthDeviceResponse["status"],
+): string | null {
+  switch (status) {
+    case "pending":
+      return null;
+    case "denied":
+      return AUTH_DEVICE_ERROR_MESSAGES[11204] ?? null;
+    case "expired":
+      return AUTH_DEVICE_ERROR_MESSAGES[11201] ?? null;
+    case "approved":
+    case "delivered":
+      return AUTH_DEVICE_ERROR_MESSAGES[11205] ?? null;
+  }
+}

--- a/frontend/src/schemas/auth-device.ts
+++ b/frontend/src/schemas/auth-device.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const AUTH_DEVICE_ERROR_MESSAGES: Record<number, string> = {
   11200: "That code is no longer valid. Run `nyxid login --device` again.",
   11201: "This code has expired.",
+  11204: "This login request was already denied.",
   11205: "This code was already used.",
   11206: "Too many attempts. Try again in a few minutes.",
   11207: "That code is no longer valid. Run `nyxid login --device` again.",
@@ -17,6 +18,10 @@ export const approveBodySchema = z.object({
   user_code: userCodeSchema,
 });
 
+export const denyBodySchema = z.object({
+  user_code: userCodeSchema,
+});
+
 export const approveResponseSchema = z.object({
   ok: z.literal(true),
 });
@@ -24,6 +29,7 @@ export const approveResponseSchema = z.object({
 export const previewResponseSchema = z.object({
   client_label: z.string().nullable(),
   client_user_agent: z.string().nullable(),
+  client_ip: z.string().nullable(),
   initiated_at: z.string().datetime(),
   expires_at: z.string().datetime(),
   status: z.enum(["pending", "approved", "denied", "expired", "delivered"]),
@@ -37,6 +43,7 @@ export const errorEnvelopeSchema = z.object({
 
 export type ApproveAuthDeviceBody = z.output<typeof approveBodySchema>;
 export type ApproveAuthDeviceResponse = z.infer<typeof approveResponseSchema>;
+export type DenyAuthDeviceBody = z.output<typeof denyBodySchema>;
 export type PreviewAuthDeviceResponse = z.infer<typeof previewResponseSchema>;
 export type AuthDeviceErrorEnvelope = z.infer<typeof errorEnvelopeSchema>;
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -293,6 +293,9 @@ All under `/api/v1` on the configured `*_API_BASE_URL`:
 | --- | --- |
 | `POST /auth/login` | Email + password login |
 | `POST /auth/mfa/verify` | MFA second-factor verification |
+| `POST /auth/device/preview` | Preview a login request's requester context |
+| `POST /auth/device/approve` | Approve a device login with the human session |
+| `POST /auth/device/deny` | Reject a device login with the human session |
 | `GET /approvals/requests?status=pending` | Pending challenges list |
 | `GET /approvals/requests/{id}` | Challenge detail |
 | `POST /approvals/requests/{id}/decide` | Approve / deny a challenge |
@@ -304,6 +307,8 @@ All under `/api/v1` on the configured `*_API_BASE_URL`:
 ## Deep links & push
 
 - Custom URL scheme: `{APP_SCHEME}://challenge/{challenge_id}` → opens the challenge detail screen
+- Device login scheme: `nyxid://login/device?user_code=...` -> prefills the confirmation screen without previewing or approving
+- The QR scanner accepts HTTPS or `nyxid://` login URLs but extracts only `user_code`; API calls always use `*_API_BASE_URL`
 - Supported push payload fields: `deeplink`, `url`, `challenge_id`, `challengeId`
 - Universal Links: when `*_UNIVERSAL_LINK_HOST` is set, that host is added to iOS `associatedDomains` and Android's intent filter. The host of `*_API_BASE_URL` is also auto-added to iOS `associatedDomains` so backend-issued links open in the app.
 

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -62,12 +62,16 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       bundleIdentifier: r.iosBundleId,
       buildNumber: r.iosBuildNumber,
       associatedDomains,
-      infoPlist: { ITSAppUsesNonExemptEncryption: false },
+      infoPlist: {
+        ITSAppUsesNonExemptEncryption: false,
+        NSCameraUsageDescription: "Allow NyxID to scan login approval QR codes.",
+      },
     },
     android: {
       package: r.androidPackage,
       versionCode: Number(r.androidVersionCode),
       googleServicesFile: "./google-services.json",
+      permissions: ["android.permission.CAMERA"],
       blockedPermissions: [
         "android.permission.READ_EXTERNAL_STORAGE",
         "android.permission.WRITE_EXTERNAL_STORAGE",
@@ -101,6 +105,13 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       ],
       "expo-font",
       "expo-web-browser",
+      [
+        "expo-camera",
+        {
+          cameraPermission: "Allow NyxID to scan login approval QR codes.",
+          recordAudioAndroid: false,
+        },
+      ],
     ],
     extra: {
       APP_ENV: appEnv,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -54,6 +54,7 @@
     "@tanstack/react-query": "^5.96.2",
     "expo": "~55.0.12",
     "expo-blur": "~55.0.13",
+    "expo-camera": "~55.0.22",
     "expo-clipboard": "~55.0.12",
     "expo-dev-client": "~55.0.23",
     "expo-font": "~55.0.6",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,6 +8,7 @@
     "android": "APP_ENV=dev expo run:android",
     "ios": "APP_ENV=dev expo run:ios",
     "web": "APP_ENV=dev expo start --web",
+    "test": "tsx --test src/lib/api/authDeviceSchema.test.ts",
     "typecheck": "tsc --noEmit",
     "build:ios": "APP_ENV=prod node scripts/build-ios.js",
     "build:ios:dev": "APP_ENV=dev node scripts/build-ios.js",
@@ -83,6 +84,7 @@
     "@types/react": "~19.2.14",
     "dotenv": "^16.4.5",
     "googleapis": "^144.0.0",
+    "tsx": "^4.23.12",
     "typescript": "~5.9.3"
   }
 }

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       expo-blur:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-camera:
+        specifier: ~55.0.22
+        version: 55.0.22(@types/emscripten@1.41.5)(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-clipboard:
         specifier: ~55.0.12
         version: 55.0.12(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1076,6 +1079,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -1261,6 +1267,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  barcode-detector@3.2.2:
+    resolution: {integrity: sha512-/4QOrrNrCRmDSBWiiP4aC72dnkuXUEdcFRidHgbPRXUpy82XcCMvJssI6fEs6JT42LS7DvBVZO70qasJbYKyrA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1634,6 +1643,17 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-camera@55.0.22:
+    resolution: {integrity: sha512-VJ4MeNxkZ9H//2C9UqB4zJo40p3N3FUgPFSQvW7Y2NJsgtPhT2fawC8cNxT9hfvqc1Ryh0MGD3RQgRFmgFc92g==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+      react-native-web: '*'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
 
   expo-clipboard@55.0.12:
     resolution: {integrity: sha512-DaLjhidJvpkAovzrMUv9LN9OZhiBpwqBOTFeTStRSLiMSwX4QWS0wjqRE2A0v8YnIgjSPrZxLXHLmRJ6TEceow==}
@@ -2149,24 +2169,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2979,6 +3003,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
@@ -3027,6 +3055,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3208,6 +3240,11 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zxing-wasm@3.1.3:
+    resolution: {integrity: sha512-3lC9BJk4fR5ZJxcGjb0hVnDFOW7KpLXHIebiBmVd4FDRQZVeObztoTKxRUPxlWwSgxrMRONK0u50hBD1aTYEKg==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -4661,6 +4698,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/emscripten@1.41.5': {}
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 25.3.3
@@ -4892,6 +4931,12 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  barcode-detector@3.2.2(@types/emscripten@1.41.5):
+    dependencies:
+      zxing-wasm: 3.1.3(@types/emscripten@1.41.5)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   base64-js@1.5.1: {}
 
@@ -5235,6 +5280,15 @@ snapshots:
       expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+
+  expo-camera@55.0.22(@types/emscripten@1.41.5)(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      barcode-detector: 3.2.2(@types/emscripten@1.41.5)
+      expo: 55.0.12(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   expo-clipboard@55.0.12(expo@55.0.12)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -6869,6 +6923,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tagged-tag@1.0.0: {}
+
   terminal-link@2.1.1:
     dependencies:
       ansi-escapes: 4.3.2
@@ -6912,6 +6968,10 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -7039,3 +7099,8 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zxing-wasm@3.1.3(@types/emscripten@1.41.5):
+    dependencies:
+      '@types/emscripten': 1.41.5
+      type-fest: 5.8.0

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       googleapis:
         specifier: ^144.0.0
         version: 144.0.0
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -658,6 +661,162 @@ packages:
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@expo-google-fonts/jetbrains-mono@0.4.1':
     resolution: {integrity: sha512-CslACrtMOcRwoWXCO7OMEI+9w3fukWSoBtvNz46OqPoogEuuoY0tkDY1O8sFumk8t0pC6Cx0Xr95O0TOQhpkug==}
@@ -1592,6 +1751,11 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3044,6 +3208,11 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -3894,6 +4063,84 @@ snapshots:
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
 
   '@expo-google-fonts/jetbrains-mono@0.4.1': {}
 
@@ -5243,6 +5490,35 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -6962,6 +7238,12 @@ snapshots:
   toqr@0.1.1: {}
 
   tr46@0.0.3: {}
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-detect@4.0.8: {}
 

--- a/mobile/src/app/AppNavigator.tsx
+++ b/mobile/src/app/AppNavigator.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { StyleSheet, View } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { AuthHomeScreen } from "../features/auth/AuthHomeScreen";
+import { DeviceLoginScreen } from "../features/auth/DeviceLoginScreen";
 import { useAuthSession } from "../features/auth/AuthSessionContext";
 import { AccountSettingsScreen } from "../features/account/AccountSettingsScreen";
 import { ActivityScreen } from "../features/activity/ActivityScreen";
@@ -21,6 +22,7 @@ export type RootStackParamList = {
   AccountSettings: undefined;
   TermsOfService: undefined;
   PrivacyPolicy: undefined;
+  DeviceLogin: { user_code?: string } | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -47,7 +49,13 @@ export function AppNavigator({ currentRouteName, onMainTabPress, onNyxPress }: A
   const activeMainTab = resolveActiveMainTab(currentRouteName);
   const isLegalRoute = currentRouteName === "TermsOfService" || currentRouteName === "PrivacyPolicy";
   const isDetailRoute = currentRouteName === "ActivityDetail";
-  const showGlobalBottomNav = isAuthenticated && Boolean(onMainTabPress) && !isLegalRoute && !isDetailRoute;
+  const isDeviceLoginRoute = currentRouteName === "DeviceLogin";
+  const showGlobalBottomNav =
+    isAuthenticated &&
+    Boolean(onMainTabPress) &&
+    !isLegalRoute &&
+    !isDetailRoute &&
+    !isDeviceLoginRoute;
 
   if (isRestoring) {
     return <FullScreenLoading title="Restoring session..." subtitle="Validating local secure session" />;
@@ -97,6 +105,11 @@ export function AppNavigator({ currentRouteName, onMainTabPress, onNyxPress }: A
             name="PrivacyPolicy"
             component={PrivacyPolicyScreen}
             options={{ title: "Privacy Policy", animation: "slide_from_left" }}
+          />
+          <Stack.Screen
+            name="DeviceLogin"
+            component={DeviceLoginScreen}
+            options={{ title: "Approve Device Login", animation: "slide_from_right" }}
           />
         </Stack.Navigator>
       </View>

--- a/mobile/src/app/linking.ts
+++ b/mobile/src/app/linking.ts
@@ -289,6 +289,10 @@ export const appLinking: LinkingOptions<RootStackParamList> = {
         parse: { challengeId: String },
       },
       AccountSettings: "account",
+      DeviceLogin: {
+        path: "login/device",
+        parse: { user_code: String },
+      },
       TermsOfService: "terms",
       PrivacyPolicy: "privacy",
     },

--- a/mobile/src/features/activity/ActivityScreen.tsx
+++ b/mobile/src/features/activity/ActivityScreen.tsx
@@ -52,6 +52,7 @@ import type { RootStackParamList } from "../../app/AppNavigator";
 import type { ActivitySegment } from "./activityTypes";
 import type { ApprovalMode, ChallengeDetail, ApprovalItem } from "../../lib/api/types";
 import { usePushPollingActive } from "../../lib/notifications/pushPollingSignal";
+import { ScanQrCode } from "lucide-react-native";
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
 
@@ -616,10 +617,20 @@ export function ActivityScreen() {
   return (
     <ScreenContainer>
       <View style={styles.header}>
-        <Text style={styles.title}>Activity</Text>
-        <Text style={styles.subtitle}>
-          {pendingCount} pending · {activeCount} active grant{activeCount !== 1 ? "s" : ""}
-        </Text>
+        <View style={styles.headerCopy}>
+          <Text style={styles.title}>Activity</Text>
+          <Text style={styles.subtitle}>
+            {pendingCount} pending · {activeCount} active grant{activeCount !== 1 ? "s" : ""}
+          </Text>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Scan login QR code"
+          onPress={() => navigation.navigate("DeviceLogin")}
+          style={({ pressed }) => [styles.scanLoginButton, pressed && styles.scanLoginButtonPressed]}
+        >
+          <ScanQrCode size={21} color={colors.primary} />
+        </Pressable>
       </View>
 
       <View style={styles.segmentWrap}>
@@ -764,6 +775,13 @@ const createStyles = (c: ThemeColors) => StyleSheet.create({
     paddingHorizontal: spacing.xxl,
     paddingTop: spacing.sm,
     minHeight: 41,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: spacing.lg,
+  },
+  headerCopy: {
+    flex: 1,
     gap: spacing.xxs,
   },
   // DESIGN.md §PageHeader: mobile page title is text-[22px] font-bold leading-none
@@ -776,6 +794,19 @@ const createStyles = (c: ThemeColors) => StyleSheet.create({
     ...typeScale.label,
     color: c.textSecondary,
     marginBottom: spacing.md,
+  },
+  scanLoginButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: c.border,
+    backgroundColor: c.ghostBg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  scanLoginButtonPressed: {
+    opacity: 0.7,
   },
   segmentWrap: {
     paddingHorizontal: spacing.xxl,

--- a/mobile/src/features/auth/DeviceCodeScanner.tsx
+++ b/mobile/src/features/auth/DeviceCodeScanner.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import {
+  CameraView,
+  useCameraPermissions,
+  type BarcodeScanningResult,
+} from "expo-camera";
+import { Camera, X } from "lucide-react-native";
+
+import { PrimaryButton } from "../../components/PrimaryButton";
+import { useTheme } from "../../theme/ThemeContext";
+import type { ThemeColors } from "../../theme/mobileTheme";
+import { radius, spacing, typeScale, TOUCH_TARGET } from "../../theme/designTokens";
+import { extractAuthDeviceUserCodeFromQr } from "./deviceUserCode";
+
+type DeviceCodeScannerProps = {
+  onCancel: () => void;
+  onCode: (userCode: string) => void;
+};
+
+export function DeviceCodeScanner({ onCancel, onCode }: DeviceCodeScannerProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const [permission, requestPermission] = useCameraPermissions();
+  const [scanError, setScanError] = useState<string | null>(null);
+  const [permissionPending, setPermissionPending] = useState(false);
+  const scanHandled = useRef(false);
+
+  const handleBarcode = (result: BarcodeScanningResult) => {
+    if (scanHandled.current) return;
+    scanHandled.current = true;
+
+    const userCode = extractAuthDeviceUserCodeFromQr(result.data);
+    if (!userCode) {
+      setScanError("This QR code is not a valid NyxID login request.");
+      return;
+    }
+
+    onCode(userCode);
+  };
+
+  const retryScan = () => {
+    scanHandled.current = false;
+    setScanError(null);
+  };
+
+  const handlePermissionRequest = async () => {
+    setPermissionPending(true);
+    try {
+      await requestPermission();
+    } finally {
+      setPermissionPending(false);
+    }
+  };
+
+  if (!permission) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (!permission.granted) {
+    return (
+      <View style={styles.permissionScreen}>
+        <View style={styles.permissionIcon}>
+          <Camera size={28} color={colors.primary} />
+        </View>
+        <Text style={styles.permissionTitle}>Camera access needed</Text>
+        <Text style={styles.permissionBody}>
+          NyxID uses the camera only to read login approval QR codes.
+        </Text>
+        {permission.canAskAgain ? (
+          <PrimaryButton
+            label={permissionPending ? "Requesting access..." : "Allow camera"}
+            disabled={permissionPending}
+            onPress={() => void handlePermissionRequest()}
+          />
+        ) : (
+          <>
+            <Text style={styles.permissionError}>
+              Enable camera access for NyxID in system settings, then try again.
+            </Text>
+            <PrimaryButton label="Open settings" onPress={() => void Linking.openSettings()} />
+          </>
+        )}
+        <PrimaryButton label="Back" kind="ghost" disabled={permissionPending} onPress={onCancel} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.cameraScreen}>
+      <CameraView
+        style={StyleSheet.absoluteFill}
+        facing="back"
+        barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
+        onBarcodeScanned={scanHandled.current ? undefined : handleBarcode}
+      />
+      <View style={styles.cameraShade} pointerEvents="none" />
+      <View style={styles.cameraHeader}>
+        <Text style={styles.cameraTitle}>Scan login QR code</Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close scanner"
+          onPress={onCancel}
+          style={styles.closeButton}
+        >
+          <X size={22} color="#FFFFFF" />
+        </Pressable>
+      </View>
+      <View style={styles.scanArea} pointerEvents="none" />
+      <View style={styles.cameraFooter}>
+        {scanError ? (
+          <View style={styles.scanErrorPanel}>
+            <Text style={styles.scanErrorText}>{scanError}</Text>
+            <PrimaryButton label="Scan another code" kind="ghost" onPress={retryScan} />
+          </View>
+        ) : (
+          <Text style={styles.cameraHint}>Center the complete QR code inside the frame.</Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const createStyles = (c: ThemeColors) =>
+  StyleSheet.create({
+    centered: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: c.bg,
+    },
+    permissionScreen: {
+      flex: 1,
+      justifyContent: "center",
+      padding: spacing.huge,
+      gap: spacing.lg,
+      backgroundColor: c.bg,
+    },
+    permissionIcon: {
+      width: 56,
+      height: 56,
+      borderRadius: radius.lg,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: c.primaryTone.bg,
+      borderWidth: 1,
+      borderColor: c.primaryTone.border,
+    },
+    permissionTitle: { ...typeScale.h2, color: c.textPrimary },
+    permissionBody: { ...typeScale.description, color: c.textSecondary },
+    permissionError: { ...typeScale.body, color: c.danger },
+    cameraScreen: { flex: 1, backgroundColor: "#000000" },
+    cameraShade: { ...StyleSheet.absoluteFillObject, backgroundColor: "rgba(0,0,0,0.22)" },
+    cameraHeader: {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      paddingTop: 54,
+      paddingHorizontal: spacing.xxl,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    cameraTitle: { ...typeScale.h2, color: "#FFFFFF" },
+    closeButton: {
+      width: TOUCH_TARGET,
+      height: TOUCH_TARGET,
+      borderRadius: radius.full,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: "rgba(0,0,0,0.55)",
+      borderWidth: 1,
+      borderColor: "rgba(255,255,255,0.28)",
+    },
+    scanArea: {
+      position: "absolute",
+      width: 252,
+      height: 252,
+      top: "50%",
+      left: "50%",
+      marginTop: -144,
+      marginLeft: -126,
+      borderRadius: radius.lg,
+      borderWidth: 3,
+      borderColor: "#FFFFFF",
+      backgroundColor: "rgba(255,255,255,0.03)",
+    },
+    cameraFooter: {
+      position: "absolute",
+      left: spacing.xxl,
+      right: spacing.xxl,
+      bottom: 52,
+      alignItems: "center",
+    },
+    cameraHint: {
+      ...typeScale.bodyStrong,
+      color: "#FFFFFF",
+      textAlign: "center",
+      backgroundColor: "rgba(0,0,0,0.62)",
+      paddingHorizontal: spacing.xxl,
+      paddingVertical: spacing.md,
+      borderRadius: radius.md,
+    },
+    scanErrorPanel: {
+      width: "100%",
+      gap: spacing.lg,
+      padding: spacing.xxl,
+      borderRadius: radius.lg,
+      backgroundColor: c.card,
+      borderWidth: 1,
+      borderColor: c.dangerTone.border,
+    },
+    scanErrorText: { ...typeScale.body, color: c.danger, textAlign: "center" },
+  });

--- a/mobile/src/features/auth/DeviceLoginScreen.tsx
+++ b/mobile/src/features/auth/DeviceLoginScreen.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { ScanQrCode, ShieldCheck, ShieldX, TriangleAlert } from "lucide-react-native";
+
+import type { RootStackParamList } from "../../app/AppNavigator";
+import { BlurBackButton } from "../../components/BlurBackButton";
+import { PrimaryButton } from "../../components/PrimaryButton";
+import { ScreenContainer } from "../../components/ScreenContainer";
+import { resolveErrorMessage } from "../../lib/api/errorMessages";
+import { mobileApi } from "../../lib/api/mobileApi";
+import type { AuthDevicePreview } from "../../lib/api/authDeviceApi";
+import { useTheme } from "../../theme/ThemeContext";
+import { DeviceCodeScanner } from "./DeviceCodeScanner";
+import { createDeviceLoginStyles } from "./deviceLoginStyles";
+import {
+  formatAuthDeviceUserCode,
+  normalizeAuthDeviceUserCode,
+} from "./deviceUserCode";
+import { useAuthSession } from "./AuthSessionContext";
+
+type Props = NativeStackScreenProps<RootStackParamList, "DeviceLogin">;
+type TerminalState = "approved" | "denied" | null;
+
+const ACTION_THROTTLE_MS = 750;
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "Unknown time" : parsed.toLocaleString();
+}
+
+function formatRemaining(seconds: number): string {
+  const safeSeconds = Math.max(0, seconds);
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainder = safeSeconds % 60;
+  return `${minutes}:${String(remainder).padStart(2, "0")}`;
+}
+
+function DetailRow({ label, value, styles }: {
+  label: string;
+  value: string;
+  styles: ReturnType<typeof createDeviceLoginStyles>;
+}) {
+  return (
+    <View style={styles.detailRow}>
+      <Text style={styles.detailLabel}>{label}</Text>
+      <Text style={styles.detailValue}>{value}</Text>
+    </View>
+  );
+}
+
+export function DeviceLoginScreen({ navigation, route }: Props) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createDeviceLoginStyles(colors), [colors]);
+  const { isAuthenticated } = useAuthSession();
+  const [userCode, setUserCode] = useState(() =>
+    formatAuthDeviceUserCode(route.params?.user_code ?? "")
+  );
+  const [confirmedCode, setConfirmedCode] = useState<string | null>(null);
+  const [preview, setPreview] = useState<AuthDevicePreview | null>(null);
+  const [terminal, setTerminal] = useState<TerminalState>(null);
+  const [isScanning, setIsScanning] = useState(false);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [decisionPending, setDecisionPending] = useState<"approve" | "deny" | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [clockMs, setClockMs] = useState(Date.now());
+  const lastActionAt = useRef(0);
+
+  useEffect(() => {
+    if (route.params?.user_code === undefined) return;
+    setUserCode(formatAuthDeviceUserCode(route.params.user_code));
+    setConfirmedCode(null);
+    setPreview(null);
+    setTerminal(null);
+    setErrorMessage(null);
+  }, [route.params?.user_code]);
+
+  useEffect(() => {
+    if (!preview || terminal) return;
+    const interval = setInterval(() => setClockMs(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [preview, terminal]);
+
+  const claimAction = useCallback(() => {
+    const now = Date.now();
+    if (now - lastActionAt.current < ACTION_THROTTLE_MS) return false;
+    lastActionAt.current = now;
+    return true;
+  }, []);
+
+  const runPreview = useCallback(async (candidate: string) => {
+    if (!claimAction()) {
+      setErrorMessage("Please wait a moment before trying again.");
+      return;
+    }
+
+    const normalized = normalizeAuthDeviceUserCode(candidate);
+    if (!normalized) {
+      setErrorMessage("Enter a valid eight-character login code.");
+      return;
+    }
+
+    setIsPreviewing(true);
+    setErrorMessage(null);
+    try {
+      const result = await mobileApi.previewAuthDevice(normalized);
+      if (result.status === "denied") {
+        setTerminal("denied");
+        return;
+      }
+      if (result.status !== "pending") {
+        setErrorMessage(
+          result.status === "expired"
+            ? "This login request has expired."
+            : "This login request was already completed."
+        );
+        return;
+      }
+
+      setConfirmedCode(normalized);
+      setPreview(result);
+      setClockMs(Date.now());
+    } catch (error) {
+      setErrorMessage(resolveErrorMessage(error));
+    } finally {
+      setIsPreviewing(false);
+    }
+  }, [claimAction]);
+
+  const handleScannedCode = (normalized: string) => {
+    const formatted = formatAuthDeviceUserCode(normalized);
+    setUserCode(formatted);
+    setIsScanning(false);
+    void runPreview(formatted);
+  };
+
+  const handleDecision = async (decision: "approve" | "deny") => {
+    if (!confirmedCode || !preview) return;
+    if (!claimAction()) {
+      setErrorMessage("Please wait a moment before trying again.");
+      return;
+    }
+
+    const expiresAt = Date.parse(preview.expires_at);
+    if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+      setErrorMessage("This login request has expired.");
+      return;
+    }
+
+    setDecisionPending(decision);
+    setErrorMessage(null);
+    try {
+      if (decision === "approve") {
+        await mobileApi.approveAuthDevice(confirmedCode);
+        setTerminal("approved");
+      } else {
+        await mobileApi.denyAuthDevice(confirmedCode);
+        setTerminal("denied");
+      }
+    } catch (error) {
+      setErrorMessage(resolveErrorMessage(error));
+    } finally {
+      setDecisionPending(null);
+    }
+  };
+
+  const handleBack = () => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate(isAuthenticated ? "Activity" : "Auth");
+    }
+  };
+
+  const resetRequest = () => {
+    setConfirmedCode(null);
+    setPreview(null);
+    setTerminal(null);
+    setErrorMessage(null);
+    setClockMs(Date.now());
+  };
+
+  if (isScanning) {
+    return (
+      <DeviceCodeScanner
+        onCancel={() => setIsScanning(false)}
+        onCode={handleScannedCode}
+      />
+    );
+  }
+
+  const expiresAtMs = preview ? Date.parse(preview.expires_at) : Number.NaN;
+  const secondsRemaining = Number.isFinite(expiresAtMs)
+    ? Math.max(0, Math.ceil((expiresAtMs - clockMs) / 1000))
+    : 0;
+  const isExpired = Boolean(preview) && secondsRemaining === 0;
+  const isPending = isPreviewing || decisionPending !== null;
+
+  if (terminal) {
+    const approved = terminal === "approved";
+    return (
+      <ScreenContainer>
+        <View style={styles.terminalScreen}>
+          <View style={[styles.terminalIcon, approved ? styles.successIcon : styles.deniedIcon]}>
+            {approved ? (
+              <ShieldCheck size={36} color={colors.success} />
+            ) : (
+              <ShieldX size={36} color={colors.danger} />
+            )}
+          </View>
+          <Text style={styles.terminalTitle}>
+            {approved ? "Login approved" : "Request denied"}
+          </Text>
+          <Text style={styles.terminalBody}>
+            {approved
+              ? "The requesting device can now complete sign-in."
+              : "The requesting device cannot use this login request."}
+          </Text>
+          <PrimaryButton label="Done" onPress={handleBack} />
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  return (
+    <ScreenContainer>
+      <KeyboardAvoidingView
+        style={styles.fill}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+        >
+          <BlurBackButton onPress={handleBack} />
+          <Text style={styles.title}>Approve device login</Text>
+          <Text style={styles.subtitle}>
+            Review where the request started before allowing another device to sign in.
+          </Text>
+
+          {!preview ? (
+            <View style={styles.inputSection}>
+              <Text style={styles.inputLabel}>Login code</Text>
+              <TextInput
+                accessibilityLabel="Login code"
+                value={userCode}
+                onChangeText={(value) => {
+                  setUserCode(formatAuthDeviceUserCode(value));
+                  setErrorMessage(null);
+                }}
+                editable={!isPending}
+                autoCapitalize="characters"
+                autoCorrect={false}
+                maxLength={9}
+                placeholder="ABCD-EFGH"
+                placeholderTextColor={colors.textTertiary}
+                style={styles.codeInput}
+              />
+              <PrimaryButton
+                label={isPreviewing ? "Checking request..." : "Continue"}
+                onPress={() => void runPreview(userCode)}
+                disabled={isPending}
+              />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Scan login QR code"
+                disabled={isPending}
+                onPress={() => setIsScanning(true)}
+                style={({ pressed }) => [
+                  styles.scanButton,
+                  pressed && styles.pressed,
+                  isPending && styles.disabled,
+                ]}
+              >
+                <ScanQrCode size={20} color={colors.primary} />
+                <Text style={styles.scanButtonText}>Scan QR code</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <View style={styles.previewSection}>
+              <View style={styles.warningBanner}>
+                <TriangleAlert size={20} color={colors.warningTone.text} />
+                <Text style={styles.warningText}>
+                  Reject this request if you do not recognize the device, IP address, or time.
+                </Text>
+              </View>
+
+              <View style={styles.detailPanel}>
+                <DetailRow
+                  label="Reported device"
+                  value={preview.client_label ?? "Not provided"}
+                  styles={styles}
+                />
+                <DetailRow
+                  label="Reported client"
+                  value={preview.client_user_agent ?? "Not provided"}
+                  styles={styles}
+                />
+                <DetailRow
+                  label="Requester"
+                  value={`${preview.client_ip ?? "Unknown IP"} at ${formatTimestamp(preview.initiated_at)}`}
+                  styles={styles}
+                />
+                <DetailRow
+                  label="Expires in"
+                  value={isExpired ? "Expired" : formatRemaining(secondsRemaining)}
+                  styles={styles}
+                />
+              </View>
+
+              {isAuthenticated ? (
+                <View style={styles.decisionRow}>
+                  <View style={styles.decisionButton}>
+                    <PrimaryButton
+                      label={decisionPending === "deny" ? "Rejecting..." : "Reject"}
+                      kind="danger"
+                      disabled={isPending || isExpired}
+                      onPress={() => void handleDecision("deny")}
+                    />
+                  </View>
+                  <View style={styles.decisionButton}>
+                    <PrimaryButton
+                      label={decisionPending === "approve" ? "Approving..." : "Approve"}
+                      disabled={isPending || isExpired}
+                      onPress={() => void handleDecision("approve")}
+                    />
+                  </View>
+                </View>
+              ) : (
+                <View style={styles.signInNotice}>
+                  <Text style={styles.signInText}>Sign in to approve or reject this request.</Text>
+                  <PrimaryButton label="Sign in" onPress={() => navigation.navigate("Auth")} />
+                </View>
+              )}
+
+              <PrimaryButton
+                label="Use another code"
+                kind="ghost"
+                disabled={isPending}
+                onPress={resetRequest}
+              />
+            </View>
+          )}
+
+          {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+          {isPending ? <ActivityIndicator color={colors.primary} /> : null}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/features/auth/deviceLoginStyles.ts
+++ b/mobile/src/features/auth/deviceLoginStyles.ts
@@ -1,0 +1,111 @@
+import { StyleSheet } from "react-native";
+
+import { radius, spacing, typeScale, TOUCH_TARGET } from "../../theme/designTokens";
+import type { ThemeColors } from "../../theme/mobileTheme";
+
+export function createDeviceLoginStyles(c: ThemeColors) {
+  return StyleSheet.create({
+    fill: { flex: 1 },
+    content: { padding: spacing.xxl, paddingBottom: 48 },
+    title: { ...typeScale.pageHeader, color: c.textPrimary },
+    subtitle: {
+      ...typeScale.description,
+      color: c.textSecondary,
+      marginTop: spacing.sm,
+      marginBottom: spacing.huge,
+    },
+    inputSection: { gap: spacing.lg },
+    inputLabel: { ...typeScale.bodyStrong, color: c.textPrimary },
+    codeInput: {
+      minHeight: 52,
+      borderRadius: radius.md,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.card,
+      paddingHorizontal: spacing.xxl,
+      color: c.textPrimary,
+      ...typeScale.mono,
+      fontSize: 18,
+      textAlign: "center" as const,
+    },
+    scanButton: {
+      minHeight: TOUCH_TARGET,
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      gap: spacing.sm,
+      borderRadius: radius.md,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.ghostBg,
+    },
+    scanButtonText: { ...typeScale.label, color: c.primary },
+    previewSection: { gap: spacing.lg },
+    warningBanner: {
+      flexDirection: "row" as const,
+      alignItems: "flex-start" as const,
+      gap: spacing.md,
+      padding: spacing.lg,
+      borderRadius: radius.lg,
+      borderWidth: 1,
+      borderColor: c.warningTone.border,
+      backgroundColor: c.warningTone.bg,
+    },
+    warningText: { ...typeScale.body, color: c.warningTone.text, flex: 1 },
+    detailPanel: {
+      borderRadius: radius.lg,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.card,
+      paddingHorizontal: spacing.xxl,
+    },
+    detailRow: {
+      paddingVertical: spacing.lg,
+      borderBottomWidth: 1,
+      borderBottomColor: c.borderSoft,
+      gap: spacing.xs,
+    },
+    detailLabel: { ...typeScale.overline, color: c.textMuted },
+    detailValue: { ...typeScale.body, color: c.textPrimary },
+    decisionRow: { flexDirection: "row" as const, gap: spacing.md },
+    decisionButton: { flex: 1 },
+    signInNotice: { gap: spacing.lg },
+    signInText: { ...typeScale.body, color: c.textSecondary },
+    errorText: {
+      ...typeScale.body,
+      color: c.danger,
+      marginTop: spacing.xxl,
+      textAlign: "center" as const,
+    },
+    pressed: { opacity: 0.72 },
+    disabled: { opacity: 0.5 },
+    terminalScreen: {
+      flex: 1,
+      justifyContent: "center" as const,
+      padding: spacing.huge,
+      gap: spacing.lg,
+    },
+    terminalIcon: {
+      width: 64,
+      height: 64,
+      borderRadius: radius.lg,
+      alignItems: "center" as const,
+      justifyContent: "center" as const,
+      borderWidth: 1,
+    },
+    successIcon: {
+      backgroundColor: c.successTone.bg,
+      borderColor: c.successTone.border,
+    },
+    deniedIcon: {
+      backgroundColor: c.dangerTone.bg,
+      borderColor: c.dangerTone.border,
+    },
+    terminalTitle: { ...typeScale.pageHeader, color: c.textPrimary },
+    terminalBody: {
+      ...typeScale.description,
+      color: c.textSecondary,
+      marginBottom: spacing.md,
+    },
+  });
+}

--- a/mobile/src/features/auth/deviceUserCode.ts
+++ b/mobile/src/features/auth/deviceUserCode.ts
@@ -1,0 +1,56 @@
+const NORMALIZED_USER_CODE_LENGTH = 8;
+const NORMALIZED_USER_CODE_PATTERN = /^[0-9A-HJKMNP-TV-Z]{8}$/;
+
+export function normalizeAuthDeviceUserCode(raw: string): string | null {
+  const compact = raw.replace(/[- \t]/g, "").toUpperCase();
+  const normalized = compact
+    .replace(/[IL]/g, "1")
+    .replace(/O/g, "0")
+    .replace(/U/g, "V");
+
+  if (
+    normalized.length !== NORMALIZED_USER_CODE_LENGTH ||
+    !NORMALIZED_USER_CODE_PATTERN.test(normalized)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function formatAuthDeviceUserCode(raw: string): string {
+  const compact = raw
+    .replace(/[- \t]/g, "")
+    .toUpperCase()
+    .slice(0, NORMALIZED_USER_CODE_LENGTH);
+
+  return compact.length > 4
+    ? `${compact.slice(0, 4)}-${compact.slice(4)}`
+    : compact;
+}
+
+export function extractAuthDeviceUserCodeFromQr(raw: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+
+  const isWebLogin =
+    parsed.protocol === "https:" &&
+    (parsed.pathname === "/login/device" || parsed.pathname === "/login/device/");
+  const isAppLogin =
+    parsed.protocol === "nyxid:" &&
+    ((parsed.hostname.toLowerCase() === "login" &&
+      (parsed.pathname === "/device" || parsed.pathname === "/device/")) ||
+      (parsed.hostname === "" &&
+        (parsed.pathname === "/login/device" || parsed.pathname === "/login/device/")));
+
+  if (!isWebLogin && !isAppLogin) return null;
+
+  const userCodes = parsed.searchParams.getAll("user_code");
+  if (userCodes.length !== 1) return null;
+
+  return normalizeAuthDeviceUserCode(userCodes[0] ?? "");
+}

--- a/mobile/src/lib/api/authDeviceApi.ts
+++ b/mobile/src/lib/api/authDeviceApi.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import { requestJson } from "./http";
+
+const authDevicePreviewSchema = z.object({
+  client_label: z.string().nullable(),
+  client_user_agent: z.string().nullable(),
+  client_ip: z.string().nullable(),
+  initiated_at: z.string().datetime(),
+  expires_at: z.string().datetime(),
+  status: z.enum(["pending", "approved", "denied", "expired", "delivered"]),
+});
+
+const authDeviceDecisionSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type AuthDevicePreview = z.infer<typeof authDevicePreviewSchema>;
+
+export async function previewAuthDeviceRequest(userCode: string): Promise<AuthDevicePreview> {
+  const response = await requestJson<unknown>("/auth/device/preview", {
+    method: "POST",
+    body: { user_code: userCode },
+    requiresAuth: false,
+    retryOnAuthFailure: false,
+  });
+
+  return authDevicePreviewSchema.parse(response);
+}
+
+export async function approveAuthDeviceRequest(userCode: string): Promise<void> {
+  const response = await requestJson<unknown>("/auth/device/approve", {
+    method: "POST",
+    body: { user_code: userCode },
+  });
+
+  authDeviceDecisionSchema.parse(response);
+}
+
+export async function denyAuthDeviceRequest(userCode: string): Promise<void> {
+  const response = await requestJson<unknown>("/auth/device/deny", {
+    method: "POST",
+    body: { user_code: userCode },
+  });
+
+  authDeviceDecisionSchema.parse(response);
+}

--- a/mobile/src/lib/api/authDeviceApi.ts
+++ b/mobile/src/lib/api/authDeviceApi.ts
@@ -1,21 +1,16 @@
 import { z } from "zod";
 
 import { requestJson } from "./http";
-
-const authDevicePreviewSchema = z.object({
-  client_label: z.string().nullable(),
-  client_user_agent: z.string().nullable(),
-  client_ip: z.string().nullable(),
-  initiated_at: z.string().datetime(),
-  expires_at: z.string().datetime(),
-  status: z.enum(["pending", "approved", "denied", "expired", "delivered"]),
-});
+import {
+  parseAuthDevicePreview,
+  type AuthDevicePreview,
+} from "./authDeviceSchema";
 
 const authDeviceDecisionSchema = z.object({
   ok: z.literal(true),
 });
 
-export type AuthDevicePreview = z.infer<typeof authDevicePreviewSchema>;
+export type { AuthDevicePreview } from "./authDeviceSchema";
 
 export async function previewAuthDeviceRequest(userCode: string): Promise<AuthDevicePreview> {
   const response = await requestJson<unknown>("/auth/device/preview", {
@@ -25,7 +20,7 @@ export async function previewAuthDeviceRequest(userCode: string): Promise<AuthDe
     retryOnAuthFailure: false,
   });
 
-  return authDevicePreviewSchema.parse(response);
+  return parseAuthDevicePreview(response);
 }
 
 export async function approveAuthDeviceRequest(userCode: string): Promise<void> {

--- a/mobile/src/lib/api/authDeviceSchema.test.ts
+++ b/mobile/src/lib/api/authDeviceSchema.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAuthDevicePreview } from "./authDeviceSchema";
+
+test("normalizes a missing client_ip from an older backend to null", () => {
+  const preview = parseAuthDevicePreview({
+    client_label: "workstation",
+    client_user_agent: "nyxid-cli",
+    initiated_at: "2026-08-20T10:00:00Z",
+    expires_at: "2026-08-20T10:10:00Z",
+    status: "pending",
+  });
+
+  assert.equal(preview.client_ip, null);
+});

--- a/mobile/src/lib/api/authDeviceSchema.ts
+++ b/mobile/src/lib/api/authDeviceSchema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+const authDevicePreviewSchema = z.object({
+  client_label: z.string().nullable(),
+  client_user_agent: z.string().nullable(),
+  client_ip: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null),
+  initiated_at: z.string().datetime(),
+  expires_at: z.string().datetime(),
+  status: z.enum(["pending", "approved", "denied", "expired", "delivered"]),
+});
+
+export type AuthDevicePreview = z.infer<typeof authDevicePreviewSchema>;
+
+export function parseAuthDevicePreview(value: unknown): AuthDevicePreview {
+  return authDevicePreviewSchema.parse(value);
+}

--- a/mobile/src/lib/api/errorMessages.ts
+++ b/mobile/src/lib/api/errorMessages.ts
@@ -33,6 +33,16 @@ const ERROR_MESSAGES: Record<number, string> = {
   // ── Nodes ──
   8001: "The credential node is offline. Try again later.",
   8002: "Request timed out waiting for the credential node.",
+
+  // ── Auth device login ──
+  11200: "That login code is no longer valid.",
+  11201: "This login request has expired.",
+  11202: "This login request is still waiting for approval.",
+  11203: "Please wait before trying again.",
+  11204: "This login request was denied.",
+  11205: "This login request was already completed.",
+  11206: "Too many attempts. Please wait and try again.",
+  11207: "Enter a valid eight-character login code.",
 };
 
 /**

--- a/mobile/src/lib/api/mobileApi.ts
+++ b/mobile/src/lib/api/mobileApi.ts
@@ -1,4 +1,9 @@
 import { ApiError } from "./ApiError";
+import {
+  approveAuthDeviceRequest,
+  denyAuthDeviceRequest,
+  previewAuthDeviceRequest,
+} from "./authDeviceApi";
 import { createIdempotencyKey } from "./idempotency";
 import {
   deleteCurrentUserAccountRequest,
@@ -71,6 +76,9 @@ function getApiBaseUrl(): string {
 }
 
 export const mobileApi = {
+  previewAuthDevice: previewAuthDeviceRequest,
+  approveAuthDevice: approveAuthDeviceRequest,
+  denyAuthDevice: denyAuthDeviceRequest,
   async loginWithPassword(input: LoginWithPasswordInput): Promise<LoginWithPasswordResponse> {
     const response = await loginWithPasswordRequest({
       email: input.email,

--- a/skills/nyxid/references/devices.md
+++ b/skills/nyxid/references/devices.md
@@ -30,10 +30,11 @@ Do not confuse this page with provider OAuth device-code flows.
 
 | Flow | Purpose | CLI / API surface |
 |---|---|---|
+| Auth device-code login | A human reviews and approves or rejects a headless `nyxid login --device` request; the CLI receives normal session tokens only after approval. | `/auth/device/{request,poll,preview,approve,deny}`; the web page or mobile app performs the decision |
 | Device-code grant | A fresh headless device asks NyxID for its own NyxID API key, node id, and refresh token. | `nyxid device approve`, `nyxid device onboard`, `nyxid device factory-key`, `/devices/code/*`, `/devices/onboard` |
 | Provider device-code OAuth | A user connects a downstream provider credential, such as Codex or GitHub, using that provider's RFC 8628 OAuth flow. | `nyxid service add <slug> --device-code`, `/providers/{id}/connect/device-code/*`; see `services.md` / `managing.md` |
 
-When a user says "approve my ESP32", "factory key", "headless device", "nyxprov QR", or gives a 12-character hardware user code, use this reference. When they say "connect Codex/OpenAI/GitHub with device code", use the service/provider references.
+When a user says "approve my ESP32", "factory key", "headless device", "nyxprov QR", or gives a 12-character hardware user code, use this reference. An 8-character `nyxid login --device` code is the auth device-code login flow instead. When they ask to connect a service with device code, use the service/provider references.
 
 ## Provisioning flow
 


### PR DESCRIPTION
## Summary

Hardens and extends the auth device-code login flow (`nyxid login --device`, `/api/v1/auth/device/*`) for QR scan-to-login consumers. Three improvements, in priority order:

### 1. Deny endpoint
- New `POST /api/v1/auth/device/deny` (human session only, mounted beside `/approve` in the human-only router: API-key, service-account, delegated, and relay tokens rejected by the shared layers; same per-IP + per-user rate limiters as approve, which share one decision abuse budget).
- Atomic `pending -> denied` transition guarded on status; records `denied_at` + `denied_by_user_id`; emits metadata-only `auth_device_code_denied` audit (redacted user code). No tokens are minted; the requester's next poll returns 11204 immediately.
- Approve/deny race has exactly one winner; the loser now receives an error reflecting the actual terminal state (deny-after-approve -> 11205, approve-after-deny -> 11204) instead of a blanket "already delivered".
- Web `/login/device` gains a throttled Reject button (same >=750ms/pending rules) with a "Request denied" terminal state; decision buttons are now gated on `status == "pending"` with friendly terminal copy otherwise. CLI already stops polling on 11204.

### 2. Richer preview payload (anti-phishing)
- `AuthDeviceCode` gains a short-lived plaintext `client_ip` (server-resolved, trusted-proxy-aware; HMAC kept; Debug-redacted; serde-defaulted so legacy rows still parse). Rows expire after 10 minutes.
- `POST /auth/device/preview` now returns `client_ip`; web and mobile approval screens render "Requested from <ip> at <time> - reject if you do not recognize it" so approvers have server-observed facts beyond attacker-controlled `client_label`/`client_user_agent`.
- Web + mobile preview schemas tolerate a missing `client_ip` (older backends) by normalizing to null.
- Coarse geo intentionally omitted: no geo-resolution capability exists in the repo and adding a dependency/database was out of scope.

### 3. Mobile QR approval (NyxID Authenticator)
- expo-camera `CameraView` QR scanner + confirm screen: scan -> preview -> explicit Approve/Reject (throttled, expiry countdown, never auto-approves).
- Security invariant: the QR (https verification URL or `nyxid://login/device?user_code=...`) only ever supplies the `user_code`; every API call uses the app's configured base URL. Codes are normalized with the same rules as the backend before any request.
- `nyxid://login/device?user_code=...` deep link prefills the screen without firing any request; "Scan to approve login" entry on the Activity screen; camera permission config for iOS/Android.
- Universal links omitted: requires Apple team ID / Android signing fingerprints not present in the repo (custom scheme complete).

### Docs
CLAUDE.md Critical Rule 12 + Key API Routes, docs/API.md (full endpoint docs for preview/approve/deny), AI agent playbook, SSH tunneling doc, site docs, mobile README, and skills/nyxid device references. OpenAPI now documents all five `/auth/device/*` routes under an "Auth Device Login" tag. Stale mobile stack facts corrected (Expo 55 / RN 0.83).

## Test plan
- [x] Backend: 46 auth-device tests against real MongoDB (deny happy path/audit, wrong code, non-pending mapping, expiry, concurrent approve-vs-deny race with no orphaned session, poll-after-deny 11204, API-key rejection on deny, preview `client_ip` + legacy-row null, Z-suffix timestamps)
- [x] `cargo fmt --check`, `cargo clippy` (no code warnings), `cargo test -p nyxid-cli`
- [x] Frontend: 2856 vitest tests (incl. new login-device page, schema, and hook tests), lint 0 errors, `tsc -b`
- [x] Mobile: `tsc --noEmit`, schema test via `pnpm test`, QR/code-normalization vectors
- [x] Full backend suite: only pre-existing failures requiring a MongoDB replica set (transactions), also failing on main