### PR TITLE
feat(cursor): NyxID Cursor Marketplace plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -4,15 +4,19 @@
   "owner": {
     "name": "ChronoAIProject"
   },
-  "metadata": {
-    "pluginRoot": "integrations/cursor-plugin"
-  },
   "plugins": [
     {
       "name": "nyxid",
-      "source": "./integrations/cursor-plugin",
+      "displayName": "NyxID",
+      "source": "integrations/cursor-plugin",
       "description": "Connect Cursor agents to NyxID for credential brokering, service discovery, and proxied downstream API calls without exposing upstream secrets.",
       "version": "0.1.0",
+      "category": "developer-tools",
+      "tags": [
+        "credentials",
+        "mcp",
+        "api-proxy"
+      ],
       "author": {
         "name": "ChronoAIProject"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "nyxid",
+  "description": "NyxID Cursor plugins for credential brokering, service discovery, and proxied downstream API calls.",
+  "owner": {
+    "name": "ChronoAIProject"
+  },
+  "metadata": {
+    "pluginRoot": "integrations/cursor-plugin"
+  },
+  "plugins": [
+    {
+      "name": "nyxid",
+      "source": "./integrations/cursor-plugin",
+      "description": "Connect Cursor agents to NyxID for credential brokering, service discovery, and proxied downstream API calls without exposing upstream secrets.",
+      "version": "0.1.0",
+      "author": {
+        "name": "ChronoAIProject"
+      },
+      "homepage": "https://github.com/ChronoAIProject/NyxID",
+      "repository": "https://github.com/ChronoAIProject/NyxID",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,6 @@
   "plugins": [
     {
       "name": "nyxid",
-      "displayName": "NyxID",
       "source": "integrations/cursor-plugin",
       "description": "Connect Cursor agents to NyxID for credential brokering, service discovery, and proxied downstream API calls without exposing upstream secrets.",
       "version": "0.1.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       sdk: ${{ steps.filter.outputs.sdk }}
       wizard: ${{ steps.filter.outputs.wizard }}
+      cursor_plugin: ${{ steps.filter.outputs.cursor_plugin }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v6
@@ -142,12 +143,29 @@ jobs:
               - '.node-version'
               - 'cli/src/wizard/**'
               - 'cli/tests/wizard_bundle_freshness.rs'
+            cursor_plugin:
+              - 'integrations/cursor-plugin/**'
+              - '.cursor-plugin/**'
+              - 'scripts/validate-cursor-plugin.py'
             # Any workflow change forces a full run -- stops a broken
             # publish-gate or release pipeline from sneaking through under
             # path filtering.
             ci:
               - '.github/workflows/**'
               - '.github/actions/**'
+
+  # ---------------------------------------------------------------------------
+  # Cursor plugin: manifest, component, MCP variable, and marketplace checks.
+  # ---------------------------------------------------------------------------
+  cursor-plugin-validate:
+    name: Cursor Plugin Validate
+    needs: changes
+    if: inputs.force-all || needs.changes.outputs.ci == 'true' || needs.changes.outputs.cursor_plugin == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate Cursor plugin
+        run: python3 scripts/validate-cursor-plugin.py
 
   # ---------------------------------------------------------------------------
   # Rust: format check
@@ -759,6 +777,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - cursor-plugin-validate
       - rust-fmt
       - rust-clippy
       - backend-test
@@ -780,6 +799,7 @@ jobs:
           # coverage drops below the enforced threshold.
           RESULTS: |
             changes=${{ needs.changes.result }}
+            cursor-plugin-validate=${{ needs.cursor-plugin-validate.result }}
             rust-fmt=${{ needs.rust-fmt.result }}
             rust-clippy=${{ needs.rust-clippy.result }}
             backend-test=${{ needs.backend-test.result }}

--- a/docs/CURSOR_PLUGIN.md
+++ b/docs/CURSOR_PLUGIN.md
@@ -1,0 +1,25 @@
+# Cursor Marketplace Plugin
+
+NyxID's Cursor plugin lives in [`integrations/cursor-plugin/`](../integrations/cursor-plugin/). It is deliberately self-contained so the directory can be mirrored into a standalone public repository without changing its manifest paths.
+
+## Publish from this repository
+
+1. Keep the repository public and make sure the plugin manifest, logo, rules, skills, commands, MCP config, and README are committed.
+2. Run `python3 scripts/validate-cursor-plugin.py` from the repository root.
+3. Open <https://cursor.com/marketplace/publish> and submit the public GitHub repository.
+4. Select the `nyxid` plugin entry from `.cursor-plugin/marketplace.json` when prompted.
+5. Complete Cursor's manual review. Marketplace updates are reviewed again, so publish a new version for substantive changes and rerun validation before submitting.
+
+The root marketplace file is needed because the plugin is nested in this monorepo. Its `source` is `./integrations/cursor-plugin`, and `metadata.pluginRoot` documents the directory for marketplace tooling.
+
+## Mirror into a standalone repository
+
+For a dedicated marketplace repository, copy the complete `integrations/cursor-plugin/` directory to the repository root, preserving `.cursor-plugin/plugin.json` and all relative paths. The standalone repository can submit that root plugin directly; it does not need the monorepo marketplace index. Keep the repository public and include the plugin README and Apache-2.0 license notice.
+
+After mirroring, run the validator against the standalone plugin path if needed:
+
+```bash
+python3 scripts/validate-cursor-plugin.py /path/to/standalone-repo
+```
+
+Do not change `${NYXID_BASE_URL}` into a secret-bearing variable. The default browser OAuth flow is intentionally zero-config; users configure only the NyxID API origin in Cursor's plugin settings.

--- a/docs/CURSOR_PLUGIN.md
+++ b/docs/CURSOR_PLUGIN.md
@@ -7,10 +7,10 @@ NyxID's Cursor plugin lives in [`integrations/cursor-plugin/`](../integrations/c
 1. Keep the repository public and make sure the plugin manifest, logo, rules, skills, commands, MCP config, and README are committed.
 2. Run `python3 scripts/validate-cursor-plugin.py` from the repository root.
 3. Open <https://cursor.com/marketplace/publish> and submit the public GitHub repository.
-4. Select the `nyxid` plugin entry from `.cursor-plugin/marketplace.json` when prompted.
+4. The root `.cursor-plugin/marketplace.json` identifies the `nyxid` plugin and its `integrations/cursor-plugin` source directory for the marketplace submission.
 5. Complete Cursor's manual review. Marketplace updates are reviewed again, so publish a new version for substantive changes and rerun validation before submitting.
 
-The root marketplace file is needed because the plugin is nested in this monorepo. Its `source` is `./integrations/cursor-plugin`, and `metadata.pluginRoot` documents the directory for marketplace tooling.
+The root marketplace file is needed because the plugin is nested in this monorepo. Its `source` is `integrations/cursor-plugin`, relative to the repository root.
 
 ## Mirror into a standalone repository
 

--- a/integrations/cursor-plugin/.cursor-plugin/plugin.json
+++ b/integrations/cursor-plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,14 @@
 {
   "name": "nyxid",
+  "displayName": "NyxID",
   "description": "Connect Cursor agents to NyxID for credential brokering, service discovery, and proxied downstream API calls without exposing upstream secrets.",
   "version": "0.1.0",
+  "category": "developer-tools",
+  "tags": [
+    "credentials",
+    "mcp",
+    "api-proxy"
+  ],
   "author": {
     "name": "ChronoAIProject"
   },

--- a/integrations/cursor-plugin/.cursor-plugin/plugin.json
+++ b/integrations/cursor-plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "nyxid",
+  "description": "Connect Cursor agents to NyxID for credential brokering, service discovery, and proxied downstream API calls without exposing upstream secrets.",
+  "version": "0.1.0",
+  "author": {
+    "name": "ChronoAIProject"
+  },
+  "homepage": "https://github.com/ChronoAIProject/NyxID",
+  "repository": "https://github.com/ChronoAIProject/NyxID",
+  "license": "Apache-2.0",
+  "keywords": [
+    "credentials",
+    "oauth",
+    "proxy",
+    "mcp",
+    "service-discovery",
+    "nyxid"
+  ],
+  "logo": "assets/nyxid-icon.svg",
+  "rules": [
+    "rules/nyxid.mdc"
+  ],
+  "skills": [
+    "skills/nyxid"
+  ],
+  "commands": [
+    "commands/nyxid-connect.md"
+  ],
+  "mcpServers": "mcp.json",
+  "variables": {
+    "type": "object",
+    "properties": {
+      "NYXID_BASE_URL": {
+        "type": "string",
+        "title": "NyxID base URL",
+        "description": "API origin where the hosted NyxID MCP endpoint is served.",
+        "format": "uri",
+        "default": "https://nyx-api.chrono-ai.fun"
+      }
+    }
+  }
+}

--- a/integrations/cursor-plugin/README.md
+++ b/integrations/cursor-plugin/README.md
@@ -1,0 +1,63 @@
+# NyxID for Cursor
+
+NyxID gives Cursor agents a credential broker and MCP proxy for downstream APIs. Install this plugin once, authenticate NyxID in the browser, and let the agent discover connected services and call their tools without receiving the provider's API key or OAuth token.
+
+## Install
+
+### Cursor Marketplace
+
+In Cursor, open **Settings -> Plugins -> Marketplace**, search for **nyxid**, and install the plugin. Restart or reload Cursor if it does not immediately appear in the MCP tools list.
+
+### Manual install
+
+This repository keeps the plugin source at `integrations/cursor-plugin/`. Clone the public repository and add that directory through Cursor's local plugin/development install flow. The plugin root is the directory containing `.cursor-plugin/plugin.json`; do not select the monorepo root.
+
+If the Cursor build in use does not support local plugin loading, copy `integrations/cursor-plugin/mcp.json` to the project's `.cursor/mcp.json`, replace `${NYXID_BASE_URL}` with the API origin for the NyxID deployment, and copy the bundled `rules/`, `skills/`, and `commands/` content into the corresponding Cursor project directories. The hosted default is `https://nyx-api.chrono-ai.fun`.
+
+## Configuration
+
+The plugin declares one Cursor variable:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `NYXID_BASE_URL` | `https://nyx-api.chrono-ai.fun` | API origin where NyxID serves `/mcp` |
+
+Change it in **Settings -> Plugins -> nyxid -> Configure** for a self-hosted deployment, for example `http://localhost:3001`. The resulting MCP URL is `${NYXID_BASE_URL}/mcp`.
+
+No API-key variable is required for the happy path. NyxID's hosted MCP transport authenticates Cursor with browser OAuth and then maintains an MCP session. The backend also supports headless API-key authentication through an `X-API-Key` header, but this plugin does not silently put a secret into Cursor configuration; use the NyxID CLI or an explicitly managed integration when a headless setup is required.
+
+## Use it
+
+After installation, ask the agent to find or connect a service. The bundled skill teaches this flow:
+
+1. `nyx__list_connected_services` or `nyx__discover_services` finds the service.
+2. `nyx__connect_service` starts a connection without a credential argument.
+3. The user completes the returned hosted URL in a browser.
+4. `nyx__wait_for_connection` waits for completion.
+5. `nyx__search_tools` finds the exact operation and schema.
+6. A typed service tool or `nyx__call_tool` performs the proxied call.
+
+The core built-in tools are `nyx__discover_services`, `nyx__list_connected_services`, `nyx__connect_service`, `nyx__wait_for_connection`, `nyx__search_tools`, and `nyx__call_tool`. The server also registers `nyx__ssh_list_services`, `nyx__ssh_exec`, and the Oracle relay tools (`nyx__oracle_pools`, `nyx__oracle_ask`, `nyx__oracle_result`, `nyx__oracle_attach`, `nyx__oracle_extract`, `nyx__oracle_session`). Connected OpenAPI services add tools whose names come from their service slug and operation ID.
+
+The `/mcp` proxy decrypts and injects stored downstream credentials at call time. Credentials, connection secrets, and raw API keys must never be pasted into chat, committed to a repository, or echoed in a command.
+
+When a shell is available, the CLI is an optional fallback:
+
+```bash
+nyxid mcp config --tool cursor
+nyxid login --base-url https://nyx-api.chrono-ai.fun
+```
+
+The first command prints the same `.cursor/mcp.json` shape used by this plugin. The CLI can also manage services and proxy requests; see the repository's [NyxID skill](../../skills/nyxid/SKILL.md).
+
+## Troubleshooting
+
+- **Browser login does not open:** open the MCP authentication link from Cursor manually, finish OAuth, and reconnect the `nyxid` server.
+- **Only `nyx__...` tools appear:** connect a service first. Typed downstream tools appear after a successful connection and tool-list refresh; restart Cursor if its cache is stale.
+- **The hosted link expired or was cancelled:** call `nyx__connect_service` again and complete the new browser flow.
+- **A tool returns an upstream authorization error:** verify that the intended NyxID service is connected and active. Do not paste a replacement secret into chat; reconnect through the hosted flow or the NyxID web console.
+- **Self-hosted deployment fails:** set `NYXID_BASE_URL` to the backend API origin, not the separate web-console origin, and confirm `<NYXID_BASE_URL>/mcp` is reachable.
+
+## Publishing
+
+The root `.cursor-plugin/marketplace.json` points Cursor's marketplace tooling at this directory. To publish, use the open-source repository at <https://github.com/ChronoAIProject/NyxID>, submit through <https://cursor.com/marketplace/publish>, and select the `nyxid` entry. Cursor performs a manual review; every update is reviewed again. See [`docs/CURSOR_PLUGIN.md`](../../docs/CURSOR_PLUGIN.md) for the extraction flow if this plugin is mirrored into a standalone public repository.

--- a/integrations/cursor-plugin/assets/nyxid-icon.svg
+++ b/integrations/cursor-plugin/assets/nyxid-icon.svg
@@ -1,0 +1,21 @@
+<svg width="424" height="424" viewBox="0 0 424 424" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M422.875 88.0461V335.824C422.875 383.898 383.903 422.87 335.829 422.87H214.328C213.008 422.87 211.938 421.799 211.938 420.48V191.899C211.938 189.461 208.72 188.587 207.487 190.69L72.0088 421.69C71.5786 422.421 70.7947 422.87 69.9486 422.87H3.39006C2.07075 422.87 1 421.799 1 420.48V3.39006C1 2.07075 2.07075 1 3.39006 1H139.237C140.556 1 141.627 2.07075 141.627 3.39006V231.971C141.627 234.409 144.844 235.284 146.077 233.18L281.56 2.18069C281.99 1.44933 282.774 1 283.62 1H335.824C383.898 1 422.87 39.9724 422.87 88.0461H422.875Z" fill="url(#paint0_linear_5_295)"/>
+<g filter="url(#filter0_f_5_295)">
+<path d="M3.38965 2.25H139.236C139.865 2.25 140.377 2.76088 140.377 3.38965V231.971C140.377 235.681 145.277 237.016 147.155 233.812L282.638 2.8125C282.844 2.46246 283.219 2.25007 283.62 2.25H335.824C383.207 2.25007 421.62 40.6627 421.62 88.0459V89.2959H421.625V335.824C421.625 383.207 383.212 421.62 335.829 421.62H214.327C213.698 421.62 213.188 421.109 213.188 420.48V191.899C213.188 188.189 208.288 186.854 206.409 190.058L70.9316 421.056C70.7252 421.407 70.3497 421.62 69.9482 421.62H3.38965C2.76098 421.62 2.25017 421.109 2.25 420.48V3.38965C2.25023 2.76102 2.76102 2.25023 3.38965 2.25Z" stroke="url(#paint1_linear_5_295)" stroke-opacity="0.5" stroke-width="2.5"/>
+</g>
+<defs>
+<filter id="filter0_f_5_295" x="0" y="0" width="423.875" height="423.87" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.5" result="effect1_foregroundBlur_5_295"/>
+</filter>
+<linearGradient id="paint0_linear_5_295" x1="211.938" y1="1" x2="211.938" y2="422.87" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A672FB" style="stop-color:#A672FB;stop-color:color(display-p3 0.6510 0.4471 0.9843);stop-opacity:1;"/>
+<stop offset="1" stop-color="#5E00F5" style="stop-color:#5E00F5;stop-color:color(display-p3 0.3671 0.0000 0.9609);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="paint1_linear_5_295" x1="211.938" y1="1" x2="211.938" y2="422.87" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" style="stop-color:white;stop-opacity:1;"/>
+<stop offset="1" stop-color="white" stop-opacity="0" style="stop-color:none;stop-opacity:0;"/>
+</linearGradient>
+</defs>
+</svg>

--- a/integrations/cursor-plugin/commands/nyxid-connect.md
+++ b/integrations/cursor-plugin/commands/nyxid-connect.md
@@ -1,0 +1,11 @@
+---
+name: nyxid-connect
+description: Connect a catalog service through NyxID without placing its credential in the agent context.
+---
+
+Use NyxID's MCP tools to connect a service for the current user.
+
+1. Call `nyx__discover_services` and show a concise list of matching services. Ask which service the user wants if the request did not identify one.
+2. Call `nyx__connect_service` with the selected `service_id` only. Do not request or pass a raw API key, OAuth token, password, or other credential.
+3. If the result is `pending_connection`, give the user the hosted connection URL and wait for them to complete it in their browser. Then call `nyx__wait_for_connection` with `connect_link_id`.
+4. After a successful connection, call `nyx__search_tools` for the service and report that its tools are available. Do not claim a downstream call succeeded until you actually call one when the user asks for verification.

--- a/integrations/cursor-plugin/mcp.json
+++ b/integrations/cursor-plugin/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "nyxid": {
+      "url": "${NYXID_BASE_URL}/mcp"
+    }
+  }
+}

--- a/integrations/cursor-plugin/rules/nyxid.mdc
+++ b/integrations/cursor-plugin/rules/nyxid.mdc
@@ -1,7 +1,6 @@
 ---
 description: Route credential-backed downstream API work through NyxID instead of asking for or handling raw provider secrets.
 alwaysApply: false
-globs: ["**/*"]
 ---
 
 When a task needs an authenticated downstream service and no suitable native integration is already available, use the NyxID MCP server. Discover or connect the service with NyxID's MCP tools, then call the exposed service tool through NyxID so its stored credential is injected server-side. Do not ask the user to paste an API key or OAuth token into chat or source files.

--- a/integrations/cursor-plugin/rules/nyxid.mdc
+++ b/integrations/cursor-plugin/rules/nyxid.mdc
@@ -1,0 +1,7 @@
+---
+description: Route credential-backed downstream API work through NyxID instead of asking for or handling raw provider secrets.
+alwaysApply: false
+globs: ["**/*"]
+---
+
+When a task needs an authenticated downstream service and no suitable native integration is already available, use the NyxID MCP server. Discover or connect the service with NyxID's MCP tools, then call the exposed service tool through NyxID so its stored credential is injected server-side. Do not ask the user to paste an API key or OAuth token into chat or source files.

--- a/integrations/cursor-plugin/skills/nyxid/SKILL.md
+++ b/integrations/cursor-plugin/skills/nyxid/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: nyxid
+description: Use NyxID's hosted MCP server to discover connected services, connect a service through a browser-hosted link, and call downstream APIs with credentials kept out of the agent context.
+---
+
+# NyxID for Cursor
+
+Use NyxID when the user wants a credential-backed downstream API call, service discovery, or a connection to an external service. NyxID stores the provider credential and injects it when it proxies a tool call. The agent should see the downstream response, not the provider secret.
+
+## MCP-first workflow
+
+The plugin configures the hosted `${NYXID_BASE_URL}/mcp` endpoint. Authenticate in the browser when Cursor prompts. The built-in MCP tools are:
+
+- `nyx__discover_services` lists catalog services that are not connected. Use its optional `query` or `category` filters when useful.
+- `nyx__list_connected_services` lists the user's connected services and availability.
+- `nyx__connect_service` starts a connection for a `service_id` returned by discovery. Omit `credential` by default: when a human connection is needed, the result contains a hosted connection URL and `connect_link_id`.
+- `nyx__wait_for_connection` waits on that `connect_link_id`; call it after the user completes the hosted flow, then retry the original operation.
+- `nyx__search_tools` searches the connected service tools and returns their input schemas.
+- `nyx__call_tool` invokes a discovered tool by its full name. Pass `arguments_json` as a JSON string matching the schema returned by `nyx__search_tools`.
+
+Per-service tools may also be listed directly after a connection. Their names are derived from the service slug and OpenAPI operation ID; do not guess a name when `nyx__search_tools` can find it.
+
+## Connecting without handling secrets
+
+Never ask the user to paste a raw API key, OAuth token, password, or private credential into chat, a prompt, or a repository. Start with `nyx__connect_service` using only the discovered `service_id`. Tell the user to open the returned hosted URL and finish the provider flow in the browser. Then call `nyx__wait_for_connection` with the returned `connect_link_id`. Do not repeat or log the URL's token, and do not put credentials in command arguments or files.
+
+If the user already has a service connected, skip connection and use `nyx__list_connected_services`, `nyx__search_tools`, and the matching service tool. If the hosted link expires or is cancelled, start a new connection rather than requesting the secret.
+
+## Calling a downstream API
+
+1. Use `nyx__list_connected_services` to confirm the service, or `nyx__discover_services` to find one.
+2. If it is not connected, use the hosted connection flow above.
+3. Search with `nyx__search_tools` and inspect the returned `inputSchema`.
+4. Prefer a typed per-service tool. Otherwise invoke it through `nyx__call_tool` with exact JSON arguments.
+5. Report the downstream response and any service error without exposing credential material.
+
+NyxID's MCP proxy supports the user's connected catalog and user-managed services. A service with no OpenAPI operation may still be available through its generic proxy tool; use the search results as the source of truth.
+
+## Optional shell fallback
+
+Use the `nyxid` CLI only when a shell is available and the user wants a terminal workflow. Install it with the repository's documented installer, then authenticate once:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/ChronoAIProject/NyxID/main/skills/nyxid/scripts/install.sh)"
+nyxid login --base-url https://nyx-api.chrono-ai.fun
+```
+
+The CLI stores its session locally and can list services, manage keys, and issue proxy requests. Prefer the MCP tools in Cursor because they preserve the browser OAuth flow and keep credentials in NyxID. Never print a stored token or ask the user to paste one into this chat.
+
+## Oracle and SSH tools
+
+The hosted MCP server also exposes these NyxID-owned tools when the account has the corresponding capability:
+
+- SSH: `nyx__ssh_list_services`, `nyx__ssh_exec`.
+- Browser-backed Oracle relay: `nyx__oracle_pools`, `nyx__oracle_ask`, `nyx__oracle_result`, `nyx__oracle_attach`, `nyx__oracle_extract`, `nyx__oracle_session`.
+
+Use `nyx__oracle_pools` before submitting Oracle work. Poll a pending task with `nyx__oracle_result`. Use `nyx__oracle_attach` only when the user supplies an existing ChatGPT conversation URL and asks to import it.

--- a/integrations/cursor-plugin/skills/nyxid/SKILL.md
+++ b/integrations/cursor-plugin/skills/nyxid/SKILL.md
@@ -9,7 +9,7 @@ Use NyxID when the user wants a credential-backed downstream API call, service d
 
 ## MCP-first workflow
 
-The plugin configures the hosted `${NYXID_BASE_URL}/mcp` endpoint. Authenticate in the browser when Cursor prompts. The built-in MCP tools are:
+The plugin configures the MCP endpoint at `<base URL>/mcp`, using the plugin's `NYXID_BASE_URL` variable for the configured NyxID base URL. Authenticate in the browser when Cursor prompts. The built-in MCP tools are:
 
 - `nyx__discover_services` lists catalog services that are not connected. Use its optional `query` or `category` filters when useful.
 - `nyx__list_connected_services` lists the user's connected services and availability.

--- a/scripts/validate-cursor-plugin.py
+++ b/scripts/validate-cursor-plugin.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Validate the NyxID Cursor plugin using only the Python standard library."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+class ValidationError(Exception):
+    """A user-facing validation failure."""
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"{path}: invalid JSON ({exc})")
+
+
+def require_mapping(value: object, label: str) -> dict:
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value
+
+
+def validate_relative_path(root: Path, raw: object, label: str) -> None:
+    if not isinstance(raw, str) or not raw:
+        fail(f"{label} must be a non-empty relative path")
+    path = Path(raw)
+    if path.is_absolute() or ".." in path.parts:
+        fail(f"{label} must be relative and must not contain '..': {raw!r}")
+    target = root / path
+    if not target.exists():
+        fail(f"{label} does not exist: {raw}")
+
+
+def validate_manifest(root: Path) -> tuple[dict, dict]:
+    manifest_path = root / ".cursor-plugin" / "plugin.json"
+    if not manifest_path.is_file():
+        fail(f"missing required manifest: {manifest_path}")
+    manifest = require_mapping(load_json(manifest_path), "plugin.json")
+
+    name = manifest.get("name")
+    if not isinstance(name, str) or not NAME_RE.fullmatch(name):
+        fail("plugin name must be lowercase kebab-case")
+    if not isinstance(manifest.get("description"), str) or not manifest["description"].strip():
+        fail("plugin description is required")
+    if "version" in manifest and (
+        not isinstance(manifest["version"], str) or not SEMVER_RE.fullmatch(manifest["version"])
+    ):
+        fail("plugin version must be semantic versioning")
+    if not isinstance(manifest.get("license"), str) or not manifest["license"].strip():
+        fail("plugin license is required")
+
+    validate_relative_path(root, manifest.get("logo"), "logo")
+    if not (root / "README.md").is_file():
+        fail("README.md is required")
+
+    for field in ("rules", "agents", "skills", "commands", "hooks"):
+        value = manifest.get(field, [])
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list):
+            fail(f"manifest field {field} must be a path or array of paths")
+        for index, item in enumerate(value):
+            validate_relative_path(root, item, f"{field}[{index}]")
+        manifest[field] = value
+
+    mcp_ref = manifest.get("mcpServers")
+    if isinstance(mcp_ref, str):
+        validate_relative_path(root, mcp_ref, "mcpServers")
+    elif mcp_ref is not None and not isinstance(mcp_ref, (dict, list)):
+        fail("mcpServers must be a path, object, or array")
+    if not isinstance(mcp_ref, str):
+        fail("this plugin must declare mcpServers as the mcp.json path")
+
+    variables = require_mapping(manifest.get("variables", {}), "variables")
+    properties = variables.get("properties", {})
+    if not isinstance(properties, dict):
+        fail("variables.properties must be an object")
+    for variable_name, schema in properties.items():
+        if not isinstance(variable_name, str) or not isinstance(schema, dict):
+            fail("variables.properties entries must be named schema objects")
+        if not isinstance(schema.get("type"), str):
+            fail(f"variable {variable_name} must declare a type")
+    return manifest, properties
+
+
+def frontmatter(path: Path) -> dict:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        fail(f"cannot read {path}: {exc}")
+    if not lines or lines[0].strip() != "---":
+        fail(f"{path}: missing YAML frontmatter")
+    try:
+        end = next(index for index, line in enumerate(lines[1:], 1) if line.strip() == "---")
+    except StopIteration:
+        fail(f"{path}: unterminated YAML frontmatter")
+    result: dict[str, object] = {}
+    for line in lines[1:end]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line or line[:1].isspace():
+            fail(f"{path}: unsupported frontmatter line: {line!r}")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value in {"true", "false"}:
+            result[key] = value == "true"
+        elif (value.startswith("\"") and value.endswith("\"")) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            result[key] = value[1:-1]
+        else:
+            result[key] = value
+    return result
+
+
+def validate_components(root: Path, manifest: dict) -> None:
+    for relative in manifest.get("skills", []):
+        path = root / relative
+        skill_files = [path / "SKILL.md"] if path.is_dir() else [path]
+        for skill in skill_files:
+            fields = frontmatter(skill)
+            for field in ("name", "description"):
+                if not isinstance(fields.get(field), str) or not fields[field].strip():
+                    fail(f"{skill}: skill frontmatter requires {field}")
+
+    for relative in manifest.get("rules", []):
+        fields = frontmatter(root / relative)
+        if not isinstance(fields.get("description"), str) or not fields["description"].strip():
+            fail(f"{root / relative}: rule frontmatter requires description")
+        if not isinstance(fields.get("alwaysApply"), bool):
+            fail(f"{root / relative}: rule frontmatter requires boolean alwaysApply")
+        if "globs" not in fields or not str(fields["globs"]).strip():
+            fail(f"{root / relative}: rule frontmatter requires globs")
+
+    for relative in manifest.get("commands", []):
+        fields = frontmatter(root / relative)
+        for field in ("name", "description"):
+            if not isinstance(fields.get(field), str) or not fields[field].strip():
+                fail(f"{root / relative}: command frontmatter requires {field}")
+
+
+def validate_mcp(root: Path, properties: dict) -> None:
+    mcp_path = root / "mcp.json"
+    mcp_text = mcp_path.read_text(encoding="utf-8")
+    mcp = require_mapping(load_json(mcp_path), "mcp.json")
+    servers = require_mapping(mcp.get("mcpServers"), "mcpServers")
+    if "nyxid" not in servers:
+        fail("mcp.json must declare an nyxid server")
+    server = require_mapping(servers["nyxid"], "mcpServers.nyxid")
+    if not isinstance(server.get("url"), str) or not server["url"].strip():
+        fail("mcpServers.nyxid.url is required")
+    used = set(VAR_RE.findall(mcp_text))
+    declared = set(properties)
+    missing = sorted(used - declared)
+    if missing:
+        fail(f"mcp.json uses undeclared variables: {', '.join(missing)}")
+
+
+def main() -> int:
+    default_root = Path(__file__).resolve().parents[1] / "integrations" / "cursor-plugin"
+    root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else default_root
+    try:
+        manifest, properties = validate_manifest(root)
+        validate_components(root, manifest)
+        validate_mcp(root, properties)
+    except ValidationError as exc:
+        print(f"Cursor plugin validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Cursor plugin validation passed: {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-cursor-plugin.py
+++ b/scripts/validate-cursor-plugin.py
@@ -145,8 +145,8 @@ def validate_components(root: Path, manifest: dict) -> None:
             fail(f"{root / relative}: rule frontmatter requires description")
         if not isinstance(fields.get("alwaysApply"), bool):
             fail(f"{root / relative}: rule frontmatter requires boolean alwaysApply")
-        if "globs" not in fields or not str(fields["globs"]).strip():
-            fail(f"{root / relative}: rule frontmatter requires globs")
+        if "globs" in fields and not str(fields["globs"]).strip():
+            fail(f"{root / relative}: rule frontmatter globs must be non-empty when present")
 
     for relative in manifest.get("commands", []):
         fields = frontmatter(root / relative)
@@ -172,6 +172,70 @@ def validate_mcp(root: Path, properties: dict) -> None:
         fail(f"mcp.json uses undeclared variables: {', '.join(missing)}")
 
 
+def find_marketplace(plugin_root: Path) -> tuple[Path, Path] | None:
+    """Find a repository marketplace index above a plugin root, if present."""
+    current = plugin_root
+    while True:
+        candidate = current / ".cursor-plugin" / "marketplace.json"
+        if candidate.is_file():
+            return candidate, current
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def validate_marketplace(plugin_root: Path) -> None:
+    """Validate monorepo marketplace entries without requiring one standalone."""
+    found = find_marketplace(plugin_root)
+    if found is None:
+        return
+
+    marketplace_path, marketplace_root = found
+    marketplace = require_mapping(load_json(marketplace_path), "marketplace.json")
+    marketplace_name = marketplace.get("name")
+    if not isinstance(marketplace_name, str) or not NAME_RE.fullmatch(marketplace_name):
+        fail("marketplace name must be lowercase kebab-case")
+
+    plugins = marketplace.get("plugins")
+    if not isinstance(plugins, list) or not plugins:
+        fail("marketplace plugins must be a non-empty array")
+
+    metadata = marketplace.get("metadata", {})
+    if not isinstance(metadata, dict):
+        fail("marketplace metadata must be an object when present")
+    plugin_prefix = metadata.get("pluginRoot", "")
+    if not isinstance(plugin_prefix, str):
+        fail("marketplace metadata.pluginRoot must be a relative path when present")
+    if plugin_prefix:
+        prefix_path = Path(plugin_prefix)
+        if prefix_path.is_absolute() or ".." in prefix_path.parts:
+            fail("marketplace metadata.pluginRoot must be relative and must not contain '..'")
+
+    for index, entry_value in enumerate(plugins):
+        entry = require_mapping(entry_value, f"marketplace.plugins[{index}]")
+        entry_name = entry.get("name")
+        if not isinstance(entry_name, str) or not NAME_RE.fullmatch(entry_name):
+            fail(f"marketplace.plugins[{index}].name must be lowercase kebab-case")
+        source = entry.get("source")
+        if not isinstance(source, str) or not source:
+            fail(f"marketplace.plugins[{index}].source must be a non-empty relative path")
+        source_path = Path(source)
+        if source_path.is_absolute() or ".." in source_path.parts:
+            fail(f"marketplace.plugins[{index}].source must be relative and must not contain '..'")
+        effective_source = marketplace_root / plugin_prefix / source_path
+        manifest_path = effective_source / ".cursor-plugin" / "plugin.json"
+        if not manifest_path.is_file():
+            fail(
+                f"marketplace.plugins[{index}].source does not resolve to a plugin: "
+                f"{effective_source}"
+            )
+        plugin_manifest = require_mapping(load_json(manifest_path), f"{manifest_path}")
+        if plugin_manifest.get("name") != entry_name:
+            fail(f"marketplace.plugins[{index}].name does not match {manifest_path}")
+        if "version" not in entry or entry.get("version") != plugin_manifest.get("version"):
+            fail(f"marketplace.plugins[{index}].version does not match {manifest_path}")
+
+
 def main() -> int:
     default_root = Path(__file__).resolve().parents[1] / "integrations" / "cursor-plugin"
     root = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else default_root
@@ -179,6 +243,7 @@ def main() -> int:
         manifest, properties = validate_manifest(root)
         validate_components(root, manifest)
         validate_mcp(root, properties)
+        validate_marketplace(root)
     except ValidationError as exc:
         print(f"Cursor plugin validation failed: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Adds a publish-ready Cursor Marketplace plugin so any Cursor agent (including Grok-model bots) can use NyxID for credential brokering, service discovery, and proxied downstream API calls without credentials ever entering the agent context.

- `integrations/cursor-plugin/` — self-contained plugin: `.cursor-plugin/plugin.json` manifest, `mcp.json` pointing at `${NYXID_BASE_URL}/mcp` (single declared variable, default `https://nyx-api.chrono-ai.fun`; browser OAuth is the zero-config auth path), an MCP-first skill (discover → connect via hosted link → wait → search tools → call, tool/argument names verified against `backend/src/services/mcp_service.rs`), a description-triggered credential-safety rule, a `/nyxid-connect` command, the NyxID coloured icon, and a usage README
- Root `.cursor-plugin/marketplace.json` identifying the nested plugin for monorepo submission (plain relative `source`, matching the official `cursor/plugins` convention)
- `docs/CURSOR_PLUGIN.md` — publish flow (cursor.com/marketplace/publish, manual review) and the standalone-mirror path
- `scripts/validate-cursor-plugin.py` — stdlib-only validator for manifest, component frontmatter, `${VAR}` declarations, and marketplace-entry consistency; wired into CI as a path-filtered `cursor-plugin-validate` job included in the `ci-pass` gate

## Verification

- Validator passes in monorepo, explicit-path, and standalone-mirror layouts
- `ci.yml` YAML parses; new job follows the existing `changes`-filter / `force-all` / gate idioms
- No API-key variable by design: the MCP transport takes keys via `X-API-Key` (not `Bearer`), and the plugin keeps browser OAuth as the happy path rather than placing a secret in Cursor config

Note: marketplace publication itself requires the plugin's repository to be public open source (documented in `docs/CURSOR_PLUGIN.md`, including mirroring `integrations/cursor-plugin/` to a standalone public repo if this repo stays private).