### PR TITLE
fix(mobile): suppress OS notifications while the app is foregrounded

### DIFF
--- a/mobile/src/app/App.tsx
+++ b/mobile/src/app/App.tsx
@@ -12,7 +12,7 @@ SplashScreen.preventAutoHideAsync().catch(() => {
      been hidden, e.g. during fast refresh. Safe to ignore. */
 });
 import { ActivityIndicator, AppState, StyleSheet, Text, View } from "react-native";
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import { SafeAreaProvider, useSafeAreaInsets } from "react-native-safe-area-context";
 import { onlineManager, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import NetInfo from "@react-native-community/netinfo";
 import {
@@ -41,8 +41,10 @@ import {
   consumePendingPushSyncSignal,
   initializeNotificationRuntime,
   PushSyncSignal,
+  setForegroundNotificationHandler,
   setPushSyncHandler,
 } from "../lib/notifications/pushNotifications";
+import { ToastOverlay, type ToastState } from "../components/ToastOverlay";
 import { startPushPolling } from "../lib/notifications/pushPollingSignal";
 import { AuthSessionProvider } from "../features/auth/AuthSessionContext";
 import { MobileConsentProvider } from "../lib/consent";
@@ -92,6 +94,7 @@ export default function App() {
   const [isNyxOpen, setIsNyxOpen] = useState(false);
   const pendingChallengeFromTapRef = useRef<string | null>(null);
   const lastAppStateRef = useRef(AppState.currentState);
+  const [pushToast, setPushToast] = useState<ToastState | null>(null);
 
   const flushPendingChallengeTapNavigation = useCallback(() => {
     if (!navigationRef.isReady()) return;
@@ -107,6 +110,18 @@ export default function App() {
     pendingChallengeFromTapRef.current = null;
     navigationRef.navigate("Activity", { challengeId: pendingChallengeId });
   }, [navigationRef]);
+
+  // Tapping the in-app toast resolves to exactly the same navigation as
+  // tapping an OS notification, including the "Activity route not mounted
+  // yet" deferral -- the pending id survives until the navigator is ready
+  // and `onStateChange` flushes it.
+  const openChallengeFromNotification = useCallback(
+    (challengeId: string) => {
+      pendingChallengeFromTapRef.current = challengeId;
+      flushPendingChallengeTapNavigation();
+    },
+    [flushPendingChallengeTapNavigation]
+  );
 
   const [fontsLoaded] = useFonts({
     Manrope_400Regular,
@@ -246,6 +261,30 @@ export default function App() {
     };
   }, [flushPendingChallengeTapNavigation]);
 
+  // In-app replacement for the OS banner suppressed while the app is
+  // foregrounded (see `configureNotificationHandler`). Without this, a push
+  // arriving with the app open would be silent to the user. Reuses the same
+  // toast the rest of the app uses; the backend's push body is boilerplate
+  // ("A service is requesting access"), so the title alone loses nothing.
+  useEffect(() => {
+    return setForegroundNotificationHandler((notification) => {
+      const message = notification.title ?? notification.body;
+      if (!message) return;
+
+      const { challengeId } = notification;
+      setPushToast({
+        message,
+        kind: "info",
+        action: challengeId
+          ? {
+              label: "Review",
+              onPress: () => openChallengeFromNotification(challengeId),
+            }
+          : undefined,
+      });
+    });
+  }, [openChallengeFromNotification]);
+
   useEffect(() => {
     const onPushSyncSignal = (signal: PushSyncSignal) => {
       refreshQueryCacheFromPushSignal(signal);
@@ -308,6 +347,7 @@ export default function App() {
                     flushPendingChallengeTapNavigation={flushPendingChallengeTapNavigation}
                     isNyxOpen={isNyxOpen}
                     setIsNyxOpen={setIsNyxOpen}
+                    pushToast={pushToast}
                   />
                 </AuthSessionProvider>
               </MobileConsentProvider>
@@ -326,6 +366,7 @@ function ThemedAppShell({
   flushPendingChallengeTapNavigation,
   isNyxOpen,
   setIsNyxOpen,
+  pushToast,
 }: {
   navigationRef: ReturnType<typeof useNavigationContainerRef<RootStackParamList>>;
   currentRouteName: string | undefined;
@@ -333,8 +374,10 @@ function ThemedAppShell({
   flushPendingChallengeTapNavigation: () => void;
   isNyxOpen: boolean;
   setIsNyxOpen: (open: boolean) => void;
+  pushToast: ToastState | null;
 }) {
   const { mode } = useTheme();
+  const insets = useSafeAreaInsets();
 
   return (
     <>
@@ -367,6 +410,15 @@ function ThemedAppShell({
           // onNyxPress={() => setIsNyxOpen(true)} // TODO: re-enable when chat is ready
         />
       </NavigationContainer>
+      {/* ToastOverlay anchors to `top: 0` of its parent and relies on the
+          screen's SafeAreaView for inset. Mounted globally it has no such
+          parent, so give it explicit bounds below the notch. */}
+      <View
+        style={[pushToastStyles.overlay, { top: insets.top }]}
+        pointerEvents="box-none"
+      >
+        <ToastOverlay toast={pushToast} duration={6000} />
+      </View>
       {/* <NyxSheet isOpen={isNyxOpen} onClose={() => setIsNyxOpen(false)} /> */}{/* TODO: re-enable when chat is ready */}
     </>
   );
@@ -383,6 +435,15 @@ const appLoadingStyles = StyleSheet.create({
   text: {
     color: "#e8e4f0",
     fontSize: 16,
+  },
+});
+
+const pushToastStyles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
 });
 

--- a/mobile/src/features/activity/ActivityDetailScreen.tsx
+++ b/mobile/src/features/activity/ActivityDetailScreen.tsx
@@ -7,6 +7,7 @@ import { ScreenContainer } from "../../components/ScreenContainer";
 
 import { FullScreenLoading } from "../../components/FullScreenLoading";
 import { ToastOverlay, type ToastState } from "../../components/ToastOverlay";
+import { setActiveChallengeId } from "../../lib/notifications/pushNotifications";
 import { StatusBadge } from "../../components/StatusBadge";
 import { PrimaryButton } from "../../components/PrimaryButton";
 import { mobileApi } from "../../lib/api/mobileApi";
@@ -49,6 +50,13 @@ export function ActivityDetailScreen({ navigation, route }: Props) {
   const { challengeId } = route.params;
   const queryClient = useQueryClient();
   const [toast, setToast] = useState<ToastState | null>(null);
+
+  // Same gate as ActivityScreen: suppress the in-app toast for the approval
+  // that is already filling the screen.
+  useEffect(() => {
+    setActiveChallengeId(challengeId);
+    return () => setActiveChallengeId(null);
+  }, [challengeId]);
 
   useEffect(() => {
     if (!toast) return;

--- a/mobile/src/features/activity/ActivityScreen.tsx
+++ b/mobile/src/features/activity/ActivityScreen.tsx
@@ -31,6 +31,7 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tansta
 import { ScreenContainer } from "../../components/ScreenContainer";
 
 import { ToastOverlay, type ToastState } from "../../components/ToastOverlay";
+import { setActiveChallengeId } from "../../lib/notifications/pushNotifications";
 import { SegmentControl } from "../../components/SegmentControl";
 import { ChallengeCard } from "../../components/ChallengeCard";
 import { GrantCard } from "../../components/GrantCard";
@@ -291,6 +292,15 @@ export function ActivityScreen() {
   const [toast, setToast] = useState<ToastState | null>(null);
   const [mutatingIds, setMutatingIds] = useState<Set<string>>(new Set());
   const [detailChallenge, setDetailChallenge] = useState<ChallengeDetail | null>(null);
+
+  // Tell the push layer which approval is on screen, so a push for THIS
+  // challenge does not raise an in-app toast over the sheet the user is
+  // already acting on. Cleared on unmount so an unmounted screen never
+  // keeps suppressing.
+  useEffect(() => {
+    setActiveChallengeId(detailChallenge?.id ?? null);
+    return () => setActiveChallengeId(null);
+  }, [detailChallenge?.id]);
   // Track when the approval-detail sheet was opened so we can report
   // both the view duration on abandonment and the view->tap latency on
   // decision emission.

--- a/mobile/src/lib/notifications/pushNotifications.ts
+++ b/mobile/src/lib/notifications/pushNotifications.ts
@@ -1,7 +1,7 @@
 import * as Notifications from "expo-notifications";
 import * as SecureStore from "expo-secure-store";
 import * as TaskManager from "expo-task-manager";
-import { Platform } from "react-native";
+import { AppState, Platform } from "react-native";
 import { mobileApi } from "../api/mobileApi";
 
 type PushActivateResult = {
@@ -45,21 +45,107 @@ let isBootstrapped = false;
 const NOTIFICATION_DEDUPE_WINDOW_MS = 2000;
 const lastShownAtByNotificationKey = new Map<string, number>();
 
+/**
+ * Behaviour returned when a notification must not surface as an OS alert.
+ * Also keeps it out of Notification Center: an approval the user has already
+ * seen (or acted on) in-app should not linger in the shade as a stale entry.
+ */
+const SUPPRESS_OS_NOTIFICATION = {
+  shouldShowAlert: false,
+  shouldShowBanner: false,
+  shouldShowList: false,
+  shouldPlaySound: false,
+  shouldSetBadge: false,
+} as const;
+
+const PRESENT_OS_NOTIFICATION = {
+  shouldShowAlert: true,
+  shouldShowBanner: true,
+  shouldShowList: true,
+  shouldPlaySound: true,
+  shouldSetBadge: false,
+} as const;
+
+/**
+ * Notification content that arrived while the app was in front of the user.
+ * The OS banner for it was suppressed, so the app owes them an in-app
+ * equivalent -- the app shell renders it through `ToastOverlay`.
+ */
+export type ForegroundNotification = {
+  title: string | null;
+  body: string | null;
+  challengeId: string | null;
+  type: PushSyncSignalType | null;
+};
+
+type ForegroundNotificationHandler = (notification: ForegroundNotification) => void;
+
+let foregroundNotificationHandler: ForegroundNotificationHandler | null = null;
+
+/**
+ * Registered by the app shell. Unlike `setPushSyncHandler`, there is no
+ * persist-for-later fallback: an in-app toast is only meaningful while the
+ * app is actually on screen, and the cache refresh + Activity list already
+ * cover the "user comes back later" case.
+ */
+export function setForegroundNotificationHandler(
+  handler: ForegroundNotificationHandler
+): () => void {
+  foregroundNotificationHandler = handler;
+  return () => {
+    if (foregroundNotificationHandler === handler) {
+      foregroundNotificationHandler = null;
+    }
+  };
+}
+
+// The approval the user currently has open (detail sheet or detail screen).
+// Set by those screens; `null` whenever nothing specific is being viewed.
+let activeChallengeId: string | null = null;
+
+export function setActiveChallengeId(challengeId: string | null): void {
+  activeChallengeId = challengeId;
+}
+
+function pruneNotificationDedupeKeys(now: number): void {
+  for (const [key, shownAt] of lastShownAtByNotificationKey) {
+    if (now - shownAt >= NOTIFICATION_DEDUPE_WINDOW_MS) {
+      lastShownAtByNotificationKey.delete(key);
+    }
+  }
+}
+
+/**
+ * Decide whether a notification arriving right now should be shown by the OS.
+ *
+ * `handleNotification` is only consulted while the JS runtime is live -- in
+ * practice, while the app is foregrounded. Background and killed delivery is
+ * rendered by the OS without asking us, so nothing here can suppress those.
+ */
 function configureNotificationHandler() {
   if (isNotificationHandlerConfigured) return;
 
   Notifications.setNotificationHandler({
     handleNotification: async (notification) => {
       const content = notification.request.content;
+
+      // Data-only pushes carry no user-visible copy; showing them yields an
+      // empty alert.
       const isSilent = !content.title && !content.body;
       if (isSilent) {
-        return {
-          shouldShowAlert: false,
-          shouldShowBanner: false,
-          shouldShowList: false,
-          shouldPlaySound: false,
-          shouldSetBadge: false,
-        };
+        return SUPPRESS_OS_NOTIFICATION;
+      }
+
+      // The app is open and in front of the user. An OS banner here would
+      // cover the very screen that is already reacting to this event (the
+      // Activity list refreshes off the same push). Suppress it and let the
+      // in-app toast present it instead, which is also what the platform
+      // conventions expect. Note this deliberately tests `active` and not
+      // merely "not background": during a transition (`inactive` -- app
+      // switcher, Control Centre pulled down, incoming call) the user is not
+      // looking at our UI, so the OS banner is still the right surface.
+      if (AppState.currentState === "active") {
+        return SUPPRESS_OS_NOTIFICATION;
       }
 
       const signal = parsePushSyncSignalFromData(content.data, "foreground");
@@ -71,27 +157,46 @@ function configureNotificationHandler() {
       const now = Date.now();
       const lastShownAt = lastShownAtByNotificationKey.get(notificationKey);
       if (lastShownAt && now - lastShownAt < NOTIFICATION_DEDUPE_WINDOW_MS) {
-        return {
-          shouldShowAlert: false,
-          shouldShowBanner: false,
-          shouldShowList: false,
-          shouldPlaySound: false,
-          shouldSetBadge: false,
-        };
+        return SUPPRESS_OS_NOTIFICATION;
       }
+      pruneNotificationDedupeKeys(now);
       lastShownAtByNotificationKey.set(notificationKey, now);
 
-      return {
-        shouldShowAlert: true,
-        shouldShowBanner: true,
-        shouldShowList: true,
-        shouldPlaySound: true,
-        shouldSetBadge: false,
-      };
+      return PRESENT_OS_NOTIFICATION;
     },
   });
 
   isNotificationHandlerConfigured = true;
+}
+
+/**
+ * Stand-in for the OS banner we suppressed above. Called for every
+ * notification received while the runtime is live; bails out unless the app
+ * really is on screen, so a backgrounded-but-live runtime does not end up
+ * showing both an OS banner and an in-app one.
+ */
+function presentForegroundNotification(
+  content: Notifications.NotificationContent,
+  signal: PushSyncSignal | null
+): void {
+  if (AppState.currentState !== "active") return;
+
+  const title = asNonEmptyString(content.title);
+  const body = asNonEmptyString(content.body);
+  if (!title && !body) return;
+
+  // The user already has this exact approval open. Announcing it on top of
+  // the screen they are acting on is pure noise.
+  if (signal && activeChallengeId && signal.challengeId === activeChallengeId) {
+    return;
+  }
+
+  foregroundNotificationHandler?.({
+    title,
+    body,
+    challengeId: signal?.challengeId ?? null,
+    type: signal?.type ?? null,
+  });
 }
 
 /**
@@ -408,12 +513,16 @@ export async function initializeNotificationRuntime(): Promise<() => void> {
 
     foregroundSubscription = Notifications.addNotificationReceivedListener(
       (notification) => {
-        const signal = parsePushSyncSignalFromData(
-          notification.request.content.data,
-          "foreground"
-        );
-        if (!signal) return;
-        void emitOrPersistPushSyncSignal(signal);
+        const content = notification.request.content;
+        const signal = parsePushSyncSignalFromData(content.data, "foreground");
+
+        if (signal) {
+          void emitOrPersistPushSyncSignal(signal);
+        }
+
+        // Runs for non-approval pushes too -- those have no sync signal but
+        // still deserve the in-app toast that replaced their OS one.
+        presentForegroundNotification(content, signal);
       }
     );
 


### PR DESCRIPTION
## Problem

An approval push arriving **while the app is open** raised a full OS banner with sound, on top of the very screen already reacting to that push (the Activity list refreshes off the same push).

This was not the platform default. On iOS, `UNUserNotificationCenter` only presents a foreground notification if the `willPresent` delegate explicitly asks it to — expo's `handleNotification` is that opt-in, and the previous handler opted in during a run of "notifications aren't showing" fixes (`8f498c81`, `1d138445`) that were really about the *background* path.

## Change

Suppress the OS alert when the app is genuinely in front of the user, and stand in with the app's existing `ToastOverlay` — `"Approval Required"` plus a **Review** action that routes through the exact same path as an OS notification tap, deferral included.

| App state | Before | After |
|---|---|---|
| Foreground (`active`) | OS banner + sound | In-app toast, Review → the approval |
| Foreground, already viewing that approval | OS banner + sound | Nothing — the screen already shows it |
| Transitioning (`inactive` — app switcher, Control Centre) | OS banner | OS banner (unchanged) |
| Background / killed | OS banner | OS banner (unchanged) |
| Silent / data-only push | Nothing | Nothing (unchanged) |

The `active`-vs-"not background" distinction is deliberate: mid-transition the user is not looking at our UI, so the OS banner is still the right surface.

## Notes for review

- **Load-bearing assumption, verified in native source rather than docs:** suppressing presentation does *not* suppress `addNotificationReceivedListener`. iOS `EmitterModule.willPresent` emits the event and returns `false`, leaving the decision to the handler module; Android's `NotificationsEmitter.onNotificationReceived` is a separate `NotificationManager` listener. The toast genuinely fires.
- **Single-line toast loses nothing here.** The backend sends generic copy — title `"Approval Required"`, body `"A service is requesting access"` (`notification_service.rs:290-296`).
- **Safe area.** `ToastOverlay` anchors to `top: 0` and relies on `ScreenContainer`'s `SafeAreaView`, which the app shell does not provide. The global instance is wrapped in an inset-bounded `View`; the four existing usages are untouched.
- **Foreground pushes no longer land in Notification Center** (`shouldShowList: false`) — avoids stale entries for approvals already actioned. Flagging as a product call, easily reverted.
- Bounds the pre-existing dedupe map, which grew unbounded across a session.
- `ActivityDetail` is a registered but currently unreachable route; its `setActiveChallengeId` wiring is inert today and correct if it is ever linked up.

## Verification

`tsc --noEmit` clean, full Metro iOS bundle clean.

**Not exercised on a device.** `mobile/` has no test runner and no CI job, so no actual push has been run through this — it needs a device pass with the app open before it is trusted. Note also that rollup PRs get no CI at all (`ci.yml` gates `main`/`dev` only).

**One race left open:** if the app backgrounds in the milliseconds between the suppression decision and the toast firing, you get neither alert. Closing it would require assuming an ordering between two native callbacks that neither platform guarantees. The approval still reaches the list via the sync signal; it just is not alerted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)