### PR TITLE
fix(credits): clarify allowance units and repair dialog scrolling

### DIFF
--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -6804,6 +6804,47 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn plain_http_llm_proxy_and_allowance_creation_use_the_same_metric() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("proxy_allowance_metric_agreement").await
+        else {
+            return;
+        };
+        let mut target = make_target("http://localhost:8080");
+        target.service.id = uuid::Uuid::new_v4().to_string();
+        target.service.slug = "llm-websocket-capable".to_string();
+        target.service.capabilities =
+            Some(crate::models::downstream_service::ServiceCapabilities {
+                supports_websocket: true,
+                ..Default::default()
+            });
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_one(&target.service)
+        .await
+        .expect("insert catalog service");
+
+        let allowance = crate::services::billing::allowances::create_allowance(
+            &db,
+            crate::services::billing::allowances::CreateAllowanceInput {
+                service_ref: target.service.id.clone(),
+                quantity: 1_000,
+                recurrence: crate::models::usage_allowance::AllowanceRecurrence::Monthly,
+                target_kind: crate::models::billing_target::BillingTargetKind::AllUsers,
+                target_user_ids: Vec::new(),
+                created_by: "admin-1".to_string(),
+            },
+        )
+        .await
+        .expect("create allowance");
+        let proxy_metric = super::platform_metric_for_target(&target, false);
+
+        assert_eq!(proxy_metric, BillingMetric::Tokens);
+        assert_eq!(allowance.metric, proxy_metric);
+    }
+
     #[test]
     fn llm_usage_capture_preserves_slug_allowlist_and_adds_token_metrics() {
         assert!(super::should_capture_llm_usage(

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -4109,24 +4109,10 @@ fn platform_metric_for_target(
     target: &proxy_service::ProxyTarget,
     is_connection: bool,
 ) -> BillingMetric {
-    // An admin-selected metric on the service's billing config wins;
-    // the slug/transport heuristic is only the fallback, so billing
-    // classification does not depend on service naming conventions.
-    if let Some(metric) = target
-        .service
-        .billing
-        .as_ref()
-        .and_then(|billing| billing.platform_metric)
-    {
-        return metric;
-    }
-    if is_connection || target.service.service_type == "ssh" {
-        BillingMetric::Bytes
-    } else if target.service.slug.starts_with("llm-") {
-        BillingMetric::Tokens
-    } else {
-        BillingMetric::Requests
-    }
+    crate::services::billing::metric_resolution::platform_metric_for_request(
+        &target.service,
+        is_connection,
+    )
 }
 
 fn should_capture_llm_usage(service_slug: &str, platform_metric: BillingMetric) -> bool {

--- a/backend/src/handlers/services.rs
+++ b/backend/src/handlers/services.rs
@@ -17,7 +17,7 @@ use crate::models::downstream_service::{
     ProxyOperationPolicy, ServiceCapabilities, TokenExchangeConfig,
 };
 use crate::models::oauth_client::{COLLECTION_NAME as OAUTH_CLIENTS, OauthClient};
-use crate::models::service_billing::ServiceBilling;
+use crate::models::service_billing::{BillingMetric, ServiceBilling};
 use crate::models::ssh_auth_mode::SshAuthMode;
 use crate::models::ws_frame_injection::WsFrameInjection;
 use crate::mw::auth::{AuthUser, SERVICE_DELEGATION_SCOPES};
@@ -176,6 +176,9 @@ pub struct ServiceResponse {
     pub capabilities: Option<ServiceCapabilities>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing: Option<ServiceBilling>,
+    /// Resolved allowance and platform metering unit after applying the
+    /// service's explicit billing override or protocol/slug heuristic.
+    pub effective_platform_metric: BillingMetric,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_notes: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2444,7 +2447,7 @@ mod tests {
         COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
     };
     use crate::models::service_billing::{
-        PricingSyncStatus, ServiceBilling, ServicePlatformPricing,
+        BillingMetric, PricingSyncStatus, ServiceBilling, ServicePlatformPricing,
     };
     use crate::models::user::{COLLECTION_NAME as USERS, User, UserType};
     use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
@@ -2668,6 +2671,7 @@ mod tests {
         assert_eq!(response.name, "Admin Service");
         assert_eq!(response.slug, "admin-service");
         assert_eq!(response.visibility, "public");
+        assert_eq!(response.effective_platform_metric, BillingMetric::Requests);
         let service_count = db
             .collection::<DownstreamService>(DOWNSTREAM_SERVICES)
             .count_documents(doc! { "_id": &response.id })

--- a/backend/src/handlers/services_helpers.rs
+++ b/backend/src/handlers/services_helpers.rs
@@ -237,6 +237,8 @@ pub fn service_to_response_with_viewer(
     s: DownstreamService,
     viewer: Option<&ViewerRouting>,
 ) -> ServiceResponse {
+    let effective_platform_metric =
+        crate::services::billing::metric_resolution::effective_platform_metric(&s);
     ServiceResponse {
         id: s.id,
         name: s.name,
@@ -278,6 +280,7 @@ pub fn service_to_response_with_viewer(
         issues_url: s.issues_url,
         capabilities: s.capabilities,
         billing: s.billing,
+        effective_platform_metric,
         auth_notes: s.auth_notes,
         known_limitations: s.known_limitations,
         required_permissions: s.required_permissions,

--- a/backend/src/services/billing/allowances.rs
+++ b/backend/src/services/billing/allowances.rs
@@ -53,7 +53,7 @@ pub async fn create_allowance(
     validate_quantity(input.quantity)?;
     validate_targets(db, input.target_kind, &input.target_user_ids).await?;
     let service = resolve_service(db, &input.service_ref).await?;
-    let metric = service_metric(&service);
+    let metric = super::metric_resolution::effective_platform_metric(&service);
     let now = Utc::now();
     let allowance = UsageAllowance {
         id: Uuid::new_v4().to_string(),
@@ -119,7 +119,7 @@ pub async fn update_allowance(
         set.insert("is_active", is_active);
     }
     if let Some(service) = service {
-        let metric = service_metric(&service);
+        let metric = super::metric_resolution::effective_platform_metric(&service);
         set.insert("service_id", service.id);
         set.insert("service_slug", service.slug.clone());
         set.insert(
@@ -355,22 +355,6 @@ pub fn available_period_quantity(period: &UsageAllowancePeriod) -> i64 {
         .saturating_sub(period.consumed_quantity)
         .saturating_sub(period.reserved_quantity)
         .max(0)
-}
-
-fn service_metric(service: &DownstreamService) -> BillingMetric {
-    if let Some(metric) = service
-        .billing
-        .as_ref()
-        .and_then(|billing| billing.platform_metric)
-    {
-        metric
-    } else if service.slug.starts_with("llm-") {
-        BillingMetric::Tokens
-    } else if service.service_type == "ssh" {
-        BillingMetric::Bytes
-    } else {
-        BillingMetric::Requests
-    }
 }
 
 fn validate_quantity(quantity: i64) -> AppResult<()> {

--- a/backend/src/services/billing/metric_resolution.rs
+++ b/backend/src/services/billing/metric_resolution.rs
@@ -1,0 +1,102 @@
+use crate::models::downstream_service::DownstreamService;
+use crate::models::service_billing::BillingMetric;
+
+/// Resolve the service-level metric used by allowances and catalog UIs.
+/// WebSocket-capable catalog services are treated as byte-metered because an
+/// allowance has one metric for every route on the service.
+pub fn effective_platform_metric(service: &DownstreamService) -> BillingMetric {
+    resolve_platform_metric(service, service_supports_websocket(service))
+}
+
+/// Resolve the metric for one proxy request. A WebSocket upgrade is
+/// byte-metered even when older catalog metadata does not advertise the
+/// capability yet.
+pub fn platform_metric_for_request(
+    service: &DownstreamService,
+    is_websocket: bool,
+) -> BillingMetric {
+    resolve_platform_metric(service, is_websocket || service_supports_websocket(service))
+}
+
+fn resolve_platform_metric(
+    service: &DownstreamService,
+    uses_websocket_protocol: bool,
+) -> BillingMetric {
+    if let Some(metric) = service
+        .billing
+        .as_ref()
+        .and_then(|billing| billing.platform_metric)
+    {
+        metric
+    } else if uses_websocket_protocol || service.service_type == "ssh" {
+        BillingMetric::Bytes
+    } else if service.slug.starts_with("llm-") {
+        BillingMetric::Tokens
+    } else {
+        BillingMetric::Requests
+    }
+}
+
+fn service_supports_websocket(service: &DownstreamService) -> bool {
+    service
+        .capabilities
+        .as_ref()
+        .is_some_and(|capabilities| capabilities.supports_websocket)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::downstream_service::{ServiceCapabilities, test_helpers::dummy_service};
+    use crate::models::service_billing::{BillingMetric, ServiceBilling};
+
+    use super::{effective_platform_metric, platform_metric_for_request};
+
+    #[test]
+    fn explicit_platform_metric_wins_over_every_heuristic() {
+        let mut service = dummy_service();
+        service.slug = "llm-explicit".to_string();
+        service.service_type = "ssh".to_string();
+        service.billing = Some(ServiceBilling {
+            platform_metric: Some(BillingMetric::Requests),
+            ..Default::default()
+        });
+
+        assert_eq!(effective_platform_metric(&service), BillingMetric::Requests);
+        assert_eq!(
+            platform_metric_for_request(&service, true),
+            BillingMetric::Requests
+        );
+    }
+
+    #[test]
+    fn websocket_and_ssh_services_default_to_bytes() {
+        let mut websocket = dummy_service();
+        websocket.capabilities = Some(ServiceCapabilities {
+            supports_websocket: true,
+            ..Default::default()
+        });
+        assert_eq!(effective_platform_metric(&websocket), BillingMetric::Bytes);
+
+        let mut ssh = dummy_service();
+        ssh.service_type = "ssh".to_string();
+        assert_eq!(effective_platform_metric(&ssh), BillingMetric::Bytes);
+
+        let plain_http = dummy_service();
+        assert_eq!(
+            platform_metric_for_request(&plain_http, true),
+            BillingMetric::Bytes
+        );
+    }
+
+    #[test]
+    fn llm_slugs_default_to_tokens_and_other_http_services_to_requests() {
+        let mut llm = dummy_service();
+        llm.slug = "llm-example".to_string();
+        assert_eq!(effective_platform_metric(&llm), BillingMetric::Tokens);
+
+        assert_eq!(
+            effective_platform_metric(&dummy_service()),
+            BillingMetric::Requests
+        );
+    }
+}

--- a/backend/src/services/billing/metric_resolution.rs
+++ b/backend/src/services/billing/metric_resolution.rs
@@ -2,46 +2,36 @@ use crate::models::downstream_service::DownstreamService;
 use crate::models::service_billing::BillingMetric;
 
 /// Resolve the service-level metric used by allowances and catalog UIs.
-/// WebSocket-capable catalog services are treated as byte-metered because an
-/// allowance has one metric for every route on the service.
+/// This is the metric for the service's plain HTTP path; an actual WebSocket
+/// connection may be byte-metered independently at request time.
 pub fn effective_platform_metric(service: &DownstreamService) -> BillingMetric {
-    resolve_platform_metric(service, service_supports_websocket(service))
+    resolve_platform_metric(service, false)
 }
 
-/// Resolve the metric for one proxy request. A WebSocket upgrade is
-/// byte-metered even when older catalog metadata does not advertise the
-/// capability yet.
+/// Resolve the metric for one proxy request. Only an actual WebSocket
+/// connection, not advertised WebSocket capability, changes the fallback
+/// metric to bytes.
 pub fn platform_metric_for_request(
     service: &DownstreamService,
-    is_websocket: bool,
+    is_connection: bool,
 ) -> BillingMetric {
-    resolve_platform_metric(service, is_websocket || service_supports_websocket(service))
+    resolve_platform_metric(service, is_connection)
 }
 
-fn resolve_platform_metric(
-    service: &DownstreamService,
-    uses_websocket_protocol: bool,
-) -> BillingMetric {
+fn resolve_platform_metric(service: &DownstreamService, is_connection: bool) -> BillingMetric {
     if let Some(metric) = service
         .billing
         .as_ref()
         .and_then(|billing| billing.platform_metric)
     {
         metric
-    } else if uses_websocket_protocol || service.service_type == "ssh" {
+    } else if is_connection || service.service_type == "ssh" {
         BillingMetric::Bytes
     } else if service.slug.starts_with("llm-") {
         BillingMetric::Tokens
     } else {
         BillingMetric::Requests
     }
-}
-
-fn service_supports_websocket(service: &DownstreamService) -> bool {
-    service
-        .capabilities
-        .as_ref()
-        .is_some_and(|capabilities| capabilities.supports_websocket)
 }
 
 #[cfg(test)]
@@ -69,23 +59,51 @@ mod tests {
     }
 
     #[test]
-    fn websocket_and_ssh_services_default_to_bytes() {
-        let mut websocket = dummy_service();
-        websocket.capabilities = Some(ServiceCapabilities {
+    fn websocket_capability_does_not_change_plain_http_llm_metric() {
+        let mut service = dummy_service();
+        service.slug = "llm-websocket-capable".to_string();
+        service.capabilities = Some(ServiceCapabilities {
             supports_websocket: true,
             ..Default::default()
         });
-        assert_eq!(effective_platform_metric(&websocket), BillingMetric::Bytes);
 
-        let mut ssh = dummy_service();
-        ssh.service_type = "ssh".to_string();
-        assert_eq!(effective_platform_metric(&ssh), BillingMetric::Bytes);
+        assert_eq!(effective_platform_metric(&service), BillingMetric::Tokens);
+        assert_eq!(
+            platform_metric_for_request(&service, false),
+            BillingMetric::Tokens
+        );
+        assert_eq!(
+            platform_metric_for_request(&service, true),
+            BillingMetric::Bytes
+        );
+    }
 
+    #[test]
+    fn websocket_capability_does_not_change_plain_http_request_metric() {
+        let mut service = dummy_service();
+        service.capabilities = Some(ServiceCapabilities {
+            supports_websocket: true,
+            ..Default::default()
+        });
+
+        assert_eq!(effective_platform_metric(&service), BillingMetric::Requests);
+        assert_eq!(
+            platform_metric_for_request(&service, false),
+            BillingMetric::Requests
+        );
+    }
+
+    #[test]
+    fn ssh_services_and_actual_connections_default_to_bytes() {
         let plain_http = dummy_service();
         assert_eq!(
             platform_metric_for_request(&plain_http, true),
             BillingMetric::Bytes
         );
+
+        let mut ssh = dummy_service();
+        ssh.service_type = "ssh".to_string();
+        assert_eq!(effective_platform_metric(&ssh), BillingMetric::Bytes);
     }
 
     #[test]

--- a/backend/src/services/billing/mod.rs
+++ b/backend/src/services/billing/mod.rs
@@ -4,6 +4,7 @@ pub mod grants;
 pub mod lago_client;
 pub mod ledger;
 pub mod meter;
+pub mod metric_resolution;
 pub mod owner_resolver;
 pub mod pricing;
 pub mod provisioning;

--- a/frontend/src/components/admin-credits/credit-pickers.test.tsx
+++ b/frontend/src/components/admin-credits/credit-pickers.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DownstreamService } from "@/types/api";
+import { ServicePicker } from "./credit-pickers";
+
+function service(
+  id: string,
+  name: string,
+  metric: DownstreamService["effective_platform_metric"],
+): DownstreamService {
+  return {
+    id,
+    name,
+    slug: id,
+    is_active: true,
+    effective_platform_metric: metric,
+  } as DownstreamService;
+}
+
+describe("ServicePicker", () => {
+  it("shows backend-resolved metrics and filters service rows", () => {
+    render(
+      <ServicePicker
+        services={[
+          service("llm-one", "Token service", "tokens"),
+          service("ssh-one", "Byte service", "bytes"),
+        ]}
+        selected={[]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("tokens")).toBeInTheDocument();
+    expect(screen.getByText("bytes")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search services"), {
+      target: { value: "byte" },
+    });
+    expect(screen.queryByText("Token service")).not.toBeInTheDocument();
+    expect(screen.getByText("Byte service")).toBeInTheDocument();
+  });
+
+  it("replaces the selected service in single-select mode", () => {
+    const onChange = vi.fn();
+    render(
+      <ServicePicker
+        services={[service("service-one", "Service one", "requests")]}
+        selected={[]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Service one"));
+    expect(onChange).toHaveBeenCalledWith(["service-one"]);
+  });
+});

--- a/frontend/src/components/admin-credits/credit-pickers.tsx
+++ b/frontend/src/components/admin-credits/credit-pickers.tsx
@@ -1,0 +1,188 @@
+import { useDeferredValue, useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { useAdminUsers } from "@/hooks/use-admin";
+import { resolveServiceBillingMetric } from "@/lib/billing-units";
+import type { AdminUser } from "@/types/admin";
+import type { DownstreamService } from "@/types/api";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+
+export function UserPicker({
+  selected,
+  onChange,
+}: {
+  readonly selected: readonly string[];
+  readonly onChange: (ids: string[]) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const deferredSearch = useDeferredValue(search.trim());
+  const peopleQuery = useAdminUsers(
+    1,
+    100,
+    deferredSearch || undefined,
+    "person",
+  );
+  const organizationsQuery = useAdminUsers(
+    1,
+    100,
+    deferredSearch || undefined,
+    "org",
+  );
+  const users = useMemo(() => {
+    const byId = new Map<string, AdminUser>();
+    for (const user of [
+      ...(peopleQuery.data?.users ?? []),
+      ...(organizationsQuery.data?.users ?? []),
+    ]) {
+      if (user.is_active) byId.set(user.id, user);
+    }
+    return [...byId.values()];
+  }, [organizationsQuery.data?.users, peopleQuery.data?.users]);
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return needle
+      ? users.filter((user) =>
+          `${user.display_name ?? ""} ${user.email} ${user.slug ?? ""}`
+            .toLowerCase()
+            .includes(needle),
+        )
+      : users;
+  }, [search, users]);
+  const loading = peopleQuery.isFetching || organizationsQuery.isFetching;
+
+  return (
+    <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border">
+      <div className="relative shrink-0 border-b border-border">
+        <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search owners"
+          className="border-0 pl-9 focus-visible:ring-0"
+        />
+      </div>
+      <div className="min-h-0 max-h-48 flex-1 overflow-y-auto overscroll-contain p-1">
+        {filtered.map((user) => {
+          const checked = selected.includes(user.id);
+          return (
+            <label
+              key={user.id}
+              className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/50"
+            >
+              <Checkbox
+                checked={checked}
+                onCheckedChange={(value) =>
+                  onChange(
+                    value === true
+                      ? [...selected, user.id]
+                      : selected.filter((id) => id !== user.id),
+                  )
+                }
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[12px] font-medium">
+                  {user.display_name || user.slug || user.email}
+                </span>
+                <span className="block truncate text-[11px] text-muted-foreground">
+                  {user.slug ? `Organization / ${user.slug}` : user.email}
+                </span>
+              </span>
+            </label>
+          );
+        })}
+        {filtered.length === 0 && !loading ? (
+          <p className="px-3 py-6 text-center text-[12px] text-muted-foreground">
+            No owners found.
+          </p>
+        ) : null}
+        {loading ? (
+          <p className="px-3 py-3 text-center text-[11px] text-muted-foreground">
+            Searching...
+          </p>
+        ) : null}
+      </div>
+      <div className="shrink-0 border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+        {selected.length} selected
+      </div>
+    </div>
+  );
+}
+
+export function ServicePicker({
+  services,
+  selected,
+  onChange,
+  multiple = false,
+}: {
+  readonly services: readonly DownstreamService[];
+  readonly selected: readonly string[];
+  readonly onChange: (ids: string[]) => void;
+  readonly multiple?: boolean;
+}) {
+  const [search, setSearch] = useState("");
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return services.filter(
+      (service) =>
+        service.is_active &&
+        (!needle ||
+          `${service.name} ${service.slug}`.toLowerCase().includes(needle)),
+    );
+  }, [search, services]);
+
+  return (
+    <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border">
+      <div className="relative shrink-0 border-b border-border">
+        <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search services"
+          className="border-0 pl-9 focus-visible:ring-0"
+        />
+      </div>
+      <div className="min-h-0 max-h-44 flex-1 overflow-y-auto overscroll-contain p-1">
+        {filtered.map((service) => {
+          const checked = selected.includes(service.id);
+          const metric = resolveServiceBillingMetric(service);
+          return (
+            <label
+              key={service.id}
+              className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/50"
+            >
+              <Checkbox
+                checked={checked}
+                onCheckedChange={(value) =>
+                  onChange(
+                    value === true
+                      ? multiple
+                        ? [...selected, service.id]
+                        : [service.id]
+                      : selected.filter((id) => id !== service.id),
+                  )
+                }
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[12px] font-medium">
+                  {service.name}
+                </span>
+                <span className="block truncate text-[11px] text-muted-foreground">
+                  {service.slug}
+                </span>
+              </span>
+              <Badge variant="secondary" className="shrink-0">
+                {metric}
+              </Badge>
+            </label>
+          );
+        })}
+        {filtered.length === 0 ? (
+          <p className="px-3 py-6 text-center text-[12px] text-muted-foreground">
+            No services found.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin-credits/credits-dialogs.test.tsx
+++ b/frontend/src/components/admin-credits/credits-dialogs.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AllowanceForm, IssueGrantForm } from "@/schemas/billing-credits";
+import type { DownstreamService } from "@/types/api";
+import { useAppForm } from "@/components/ui/form";
+import { AllowanceDialog, GrantDialog } from "./credits-dialogs";
+
+const tokenService = {
+  id: "service-token",
+  name: "Token service",
+  slug: "llm-token",
+  is_active: true,
+  effective_platform_metric: "tokens",
+} as DownstreamService;
+
+function AllowanceHarness() {
+  const form = useAppForm<AllowanceForm>({
+    defaultValues: {
+      service_ref: "",
+      quantity: 1_000_000,
+      recurrence: "monthly",
+      target_kind: "all_users",
+      target_user_ids: [],
+    },
+  });
+
+  return (
+    <AllowanceDialog
+      open
+      onOpenChange={vi.fn()}
+      form={form}
+      services={[tokenService]}
+      pending={false}
+      editingAllowance={null}
+      onSubmit={vi.fn()}
+    />
+  );
+}
+
+function GrantHarness() {
+  const form = useAppForm<IssueGrantForm>({
+    defaultValues: {
+      amount_credits: 100,
+      target_kind: "all_users",
+      target_user_ids: [],
+      all_services: true,
+      service_refs: [],
+      expires_at: "",
+      reason: "",
+    },
+  });
+
+  return (
+    <GrantDialog
+      open
+      onOpenChange={vi.fn()}
+      form={form}
+      services={[tokenService]}
+      pending={false}
+      onSubmit={vi.fn()}
+    />
+  );
+}
+
+describe("credits dialogs", () => {
+  it("updates the allowance label and preview from the selected service metric", () => {
+    render(<AllowanceHarness />);
+
+    expect(screen.getByText("Free units")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Token service"));
+
+    expect(screen.getByText("Free tokens")).toBeInTheDocument();
+    expect(
+      screen.getByText(/1,000,000 tokens \(1M\) free each month/),
+    ).toBeInTheDocument();
+  });
+
+  it("labels grant amounts as wallet currency rather than service units", () => {
+    render(<GrantHarness />);
+
+    expect(screen.getByText("Wallet credits per owner")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Credits are not service units/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/A credit is wallet currency/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/admin-credits/credits-dialogs.tsx
+++ b/frontend/src/components/admin-credits/credits-dialogs.tsx
@@ -1,0 +1,461 @@
+import type { UseFormReturn } from "react-hook-form";
+import {
+  billingMetricLabel,
+  formatAllowancePreview,
+  resolveServiceBillingMetric,
+} from "@/lib/billing-units";
+import type {
+  AllowanceForm,
+  IssueGrantForm,
+  UsageAllowance,
+} from "@/schemas/billing-credits";
+import type { DownstreamService } from "@/types/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { ServicePicker, UserPicker } from "./credit-pickers";
+
+type GrantFormApi = UseFormReturn<IssueGrantForm>;
+type AllowanceFormApi = UseFormReturn<AllowanceForm>;
+
+export function GrantDialog({
+  open,
+  onOpenChange,
+  form,
+  services,
+  pending,
+  onSubmit,
+}: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly form: GrantFormApi;
+  readonly services: readonly DownstreamService[];
+  readonly pending: boolean;
+  readonly onSubmit: (value: IssueGrantForm) => Promise<void>;
+}) {
+  const targetKind = form.watch("target_kind");
+  const allServices = form.watch("all_services");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent scrollMode="body" className="md:max-w-2xl">
+        <DialogHeader className="shrink-0 pr-6">
+          <DialogTitle>Issue credit grant</DialogTitle>
+          <DialogDescription>
+            Issue wallet currency to billing owners. Credits are not service
+            units such as tokens, requests, or bytes.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogBody className="-mx-1 px-1">
+              <div className="space-y-5 pb-1">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="amount_credits"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Wallet credits per owner</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={1_000_000}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.valueAsNumber)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription className="text-[11px]">
+                          A credit is wallet currency, not a metered service
+                          unit.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="expires_at"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Expiry (optional)</FormLabel>
+                        <FormControl>
+                          <Input type="datetime-local" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <GrantTargetFields form={form} targetKind={targetKind} />
+                <FormField
+                  control={form.control}
+                  name="all_services"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between rounded-lg border border-border px-3 py-2">
+                      <div>
+                        <FormLabel>All services</FormLabel>
+                        <p className="text-[11px] text-muted-foreground">
+                          Allow this wallet balance to fund any service.
+                        </p>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+                {!allServices ? (
+                  <FormField
+                    control={form.control}
+                    name="service_refs"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Service scope</FormLabel>
+                        <FormControl>
+                          <ServicePicker
+                            services={services}
+                            selected={field.value}
+                            onChange={field.onChange}
+                            multiple
+                          />
+                        </FormControl>
+                        <FormDescription className="text-[11px]">
+                          Metrics identify each service&apos;s usage unit; they
+                          do not change this grant&apos;s credit amount.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                ) : null}
+                <FormField
+                  control={form.control}
+                  name="reason"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Reason / note</FormLabel>
+                      <FormControl>
+                        <textarea
+                          rows={3}
+                          className="w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-[12px] outline-none focus:border-white/15"
+                          placeholder="Why these credits are being issued"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </DialogBody>
+            <DialogFooter className="pt-4 md:pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" isLoading={pending}>
+                Issue credits
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function AllowanceDialog({
+  open,
+  onOpenChange,
+  form,
+  services,
+  pending,
+  editingAllowance,
+  onSubmit,
+}: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly form: AllowanceFormApi;
+  readonly services: readonly DownstreamService[];
+  readonly pending: boolean;
+  readonly editingAllowance: UsageAllowance | null;
+  readonly onSubmit: (value: AllowanceForm) => Promise<void>;
+}) {
+  const targetKind = form.watch("target_kind");
+  const serviceRef = form.watch("service_ref");
+  const quantity = form.watch("quantity");
+  const recurrence = form.watch("recurrence");
+  const selectedService = services.find(
+    (service) => service.id === serviceRef || service.slug === serviceRef,
+  );
+  const metric = selectedService
+    ? resolveServiceBillingMetric(selectedService)
+    : editingAllowance?.service_id === serviceRef
+      ? editingAllowance.metric
+      : null;
+  const preview = metric
+    ? formatAllowancePreview(quantity, metric, recurrence)
+    : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent scrollMode="body" className="md:max-w-2xl">
+        <DialogHeader className="shrink-0 pr-6">
+          <DialogTitle>
+            {editingAllowance ? "Edit allowance" : "Create allowance"}
+          </DialogTitle>
+          <DialogDescription>
+            Grant free metered service usage before wallet credits are charged.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogBody className="-mx-1 px-1">
+              <div className="space-y-5 pb-1">
+                <FormField
+                  control={form.control}
+                  name="service_ref"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <FormControl>
+                        <ServicePicker
+                          services={services}
+                          selected={[field.value].filter(Boolean)}
+                          onChange={(values) => field.onChange(values[0] ?? "")}
+                        />
+                      </FormControl>
+                      <FormDescription className="text-[11px]">
+                        Each badge shows the unit this service meters.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="quantity"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          {metric
+                            ? `Free ${billingMetricLabel(metric)}`
+                            : "Free units"}
+                        </FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={1}
+                            max={1_000_000_000_000}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.valueAsNumber)
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription className="text-[11px] leading-relaxed">
+                          {metric
+                            ? `This service is metered in ${metric}. ${
+                                preview ??
+                                "Enter a whole-number quantity to preview the allowance"
+                              }.`
+                            : "Select a service to see whether its allowance is measured in tokens, requests, or bytes."}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="recurrence"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Recurrence</FormLabel>
+                        <Select
+                          value={field.value}
+                          onValueChange={field.onChange}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="one_time">One time</SelectItem>
+                            <SelectItem value="daily">Daily</SelectItem>
+                            <SelectItem value="weekly">Weekly</SelectItem>
+                            <SelectItem value="monthly">Monthly</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <AllowanceTargetFields form={form} targetKind={targetKind} />
+              </div>
+            </DialogBody>
+            <DialogFooter className="pt-4 md:pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" isLoading={pending}>
+                {editingAllowance ? "Save changes" : "Create allowance"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GrantTargetFields({
+  form,
+  targetKind,
+}: {
+  readonly form: GrantFormApi;
+  readonly targetKind: "all_users" | "selected_users";
+}) {
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="target_kind"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Recipients</FormLabel>
+            <Select
+              value={field.value}
+              onValueChange={(value) => {
+                field.onChange(value);
+                if (value === "all_users") form.setValue("target_user_ids", []);
+              }}
+            >
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="all_users">All billing owners</SelectItem>
+                <SelectItem value="selected_users">Selected owners</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      {targetKind === "selected_users" ? (
+        <FormField
+          control={form.control}
+          name="target_user_ids"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Owners</FormLabel>
+              <FormControl>
+                <UserPicker selected={field.value} onChange={field.onChange} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function AllowanceTargetFields({
+  form,
+  targetKind,
+}: {
+  readonly form: AllowanceFormApi;
+  readonly targetKind: "all_users" | "selected_users";
+}) {
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="target_kind"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Recipients</FormLabel>
+            <Select
+              value={field.value}
+              onValueChange={(value) => {
+                field.onChange(value);
+                if (value === "all_users") form.setValue("target_user_ids", []);
+              }}
+            >
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="all_users">All billing owners</SelectItem>
+                <SelectItem value="selected_users">Selected owners</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      {targetKind === "selected_users" ? (
+        <FormField
+          control={form.control}
+          name="target_user_ids"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Owners</FormLabel>
+              <FormControl>
+                <UserPicker selected={field.value} onChange={field.onChange} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -24,10 +24,21 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps extends React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> {
+  /**
+   * `content` keeps the legacy whole-dialog scroll owner. `body` makes the
+   * direct form a constrained flex column so a DialogBody can scroll between
+   * a fixed header and footer without nested overflow leaking into the shell.
+   */
+  readonly scrollMode?: "content" | "body";
+}
+
 const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, scrollMode = "content", ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -40,6 +51,8 @@ const DialogContent = React.forwardRef<
         // Desktop: centered modal
         "md:inset-auto md:left-[50%] md:top-[50%] md:translate-x-[-50%] md:translate-y-[-50%] md:rounded-xl md:border md:border-border md:shadow-xl md:shadow-primary/5 md:w-full md:max-w-lg md:overflow-y-auto md:max-h-[85vh] md:p-5 md:pt-5",
         "md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=closed]:zoom-out-95 md:data-[state=open]:zoom-in-95",
+        scrollMode === "body" &&
+          "flex flex-col overflow-hidden md:overflow-hidden",
         className,
       )}
       {...props}
@@ -51,6 +64,8 @@ const DialogContent = React.forwardRef<
           // Forms must also flex-grow so mt-auto on DialogFooter reaches bottom
           "[&>form]:flex-1 [&>form]:flex [&>form]:flex-col",
           "md:min-h-0 md:px-0 md:pt-0 md:[&>form]:flex-initial md:[&>form]:block",
+          scrollMode === "body" &&
+            "flex-auto overflow-hidden [&>form]:min-h-0 [&>form]:flex-auto md:[&>form]:flex md:[&>form]:flex-col",
         )}
       >
         {children}
@@ -67,15 +82,26 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({
+const DialogBody = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-left",
+      "min-h-0 flex-auto overflow-y-auto overscroll-contain",
       className,
     )}
+    {...props}
+  />
+);
+DialogBody.displayName = "DialogBody";
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-1.5 text-left", className)}
     {...props}
   />
 );
@@ -93,7 +119,8 @@ const DialogFooter = ({
       className,
     )}
     style={{
-      paddingBottom: "max(1.25rem, var(--sab, env(safe-area-inset-bottom, 0px)))",
+      paddingBottom:
+        "max(1.25rem, var(--sab, env(safe-area-inset-bottom, 0px)))",
       ...style,
     }}
     {...props}
@@ -135,6 +162,7 @@ export {
   DialogClose,
   DialogTrigger,
   DialogContent,
+  DialogBody,
   DialogHeader,
   DialogFooter,
   DialogTitle,

--- a/frontend/src/lib/billing-units.test.ts
+++ b/frontend/src/lib/billing-units.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  billingMetricLabel,
+  formatAllowancePreview,
+  resolveServiceBillingMetric,
+} from "./billing-units";
+
+describe("billing unit presentation", () => {
+  it("uses the backend-resolved service metric without a frontend heuristic", () => {
+    expect(
+      resolveServiceBillingMetric({ effective_platform_metric: "bytes" }),
+    ).toBe("bytes");
+  });
+
+  it("formats a live compact monthly preview", () => {
+    expect(
+      formatAllowancePreview(1_000_000, "tokens", "monthly", "en-US"),
+    ).toBe("1,000,000 tokens (1M) free each month");
+  });
+
+  it("reflects one-time recurrence and singular units", () => {
+    expect(formatAllowancePreview(1, "requests", "one_time", "en-US")).toBe(
+      "1 request free once",
+    );
+    expect(billingMetricLabel("bytes", 1)).toBe("byte");
+  });
+
+  it("omits a preview for invalid quantities", () => {
+    expect(formatAllowancePreview(Number.NaN, "tokens", "daily")).toBeNull();
+    expect(formatAllowancePreview(0, "tokens", "daily")).toBeNull();
+  });
+});

--- a/frontend/src/lib/billing-units.ts
+++ b/frontend/src/lib/billing-units.ts
@@ -1,0 +1,50 @@
+import type { BillingMetric } from "@/schemas/billing";
+import type { AllowanceForm } from "@/schemas/billing-credits";
+import type { DownstreamService } from "@/types/api";
+
+type AllowanceRecurrence = AllowanceForm["recurrence"];
+
+const RECURRENCE_PHRASES: Readonly<Record<AllowanceRecurrence, string>> = {
+  one_time: "once",
+  daily: "each day",
+  weekly: "each week",
+  monthly: "each month",
+};
+
+/**
+ * The backend owns metric resolution. Keeping this access in one utility
+ * prevents components from inspecting billing config, slugs, or protocols.
+ */
+export function resolveServiceBillingMetric(
+  service: Pick<DownstreamService, "effective_platform_metric">,
+): BillingMetric {
+  return service.effective_platform_metric;
+}
+
+export function billingMetricLabel(
+  metric: BillingMetric,
+  quantity?: number,
+): string {
+  if (quantity === 1) {
+    return metric === "bytes" ? "byte" : metric.slice(0, -1);
+  }
+  return metric;
+}
+
+export function formatAllowancePreview(
+  quantity: number,
+  metric: BillingMetric,
+  recurrence: AllowanceRecurrence,
+  locale?: string,
+): string | null {
+  if (!Number.isInteger(quantity) || quantity <= 0) return null;
+
+  const formatted = new Intl.NumberFormat(locale).format(quantity);
+  const compact = new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(quantity);
+  const compactSuffix = compact === formatted ? "" : ` (${compact})`;
+
+  return `${formatted} ${billingMetricLabel(metric, quantity)}${compactSuffix} free ${RECURRENCE_PHRASES[recurrence]}`;
+}

--- a/frontend/src/lib/constants.test.ts
+++ b/frontend/src/lib/constants.test.ts
@@ -42,6 +42,8 @@ function makeService(
     created_at: "2024-01-01T00:00:00Z",
     updated_at: "2024-01-01T00:00:00Z",
     ...overrides,
+    effective_platform_metric:
+      overrides.effective_platform_metric ?? "requests",
   };
 }
 

--- a/frontend/src/lib/node-credentials.test.ts
+++ b/frontend/src/lib/node-credentials.test.ts
@@ -32,6 +32,8 @@ function makeService(
     created_at: "2026-03-10T00:00:00Z",
     updated_at: "2026-03-10T00:00:00Z",
     ...overrides,
+    effective_platform_metric:
+      overrides.effective_platform_metric ?? "requests",
   };
 }
 

--- a/frontend/src/pages/admin-credits.tsx
+++ b/frontend/src/pages/admin-credits.tsx
@@ -1,9 +1,7 @@
-import { useDeferredValue, useMemo, useState } from "react";
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Pencil, Plus, Search, Trash2 } from "lucide-react";
-import type { UseFormReturn } from "react-hook-form";
+import { Pencil, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import { useAdminUsers } from "@/hooks/use-admin";
 import {
   useAdminAllowances,
   useAdminCreditGrants,
@@ -14,6 +12,7 @@ import {
 } from "@/hooks/use-billing-credits";
 import { useServices } from "@/hooks/use-services";
 import { ApiError } from "@/lib/api-client";
+import { billingMetricLabel } from "@/lib/billing-units";
 import {
   allowanceFormSchema,
   issueGrantFormSchema,
@@ -23,14 +22,16 @@ import {
   type UsageAllowance,
 } from "@/schemas/billing-credits";
 import { useAuthStore } from "@/stores/auth-store";
-import type { AdminUser } from "@/types/admin";
 import type { DownstreamService } from "@/types/api";
 import { canAdminWrite } from "@/types/api";
+import {
+  AllowanceDialog,
+  GrantDialog,
+} from "@/components/admin-credits/credits-dialogs";
 import { PageHeader } from "@/components/shared/page-header";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import { Badge } from "@/components/ui/badge";
 import { Button, ButtonIcon } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -39,25 +40,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-  useAppForm,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { useAppForm } from "@/components/ui/form";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Switch } from "@/components/ui/switch";
 import {
   Table,
   TableBody,
@@ -374,10 +358,18 @@ export function AdminCreditsPage() {
                           )}
                         </div>
                         <div className="text-[11px] text-muted-foreground">
-                          {allowance.metric}
+                          {allowance.service_slug}
                         </div>
                       </TableCell>
-                      <TableCell>{formatNumber(allowance.quantity)}</TableCell>
+                      <TableCell>
+                        {formatNumber(allowance.quantity)}{" "}
+                        <span className="text-[11px] text-muted-foreground">
+                          {billingMetricLabel(
+                            allowance.metric,
+                            allowance.quantity,
+                          )}
+                        </span>
+                      </TableCell>
                       <TableCell className="capitalize">
                         {allowance.recurrence.replace("_", " ")}
                       </TableCell>
@@ -452,7 +444,7 @@ export function AdminCreditsPage() {
         form={allowanceForm}
         services={services}
         pending={createAllowance.isPending || updateAllowance.isPending}
-        editing={editingAllowance !== null}
+        editingAllowance={editingAllowance}
         onSubmit={submitAllowance}
       />
       <Dialog
@@ -465,11 +457,15 @@ export function AdminCreditsPage() {
           <DialogHeader>
             <DialogTitle>Revoke credit grant</DialogTitle>
             <DialogDescription>
-              Revoke the remaining {grantToRevoke?.remaining_micros
+              Revoke the remaining{" "}
+              {grantToRevoke?.remaining_micros
                 ? formatCredits(grantToRevoke.remaining_micros)
-                : "credits"} for {grantToRevoke?.recipient_display_name ||
+                : "credits"}{" "}
+              for{" "}
+              {grantToRevoke?.recipient_display_name ||
                 grantToRevoke?.recipient_email ||
-                "this recipient"}? This cannot be undone.
+                "this recipient"}
+              ? This cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -492,543 +488,6 @@ export function AdminCreditsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  );
-}
-
-type GrantFormApi = UseFormReturn<IssueGrantForm>;
-type AllowanceFormApi = UseFormReturn<AllowanceForm>;
-
-function GrantDialog({
-  open,
-  onOpenChange,
-  form,
-  services,
-  pending,
-  onSubmit,
-}: {
-  readonly open: boolean;
-  readonly onOpenChange: (open: boolean) => void;
-  readonly form: GrantFormApi;
-  readonly services: readonly DownstreamService[];
-  readonly pending: boolean;
-  readonly onSubmit: (value: IssueGrantForm) => Promise<void>;
-}) {
-  const targetKind = form.watch("target_kind");
-  const allServices = form.watch("all_services");
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Issue credit grant</DialogTitle>
-          <DialogDescription>
-            Create one attributable grant per selected billing owner.
-          </DialogDescription>
-        </DialogHeader>
-        <Form {...form}>
-          <form className="space-y-5" onSubmit={form.handleSubmit(onSubmit)}>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <FormField
-                control={form.control}
-                name="amount_credits"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Credits per owner</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        min={1}
-                        max={1_000_000}
-                        {...field}
-                        onChange={(event) =>
-                          field.onChange(event.target.valueAsNumber)
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="expires_at"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Expiry (optional)</FormLabel>
-                    <FormControl>
-                      <Input type="datetime-local" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-            <GrantTargetFields form={form} targetKind={targetKind} />
-            <FormField
-              control={form.control}
-              name="all_services"
-              render={({ field }) => (
-                <FormItem className="flex items-center justify-between rounded-lg border border-border px-3 py-2">
-                  <div>
-                    <FormLabel>All services</FormLabel>
-                    <p className="text-[11px] text-muted-foreground">
-                      Allow this credit balance to fund any service.
-                    </p>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            {!allServices ? (
-              <FormField
-                control={form.control}
-                name="service_refs"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Service scope</FormLabel>
-                    <FormControl>
-                      <ServicePicker
-                        services={services}
-                        selected={field.value}
-                        onChange={field.onChange}
-                        multiple
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            ) : null}
-            <FormField
-              control={form.control}
-              name="reason"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Reason / note</FormLabel>
-                  <FormControl>
-                    <textarea
-                      rows={3}
-                      className="w-full resize-y rounded-lg border border-input bg-transparent px-3 py-2 text-[12px] outline-none focus:border-white/15"
-                      placeholder="Why these credits are being issued"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => onOpenChange(false)}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" variant="primary" isLoading={pending}>
-                Issue credits
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function AllowanceDialog({
-  open,
-  onOpenChange,
-  form,
-  services,
-  pending,
-  editing,
-  onSubmit,
-}: {
-  readonly open: boolean;
-  readonly onOpenChange: (open: boolean) => void;
-  readonly form: AllowanceFormApi;
-  readonly services: readonly DownstreamService[];
-  readonly pending: boolean;
-  readonly editing: boolean;
-  readonly onSubmit: (value: AllowanceForm) => Promise<void>;
-}) {
-  const targetKind = form.watch("target_kind");
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>
-            {editing ? "Edit allowance" : "Create allowance"}
-          </DialogTitle>
-          <DialogDescription>
-            Free units are consumed before credit grants and wallet credits.
-          </DialogDescription>
-        </DialogHeader>
-        <Form {...form}>
-          <form className="space-y-5" onSubmit={form.handleSubmit(onSubmit)}>
-            <FormField
-              control={form.control}
-              name="service_ref"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Service</FormLabel>
-                  <FormControl>
-                    <ServicePicker
-                      services={services}
-                      selected={[field.value].filter(Boolean)}
-                      onChange={(values) => field.onChange(values[0] ?? "")}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <div className="grid gap-4 sm:grid-cols-2">
-              <FormField
-                control={form.control}
-                name="quantity"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Free units</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        min={1}
-                        max={1_000_000_000_000}
-                        {...field}
-                        onChange={(event) =>
-                          field.onChange(event.target.valueAsNumber)
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="recurrence"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Recurrence</FormLabel>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="one_time">One time</SelectItem>
-                        <SelectItem value="daily">Daily</SelectItem>
-                        <SelectItem value="weekly">Weekly</SelectItem>
-                        <SelectItem value="monthly">Monthly</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-            <AllowanceTargetFields form={form} targetKind={targetKind} />
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => onOpenChange(false)}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" variant="primary" isLoading={pending}>
-                {editing ? "Save changes" : "Create allowance"}
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function GrantTargetFields({
-  form,
-  targetKind,
-}: {
-  readonly form: GrantFormApi;
-  readonly targetKind: "all_users" | "selected_users";
-}) {
-  return (
-    <>
-      <FormField
-        control={form.control}
-        name="target_kind"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Recipients</FormLabel>
-            <Select
-              value={field.value}
-              onValueChange={(value) => {
-                field.onChange(value);
-                if (value === "all_users") form.setValue("target_user_ids", []);
-              }}
-            >
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                <SelectItem value="all_users">All billing owners</SelectItem>
-                <SelectItem value="selected_users">Selected owners</SelectItem>
-              </SelectContent>
-            </Select>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-      {targetKind === "selected_users" ? (
-        <FormField
-          control={form.control}
-          name="target_user_ids"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Owners</FormLabel>
-              <FormControl>
-                <UserPicker selected={field.value} onChange={field.onChange} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      ) : null}
-    </>
-  );
-}
-
-function AllowanceTargetFields({
-  form,
-  targetKind,
-}: {
-  readonly form: AllowanceFormApi;
-  readonly targetKind: "all_users" | "selected_users";
-}) {
-  return (
-    <>
-      <FormField
-        control={form.control}
-        name="target_kind"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Recipients</FormLabel>
-            <Select
-              value={field.value}
-              onValueChange={(value) => {
-                field.onChange(value);
-                if (value === "all_users") form.setValue("target_user_ids", []);
-              }}
-            >
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                <SelectItem value="all_users">All billing owners</SelectItem>
-                <SelectItem value="selected_users">Selected owners</SelectItem>
-              </SelectContent>
-            </Select>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-      {targetKind === "selected_users" ? (
-        <FormField
-          control={form.control}
-          name="target_user_ids"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Owners</FormLabel>
-              <FormControl>
-                <UserPicker selected={field.value} onChange={field.onChange} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      ) : null}
-    </>
-  );
-}
-
-function UserPicker({
-  selected,
-  onChange,
-}: {
-  readonly selected: readonly string[];
-  readonly onChange: (ids: string[]) => void;
-}) {
-  const [search, setSearch] = useState("");
-  const deferredSearch = useDeferredValue(search.trim());
-  const peopleQuery = useAdminUsers(
-    1,
-    100,
-    deferredSearch || undefined,
-    "person",
-  );
-  const organizationsQuery = useAdminUsers(
-    1,
-    100,
-    deferredSearch || undefined,
-    "org",
-  );
-  const users = useMemo(() => {
-    const byId = new Map<string, AdminUser>();
-    for (const user of [
-      ...(peopleQuery.data?.users ?? []),
-      ...(organizationsQuery.data?.users ?? []),
-    ]) {
-      if (user.is_active) byId.set(user.id, user);
-    }
-    return [...byId.values()];
-  }, [organizationsQuery.data?.users, peopleQuery.data?.users]);
-  const filtered = useMemo(() => {
-    const needle = search.trim().toLowerCase();
-    return needle
-      ? users.filter((user) =>
-          `${user.display_name ?? ""} ${user.email} ${user.slug ?? ""}`
-            .toLowerCase()
-            .includes(needle),
-        )
-      : users;
-  }, [search, users]);
-  const loading = peopleQuery.isFetching || organizationsQuery.isFetching;
-  return (
-    <div className="rounded-lg border border-border">
-      <div className="relative border-b border-border">
-        <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search owners"
-          className="border-0 pl-9 focus-visible:ring-0"
-        />
-      </div>
-      <div className="max-h-48 overflow-y-auto p-1">
-        {filtered.map((user) => {
-          const checked = selected.includes(user.id);
-          return (
-            <label
-              key={user.id}
-              className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/50"
-            >
-              <Checkbox
-                checked={checked}
-                onCheckedChange={(value) =>
-                  onChange(
-                    value === true
-                      ? [...selected, user.id]
-                      : selected.filter((id) => id !== user.id),
-                  )
-                }
-              />
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-[12px] font-medium">
-                  {user.display_name || user.slug || user.email}
-                </span>
-                <span className="block truncate text-[11px] text-muted-foreground">
-                  {user.slug ? `Organization / ${user.slug}` : user.email}
-                </span>
-              </span>
-            </label>
-          );
-        })}
-        {filtered.length === 0 && !loading ? (
-          <p className="px-3 py-6 text-center text-[12px] text-muted-foreground">
-            No owners found.
-          </p>
-        ) : null}
-        {loading ? (
-          <p className="px-3 py-3 text-center text-[11px] text-muted-foreground">
-            Searching...
-          </p>
-        ) : null}
-      </div>
-      <div className="border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
-        {selected.length} selected
-      </div>
-    </div>
-  );
-}
-
-function ServicePicker({
-  services,
-  selected,
-  onChange,
-  multiple = false,
-}: {
-  readonly services: readonly DownstreamService[];
-  readonly selected: readonly string[];
-  readonly onChange: (ids: string[]) => void;
-  readonly multiple?: boolean;
-}) {
-  const [search, setSearch] = useState("");
-  const filtered = useMemo(() => {
-    const needle = search.trim().toLowerCase();
-    return services.filter(
-      (service) =>
-        service.is_active &&
-        (!needle ||
-          `${service.name} ${service.slug}`.toLowerCase().includes(needle)),
-    );
-  }, [search, services]);
-  return (
-    <div className="rounded-lg border border-border">
-      <div className="relative border-b border-border">
-        <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search services"
-          className="border-0 pl-9 focus-visible:ring-0"
-        />
-      </div>
-      <div className="max-h-44 overflow-y-auto p-1">
-        {filtered.map((service) => {
-          const checked = selected.includes(service.id);
-          return (
-            <label
-              key={service.id}
-              className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/50"
-            >
-              <Checkbox
-                checked={checked}
-                onCheckedChange={(value) =>
-                  onChange(
-                    value === true
-                      ? multiple
-                        ? [...selected, service.id]
-                        : [service.id]
-                      : selected.filter((id) => id !== service.id),
-                  )
-                }
-              />
-              <span className="min-w-0">
-                <span className="block truncate text-[12px] font-medium">
-                  {service.name}
-                </span>
-                <span className="block truncate text-[11px] text-muted-foreground">
-                  {service.slug}
-                </span>
-              </span>
-            </label>
-          );
-        })}
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/credential-push.test.tsx
+++ b/frontend/src/pages/credential-push.test.tsx
@@ -99,9 +99,18 @@ vi.mock("@/hooks/use-developer-apps", () => ({
 
 vi.mock("@/hooks/use-anonymous-endpoints", () => ({
   useAnonymousEndpoints: () => ({ data: [], isLoading: false }),
-  useCreateAnonymousEndpoint: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useUpdateAnonymousEndpoint: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useDeleteAnonymousEndpoint: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateAnonymousEndpoint: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useUpdateAnonymousEndpoint: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useDeleteAnonymousEndpoint: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
 }));
 
 vi.mock("@/stores/auth-store", () => ({
@@ -199,6 +208,8 @@ function makeService(
     your_user_service_id: "usvc-1",
     your_binding_count: 1,
     ...overrides,
+    effective_platform_metric:
+      overrides.effective_platform_metric ?? "requests",
   };
 }
 

--- a/frontend/src/pages/service-detail.test.tsx
+++ b/frontend/src/pages/service-detail.test.tsx
@@ -151,6 +151,8 @@ function makeService(
     your_user_service_id: null,
     your_binding_count: 0,
     ...overrides,
+    effective_platform_metric:
+      overrides.effective_platform_metric ?? "requests",
   };
 }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,3 +1,5 @@
+import type { BillingMetric } from "@/schemas/billing";
+
 /// Resolved platform role for a user. `admin` is full read+write,
 /// `operator` is read-only platform admin (issue #715), `user` is a
 /// regular user with no platform admin access.
@@ -243,6 +245,8 @@ export interface DownstreamService {
   readonly issues_url?: string | null;
   readonly capabilities?: ServiceCapabilities | null;
   readonly billing?: ServiceBilling | null;
+  /** Backend-resolved unit used by service allowances and platform metering. */
+  readonly effective_platform_metric: BillingMetric;
   readonly auth_notes?: string | null;
   readonly known_limitations?: string | null;
   readonly required_permissions?: readonly string[] | null;


### PR DESCRIPTION
## Summary
- Expose a backend-resolved `effective_platform_metric` on service responses so the admin UI shows each service's metering unit (tokens / requests / bytes) instead of an ambiguous bare "Free units" field; resolution logic is deduplicated into `services/billing/metric_resolution.rs`, used by both the proxy metering path and allowance create/update (previously two divergent copies)
- Allowance dialog now labels the quantity field with the selected service's unit, renders a live preview ("1,000,000 tokens (1M) free each month"), shows per-service metric badges in the service picker, and shows units in the allowances table; the grant dialog is explicitly labeled as wallet credits so the two cannot be confused
- Fix broken dialog scrolling on /admin/credits: new opt-in `scrollMode="body"` + `DialogBody` primitive give the dialogs a fixed header/footer with a properly constrained scrollable body (structural flex/min-h-0/overflow fix, default dialog behavior unchanged)
- Extract pickers and dialogs out of the oversized admin-credits page into `components/admin-credits/`
- Request metric classification is preserved exactly: bytes only for actual WebSocket connections or SSH services, `llm-` slugs meter tokens, everything else requests; explicit `billing.platform_metric` still wins (regression-tested, including a proxy/allowance agreement test)

## Test plan
- [x] Backend: cargo fmt, clippy (warnings clean), 5,444 tests passing against replica-set MongoDB
- [x] Frontend: eslint 0 errors, 2,918 vitest tests passing, production build clean
- [x] New unit tests: metric resolution semantics, allowance preview formatting, picker/dialog rendering
- [x] No new environment variables; admin-only UI plus one additive response field