### PR TITLE
feat(platform-ops): server-constructed platform operations (Twilio call, ElevenLabs TTS, X search) + admin config

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -26,6 +26,8 @@ use crate::models::node_service_binding::{
 use crate::models::oauth_broker_binding::{
     COLLECTION_NAME as OAUTH_BROKER_BINDINGS, OauthBrokerBinding,
 };
+use crate::models::platform_op_usage::COLLECTION_NAME as PLATFORM_OP_USAGE;
+use crate::models::platform_operation::COLLECTION_NAME as PLATFORM_OPERATIONS;
 use crate::models::provider_config::{COLLECTION_NAME as PROVIDER_CONFIGS, ProviderConfig};
 use crate::models::pushed_authorization_request::COLLECTION_NAME as PAR_COLLECTION;
 use crate::models::ssh_auth_mode::SshAuthMode;
@@ -287,6 +289,34 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
             IndexModel::builder()
                 .keys(doc! { "user_id": 1, "action": 1, "action_request_id": 1 })
                 .options(IndexOptions::builder().unique(true).build())
+                .build(),
+        )
+        .await?;
+
+    // ── platform operations ──
+    db.collection::<mongodb::bson::Document>(PLATFORM_OPERATIONS)
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "op": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("platform_operations_op_unique".to_string())
+                        .unique(true)
+                        .build(),
+                )
+                .build(),
+        )
+        .await?;
+    db.collection::<mongodb::bson::Document>(PLATFORM_OP_USAGE)
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "op": 1, "user_id": 1, "yyyymmdd": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .name("platform_op_usage_user_day_unique".to_string())
+                        .unique(true)
+                        .build(),
+                )
                 .build(),
         )
         .await?;

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -70,6 +70,9 @@ pub enum AppError {
     #[error("{context} request body exceeds the configured limit of {max_bytes} bytes")]
     RequestBodyTooLarge { max_bytes: usize, context: String },
 
+    #[error("Platform operation vendor is unavailable")]
+    PlatformOperationUnavailable,
+
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
@@ -527,6 +530,7 @@ impl AppError {
         match self {
             Self::BadRequest(_) | Self::ValidationError(_) => StatusCode::BAD_REQUEST,
             Self::RequestBodyTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::PlatformOperationUnavailable => StatusCode::BAD_GATEWAY,
             Self::Unauthorized(_) | Self::AuthenticationFailed(_) | Self::TokenExpired => {
                 StatusCode::UNAUTHORIZED
             }
@@ -678,6 +682,7 @@ impl AppError {
         match self {
             Self::BadRequest(_) => 1000,
             Self::RequestBodyTooLarge { .. } => 11700,
+            Self::PlatformOperationUnavailable => 11800,
             Self::Unauthorized(_) => 1001,
             Self::Forbidden(_) => 1002,
             Self::NotFound(_) => 1003,
@@ -869,6 +874,7 @@ impl AppError {
         match self {
             Self::BadRequest(_) => "bad_request",
             Self::RequestBodyTooLarge { .. } => "request_body_too_large",
+            Self::PlatformOperationUnavailable => "platform_operation_unavailable",
             Self::Unauthorized(_) => "unauthorized",
             Self::Forbidden(_) => "forbidden",
             Self::NotFound(_) => "not_found",

--- a/backend/src/handlers/admin_platform_ops.rs
+++ b/backend/src/handlers/admin_platform_ops.rs
@@ -1,0 +1,248 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::errors::AppResult;
+use crate::handlers::admin_helpers::require_admin;
+use crate::models::platform_operation::{
+    CallAndSayConfig, PlatformOperation, PlatformOperationConfig, PlatformOperationName,
+    SpeakConfig, XSearchConfig,
+};
+use crate::mw::auth::AuthUser;
+use crate::services::{audit_service, platform_operation_service};
+
+#[derive(Debug, Serialize)]
+pub struct AdminPlatformOperationListResponse {
+    pub operations: Vec<AdminPlatformOperationResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminPlatformOperationResponse {
+    pub op: &'static str,
+    pub enabled: bool,
+    pub vendor_service_slug: String,
+    pub config: AdminPlatformOperationConfigResponse,
+    pub updated_at: Option<String>,
+    pub updated_by: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AdminPlatformOperationConfigResponse {
+    XSearch(AdminXSearchConfigResponse),
+    Speak(AdminSpeakConfigResponse),
+    CallAndSay(AdminCallAndSayConfigResponse),
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminXSearchConfigResponse {
+    pub max_results_cap: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminSpeakConfigResponse {
+    pub allowed_voice_ids: Vec<String>,
+    pub max_chars: u32,
+    pub model_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminCallAndSayConfigResponse {
+    pub allowed_destination_prefixes: Vec<String>,
+    pub max_message_chars: u32,
+    pub voice: String,
+    pub max_calls_per_user_per_day: u32,
+    pub account_sid: String,
+    pub call_from: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdatePlatformOperationRequest {
+    pub enabled: bool,
+    pub vendor_service_slug: String,
+    pub config: PlatformOperationConfig,
+}
+
+/// GET /api/v1/admin/platform-ops
+pub async fn list_platform_operations(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AppResult<Json<AdminPlatformOperationListResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let configured = platform_operation_service::list_configured_operations(&state.db).await?;
+    let operations = platform_operation_service::PLATFORM_OPERATION_NAMES
+        .into_iter()
+        .map(|op| {
+            let row = configured.iter().find(|row| row.op == op).cloned();
+            platform_operation_response(op, row)
+        })
+        .collect();
+
+    Ok(Json(AdminPlatformOperationListResponse { operations }))
+}
+
+/// PUT /api/v1/admin/platform-ops/{op}
+pub async fn update_platform_operation(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(op): Path<String>,
+    Json(body): Json<UpdatePlatformOperationRequest>,
+) -> AppResult<Json<AdminPlatformOperationResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let op = platform_operation_service::parse_operation_name(&op)?;
+    let operation = platform_operation_service::upsert_operation(
+        &state.db,
+        op,
+        body.enabled,
+        body.vendor_service_slug,
+        body.config,
+        &auth_user.user_id.to_string(),
+    )
+    .await?;
+
+    audit_service::log_for_user(
+        state.db.clone(),
+        &auth_user,
+        "admin_platform_operation_updated",
+        Some(serde_json::json!({
+            "op": platform_operation_service::operation_name(op),
+            "enabled": operation.enabled,
+            "vendor_service_slug": operation.vendor_service_slug,
+        })),
+    );
+
+    Ok(Json(platform_operation_response(op, Some(operation))))
+}
+
+fn platform_operation_response(
+    op: PlatformOperationName,
+    operation: Option<PlatformOperation>,
+) -> AdminPlatformOperationResponse {
+    match operation {
+        Some(operation) => AdminPlatformOperationResponse {
+            op: platform_operation_service::operation_name(op),
+            enabled: operation.enabled,
+            vendor_service_slug: operation.vendor_service_slug,
+            config: operation.config.into(),
+            updated_at: Some(operation.updated_at.to_rfc3339()),
+            updated_by: Some(operation.updated_by),
+        },
+        None => AdminPlatformOperationResponse {
+            op: platform_operation_service::operation_name(op),
+            enabled: false,
+            vendor_service_slug: platform_operation_service::default_vendor_service_slug(op)
+                .to_string(),
+            config: platform_operation_service::default_operation_config(op).into(),
+            updated_at: None,
+            updated_by: None,
+        },
+    }
+}
+
+impl From<PlatformOperationConfig> for AdminPlatformOperationConfigResponse {
+    fn from(config: PlatformOperationConfig) -> Self {
+        match config {
+            PlatformOperationConfig::XSearch(XSearchConfig { max_results_cap }) => {
+                Self::XSearch(AdminXSearchConfigResponse { max_results_cap })
+            }
+            PlatformOperationConfig::Speak(SpeakConfig {
+                allowed_voice_ids,
+                max_chars,
+                model_id,
+            }) => Self::Speak(AdminSpeakConfigResponse {
+                allowed_voice_ids,
+                max_chars,
+                model_id,
+            }),
+            PlatformOperationConfig::CallAndSay(CallAndSayConfig {
+                allowed_destination_prefixes,
+                max_message_chars,
+                voice,
+                max_calls_per_user_per_day,
+                account_sid,
+                call_from,
+            }) => Self::CallAndSay(AdminCallAndSayConfigResponse {
+                allowed_destination_prefixes,
+                max_message_chars,
+                voice,
+                max_calls_per_user_per_day,
+                account_sid,
+                call_from,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::platform_operation::COLLECTION_NAME as PLATFORM_OPERATIONS;
+
+    #[test]
+    fn missing_rows_render_as_disabled_defaults() {
+        let response = platform_operation_response(PlatformOperationName::XSearch, None);
+        assert_eq!(response.op, "x_search");
+        assert!(!response.enabled);
+        assert_eq!(response.vendor_service_slug, "platform-x");
+        assert!(response.updated_at.is_none());
+        assert!(matches!(
+            response.config,
+            AdminPlatformOperationConfigResponse::XSearch(AdminXSearchConfigResponse {
+                max_results_cap: 10
+            })
+        ));
+    }
+
+    #[test]
+    fn update_request_rejects_unknown_fields() {
+        let value = serde_json::json!({
+            "enabled": false,
+            "vendor_service_slug": "platform-x",
+            "config": { "type": "x_search", "max_results_cap": 10 },
+            "vendor_body": { "query": "caller controlled" },
+        });
+        assert!(serde_json::from_value::<UpdatePlatformOperationRequest>(value).is_err());
+    }
+
+    #[tokio::test]
+    async fn upsert_persists_validated_typed_config() {
+        let Some(db) = crate::test_utils::connect_test_database("admin_platform_ops_upsert").await
+        else {
+            eprintln!("skipping admin platform operation test: no local MongoDB available");
+            return;
+        };
+
+        let operation = platform_operation_service::upsert_operation(
+            &db,
+            PlatformOperationName::XSearch,
+            true,
+            "platform-x".to_string(),
+            PlatformOperationConfig::XSearch(XSearchConfig {
+                max_results_cap: 12,
+            }),
+            "admin-user",
+        )
+        .await
+        .expect("upsert platform operation");
+
+        assert!(operation.enabled);
+        assert_eq!(operation.updated_by, "admin-user");
+        assert_eq!(
+            operation.config,
+            PlatformOperationConfig::XSearch(XSearchConfig {
+                max_results_cap: 12,
+            })
+        );
+        assert_eq!(
+            db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+                .count_documents(mongodb::bson::doc! { "op": "x_search" })
+                .await
+                .expect("count operation rows"),
+            1
+        );
+    }
+}

--- a/backend/src/handlers/mcp.rs
+++ b/backend/src/handlers/mcp.rs
@@ -322,11 +322,12 @@ mod tests {
                     .map(move |endpoint| format!("{}__{}", service.service_slug, endpoint.name))
             })
             .collect();
-        let mcp_operations: Vec<String> = mcp_service::generate_tool_definitions(&services, None)
-            .into_iter()
-            .filter(|tool| !tool.name.starts_with("nyx__"))
-            .map(|tool| tool.name)
-            .collect();
+        let mcp_operations: Vec<String> =
+            mcp_service::generate_tool_definitions(&services, None, &[])
+                .into_iter()
+                .filter(|tool| !tool.name.starts_with("nyx__"))
+                .map(|tool| tool.name)
+                .collect();
 
         assert_eq!(rest_operations, mcp_operations);
     }

--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -1,12 +1,15 @@
 use std::convert::Infallible;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::{Extension, State};
 use axum::http::{HeaderMap, Request, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
+use chrono::Utc;
 use mongodb::bson::doc;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio_stream::StreamExt;
 
@@ -16,10 +19,13 @@ use crate::models::mcp_session::{MCP_SESSION_COLLECTION, McpSessionRecord};
 use crate::models::service_account::{COLLECTION_NAME as SERVICE_ACCOUNTS, ServiceAccount};
 use crate::models::user::{COLLECTION_NAME as USERS, User};
 use crate::mw::auth::{self, AuthMethod};
+use crate::services::platform_operation_service::{
+    CallAndSayRequest, SpeakRequest, XSearchRequest,
+};
 use crate::services::{
     approval_service, audit_service, connect_link_service, mcp_service, notification_service,
     operation_descriptor, oracle_pool_service, oracle_session_service, oracle_task_service,
-    proxy_service, ssh_service, user_service_service,
+    platform_operation_service, proxy_service, ssh_service, user_service_service,
 };
 use crate::telemetry::{TelemetryContext, TelemetryEvent, emit_event};
 
@@ -95,6 +101,20 @@ fn tool_result(id: Option<serde_json::Value>, text: &str, is_error: bool) -> Res
         serde_json::json!({
             "content": [{ "type": "text", "text": text }],
             "isError": is_error,
+        }),
+    )
+}
+
+fn audio_tool_result(id: Option<serde_json::Value>, audio: &[u8]) -> Response {
+    rpc_success(
+        id,
+        serde_json::json!({
+            "content": [{
+                "type": "audio",
+                "data": base64::engine::general_purpose::STANDARD.encode(audio),
+                "mimeType": "audio/mpeg",
+            }],
+            "isError": false,
         }),
     )
 }
@@ -254,6 +274,8 @@ struct McpAuthContext {
     /// True when auth was via `x-api-key`. API-key requests are stateless: each
     /// request authenticates independently, no MCP session is created or required.
     is_api_key: bool,
+    /// True only for the scoped `nyxid_ag_` API-key class.
+    is_agent_api_key: bool,
     api_key_id: Option<String>,
     api_key_name: Option<String>,
     /// If false, `allowed_service_ids` constrains which UserServices this request may call.
@@ -276,6 +298,7 @@ impl McpAuthContext {
             acting_client_id: None,
             approval_owner_user_id: None,
             is_api_key: false,
+            is_agent_api_key: false,
             api_key_id: None,
             api_key_name: None,
             allow_all_services: true,
@@ -412,6 +435,7 @@ async fn authenticate_mcp(
                     acting_client_id: None,
                     approval_owner_user_id: None,
                     is_api_key: true,
+                    is_agent_api_key: api_key.key_prefix.starts_with("nyxid_ag_"),
                     api_key_id: Some(api_key.id.clone()),
                     api_key_name: Some(api_key.name.clone()),
                     allow_all_services: api_key.allow_all_services,
@@ -629,6 +653,13 @@ fn validate_session(
 /// which have no per-service/per-node binding to enforce against.
 fn is_scoped_api_key(auth: &McpAuthContext) -> bool {
     auth.is_api_key && (!auth.allow_all_services || !auth.allow_all_nodes)
+}
+
+fn platform_operations_allowed(auth: &McpAuthContext) -> bool {
+    matches!(
+        auth.auth_method,
+        AuthMethod::Session | AuthMethod::AccessToken
+    ) || (auth.auth_method == AuthMethod::ApiKey && auth.is_agent_api_key)
 }
 
 fn mcp_service_scope(auth: &McpAuthContext) -> mcp_service::ServiceScope<'_> {
@@ -1165,15 +1196,33 @@ async fn handle_tools_list(
     };
 
     let services = catalog.services;
+    let platform_operations = if platform_operations_allowed(auth) {
+        match platform_operation_service::list_enabled_operations(&state.db).await {
+            Ok(operations) => operations,
+            Err(error) => {
+                tracing::error!(
+                    error = %error,
+                    "Failed to load enabled platform operations for MCP discovery"
+                );
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
 
     // Session-backed clients get meta-tools + activated service tools only.
     // Stateless (API-key) clients with no session get the full tool list up front.
     let mut tool_defs = match session_id {
         Some(sid) => {
             let activated = state.mcp_sessions.get_activated_service_ids(sid);
-            mcp_service::generate_tool_definitions(&services, Some(&activated))
+            mcp_service::generate_tool_definitions(
+                &services,
+                Some(&activated),
+                &platform_operations,
+            )
         }
-        None => mcp_service::generate_tool_definitions(&services, None),
+        None => mcp_service::generate_tool_definitions(&services, None, &platform_operations),
     };
 
     // Scoped API keys do not get SSH meta-tools. SSH invocations would
@@ -1275,6 +1324,15 @@ async fn handle_tools_call(
                 billing_egress_permit,
             )
             .await;
+        }
+        "nyx__x_search" => {
+            return handle_platform_x_search(state, auth, &arguments, request.id.clone()).await;
+        }
+        "nyx__speak" => {
+            return handle_platform_speak(state, auth, &arguments, request.id.clone()).await;
+        }
+        "nyx__call_and_say" => {
+            return handle_platform_call_and_say(state, auth, &arguments, request.id.clone()).await;
         }
         "nyx__ssh_exec" | "nyx__ssh_list_services" => {
             if is_scoped_api_key(auth) {
@@ -1620,6 +1678,216 @@ async fn authorize_mcp_operation(
         })?;
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Platform-operation tool dispatch
+// ---------------------------------------------------------------------------
+
+fn parse_platform_operation_arguments<T: DeserializeOwned>(
+    arguments: &serde_json::Value,
+) -> Result<T, String> {
+    serde_json::from_value(arguments.clone())
+        .map_err(|error| format!("Invalid platform operation arguments: {error}"))
+}
+
+fn platform_operation_error_result(
+    request_id: Option<serde_json::Value>,
+    error: &crate::errors::AppError,
+) -> Response {
+    use crate::errors::AppError;
+
+    let message = match error {
+        AppError::BadRequest(message) | AppError::ValidationError(message) => message.clone(),
+        AppError::RateLimited => "Daily platform operation limit reached".to_string(),
+        AppError::NotFound(_) => "Platform operation is not available".to_string(),
+        AppError::PlatformOperationUnavailable => {
+            "Platform operation vendor is unavailable".to_string()
+        }
+        _ => {
+            tracing::error!(error = %error, "MCP platform operation failed");
+            "Platform operation failed".to_string()
+        }
+    };
+    tool_result(request_id, &message, true)
+}
+
+fn audit_mcp_platform_operation<T>(
+    state: &AppState,
+    auth: &McpAuthContext,
+    op: &'static str,
+    result: &crate::errors::AppResult<T>,
+    started: Instant,
+    metadata: serde_json::Value,
+) {
+    let mut data = metadata.as_object().cloned().unwrap_or_default();
+    data.insert("op".to_string(), serde_json::Value::String(op.to_string()));
+    data.insert(
+        "outcome".to_string(),
+        serde_json::Value::String(platform_operation_audit_outcome(result).to_string()),
+    );
+    data.insert(
+        "duration_ms".to_string(),
+        serde_json::Value::from(started.elapsed().as_millis() as u64),
+    );
+    audit_service::log_async(
+        state.db.clone(),
+        Some(auth.user_id.clone()),
+        "platform_operation".to_string(),
+        Some(serde_json::Value::Object(data)),
+        auth.ip_address.clone(),
+        auth.user_agent.clone(),
+        auth.api_key_id.clone(),
+        auth.api_key_name.clone(),
+    );
+}
+
+fn platform_operation_audit_outcome<T>(result: &crate::errors::AppResult<T>) -> &'static str {
+    use crate::errors::AppError;
+
+    match result {
+        Ok(_) => "succeeded",
+        Err(AppError::NotFound(_)) => "not_found",
+        Err(AppError::RateLimited) => "rate_limited",
+        Err(AppError::BadRequest(_) | AppError::ValidationError(_)) => "rejected",
+        Err(AppError::PlatformOperationUnavailable) => "vendor_unavailable",
+        Err(_) => "failed",
+    }
+}
+
+async fn handle_platform_x_search(
+    state: &AppState,
+    auth: &McpAuthContext,
+    arguments: &serde_json::Value,
+    request_id: Option<serde_json::Value>,
+) -> Response {
+    if !platform_operations_allowed(auth) {
+        return tool_result(request_id, "Platform operation is not available", true);
+    }
+    let request = match parse_platform_operation_arguments::<XSearchRequest>(arguments) {
+        Ok(request) => request,
+        Err(error) => return tool_result(request_id, &error, true),
+    };
+    let started = Instant::now();
+    let query_chars = request.query.chars().count();
+    let requested_max_results = request.max_results;
+    let result = platform_operation_service::execute_x_search(
+        &state.db,
+        &state.encryption_keys,
+        &state.http_client,
+        request,
+    )
+    .await;
+    audit_mcp_platform_operation(
+        state,
+        auth,
+        "x_search",
+        &result,
+        started,
+        serde_json::json!({
+            "query_chars": query_chars,
+            "requested_max_results": requested_max_results,
+        }),
+    );
+
+    match result {
+        Ok(response) => tool_result(request_id, &response.to_string(), false),
+        Err(error) => platform_operation_error_result(request_id, &error),
+    }
+}
+
+async fn handle_platform_speak(
+    state: &AppState,
+    auth: &McpAuthContext,
+    arguments: &serde_json::Value,
+    request_id: Option<serde_json::Value>,
+) -> Response {
+    if !platform_operations_allowed(auth) {
+        return tool_result(request_id, "Platform operation is not available", true);
+    }
+    let request = match parse_platform_operation_arguments::<SpeakRequest>(arguments) {
+        Ok(request) => request,
+        Err(error) => return tool_result(request_id, &error, true),
+    };
+    let started = Instant::now();
+    let text_chars = request.text.chars().count();
+    let voice_id = request.voice_id.clone();
+    let result = async {
+        let vendor = platform_operation_service::execute_speak(
+            &state.db,
+            &state.encryption_keys,
+            &state.http_client,
+            request,
+        )
+        .await?;
+        platform_operation_service::collect_speak_audio(vendor).await
+    }
+    .await;
+    audit_mcp_platform_operation(
+        state,
+        auth,
+        "speak",
+        &result,
+        started,
+        serde_json::json!({
+            "text_chars": text_chars,
+            "voice_id": voice_id,
+        }),
+    );
+
+    match result {
+        Ok(audio) => audio_tool_result(request_id, &audio),
+        Err(error) => platform_operation_error_result(request_id, &error),
+    }
+}
+
+async fn handle_platform_call_and_say(
+    state: &AppState,
+    auth: &McpAuthContext,
+    arguments: &serde_json::Value,
+    request_id: Option<serde_json::Value>,
+) -> Response {
+    if !platform_operations_allowed(auth) {
+        return tool_result(request_id, "Platform operation is not available", true);
+    }
+    let request = match parse_platform_operation_arguments::<CallAndSayRequest>(arguments) {
+        Ok(request) => request,
+        Err(error) => return tool_result(request_id, &error, true),
+    };
+    let started = Instant::now();
+    let message_chars = request.message.chars().count();
+    let destination_suffix = if platform_operation_service::is_e164_number(&request.to) {
+        platform_operation_service::redacted_destination_suffix(&request.to)
+    } else {
+        "invalid".to_string()
+    };
+    // The transport edge owns the UTC date; quota logic receives it explicitly.
+    let yyyymmdd = Utc::now().format("%Y%m%d").to_string();
+    let result = platform_operation_service::execute_call_and_say(
+        &state.db,
+        &state.encryption_keys,
+        &state.http_client,
+        &auth.user_id,
+        &yyyymmdd,
+        request,
+    )
+    .await;
+    audit_mcp_platform_operation(
+        state,
+        auth,
+        "call_and_say",
+        &result,
+        started,
+        serde_json::json!({
+            "message_chars": message_chars,
+            "destination_suffix": destination_suffix,
+        }),
+    );
+
+    match result {
+        Ok(response) => tool_result(request_id, &response.to_string(), false),
+        Err(error) => platform_operation_error_result(request_id, &error),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3111,6 +3379,7 @@ mod tests {
             acting_client_id: None,
             approval_owner_user_id: None,
             is_api_key: true,
+            is_agent_api_key: true,
             api_key_id: Some("key-1".into()),
             api_key_name: Some("agent".into()),
             allow_all_services: false,
@@ -3122,6 +3391,56 @@ mod tests {
             ip_address: None,
             user_agent: None,
         }
+    }
+
+    #[test]
+    fn platform_operations_accept_only_user_sessions_and_agent_keys() {
+        assert!(platform_operations_allowed(&McpAuthContext::user(
+            "user-1".to_string(),
+            AuthMethod::Session,
+        )));
+        assert!(platform_operations_allowed(&McpAuthContext::user(
+            "user-1".to_string(),
+            AuthMethod::AccessToken,
+        )));
+
+        let agent_key = api_key_auth(Vec::new());
+        assert!(platform_operations_allowed(&agent_key));
+
+        let mut ordinary_key = agent_key;
+        ordinary_key.is_agent_api_key = false;
+        assert!(!platform_operations_allowed(&ordinary_key));
+        for method in [
+            AuthMethod::Delegated,
+            AuthMethod::Relay,
+            AuthMethod::ServiceAccount,
+        ] {
+            assert!(!platform_operations_allowed(&McpAuthContext::user(
+                "user-1".to_string(),
+                method,
+            )));
+        }
+    }
+
+    #[tokio::test]
+    async fn speech_tool_result_uses_mcp_audio_content() {
+        let response = audio_tool_result(Some(serde_json::json!(17)), b"mp3-bytes");
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .expect("read MCP audio response");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("decode MCP audio response");
+        let content = &payload["result"]["content"][0];
+
+        assert_eq!(payload["id"], 17);
+        assert_eq!(payload["result"]["isError"], false);
+        assert_eq!(content["type"], "audio");
+        assert_eq!(content["mimeType"], "audio/mpeg");
+        assert_eq!(
+            content["data"],
+            base64::engine::general_purpose::STANDARD.encode(b"mp3-bytes")
+        );
+        assert!(content.get("text").is_none());
     }
 
     fn user_managed(id: &str) -> McpToolService {

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -66,6 +66,7 @@ pub mod oracle_tasks;
 pub mod oracle_worker;
 pub mod org_role_scopes;
 pub mod orgs;
+pub mod platform_ops;
 pub mod providers;
 pub mod proxy;
 pub mod public_mcp;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod admin_feature_flags;
 pub mod admin_groups;
 pub mod admin_helpers;
 pub mod admin_nodes;
+pub mod admin_platform_ops;
 pub mod admin_roles;
 pub mod admin_sa_connections;
 pub mod admin_sa_providers;

--- a/backend/src/handlers/platform_ops.rs
+++ b/backend/src/handlers/platform_ops.rs
@@ -1,0 +1,511 @@
+use std::time::Instant;
+
+use axum::{
+    Json,
+    body::Body,
+    extract::State,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use chrono::Utc;
+use serde_json::{Map, Value, json};
+
+use crate::AppState;
+use crate::errors::{AppError, AppResult};
+use crate::models::api_key::{ApiKey, COLLECTION_NAME as API_KEYS};
+use crate::mw::auth::{AuthMethod, AuthUser};
+use crate::services::platform_operation_service::{
+    CallAndSayRequest, SpeakRequest, XSearchRequest,
+};
+use crate::services::{audit_service, platform_operation_service};
+
+pub async fn x_search(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(request): Json<XSearchRequest>,
+) -> AppResult<Response> {
+    ensure_platform_operation_caller(&state, &auth_user).await?;
+    enforce_agent_rate_limit(&state, &auth_user)?;
+
+    let started = Instant::now();
+    let query_chars = request.query.chars().count();
+    let requested_max_results = request.max_results;
+    let result = platform_operation_service::execute_x_search(
+        &state.db,
+        &state.encryption_keys,
+        &state.http_client,
+        request,
+    )
+    .await;
+    audit_operation(
+        &state,
+        &auth_user,
+        "x_search",
+        &result,
+        started,
+        json!({
+            "query_chars": query_chars,
+            "requested_max_results": requested_max_results,
+        }),
+    );
+
+    Ok(Json(result?).into_response())
+}
+
+pub async fn speak(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(request): Json<SpeakRequest>,
+) -> AppResult<Response> {
+    ensure_platform_operation_caller(&state, &auth_user).await?;
+    enforce_agent_rate_limit(&state, &auth_user)?;
+
+    let started = Instant::now();
+    let text_chars = request.text.chars().count();
+    let voice_id = request.voice_id.clone();
+    let result = platform_operation_service::execute_speak(
+        &state.db,
+        &state.encryption_keys,
+        &state.http_client,
+        request,
+    )
+    .await;
+    audit_operation(
+        &state,
+        &auth_user,
+        "speak",
+        &result,
+        started,
+        json!({
+            "text_chars": text_chars,
+            "voice_id": voice_id,
+        }),
+    );
+
+    let vendor = result?;
+    let content_length = vendor.response.content_length();
+    let stream = vendor.response.bytes_stream();
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "audio/mpeg");
+    if let Some(content_length) = content_length {
+        builder = builder.header(header::CONTENT_LENGTH, content_length);
+    }
+    builder
+        .body(Body::from_stream(stream))
+        .map_err(|error| AppError::Internal(format!("Failed to build speech response: {error}")))
+}
+
+pub async fn call_and_say(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(request): Json<CallAndSayRequest>,
+) -> AppResult<Response> {
+    ensure_platform_operation_caller(&state, &auth_user).await?;
+    enforce_agent_rate_limit(&state, &auth_user)?;
+
+    let started = Instant::now();
+    let message_chars = request.message.chars().count();
+    let destination_suffix = if platform_operation_service::is_e164_number(&request.to) {
+        platform_operation_service::redacted_destination_suffix(&request.to)
+    } else {
+        "invalid".to_string()
+    };
+    // The date is deliberately derived at the transport edge and passed into
+    // the service, keeping quota tests deterministic and avoiding hidden time
+    // reads in the reservation logic.
+    let yyyymmdd = Utc::now().format("%Y%m%d").to_string();
+    let result = platform_operation_service::execute_call_and_say(
+        &state.db,
+        &state.encryption_keys,
+        &state.http_client,
+        &auth_user.user_id.to_string(),
+        &yyyymmdd,
+        request,
+    )
+    .await;
+    audit_operation(
+        &state,
+        &auth_user,
+        "call_and_say",
+        &result,
+        started,
+        json!({
+            "message_chars": message_chars,
+            "destination_suffix": destination_suffix,
+        }),
+    );
+
+    Ok(Json(result?).into_response())
+}
+
+async fn ensure_platform_operation_caller(state: &AppState, auth_user: &AuthUser) -> AppResult<()> {
+    match auth_user.auth_method {
+        AuthMethod::Session | AuthMethod::AccessToken => Ok(()),
+        AuthMethod::ApiKey => {
+            let api_key_id = auth_user.api_key_id.as_deref().ok_or_else(|| {
+                AppError::Unauthorized("Agent API key identity is missing".to_string())
+            })?;
+            let is_agent_key = state
+                .db
+                .collection::<ApiKey>(API_KEYS)
+                .find_one(mongodb::bson::doc! {
+                    "_id": api_key_id,
+                    "key_prefix": { "$regex": r"^nyxid_ag_" },
+                    "is_active": true,
+                })
+                .await?
+                .is_some();
+            if is_agent_key {
+                Ok(())
+            } else {
+                Err(AppError::Forbidden(
+                    "A nyxid_ag_ agent API key is required for API-key access.".to_string(),
+                ))
+            }
+        }
+        AuthMethod::Delegated | AuthMethod::Relay | AuthMethod::ServiceAccount => Err(
+            AppError::Forbidden("This token type cannot access platform operations.".to_string()),
+        ),
+    }
+}
+
+fn enforce_agent_rate_limit(state: &AppState, auth_user: &AuthUser) -> AppResult<()> {
+    crate::mw::rate_limit::check_agent_rate_limit_raw(
+        &state.per_agent_limiter,
+        auth_user.api_key_id.as_deref(),
+        auth_user.rate_limit_per_second,
+        auth_user.rate_limit_burst,
+    )
+}
+
+fn audit_operation<T>(
+    state: &AppState,
+    auth_user: &AuthUser,
+    op: &'static str,
+    result: &AppResult<T>,
+    started: Instant,
+    metadata: Value,
+) {
+    let mut data = match metadata {
+        Value::Object(data) => data,
+        _ => Map::new(),
+    };
+    data.insert("op".to_string(), Value::String(op.to_string()));
+    data.insert(
+        "outcome".to_string(),
+        Value::String(audit_outcome(result).to_string()),
+    );
+    data.insert(
+        "duration_ms".to_string(),
+        Value::from(started.elapsed().as_millis() as u64),
+    );
+    audit_service::log_for_user(
+        state.db.clone(),
+        auth_user,
+        "platform_operation",
+        Some(Value::Object(data)),
+    );
+}
+
+fn audit_outcome<T>(result: &AppResult<T>) -> &'static str {
+    match result {
+        Ok(_) => "succeeded",
+        Err(AppError::NotFound(_)) => "not_found",
+        Err(AppError::RateLimited) => "rate_limited",
+        Err(AppError::BadRequest(_) | AppError::ValidationError(_)) => "rejected",
+        Err(AppError::PlatformOperationUnavailable) => "vendor_unavailable",
+        Err(_) => "failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, routing::post};
+    use mongodb::{IndexModel, options::IndexOptions};
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+
+    use crate::models::downstream_service::{
+        COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
+    };
+    use crate::models::platform_op_usage::{COLLECTION_NAME as PLATFORM_OP_USAGE, PlatformOpUsage};
+    use crate::models::platform_operation::{
+        COLLECTION_NAME as PLATFORM_OPERATIONS, CallAndSayConfig, PlatformOperation,
+        PlatformOperationConfig, PlatformOperationName, XSearchConfig,
+    };
+
+    const USER_ID: &str = "65de27dc-8cf8-44b6-b8d2-5304e4a90aa4";
+
+    fn operation(
+        op: PlatformOperationName,
+        enabled: bool,
+        config: PlatformOperationConfig,
+    ) -> PlatformOperation {
+        PlatformOperation {
+            id: uuid::Uuid::new_v4().to_string(),
+            op,
+            enabled,
+            vendor_service_slug: platform_operation_service::default_vendor_service_slug(op)
+                .to_string(),
+            config,
+            updated_at: Utc::now(),
+            updated_by: USER_ID.to_string(),
+        }
+    }
+
+    fn call_config(cap: u32) -> CallAndSayConfig {
+        CallAndSayConfig {
+            allowed_destination_prefixes: vec!["+65".to_string()],
+            max_message_chars: 500,
+            voice: "alice".to_string(),
+            max_calls_per_user_per_day: cap,
+            account_sid: format!("AC{}", "1".repeat(32)),
+            call_from: "+16505550100".to_string(),
+        }
+    }
+
+    async fn insert_twilio_vendor(state: &AppState, base_url: String) {
+        let mut service = crate::models::downstream_service::test_helpers::dummy_service();
+        service.id = uuid::Uuid::new_v4().to_string();
+        service.slug = platform_operation_service::CALL_AND_SAY_VENDOR_SLUG.to_string();
+        service.name = "Platform Twilio".to_string();
+        service.base_url = base_url;
+        service.service_category = "internal".to_string();
+        service.visibility = "public".to_string();
+        service.auth_method = "basic".to_string();
+        service.auth_key_name = "Authorization".to_string();
+        service.credential_encrypted = state
+            .encryption_keys
+            .encrypt(b"twilio-auth-token")
+            .await
+            .expect("encrypt Twilio token");
+        state
+            .db
+            .collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+            .insert_one(service)
+            .await
+            .expect("insert Twilio vendor row");
+    }
+
+    async fn ensure_usage_index(db: &mongodb::Database) {
+        db.collection::<mongodb::bson::Document>(PLATFORM_OP_USAGE)
+            .create_index(
+                IndexModel::builder()
+                    .keys(mongodb::bson::doc! {
+                        "op": 1,
+                        "user_id": 1,
+                        "yyyymmdd": 1,
+                    })
+                    .options(IndexOptions::builder().unique(true).build())
+                    .build(),
+            )
+            .await
+            .expect("create platform operation usage index");
+    }
+
+    async fn spawn_twilio(status: StatusCode) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().route(
+            "/2010-04-01/Accounts/{account_sid}/Calls.json",
+            post(move || async move {
+                (
+                    status,
+                    Json(json!({ "sid": "CA-test", "status": "queued" })),
+                )
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind Twilio test server");
+        let address = listener.local_addr().expect("Twilio test server address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve Twilio test server");
+        });
+        (format!("http://{address}"), server)
+    }
+
+    #[tokio::test]
+    async fn disabled_operation_returns_not_found() {
+        let Some(db) = crate::test_utils::connect_test_database("platform_ops_disabled").await
+        else {
+            eprintln!("skipping platform operation handler test: no local MongoDB available");
+            return;
+        };
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_one(operation(
+                PlatformOperationName::XSearch,
+                false,
+                PlatformOperationConfig::XSearch(XSearchConfig {
+                    max_results_cap: 10,
+                }),
+            ))
+            .await
+            .expect("insert disabled operation");
+        let result = x_search(
+            State(crate::test_utils::test_app_state(db)),
+            crate::test_utils::test_auth_user(USER_ID),
+            Json(XSearchRequest {
+                query: "nyxid".to_string(),
+                max_results: None,
+            }),
+        )
+        .await;
+        assert!(matches!(result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn enabled_operation_with_missing_vendor_returns_bad_gateway_error() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("platform_ops_vendor_missing").await
+        else {
+            eprintln!("skipping platform operation handler test: no local MongoDB available");
+            return;
+        };
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_one(operation(
+                PlatformOperationName::XSearch,
+                true,
+                PlatformOperationConfig::XSearch(XSearchConfig {
+                    max_results_cap: 10,
+                }),
+            ))
+            .await
+            .expect("insert enabled operation");
+        let result = x_search(
+            State(crate::test_utils::test_app_state(db)),
+            crate::test_utils::test_auth_user(USER_ID),
+            Json(XSearchRequest {
+                query: "nyxid".to_string(),
+                max_results: None,
+            }),
+        )
+        .await;
+        let error = result.expect_err("missing vendor must fail closed");
+        assert!(matches!(error, AppError::PlatformOperationUnavailable));
+        assert_eq!(error.into_response().status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn daily_cap_allows_n_calls_and_rejects_n_plus_one() {
+        let Some(db) = crate::test_utils::connect_test_database("platform_ops_daily_cap").await
+        else {
+            eprintln!("skipping platform operation handler test: no local MongoDB available");
+            return;
+        };
+        ensure_usage_index(&db).await;
+        let state = crate::test_utils::test_app_state(db.clone());
+        let (base_url, server) = spawn_twilio(StatusCode::CREATED).await;
+        insert_twilio_vendor(&state, base_url).await;
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_one(operation(
+                PlatformOperationName::CallAndSay,
+                true,
+                PlatformOperationConfig::CallAndSay(call_config(2)),
+            ))
+            .await
+            .expect("insert call operation");
+
+        for _ in 0..2 {
+            let result = call_and_say(
+                State(state.clone()),
+                crate::test_utils::test_auth_user(USER_ID),
+                Json(CallAndSayRequest {
+                    to: "+6512345678".to_string(),
+                    message: "Hello".to_string(),
+                }),
+            )
+            .await;
+            assert!(result.is_ok());
+        }
+        let result = call_and_say(
+            State(state),
+            crate::test_utils::test_auth_user(USER_ID),
+            Json(CallAndSayRequest {
+                to: "+6512345678".to_string(),
+                message: "Hello again".to_string(),
+            }),
+        )
+        .await;
+        assert!(matches!(result, Err(AppError::RateLimited)));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn vendor_failure_releases_daily_call_reservation() {
+        let Some(db) = crate::test_utils::connect_test_database("platform_ops_failed_call").await
+        else {
+            eprintln!("skipping platform operation handler test: no local MongoDB available");
+            return;
+        };
+        ensure_usage_index(&db).await;
+        let state = crate::test_utils::test_app_state(db.clone());
+        let (base_url, server) = spawn_twilio(StatusCode::INTERNAL_SERVER_ERROR).await;
+        insert_twilio_vendor(&state, base_url).await;
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_one(operation(
+                PlatformOperationName::CallAndSay,
+                true,
+                PlatformOperationConfig::CallAndSay(call_config(2)),
+            ))
+            .await
+            .expect("insert call operation");
+
+        let result = call_and_say(
+            State(state),
+            crate::test_utils::test_auth_user(USER_ID),
+            Json(CallAndSayRequest {
+                to: "+6512345678".to_string(),
+                message: "Hello".to_string(),
+            }),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(AppError::PlatformOperationUnavailable)
+        ));
+        let usage = db
+            .collection::<PlatformOpUsage>(PLATFORM_OP_USAGE)
+            .find_one(mongodb::bson::doc! {
+                "op": "call_and_say",
+                "user_id": USER_ID,
+            })
+            .await
+            .expect("read usage row")
+            .expect("usage row remains for the day");
+        assert_eq!(usage.count, 0);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn delegated_relay_and_service_account_callers_are_rejected() {
+        let state = Arc::new(crate::test_utils::test_app_state_no_db().await);
+        for method in [
+            AuthMethod::Delegated,
+            AuthMethod::Relay,
+            AuthMethod::ServiceAccount,
+        ] {
+            let mut auth_user = crate::test_utils::test_auth_user(USER_ID);
+            auth_user.auth_method = method;
+            assert!(matches!(
+                ensure_platform_operation_caller(&state, &auth_user).await,
+                Err(AppError::Forbidden(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn audit_payloads_are_metadata_only() {
+        let result: AppResult<()> = Ok(());
+        assert_eq!(audit_outcome(&result), "succeeded");
+        let call_metadata = json!({
+            "message_chars": 12,
+            "destination_suffix": "***5678",
+        });
+        let encoded = serde_json::to_string(&call_metadata).expect("encode audit metadata");
+        assert!(!encoded.contains("Hello world"));
+        assert!(!encoded.contains("+6512345678"));
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -56,6 +56,10 @@ pub mod oracle_worker;
 pub mod org_invite;
 pub mod org_membership;
 pub mod org_role_scope;
+#[allow(dead_code)] // Removed when the platform operation handlers are mounted.
+pub mod platform_op_usage;
+#[allow(dead_code)] // Removed when the platform operation handlers are mounted.
+pub mod platform_operation;
 pub mod platform_settings;
 pub mod provider_config;
 pub mod pushed_authorization_request;

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -56,9 +56,7 @@ pub mod oracle_worker;
 pub mod org_invite;
 pub mod org_membership;
 pub mod org_role_scope;
-#[allow(dead_code)] // Removed when the platform operation handlers are mounted.
 pub mod platform_op_usage;
-#[allow(dead_code)] // Removed when the platform operation handlers are mounted.
 pub mod platform_operation;
 pub mod platform_settings;
 pub mod provider_config;

--- a/backend/src/models/platform_op_usage.rs
+++ b/backend/src/models/platform_op_usage.rs
@@ -1,0 +1,18 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::platform_operation::PlatformOperationName;
+
+pub const COLLECTION_NAME: &str = "platform_op_usage";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlatformOpUsage {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub op: PlatformOperationName,
+    pub user_id: String,
+    pub yyyymmdd: String,
+    pub count: u32,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub updated_at: DateTime<Utc>,
+}

--- a/backend/src/models/platform_operation.rs
+++ b/backend/src/models/platform_operation.rs
@@ -1,0 +1,135 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const COLLECTION_NAME: &str = "platform_operations";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlatformOperationName {
+    XSearch,
+    Speak,
+    CallAndSay,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct XSearchConfig {
+    #[serde(default = "default_x_search_max_results_cap")]
+    pub max_results_cap: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpeakConfig {
+    pub allowed_voice_ids: Vec<String>,
+    #[serde(default = "default_speak_max_chars")]
+    pub max_chars: u32,
+    #[serde(default = "default_speak_model_id")]
+    pub model_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CallAndSayConfig {
+    #[serde(default)]
+    pub allowed_destination_prefixes: Vec<String>,
+    #[serde(default = "default_call_max_message_chars")]
+    pub max_message_chars: u32,
+    #[serde(default = "default_call_voice")]
+    pub voice: String,
+    #[serde(default = "default_call_max_per_user_per_day")]
+    pub max_calls_per_user_per_day: u32,
+    pub account_sid: String,
+    pub call_from: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum PlatformOperationConfig {
+    XSearch(XSearchConfig),
+    Speak(SpeakConfig),
+    CallAndSay(CallAndSayConfig),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlatformOperation {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub op: PlatformOperationName,
+    #[serde(default)]
+    pub enabled: bool,
+    pub vendor_service_slug: String,
+    pub config: PlatformOperationConfig,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub updated_at: DateTime<Utc>,
+    pub updated_by: String,
+}
+
+pub const fn default_x_search_max_results_cap() -> u32 {
+    10
+}
+
+pub const fn default_speak_max_chars() -> u32 {
+    1_000
+}
+
+pub fn default_speak_model_id() -> String {
+    "eleven_multilingual_v2".to_string()
+}
+
+pub const fn default_call_max_message_chars() -> u32 {
+    500
+}
+
+pub fn default_call_voice() -> String {
+    "alice".to_string()
+}
+
+pub const fn default_call_max_per_user_per_day() -> u32 {
+    3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_rejects_unknown_fields() {
+        let value = serde_json::json!({
+            "type": "speak",
+            "allowed_voice_ids": ["voice-a"],
+            "max_chars": 100,
+            "model_id": "eleven_multilingual_v2",
+            "caller_supplied_body": true,
+        });
+
+        assert!(serde_json::from_value::<PlatformOperationConfig>(value).is_err());
+    }
+
+    #[test]
+    fn bson_roundtrip_preserves_typed_config_and_datetime() {
+        let operation = PlatformOperation {
+            id: uuid::Uuid::new_v4().to_string(),
+            op: PlatformOperationName::XSearch,
+            enabled: false,
+            vendor_service_slug: "platform-x".to_string(),
+            config: PlatformOperationConfig::XSearch(XSearchConfig {
+                max_results_cap: 10,
+            }),
+            updated_at: Utc::now(),
+            updated_by: uuid::Uuid::new_v4().to_string(),
+        };
+
+        let document = bson::to_document(&operation).expect("serialize platform operation");
+        let restored: PlatformOperation =
+            bson::from_document(document).expect("deserialize platform operation");
+
+        assert_eq!(restored.id, operation.id);
+        assert_eq!(restored.op, operation.op);
+        assert_eq!(restored.config, operation.config);
+        assert_eq!(
+            restored.updated_at.timestamp_millis(),
+            operation.updated_at.timestamp_millis()
+        );
+    }
+}

--- a/backend/src/mw/auth.rs
+++ b/backend/src/mw/auth.rs
@@ -321,6 +321,7 @@ fn api_key_management_write_requires_scope(method: &Method, path: &str) -> bool 
         "/api/v1/channel-relay",
         "/api/v1/delegation",
         "/api/v1/llm",
+        "/api/v1/platform-ops",
         "/api/v1/proxy",
         "/api/v1/ssh",
         "/api/v1/approvals/exact-service",
@@ -413,6 +414,7 @@ fn delegated_read_denied_path(path: &str) -> bool {
                 | "channel-bots"
                 | "channel-conversations"
                 | "connect-links"
+                | "platform-ops"
         )
     ) {
         return true;
@@ -1538,6 +1540,7 @@ mod tests {
             "/api/v1/oracle/pools",
             "/api/v1/channel-bots",
             "/api/v1/channel-conversations/conversation-id",
+            "/api/v1/platform-ops/x-search",
             "/api/v1/nodes/ws",
             "/api/v1/nodes/node-id/credentials",
             "/api/v1/nodes/node-id/credentials/pending",
@@ -3041,6 +3044,7 @@ mod tests {
             (Method::POST, "/api/v1/llm/gateway/v1/chat/completions"),
             (Method::POST, "/api/v1/channel-relay/reply"),
             (Method::POST, "/api/v1/channel-events/conversation-1"),
+            (Method::POST, "/api/v1/platform-ops/x-search"),
             (Method::POST, "/api/v1/ssh/service-1/exec"),
             (Method::POST, "/oauth/token"),
         ];

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -757,6 +757,14 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
 
     let admin_routes = Router::new()
         .route(
+            "/platform-ops",
+            get(handlers::admin_platform_ops::list_platform_operations),
+        )
+        .route(
+            "/platform-ops/{op}",
+            put(handlers::admin_platform_ops::update_platform_operation),
+        )
+        .route(
             "/feature-flags",
             get(handlers::admin_feature_flags::list_feature_flags),
         )

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1525,6 +1525,16 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
     )
     .layer(DefaultBodyLimit::max(16 * 1024 * 1024));
 
+    let platform_operation_routes = Router::new()
+        .route("/x-search", post(handlers::platform_ops::x_search))
+        .route("/speak", post(handlers::platform_ops::speak))
+        .route("/call-and-say", post(handlers::platform_ops::call_and_say))
+        .layer(middleware::from_fn(reject_delegated_tokens))
+        .layer(middleware::from_fn(reject_service_account_tokens))
+        .layer(middleware::from_fn(reject_relay_tokens));
+
+    let api_v1_platform_operations = Router::new().nest("/platform-ops", platform_operation_routes);
+
     // Routes accessible by both users and service accounts (block delegated tokens)
     let api_v1_shared = Router::new()
         .nest("/connections", connection_routes)
@@ -1681,6 +1691,7 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
     let api_v1 = api_v1_public
         .merge(api_v1_delegated)
         .merge(api_v1_shared)
+        .merge(api_v1_platform_operations)
         .merge(api_v1_human_only);
 
     let well_known_routes = Router::new()

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -11,6 +11,7 @@ use crate::models::downstream_service::{
     COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService, ProxyOperationPolicy,
     legacy_http_service_type_filter,
 };
+use crate::models::platform_operation::{PlatformOperation, PlatformOperationConfig};
 use crate::models::service_billing::{BillingMetric, PlatformUsage};
 use crate::models::service_endpoint::{
     COLLECTION_NAME as SERVICE_ENDPOINTS, EndpointRisk, OperationResponseContract, ServiceEndpoint,
@@ -1822,6 +1823,7 @@ fn build_generic_proxy_input_schema() -> serde_json::Value {
 pub fn generate_tool_definitions(
     services: &[McpToolService],
     activated_service_ids: Option<&HashSet<String>>,
+    platform_operations: &[PlatformOperation],
 ) -> Vec<McpToolDefinition> {
     let mut tools = Vec::new();
 
@@ -2141,6 +2143,102 @@ pub fn generate_tool_definitions(
             "required": ["conversation_id"]
         }),
     });
+
+    // -- First-party platform operations (present only while enabled) --
+    for operation in platform_operations {
+        if !operation.enabled {
+            continue;
+        }
+        let definition = match &operation.config {
+            PlatformOperationConfig::XSearch(config)
+                if operation.op
+                    == crate::models::platform_operation::PlatformOperationName::XSearch =>
+            {
+                McpToolDefinition {
+                    name: "nyx__x_search".to_string(),
+                    description: "Search recent posts on X through NyxID's constrained platform operation."
+                        .to_string(),
+                    input_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 512,
+                                "description": "Search query"
+                            },
+                            "max_results": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": config.max_results_cap,
+                                "description": "Maximum results to return"
+                            }
+                        },
+                        "required": ["query"],
+                        "additionalProperties": false
+                    }),
+                }
+            }
+            PlatformOperationConfig::Speak(config)
+                if operation.op
+                    == crate::models::platform_operation::PlatformOperationName::Speak =>
+            {
+                McpToolDefinition {
+                    name: "nyx__speak".to_string(),
+                    description: "Synthesize MP3 speech through NyxID's constrained platform operation."
+                        .to_string(),
+                    input_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "text": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": config.max_chars,
+                                "description": "Text to synthesize"
+                            },
+                            "voice_id": {
+                                "type": "string",
+                                "enum": config.allowed_voice_ids,
+                                "description": "Allowlisted ElevenLabs voice ID"
+                            }
+                        },
+                        "required": ["text", "voice_id"],
+                        "additionalProperties": false
+                    }),
+                }
+            }
+            PlatformOperationConfig::CallAndSay(config)
+                if operation.op
+                    == crate::models::platform_operation::PlatformOperationName::CallAndSay =>
+            {
+                McpToolDefinition {
+                    name: "nyx__call_and_say".to_string(),
+                    description: "Place a constrained voice call and speak a message using server-composed TwiML."
+                        .to_string(),
+                    input_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "to": {
+                                "type": "string",
+                                "pattern": "^\\+[1-9][0-9]{0,14}$",
+                                "description": "Allowlisted E.164 destination"
+                            },
+                            "message": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": config.max_message_chars,
+                                "description": "Message to speak"
+                            }
+                        },
+                        "required": ["to", "message"],
+                        "additionalProperties": false
+                    }),
+                }
+            }
+            _ => continue,
+        };
+        tools.push(definition);
+    }
 
     // -- Per-service tools (filtered by activated set) --
     for service in services {
@@ -5580,7 +5678,7 @@ mod tests {
         )];
 
         let empty_set = HashSet::new();
-        let tools = generate_tool_definitions(&services, Some(&empty_set));
+        let tools = generate_tool_definitions(&services, Some(&empty_set), &[]);
 
         // Should only have the 14 meta-tools (6 core + 2 SSH + 6 oracle)
         assert_eq!(tools.len(), 14);
@@ -5606,7 +5704,7 @@ mod tests {
 
         let mut activated = HashSet::new();
         activated.insert("svc-1".to_string());
-        let tools = generate_tool_definitions(&services, Some(&activated));
+        let tools = generate_tool_definitions(&services, Some(&activated), &[]);
 
         // 14 meta-tools + 1 weather tool (news excluded)
         assert_eq!(tools.len(), 15);
@@ -5631,7 +5729,7 @@ mod tests {
             ),
         ];
 
-        let tools = generate_tool_definitions(&services, None);
+        let tools = generate_tool_definitions(&services, None, &[]);
 
         // 14 meta-tools + 2 service tools
         assert_eq!(tools.len(), 16);
@@ -5641,7 +5739,7 @@ mod tests {
 
     #[test]
     fn generate_tool_definitions_includes_oracle_meta_tools() {
-        let tools = generate_tool_definitions(&[], None);
+        let tools = generate_tool_definitions(&[], None, &[]);
 
         let required_for = |name: &str| -> Vec<String> {
             tools
@@ -5671,7 +5769,7 @@ mod tests {
 
     #[test]
     fn generate_tool_definitions_includes_connected_services_meta_tool() {
-        let tools = generate_tool_definitions(&[], None);
+        let tools = generate_tool_definitions(&[], None, &[]);
         let tool = tools
             .iter()
             .find(|tool| tool.name == "nyx__list_connected_services")
@@ -5679,6 +5777,53 @@ mod tests {
 
         assert_eq!(tool.input_schema["required"], serde_json::json!([]));
         assert!(tool.input_schema["properties"]["query"].is_object());
+    }
+
+    #[test]
+    fn generate_tool_definitions_publishes_only_enabled_platform_operation_rows() {
+        let enabled_operation = PlatformOperation {
+            id: "platform-speak".to_string(),
+            op: crate::models::platform_operation::PlatformOperationName::Speak,
+            enabled: true,
+            vendor_service_slug: "platform-elevenlabs".to_string(),
+            config: PlatformOperationConfig::Speak(
+                crate::models::platform_operation::SpeakConfig {
+                    allowed_voice_ids: vec!["voice-a".to_string(), "voice-b".to_string()],
+                    max_chars: 321,
+                    model_id: "eleven_multilingual_v2".to_string(),
+                },
+            ),
+            updated_at: chrono::Utc::now(),
+            updated_by: "admin-user".to_string(),
+        };
+        let disabled_operation = PlatformOperation {
+            id: "platform-x-search".to_string(),
+            op: crate::models::platform_operation::PlatformOperationName::XSearch,
+            enabled: false,
+            vendor_service_slug: "platform-x".to_string(),
+            config: PlatformOperationConfig::XSearch(
+                crate::models::platform_operation::XSearchConfig {
+                    max_results_cap: 10,
+                },
+            ),
+            updated_at: chrono::Utc::now(),
+            updated_by: "admin-user".to_string(),
+        };
+
+        let tools = generate_tool_definitions(&[], None, &[enabled_operation, disabled_operation]);
+        let speak = tools
+            .iter()
+            .find(|tool| tool.name == "nyx__speak")
+            .expect("enabled speak tool");
+
+        assert!(!tools.iter().any(|tool| tool.name == "nyx__x_search"));
+        assert!(!tools.iter().any(|tool| tool.name == "nyx__call_and_say"));
+        assert_eq!(speak.input_schema["properties"]["text"]["maxLength"], 321);
+        assert_eq!(
+            speak.input_schema["properties"]["voice_id"]["enum"],
+            serde_json::json!(["voice-a", "voice-b"])
+        );
+        assert_eq!(speak.input_schema["additionalProperties"], false);
     }
 
     #[test]

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -86,6 +86,8 @@ pub mod org_role_scope_service;
 pub mod org_service;
 pub mod org_slug;
 pub mod par_service;
+#[allow(dead_code)] // Removed when the platform operation handlers are mounted.
+pub mod platform_operation_service;
 pub mod platform_settings_service;
 pub mod provider_service;
 pub mod provider_token_exchange_service;

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -86,7 +86,6 @@ pub mod org_role_scope_service;
 pub mod org_service;
 pub mod org_slug;
 pub mod par_service;
-#[allow(dead_code)] // Removed when the platform operation handlers are mounted.
 pub mod platform_operation_service;
 pub mod platform_settings_service;
 pub mod provider_service;

--- a/backend/src/services/platform_operation_service.rs
+++ b/backend/src/services/platform_operation_service.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use chrono::Utc;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use mongodb::bson::doc;
 use mongodb::options::ReturnDocument;
 use reqwest::header::CONTENT_TYPE;
@@ -24,12 +24,14 @@ pub const SPEAK_HARD_MAX_CHARS: u32 = 5_000;
 pub const CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS: u32 = 1_000;
 const MAX_VENDOR_JSON_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
 
-#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub const X_SEARCH_VENDOR_SLUG: &str = "platform-x";
-#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub const SPEAK_VENDOR_SLUG: &str = "platform-elevenlabs";
-#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub const CALL_AND_SAY_VENDOR_SLUG: &str = "platform-twilio";
+pub const PLATFORM_OPERATION_NAMES: [PlatformOperationName; 3] = [
+    PlatformOperationName::XSearch,
+    PlatformOperationName::Speak,
+    PlatformOperationName::CallAndSay,
+];
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -90,7 +92,6 @@ pub fn operation_name(op: PlatformOperationName) -> &'static str {
     }
 }
 
-#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub fn parse_operation_name(value: &str) -> AppResult<PlatformOperationName> {
     match value {
         "x_search" => Ok(PlatformOperationName::XSearch),
@@ -102,7 +103,6 @@ pub fn parse_operation_name(value: &str) -> AppResult<PlatformOperationName> {
     }
 }
 
-#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub fn default_operation_config(op: PlatformOperationName) -> PlatformOperationConfig {
     match op {
         PlatformOperationName::XSearch => PlatformOperationConfig::XSearch(XSearchConfig {
@@ -126,7 +126,6 @@ pub fn default_operation_config(op: PlatformOperationName) -> PlatformOperationC
     }
 }
 
-#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub fn default_vendor_service_slug(op: PlatformOperationName) -> &'static str {
     match op {
         PlatformOperationName::XSearch => X_SEARCH_VENDOR_SLUG,
@@ -465,6 +464,62 @@ pub async fn load_enabled_operation(
         return Err(AppError::PlatformOperationUnavailable);
     }
     Ok(operation)
+}
+
+pub async fn list_configured_operations(
+    db: &mongodb::Database,
+) -> AppResult<Vec<PlatformOperation>> {
+    let operation_names = PLATFORM_OPERATION_NAMES
+        .iter()
+        .map(|op| operation_name(*op))
+        .collect::<Vec<_>>();
+    db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+        .find(doc! { "op": { "$in": operation_names } })
+        .await?
+        .try_collect()
+        .await
+        .map_err(AppError::DatabaseError)
+}
+
+pub async fn upsert_operation(
+    db: &mongodb::Database,
+    op: PlatformOperationName,
+    enabled: bool,
+    vendor_service_slug: String,
+    config: PlatformOperationConfig,
+    updated_by: &str,
+) -> AppResult<PlatformOperation> {
+    validate_operation_config(op, &vendor_service_slug, &config)?;
+
+    let config = bson::to_bson(&config).map_err(|error| {
+        AppError::Internal(format!(
+            "Failed to serialize platform operation config: {error}"
+        ))
+    })?;
+    let updated_at = Utc::now();
+    db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+        .find_one_and_update(
+            doc! { "op": operation_name(op) },
+            doc! {
+                "$set": {
+                    "enabled": enabled,
+                    "vendor_service_slug": vendor_service_slug,
+                    "config": config,
+                    "updated_at": bson::DateTime::from_chrono(updated_at),
+                    "updated_by": updated_by,
+                },
+                "$setOnInsert": {
+                    "_id": uuid::Uuid::new_v4().to_string(),
+                    "op": operation_name(op),
+                },
+            },
+        )
+        .upsert(true)
+        .return_document(ReturnDocument::After)
+        .await?
+        .ok_or_else(|| {
+            AppError::Internal("Platform operation upsert returned no document".to_string())
+        })
 }
 
 pub async fn execute_x_search(

--- a/backend/src/services/platform_operation_service.rs
+++ b/backend/src/services/platform_operation_service.rs
@@ -22,6 +22,7 @@ use crate::services::{assistant_service, proxy_service};
 pub const X_SEARCH_HARD_MAX_RESULTS: u32 = 25;
 pub const SPEAK_HARD_MAX_CHARS: u32 = 5_000;
 pub const CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS: u32 = 1_000;
+pub const MCP_SPEAK_HARD_MAX_AUDIO_BYTES: usize = 16 * 1024 * 1024;
 const MAX_VENDOR_JSON_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
 
 pub const X_SEARCH_VENDOR_SLUG: &str = "platform-x";
@@ -481,6 +482,31 @@ pub async fn list_configured_operations(
         .map_err(AppError::DatabaseError)
 }
 
+pub async fn list_enabled_operations(db: &mongodb::Database) -> AppResult<Vec<PlatformOperation>> {
+    let configured = list_configured_operations(db).await?;
+    Ok(configured
+        .into_iter()
+        .filter(|operation| {
+            if !operation.enabled {
+                return false;
+            }
+            if let Err(error) = validate_operation_config(
+                operation.op,
+                &operation.vendor_service_slug,
+                &operation.config,
+            ) {
+                tracing::error!(
+                    op = operation_name(operation.op),
+                    error = %error,
+                    "Omitting invalid enabled platform operation from discovery"
+                );
+                return false;
+            }
+            true
+        })
+        .collect())
+}
+
 pub async fn upsert_operation(
     db: &mongodb::Database,
     op: PlatformOperationName,
@@ -593,6 +619,30 @@ pub async fn execute_speak(
     ensure_vendor_success(PlatformOperationName::Speak, &response)?;
 
     Ok(SpeakVendorResponse { response })
+}
+
+pub async fn collect_speak_audio(vendor: SpeakVendorResponse) -> AppResult<Vec<u8>> {
+    if vendor
+        .response
+        .content_length()
+        .is_some_and(|length| length > MCP_SPEAK_HARD_MAX_AUDIO_BYTES as u64)
+    {
+        tracing::error!("Platform speak response exceeded the MCP audio response limit");
+        return Err(AppError::PlatformOperationUnavailable);
+    }
+
+    let mut audio = Vec::new();
+    let mut stream = vendor.response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk =
+            chunk.map_err(|error| vendor_request_failed(PlatformOperationName::Speak, error))?;
+        if audio.len().saturating_add(chunk.len()) > MCP_SPEAK_HARD_MAX_AUDIO_BYTES {
+            tracing::error!("Platform speak response exceeded the MCP audio response limit");
+            return Err(AppError::PlatformOperationUnavailable);
+        }
+        audio.extend_from_slice(&chunk);
+    }
+    Ok(audio)
 }
 
 pub async fn execute_call_and_say(
@@ -869,6 +919,60 @@ mod tests {
             account_sid: format!("AC{}", "1".repeat(32)),
             call_from: "+16505550100".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn enabled_operation_listing_omits_disabled_and_invalid_rows() {
+        let Some(db) = crate::test_utils::connect_test_database("platform_ops_enabled_list").await
+        else {
+            eprintln!("skipping platform operation listing test: no local MongoDB available");
+            return;
+        };
+        let now = Utc::now();
+        let rows = [
+            PlatformOperation {
+                id: uuid::Uuid::new_v4().to_string(),
+                op: PlatformOperationName::XSearch,
+                enabled: true,
+                vendor_service_slug: X_SEARCH_VENDOR_SLUG.to_string(),
+                config: PlatformOperationConfig::XSearch(XSearchConfig {
+                    max_results_cap: 10,
+                }),
+                updated_at: now,
+                updated_by: "admin-user".to_string(),
+            },
+            PlatformOperation {
+                id: uuid::Uuid::new_v4().to_string(),
+                op: PlatformOperationName::Speak,
+                enabled: false,
+                vendor_service_slug: SPEAK_VENDOR_SLUG.to_string(),
+                config: PlatformOperationConfig::Speak(speak_config()),
+                updated_at: now,
+                updated_by: "admin-user".to_string(),
+            },
+            PlatformOperation {
+                id: uuid::Uuid::new_v4().to_string(),
+                op: PlatformOperationName::CallAndSay,
+                enabled: true,
+                vendor_service_slug: CALL_AND_SAY_VENDOR_SLUG.to_string(),
+                config: PlatformOperationConfig::CallAndSay(CallAndSayConfig {
+                    max_message_chars: CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS + 1,
+                    ..call_config(vec!["+65".to_string()])
+                }),
+                updated_at: now,
+                updated_by: "admin-user".to_string(),
+            },
+        ];
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_many(rows)
+            .await
+            .expect("insert platform operation rows");
+
+        let enabled = list_enabled_operations(&db)
+            .await
+            .expect("list enabled operations");
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].op, PlatformOperationName::XSearch);
     }
 
     #[test]

--- a/backend/src/services/platform_operation_service.rs
+++ b/backend/src/services/platform_operation_service.rs
@@ -1,0 +1,974 @@
+use std::collections::HashSet;
+
+use chrono::Utc;
+use futures::StreamExt;
+use mongodb::bson::doc;
+use mongodb::options::ReturnDocument;
+use reqwest::header::CONTENT_TYPE;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use crate::crypto::aes::EncryptionKeys;
+use crate::errors::{AppError, AppResult};
+use crate::models::platform_op_usage::{COLLECTION_NAME as PLATFORM_OP_USAGE, PlatformOpUsage};
+use crate::models::platform_operation::{
+    COLLECTION_NAME as PLATFORM_OPERATIONS, CallAndSayConfig, PlatformOperation,
+    PlatformOperationConfig, PlatformOperationName, SpeakConfig, XSearchConfig,
+    default_call_max_message_chars, default_call_max_per_user_per_day, default_call_voice,
+    default_speak_max_chars, default_speak_model_id, default_x_search_max_results_cap,
+};
+use crate::services::{assistant_service, proxy_service};
+
+pub const X_SEARCH_HARD_MAX_RESULTS: u32 = 25;
+pub const SPEAK_HARD_MAX_CHARS: u32 = 5_000;
+pub const CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS: u32 = 1_000;
+const MAX_VENDOR_JSON_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
+
+pub const X_SEARCH_VENDOR_SLUG: &str = "platform-x";
+pub const SPEAK_VENDOR_SLUG: &str = "platform-elevenlabs";
+pub const CALL_AND_SAY_VENDOR_SLUG: &str = "platform-twilio";
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct XSearchRequest {
+    pub query: String,
+    pub max_results: Option<u32>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SpeakRequest {
+    pub text: String,
+    pub voice_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CallAndSayRequest {
+    pub to: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct XSearchUpstreamRequest {
+    pub path: &'static str,
+    pub query: String,
+    pub max_results: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpeakUpstreamRequest {
+    pub path: String,
+    pub body: serde_json::Value,
+    pub text_chars: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallAndSayUpstreamRequest {
+    pub path: String,
+    pub form: Vec<(&'static str, String)>,
+    pub message_chars: usize,
+    pub destination_suffix: String,
+}
+
+#[derive(Debug)]
+pub struct SpeakVendorResponse {
+    pub response: reqwest::Response,
+    pub text_chars: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CallAndSayResult {
+    pub response: serde_json::Value,
+    pub destination_suffix: String,
+    pub message_chars: usize,
+}
+
+struct VendorTarget {
+    base_url: String,
+    auth_key_name: String,
+    credential: Zeroizing<String>,
+}
+
+pub fn operation_name(op: PlatformOperationName) -> &'static str {
+    match op {
+        PlatformOperationName::XSearch => "x_search",
+        PlatformOperationName::Speak => "speak",
+        PlatformOperationName::CallAndSay => "call_and_say",
+    }
+}
+
+pub fn parse_operation_name(value: &str) -> AppResult<PlatformOperationName> {
+    match value {
+        "x_search" => Ok(PlatformOperationName::XSearch),
+        "speak" => Ok(PlatformOperationName::Speak),
+        "call_and_say" => Ok(PlatformOperationName::CallAndSay),
+        _ => Err(AppError::NotFound(
+            "Platform operation not found".to_string(),
+        )),
+    }
+}
+
+pub fn default_operation_config(op: PlatformOperationName) -> PlatformOperationConfig {
+    match op {
+        PlatformOperationName::XSearch => PlatformOperationConfig::XSearch(XSearchConfig {
+            max_results_cap: default_x_search_max_results_cap(),
+        }),
+        PlatformOperationName::Speak => PlatformOperationConfig::Speak(SpeakConfig {
+            allowed_voice_ids: Vec::new(),
+            max_chars: default_speak_max_chars(),
+            model_id: default_speak_model_id(),
+        }),
+        PlatformOperationName::CallAndSay => {
+            PlatformOperationConfig::CallAndSay(CallAndSayConfig {
+                allowed_destination_prefixes: Vec::new(),
+                max_message_chars: default_call_max_message_chars(),
+                voice: default_call_voice(),
+                max_calls_per_user_per_day: default_call_max_per_user_per_day(),
+                account_sid: String::new(),
+                call_from: String::new(),
+            })
+        }
+    }
+}
+
+pub fn default_vendor_service_slug(op: PlatformOperationName) -> &'static str {
+    match op {
+        PlatformOperationName::XSearch => X_SEARCH_VENDOR_SLUG,
+        PlatformOperationName::Speak => SPEAK_VENDOR_SLUG,
+        PlatformOperationName::CallAndSay => CALL_AND_SAY_VENDOR_SLUG,
+    }
+}
+
+pub fn validate_operation_config(
+    op: PlatformOperationName,
+    vendor_service_slug: &str,
+    config: &PlatformOperationConfig,
+) -> AppResult<()> {
+    validate_vendor_service_slug(vendor_service_slug)?;
+
+    match (op, config) {
+        (PlatformOperationName::XSearch, PlatformOperationConfig::XSearch(config)) => {
+            if !(1..=X_SEARCH_HARD_MAX_RESULTS).contains(&config.max_results_cap) {
+                return Err(AppError::BadRequest(format!(
+                    "max_results_cap must be between 1 and {X_SEARCH_HARD_MAX_RESULTS}."
+                )));
+            }
+        }
+        (PlatformOperationName::Speak, PlatformOperationConfig::Speak(config)) => {
+            validate_speak_config(config)?;
+        }
+        (PlatformOperationName::CallAndSay, PlatformOperationConfig::CallAndSay(config)) => {
+            validate_call_and_say_config(config)?
+        }
+        _ => {
+            return Err(AppError::BadRequest(
+                "config type must match the platform operation.".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_vendor_service_slug(slug: &str) -> AppResult<()> {
+    let valid = !slug.is_empty()
+        && slug.len() <= 128
+        && slug
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-');
+    if !valid {
+        return Err(AppError::BadRequest(
+            "vendor_service_slug must contain only lowercase letters, digits, and hyphens."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_speak_config(config: &SpeakConfig) -> AppResult<()> {
+    if config.allowed_voice_ids.is_empty() {
+        return Err(AppError::BadRequest(
+            "allowed_voice_ids must contain at least one voice id.".to_string(),
+        ));
+    }
+    if config.allowed_voice_ids.len() > 100 {
+        return Err(AppError::BadRequest(
+            "allowed_voice_ids must contain at most 100 voice ids.".to_string(),
+        ));
+    }
+    let mut unique = HashSet::new();
+    for voice_id in &config.allowed_voice_ids {
+        if !is_safe_identifier(voice_id, 128) {
+            return Err(AppError::BadRequest(
+                "Each allowed voice id must use only letters, digits, hyphens, and underscores."
+                    .to_string(),
+            ));
+        }
+        if !unique.insert(voice_id) {
+            return Err(AppError::BadRequest(
+                "allowed_voice_ids must not contain duplicates.".to_string(),
+            ));
+        }
+    }
+    if !(1..=SPEAK_HARD_MAX_CHARS).contains(&config.max_chars) {
+        return Err(AppError::BadRequest(format!(
+            "max_chars must be between 1 and {SPEAK_HARD_MAX_CHARS}."
+        )));
+    }
+    if !is_safe_identifier(&config.model_id, 128) {
+        return Err(AppError::BadRequest(
+            "model_id must use only letters, digits, periods, hyphens, and underscores."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_call_and_say_config(config: &CallAndSayConfig) -> AppResult<()> {
+    if config.allowed_destination_prefixes.len() > 100 {
+        return Err(AppError::BadRequest(
+            "allowed_destination_prefixes must contain at most 100 prefixes.".to_string(),
+        ));
+    }
+    let mut unique = HashSet::new();
+    for prefix in &config.allowed_destination_prefixes {
+        if !is_e164_prefix(prefix) {
+            return Err(AppError::BadRequest(format!(
+                "Invalid E.164 destination prefix: {prefix}."
+            )));
+        }
+        if !unique.insert(prefix) {
+            return Err(AppError::BadRequest(
+                "allowed_destination_prefixes must not contain duplicates.".to_string(),
+            ));
+        }
+    }
+    if !(1..=CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS).contains(&config.max_message_chars) {
+        return Err(AppError::BadRequest(format!(
+            "max_message_chars must be between 1 and {CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS}."
+        )));
+    }
+    if !is_safe_identifier(&config.voice, 128) {
+        return Err(AppError::BadRequest(
+            "voice must use only letters, digits, periods, hyphens, and underscores.".to_string(),
+        ));
+    }
+    if config.max_calls_per_user_per_day == 0 {
+        return Err(AppError::BadRequest(
+            "max_calls_per_user_per_day must be at least 1.".to_string(),
+        ));
+    }
+    if !is_twilio_account_sid(&config.account_sid) {
+        return Err(AppError::BadRequest(
+            "account_sid must be a Twilio Account SID (AC followed by 32 hexadecimal characters)."
+                .to_string(),
+        ));
+    }
+    if !is_e164_number(&config.call_from) {
+        return Err(AppError::BadRequest(
+            "call_from must be a valid E.164 phone number.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_safe_identifier(value: &str, max_len: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn is_twilio_account_sid(value: &str) -> bool {
+    value.len() == 34
+        && value.starts_with("AC")
+        && value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_e164_prefix(value: &str) -> bool {
+    let Some(digits) = value.strip_prefix('+') else {
+        return false;
+    };
+    !digits.is_empty()
+        && digits.len() <= 15
+        && !digits.starts_with('0')
+        && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+pub fn is_e164_number(value: &str) -> bool {
+    is_e164_prefix(value)
+}
+
+pub fn destination_matches_prefixes(to: &str, prefixes: &[String]) -> bool {
+    prefixes.iter().any(|prefix| to.starts_with(prefix))
+}
+
+pub fn build_x_search_request(
+    config: &XSearchConfig,
+    request: &XSearchRequest,
+) -> AppResult<XSearchUpstreamRequest> {
+    let query_chars = request.query.chars().count();
+    if !(1..=512).contains(&query_chars) {
+        return Err(AppError::BadRequest(
+            "query must contain between 1 and 512 characters.".to_string(),
+        ));
+    }
+    let configured_cap = config.max_results_cap.min(X_SEARCH_HARD_MAX_RESULTS);
+    if configured_cap == 0 {
+        return Err(AppError::PlatformOperationUnavailable);
+    }
+    let requested = request.max_results.unwrap_or(configured_cap);
+    if requested == 0 {
+        return Err(AppError::BadRequest(
+            "max_results must be at least 1.".to_string(),
+        ));
+    }
+    let max_results = requested.min(configured_cap);
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("query", &request.query)
+        .append_pair("max_results", &max_results.to_string())
+        .finish();
+
+    Ok(XSearchUpstreamRequest {
+        path: "2/tweets/search/recent",
+        query,
+        max_results,
+    })
+}
+
+pub fn build_speak_request(
+    config: &SpeakConfig,
+    request: &SpeakRequest,
+) -> AppResult<SpeakUpstreamRequest> {
+    let allowed = config
+        .allowed_voice_ids
+        .iter()
+        .any(|voice_id| voice_id == &request.voice_id);
+    if !allowed {
+        return Err(AppError::BadRequest(format!(
+            "voice_id must be one of the allowed values: {}.",
+            config.allowed_voice_ids.join(", ")
+        )));
+    }
+
+    let text_chars = request.text.chars().count();
+    let max_chars = config.max_chars.min(SPEAK_HARD_MAX_CHARS) as usize;
+    if text_chars == 0 || text_chars > max_chars {
+        return Err(AppError::BadRequest(format!(
+            "text must contain between 1 and {max_chars} characters."
+        )));
+    }
+
+    Ok(SpeakUpstreamRequest {
+        path: format!("v1/text-to-speech/{}", request.voice_id),
+        body: serde_json::json!({
+            "text": request.text,
+            "model_id": config.model_id,
+        }),
+        text_chars,
+    })
+}
+
+pub fn build_call_and_say_request(
+    config: &CallAndSayConfig,
+    request: &CallAndSayRequest,
+) -> AppResult<CallAndSayUpstreamRequest> {
+    if !is_e164_number(&request.to) {
+        return Err(AppError::BadRequest(
+            "to must be a valid E.164 phone number.".to_string(),
+        ));
+    }
+    if !destination_matches_prefixes(&request.to, &config.allowed_destination_prefixes) {
+        return Err(AppError::BadRequest(
+            "Destination is not allowed for this platform operation.".to_string(),
+        ));
+    }
+
+    let message_chars = request.message.chars().count();
+    let max_chars = config
+        .max_message_chars
+        .min(CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS) as usize;
+    if message_chars == 0 || message_chars > max_chars {
+        return Err(AppError::BadRequest(format!(
+            "message must contain between 1 and {max_chars} characters."
+        )));
+    }
+    if request.message.chars().any(char::is_control) {
+        return Err(AppError::BadRequest(
+            "message must not contain control characters.".to_string(),
+        ));
+    }
+
+    let twiml = format!(
+        "<Response><Say voice=\"{}\">{}</Say></Response>",
+        xml_escape(&config.voice),
+        xml_escape(&request.message)
+    );
+
+    Ok(CallAndSayUpstreamRequest {
+        path: format!("2010-04-01/Accounts/{}/Calls.json", config.account_sid),
+        form: vec![
+            ("To", request.to.clone()),
+            ("From", config.call_from.clone()),
+            ("Twiml", twiml),
+        ],
+        message_chars,
+        destination_suffix: redacted_destination_suffix(&request.to),
+    })
+}
+
+pub fn xml_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+pub fn redacted_destination_suffix(to: &str) -> String {
+    let suffix: String = to
+        .chars()
+        .rev()
+        .take(4)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    format!("***{suffix}")
+}
+
+pub async fn load_enabled_operation(
+    db: &mongodb::Database,
+    op: PlatformOperationName,
+) -> AppResult<PlatformOperation> {
+    let operation = db
+        .collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+        .find_one(doc! { "op": operation_name(op), "enabled": true })
+        .await?
+        .ok_or_else(|| AppError::NotFound("Platform operation not found".to_string()))?;
+
+    validate_operation_config(
+        operation.op,
+        &operation.vendor_service_slug,
+        &operation.config,
+    )
+    .map_err(|error| {
+        tracing::error!(
+            op = operation_name(op),
+            error = %error,
+            "Stored platform operation config is invalid"
+        );
+        AppError::PlatformOperationUnavailable
+    })?;
+    if operation.op != op {
+        return Err(AppError::PlatformOperationUnavailable);
+    }
+    Ok(operation)
+}
+
+pub async fn execute_x_search(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    http_client: &reqwest::Client,
+    request: XSearchRequest,
+) -> AppResult<serde_json::Value> {
+    let operation = load_enabled_operation(db, PlatformOperationName::XSearch).await?;
+    let PlatformOperationConfig::XSearch(config) = &operation.config else {
+        return Err(AppError::PlatformOperationUnavailable);
+    };
+    let upstream = build_x_search_request(config, &request)?;
+    let target = resolve_vendor_target(
+        db,
+        encryption_keys,
+        PlatformOperationName::XSearch,
+        &operation.vendor_service_slug,
+        "bearer",
+        None,
+    )
+    .await?;
+    let url = format!(
+        "{}/{}?{}",
+        target.base_url.trim_end_matches('/'),
+        upstream.path,
+        upstream.query
+    );
+    let response = http_client
+        .get(url)
+        .bearer_auth(target.credential.as_str())
+        .send()
+        .await
+        .map_err(|error| vendor_request_failed(PlatformOperationName::XSearch, error))?;
+    read_vendor_json(PlatformOperationName::XSearch, response).await
+}
+
+pub async fn execute_speak(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    http_client: &reqwest::Client,
+    request: SpeakRequest,
+) -> AppResult<SpeakVendorResponse> {
+    let operation = load_enabled_operation(db, PlatformOperationName::Speak).await?;
+    let PlatformOperationConfig::Speak(config) = &operation.config else {
+        return Err(AppError::PlatformOperationUnavailable);
+    };
+    let upstream = build_speak_request(config, &request)?;
+    let target = resolve_vendor_target(
+        db,
+        encryption_keys,
+        PlatformOperationName::Speak,
+        &operation.vendor_service_slug,
+        "header",
+        Some("xi-api-key"),
+    )
+    .await?;
+    let url = format!(
+        "{}/{}",
+        target.base_url.trim_end_matches('/'),
+        upstream.path
+    );
+    let response = http_client
+        .post(url)
+        .header(&target.auth_key_name, target.credential.as_str())
+        .header(CONTENT_TYPE, "application/json")
+        .json(&upstream.body)
+        .send()
+        .await
+        .map_err(|error| vendor_request_failed(PlatformOperationName::Speak, error))?;
+    ensure_vendor_success(PlatformOperationName::Speak, &response)?;
+
+    Ok(SpeakVendorResponse {
+        response,
+        text_chars: upstream.text_chars,
+    })
+}
+
+pub async fn execute_call_and_say(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    http_client: &reqwest::Client,
+    user_id: &str,
+    yyyymmdd: &str,
+    request: CallAndSayRequest,
+) -> AppResult<CallAndSayResult> {
+    validate_usage_date(yyyymmdd)?;
+    let operation = load_enabled_operation(db, PlatformOperationName::CallAndSay).await?;
+    let PlatformOperationConfig::CallAndSay(config) = &operation.config else {
+        return Err(AppError::PlatformOperationUnavailable);
+    };
+    let upstream = build_call_and_say_request(config, &request)?;
+    let target = resolve_vendor_target(
+        db,
+        encryption_keys,
+        PlatformOperationName::CallAndSay,
+        &operation.vendor_service_slug,
+        "basic",
+        None,
+    )
+    .await?;
+
+    reserve_daily_call(db, user_id, yyyymmdd, config.max_calls_per_user_per_day).await?;
+    let response = send_call_and_say(http_client, config, &target, &upstream).await;
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            release_daily_call(db, user_id, yyyymmdd).await?;
+            return Err(error);
+        }
+    };
+
+    Ok(CallAndSayResult {
+        response,
+        destination_suffix: upstream.destination_suffix,
+        message_chars: upstream.message_chars,
+    })
+}
+
+async fn send_call_and_say(
+    http_client: &reqwest::Client,
+    config: &CallAndSayConfig,
+    target: &VendorTarget,
+    upstream: &CallAndSayUpstreamRequest,
+) -> AppResult<serde_json::Value> {
+    let url = format!(
+        "{}/{}",
+        target.base_url.trim_end_matches('/'),
+        upstream.path
+    );
+    let response = http_client
+        .post(url)
+        .basic_auth(&config.account_sid, Some(target.credential.as_str()))
+        .form(&upstream.form)
+        .send()
+        .await
+        .map_err(|error| vendor_request_failed(PlatformOperationName::CallAndSay, error))?;
+    read_vendor_json(PlatformOperationName::CallAndSay, response).await
+}
+
+async fn resolve_vendor_target(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    op: PlatformOperationName,
+    slug: &str,
+    expected_auth_method: &str,
+    expected_auth_key_name: Option<&str>,
+) -> AppResult<VendorTarget> {
+    let service = assistant_service::resolve_admin_service_by_slug(db, slug)
+        .await
+        .map_err(|error| vendor_configuration_failed(op, error))?;
+    let authorized = proxy_service::authorize_master_credential_server_chosen(db, &service)
+        .await
+        .map_err(|error| vendor_configuration_failed(op, error))?;
+    if service.auth_method != expected_auth_method
+        || expected_auth_key_name
+            .is_some_and(|expected| !service.auth_key_name.eq_ignore_ascii_case(expected))
+    {
+        tracing::error!(
+            op = operation_name(op),
+            service_slug = %service.slug,
+            auth_method = %service.auth_method,
+            auth_key_name = %service.auth_key_name,
+            "Platform operation vendor row has an invalid authentication shape"
+        );
+        return Err(AppError::PlatformOperationUnavailable);
+    }
+    let decrypted = Zeroizing::new(
+        authorized
+            .decrypt(encryption_keys)
+            .await
+            .map_err(|error| vendor_configuration_failed(op, error))?,
+    );
+    let credential = Zeroizing::new(String::from_utf8((*decrypted).clone()).map_err(|error| {
+        tracing::error!(
+            op = operation_name(op),
+            error = %error,
+            "Platform operation vendor credential is not UTF-8"
+        );
+        AppError::PlatformOperationUnavailable
+    })?);
+    if credential.is_empty() {
+        return Err(AppError::PlatformOperationUnavailable);
+    }
+
+    Ok(VendorTarget {
+        base_url: service.base_url,
+        auth_key_name: service.auth_key_name,
+        credential,
+    })
+}
+
+fn vendor_configuration_failed(op: PlatformOperationName, error: AppError) -> AppError {
+    tracing::error!(
+        op = operation_name(op),
+        error = %error,
+        "Platform operation vendor configuration is unavailable"
+    );
+    AppError::PlatformOperationUnavailable
+}
+
+fn vendor_request_failed(op: PlatformOperationName, error: reqwest::Error) -> AppError {
+    tracing::error!(
+        op = operation_name(op),
+        error = %error,
+        "Platform operation vendor request failed"
+    );
+    AppError::PlatformOperationUnavailable
+}
+
+fn ensure_vendor_success(op: PlatformOperationName, response: &reqwest::Response) -> AppResult<()> {
+    if response.status().is_success() {
+        return Ok(());
+    }
+    tracing::error!(
+        op = operation_name(op),
+        upstream_status = response.status().as_u16(),
+        "Platform operation vendor returned an unsuccessful status"
+    );
+    Err(AppError::PlatformOperationUnavailable)
+}
+
+async fn read_vendor_json(
+    op: PlatformOperationName,
+    response: reqwest::Response,
+) -> AppResult<serde_json::Value> {
+    ensure_vendor_success(op, &response)?;
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_VENDOR_JSON_RESPONSE_BYTES as u64)
+    {
+        return Err(AppError::PlatformOperationUnavailable);
+    }
+
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| vendor_request_failed(op, error))?;
+        if body.len().saturating_add(chunk.len()) > MAX_VENDOR_JSON_RESPONSE_BYTES {
+            tracing::error!(
+                op = operation_name(op),
+                "Platform operation vendor response exceeded the JSON response limit"
+            );
+            return Err(AppError::PlatformOperationUnavailable);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&body).map_err(|error| {
+        tracing::error!(
+            op = operation_name(op),
+            error = %error,
+            "Platform operation vendor returned invalid JSON"
+        );
+        AppError::PlatformOperationUnavailable
+    })
+}
+
+fn validate_usage_date(yyyymmdd: &str) -> AppResult<()> {
+    if yyyymmdd.len() == 8 && yyyymmdd.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Ok(());
+    }
+    Err(AppError::Internal(
+        "Platform operation usage date must use YYYYMMDD format".to_string(),
+    ))
+}
+
+async fn reserve_daily_call(
+    db: &mongodb::Database,
+    user_id: &str,
+    yyyymmdd: &str,
+    cap: u32,
+) -> AppResult<()> {
+    let collection = db.collection::<PlatformOpUsage>(PLATFORM_OP_USAGE);
+    let filter = doc! {
+        "op": operation_name(PlatformOperationName::CallAndSay),
+        "user_id": user_id,
+        "yyyymmdd": yyyymmdd,
+        "count": { "$lt": i64::from(cap) },
+    };
+    let update = doc! {
+        "$setOnInsert": {
+            "_id": uuid::Uuid::new_v4().to_string(),
+            "op": operation_name(PlatformOperationName::CallAndSay),
+            "user_id": user_id,
+            "yyyymmdd": yyyymmdd,
+        },
+        "$inc": { "count": 1_i64 },
+        "$set": { "updated_at": bson::DateTime::from_chrono(Utc::now()) },
+    };
+    match collection
+        .find_one_and_update(filter, update)
+        .upsert(true)
+        .return_document(ReturnDocument::After)
+        .await
+    {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(AppError::RateLimited),
+        Err(error) if is_duplicate_key_error(&error) => Err(AppError::RateLimited),
+        Err(error) => Err(AppError::DatabaseError(error)),
+    }
+}
+
+async fn release_daily_call(
+    db: &mongodb::Database,
+    user_id: &str,
+    yyyymmdd: &str,
+) -> AppResult<()> {
+    db.collection::<PlatformOpUsage>(PLATFORM_OP_USAGE)
+        .update_one(
+            doc! {
+                "op": operation_name(PlatformOperationName::CallAndSay),
+                "user_id": user_id,
+                "yyyymmdd": yyyymmdd,
+                "count": { "$gt": 0_i64 },
+            },
+            doc! {
+                "$inc": { "count": -1_i64 },
+                "$set": { "updated_at": bson::DateTime::from_chrono(Utc::now()) },
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+fn is_duplicate_key_error(error: &mongodb::error::Error) -> bool {
+    matches!(
+        error.kind.as_ref(),
+        mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(write_error))
+            if write_error.code == 11000
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn speak_config() -> SpeakConfig {
+        SpeakConfig {
+            allowed_voice_ids: vec!["voice-a".to_string(), "voice-b".to_string()],
+            max_chars: 100,
+            model_id: "eleven_multilingual_v2".to_string(),
+        }
+    }
+
+    fn call_config(prefixes: Vec<String>) -> CallAndSayConfig {
+        CallAndSayConfig {
+            allowed_destination_prefixes: prefixes,
+            max_message_chars: 500,
+            voice: "alice".to_string(),
+            max_calls_per_user_per_day: 3,
+            account_sid: format!("AC{}", "1".repeat(32)),
+            call_from: "+16505550100".to_string(),
+        }
+    }
+
+    #[test]
+    fn config_validation_enforces_hard_caps() {
+        let x = PlatformOperationConfig::XSearch(XSearchConfig {
+            max_results_cap: X_SEARCH_HARD_MAX_RESULTS + 1,
+        });
+        assert!(
+            validate_operation_config(PlatformOperationName::XSearch, X_SEARCH_VENDOR_SLUG, &x)
+                .is_err()
+        );
+
+        let speak = PlatformOperationConfig::Speak(SpeakConfig {
+            max_chars: SPEAK_HARD_MAX_CHARS + 1,
+            ..speak_config()
+        });
+        assert!(
+            validate_operation_config(PlatformOperationName::Speak, SPEAK_VENDOR_SLUG, &speak)
+                .is_err()
+        );
+
+        let call = PlatformOperationConfig::CallAndSay(CallAndSayConfig {
+            max_message_chars: CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS + 1,
+            ..call_config(vec!["+65".to_string()])
+        });
+        assert!(
+            validate_operation_config(
+                PlatformOperationName::CallAndSay,
+                CALL_AND_SAY_VENDOR_SLUG,
+                &call
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn empty_destination_prefixes_deny_every_destination() {
+        let config = call_config(Vec::new());
+        let request = CallAndSayRequest {
+            to: "+16505550199".to_string(),
+            message: "Hello".to_string(),
+        };
+
+        assert!(build_call_and_say_request(&config, &request).is_err());
+    }
+
+    #[test]
+    fn destination_prefix_matching_is_anchored_at_the_start() {
+        let prefixes = vec!["+65".to_string()];
+        assert!(destination_matches_prefixes("+6512345678", &prefixes));
+        assert!(!destination_matches_prefixes("+16512345678", &prefixes));
+        assert!(!destination_matches_prefixes("+1650000065", &prefixes));
+    }
+
+    #[test]
+    fn twiml_composition_escapes_xml_and_cdata_terminators() {
+        let config = call_config(vec!["+65".to_string()]);
+        let request = CallAndSayRequest {
+            to: "+6512345678".to_string(),
+            message: "A & B <tag> \"quoted\" 'single' ]]> done".to_string(),
+        };
+
+        let upstream = build_call_and_say_request(&config, &request).expect("valid request");
+        let twiml = upstream
+            .form
+            .iter()
+            .find(|(name, _)| *name == "Twiml")
+            .map(|(_, value)| value)
+            .expect("TwiML field");
+        assert_eq!(
+            twiml,
+            "<Response><Say voice=\"alice\">A &amp; B &lt;tag&gt; &quot;quoted&quot; &apos;single&apos; ]]&gt; done</Say></Response>"
+        );
+        assert!(!twiml.contains("<tag>"));
+        assert!(!twiml.contains("]]>"));
+    }
+
+    #[test]
+    fn twiml_composition_rejects_control_characters() {
+        let config = call_config(vec!["+65".to_string()]);
+        let request = CallAndSayRequest {
+            to: "+6512345678".to_string(),
+            message: "hello\nworld".to_string(),
+        };
+
+        assert!(build_call_and_say_request(&config, &request).is_err());
+    }
+
+    #[test]
+    fn voice_id_rejection_names_the_allowed_list() {
+        let error = build_speak_request(
+            &speak_config(),
+            &SpeakRequest {
+                text: "hello".to_string(),
+                voice_id: "voice-c".to_string(),
+            },
+        )
+        .expect_err("voice must be rejected");
+
+        let AppError::BadRequest(message) = error else {
+            panic!("expected a bad request");
+        };
+        assert!(message.contains("voice-a, voice-b"));
+    }
+
+    #[test]
+    fn speak_body_is_server_constructed() {
+        let upstream = build_speak_request(
+            &speak_config(),
+            &SpeakRequest {
+                text: "hello".to_string(),
+                voice_id: "voice-a".to_string(),
+            },
+        )
+        .expect("valid request");
+
+        assert_eq!(
+            upstream.body,
+            serde_json::json!({
+                "text": "hello",
+                "model_id": "eleven_multilingual_v2",
+            })
+        );
+    }
+
+    #[test]
+    fn request_structs_reject_vendor_shape_fields() {
+        assert!(
+            serde_json::from_value::<CallAndSayRequest>(serde_json::json!({
+                "to": "+6512345678",
+                "message": "hello",
+                "from": "+16505550100",
+                "url": "https://attacker.invalid/twiml",
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<SpeakRequest>(serde_json::json!({
+                "text": "hello",
+                "voice_id": "voice-a",
+                "model_id": "caller-model",
+            }))
+            .is_err()
+        );
+    }
+}

--- a/backend/src/services/platform_operation_service.rs
+++ b/backend/src/services/platform_operation_service.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use mongodb::bson::doc;
 use mongodb::options::ReturnDocument;
 use reqwest::header::CONTENT_TYPE;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use zeroize::Zeroizing;
 
 use crate::crypto::aes::EncryptionKeys;
@@ -24,8 +24,11 @@ pub const SPEAK_HARD_MAX_CHARS: u32 = 5_000;
 pub const CALL_AND_SAY_HARD_MAX_MESSAGE_CHARS: u32 = 1_000;
 const MAX_VENDOR_JSON_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
 
+#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub const X_SEARCH_VENDOR_SLUG: &str = "platform-x";
+#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub const SPEAK_VENDOR_SLUG: &str = "platform-elevenlabs";
+#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub const CALL_AND_SAY_VENDOR_SLUG: &str = "platform-twilio";
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -60,28 +63,17 @@ pub struct XSearchUpstreamRequest {
 pub struct SpeakUpstreamRequest {
     pub path: String,
     pub body: serde_json::Value,
-    pub text_chars: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CallAndSayUpstreamRequest {
     pub path: String,
     pub form: Vec<(&'static str, String)>,
-    pub message_chars: usize,
-    pub destination_suffix: String,
 }
 
 #[derive(Debug)]
 pub struct SpeakVendorResponse {
     pub response: reqwest::Response,
-    pub text_chars: usize,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct CallAndSayResult {
-    pub response: serde_json::Value,
-    pub destination_suffix: String,
-    pub message_chars: usize,
 }
 
 struct VendorTarget {
@@ -98,6 +90,7 @@ pub fn operation_name(op: PlatformOperationName) -> &'static str {
     }
 }
 
+#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub fn parse_operation_name(value: &str) -> AppResult<PlatformOperationName> {
     match value {
         "x_search" => Ok(PlatformOperationName::XSearch),
@@ -109,6 +102,7 @@ pub fn parse_operation_name(value: &str) -> AppResult<PlatformOperationName> {
     }
 }
 
+#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub fn default_operation_config(op: PlatformOperationName) -> PlatformOperationConfig {
     match op {
         PlatformOperationName::XSearch => PlatformOperationConfig::XSearch(XSearchConfig {
@@ -132,6 +126,7 @@ pub fn default_operation_config(op: PlatformOperationName) -> PlatformOperationC
     }
 }
 
+#[allow(dead_code)] // Used by the admin configuration surface in the next increment.
 pub fn default_vendor_service_slug(op: PlatformOperationName) -> &'static str {
     match op {
         PlatformOperationName::XSearch => X_SEARCH_VENDOR_SLUG,
@@ -367,7 +362,6 @@ pub fn build_speak_request(
             "text": request.text,
             "model_id": config.model_id,
         }),
-        text_chars,
     })
 }
 
@@ -414,8 +408,6 @@ pub fn build_call_and_say_request(
             ("From", config.call_from.clone()),
             ("Twiml", twiml),
         ],
-        message_chars,
-        destination_suffix: redacted_destination_suffix(&request.to),
     })
 }
 
@@ -545,10 +537,7 @@ pub async fn execute_speak(
         .map_err(|error| vendor_request_failed(PlatformOperationName::Speak, error))?;
     ensure_vendor_success(PlatformOperationName::Speak, &response)?;
 
-    Ok(SpeakVendorResponse {
-        response,
-        text_chars: upstream.text_chars,
-    })
+    Ok(SpeakVendorResponse { response })
 }
 
 pub async fn execute_call_and_say(
@@ -558,7 +547,7 @@ pub async fn execute_call_and_say(
     user_id: &str,
     yyyymmdd: &str,
     request: CallAndSayRequest,
-) -> AppResult<CallAndSayResult> {
+) -> AppResult<serde_json::Value> {
     validate_usage_date(yyyymmdd)?;
     let operation = load_enabled_operation(db, PlatformOperationName::CallAndSay).await?;
     let PlatformOperationConfig::CallAndSay(config) = &operation.config else {
@@ -585,11 +574,7 @@ pub async fn execute_call_and_say(
         }
     };
 
-    Ok(CallAndSayResult {
-        response,
-        destination_suffix: upstream.destination_suffix,
-        message_chars: upstream.message_chars,
-    })
+    Ok(response)
 }
 
 async fn send_call_and_say(
@@ -799,6 +784,9 @@ async fn release_daily_call(
 
 fn is_duplicate_key_error(error: &mongodb::error::Error) -> bool {
     matches!(
+        error.kind.as_ref(),
+        mongodb::error::ErrorKind::Command(command) if command.code == 11000
+    ) || matches!(
         error.kind.as_ref(),
         mongodb::error::ErrorKind::Write(mongodb::error::WriteFailure::WriteError(write_error))
             if write_error.code == 11000

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -30,6 +30,7 @@ import {
   Circle,
   QrCode,
   Webhook,
+  WandSparkles,
 } from "lucide-react";
 import {
   Popover,
@@ -40,7 +41,7 @@ import { cn } from "@/lib/utils";
 import { FEATURE_FLAG } from "@/lib/feature-flags";
 import { useFeature } from "@/hooks/use-feature-flag";
 import { useAuthStore } from "@/stores/auth-store";
-import { hasAdminRead, isBillingAvailable } from "@/types/api";
+import { canAdminWrite, hasAdminRead, isBillingAvailable } from "@/types/api";
 
 type SidebarMode = "expanded" | "collapsed" | "hover";
 const STORAGE_KEY = "nyxid:sidebar-mode";
@@ -77,6 +78,11 @@ export const ADMIN_NAV = [
   { to: "/admin/feature-flags", icon: Flag, label: "Feature Flags" },
   { to: "/admin/audit-log", icon: ClipboardList, label: "Audit Log" },
   { to: "/admin/integrity", icon: ShieldCheck, label: "Integrity" },
+  {
+    to: "/admin/platform-ops",
+    icon: WandSparkles,
+    label: "Platform Operations",
+  },
   { to: "/admin/credits", icon: Coins, label: "Credits" },
   { to: "/admin/service-accounts", icon: Bot, label: "Service Accounts" },
   { to: "/admin/oauth-clients", icon: KeyRound, label: "OAuth Clients" },
@@ -98,6 +104,15 @@ export function getVisibleMainNav(
 ): readonly NavItemDef[] {
   return MAIN_NAV.filter(
     (item) => item.to !== "/billing" || isBillingAvailable(user),
+  );
+}
+
+function getVisibleAdminNav(
+  user: Parameters<typeof canAdminWrite>[0],
+): readonly NavItemDef[] {
+  return ADMIN_NAV.filter(
+    (item) =>
+      item.to !== "/admin/platform-ops" || canAdminWrite(user),
   );
 }
 
@@ -238,6 +253,7 @@ export function Sidebar({
   const user = useAuthStore((s) => s.user);
   const currentPath = routerState.location.pathname;
   const mainNav = getVisibleMainNav(user);
+  const adminNav = getVisibleAdminNav(user);
 
   const [mode, setMode] = useState<SidebarMode>(readMode);
   const [hovered, setHovered] = useState(false);
@@ -348,7 +364,7 @@ export function Sidebar({
               )}
             </div>
             <div className="flex flex-col gap-[2px]">
-              {ADMIN_NAV.map((item) => (
+              {adminNav.map((item) => (
                 <NavItem
                   key={item.to}
                   item={item}

--- a/frontend/src/components/navigation/command-palette.tsx
+++ b/frontend/src/components/navigation/command-palette.tsx
@@ -25,8 +25,11 @@ import {
   Server,
   Plug,
   Webhook,
+  WandSparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useAuthStore } from "@/stores/auth-store";
+import { canAdminWrite } from "@/types/api";
 
 type CommandGroup = "navigation" | "admin" | "action";
 
@@ -36,6 +39,7 @@ export interface CommandItem {
   readonly group: CommandGroup;
   readonly to?: string;
   readonly search?: Record<string, string>;
+  readonly requiresAdminWrite?: boolean;
   /**
    * Optional in-place action. Takes precedence over `to` when set, so an
    * entry can open a modal or fire a side-effect instead of navigating.
@@ -62,6 +66,13 @@ export const ALL_ITEMS: readonly CommandItem[] = [
   { icon: Users, label: "Users", to: "/admin/users", group: "admin" },
   { icon: Ticket, label: "Invite Codes", to: "/admin/invite-codes", group: "admin" },
   { icon: ClipboardList, label: "Audit Log", to: "/admin/audit-log", group: "admin" },
+  {
+    icon: WandSparkles,
+    label: "Platform Operations",
+    to: "/admin/platform-ops",
+    group: "admin",
+    requiresAdminWrite: true,
+  },
   { icon: Bot, label: "Service Accounts", to: "/admin/service-accounts", group: "admin" },
   { icon: KeyRound, label: "OAuth Clients", to: "/admin/oauth-clients", group: "admin" },
   { icon: ShieldCheck, label: "Roles", to: "/admin/roles", group: "admin" },
@@ -93,6 +104,7 @@ export function CommandPalette({
   readonly onOpenChange: (open: boolean) => void;
 }) {
   const navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
   const [query, setQueryRaw] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -102,14 +114,17 @@ export function CommandPalette({
   }, []);
 
   const filtered = useMemo(() => {
-    if (!query.trim()) return ALL_ITEMS.slice(0, 8);
+    const visibleItems = ALL_ITEMS.filter(
+      (item) => !item.requiresAdminWrite || canAdminWrite(user),
+    );
+    if (!query.trim()) return visibleItems.slice(0, 8);
     const q = query.toLowerCase();
-    return ALL_ITEMS.filter(
+    return visibleItems.filter(
       (item) =>
         item.label.toLowerCase().includes(q) ||
         (item.to?.toLowerCase().includes(q) ?? false),
     );
-  }, [query]);
+  }, [query, user]);
 
   const handleSelect = useCallback(
     (item: CommandItem) => {

--- a/frontend/src/hooks/use-platform-ops.test.tsx
+++ b/frontend/src/hooks/use-platform-ops.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PLATFORM_OPERATION_QUERY_KEY,
+  type PlatformOperationList,
+} from "@/schemas/platform-ops";
+import {
+  usePlatformOperations,
+  useUpdatePlatformOperation,
+} from "./use-platform-ops";
+
+const { mockGet, mockPut } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  api: { get: mockGet, put: mockPut },
+}));
+
+const xSearchOperation = {
+  op: "x_search" as const,
+  enabled: false,
+  vendor_service_slug: "platform-x",
+  config: { type: "x_search" as const, max_results_cap: 10 },
+  updated_at: null,
+  updated_by: null,
+};
+
+function createHarness() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, Wrapper };
+}
+
+describe("platform operation hooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads and parses the admin operation list", async () => {
+    mockGet.mockResolvedValue({ operations: [xSearchOperation] });
+    const { Wrapper } = createHarness();
+    const { result } = renderHook(() => usePlatformOperations(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith("/admin/platform-ops");
+    expect(result.current.data?.operations).toEqual([xSearchOperation]);
+  });
+
+  it("rejects an invalid response instead of exposing untyped data", async () => {
+    mockGet.mockResolvedValue({ operations: [{ op: "caller_defined" }] });
+    const { Wrapper } = createHarness();
+    const { result } = renderHook(() => usePlatformOperations(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("puts the typed payload and replaces the matching cached row", async () => {
+    const updated = {
+      ...xSearchOperation,
+      enabled: true,
+      config: { type: "x_search" as const, max_results_cap: 20 },
+      updated_at: "2026-08-25T10:00:00Z",
+      updated_by: "admin-1",
+    };
+    mockPut.mockResolvedValue(updated);
+    const { queryClient, Wrapper } = createHarness();
+    queryClient.setQueryData<PlatformOperationList>(
+      PLATFORM_OPERATION_QUERY_KEY,
+      { operations: [xSearchOperation] },
+    );
+    const { result } = renderHook(() => useUpdatePlatformOperation(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        op: "x_search",
+        data: {
+          enabled: true,
+          vendor_service_slug: "platform-x",
+          config: { type: "x_search", max_results_cap: 20 },
+        },
+      });
+    });
+
+    expect(mockPut).toHaveBeenCalledWith("/admin/platform-ops/x_search", {
+      enabled: true,
+      vendor_service_slug: "platform-x",
+      config: { type: "x_search", max_results_cap: 20 },
+    });
+    expect(
+      queryClient.getQueryData<PlatformOperationList>(
+        PLATFORM_OPERATION_QUERY_KEY,
+      )?.operations[0],
+    ).toEqual(updated);
+  });
+});

--- a/frontend/src/hooks/use-platform-ops.ts
+++ b/frontend/src/hooks/use-platform-ops.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import {
+  PLATFORM_OPERATION_QUERY_KEY,
+  platformOperationListSchema,
+  platformOperationSchema,
+  type PlatformOperation,
+  type PlatformOperationList,
+  type UpdatePlatformOperationVariables,
+} from "@/schemas/platform-ops";
+
+export function usePlatformOperations() {
+  return useQuery({
+    queryKey: PLATFORM_OPERATION_QUERY_KEY,
+    queryFn: async (): Promise<PlatformOperationList> => {
+      const response = await api.get<unknown>("/admin/platform-ops");
+      return platformOperationListSchema.parse(response);
+    },
+  });
+}
+
+export function useUpdatePlatformOperation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      op,
+      data,
+    }: UpdatePlatformOperationVariables): Promise<PlatformOperation> => {
+      const response = await api.put<unknown>(
+        `/admin/platform-ops/${op}`,
+        data,
+      );
+      return platformOperationSchema.parse(response);
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<PlatformOperationList>(
+        PLATFORM_OPERATION_QUERY_KEY,
+        (current) => {
+          if (!current) return current;
+          return {
+            operations: current.operations.map((operation) =>
+              operation.op === updated.op ? updated : operation,
+            ),
+          };
+        },
+      );
+    },
+  });
+}

--- a/frontend/src/hooks/use-services.test.tsx
+++ b/frontend/src/hooks/use-services.test.tsx
@@ -171,20 +171,26 @@ describe("service CRUD mutations", () => {
     vi.clearAllMocks();
   });
 
-  it("useCreateService POSTs to /services with the payload", async () => {
+  it("useCreateService POSTs the write-only credential without altering it", async () => {
     mockPost.mockResolvedValue({ id: "svc-1" });
     const { result } = renderHook(() => useCreateService(), {
       wrapper: createWrapper(),
     });
     await result.current.mutateAsync({
       name: "Acme",
-      slug: "acme",
+      service_type: "http",
       base_url: "https://acme.test",
-    } as unknown as CreateServicePayload);
+      auth_type: "bearer",
+      service_category: "internal",
+      credential: "vendor-secret",
+    } satisfies CreateServicePayload);
     expect(mockPost).toHaveBeenCalledWith("/services", {
       name: "Acme",
-      slug: "acme",
+      service_type: "http",
       base_url: "https://acme.test",
+      auth_type: "bearer",
+      service_category: "internal",
+      credential: "vendor-secret",
     });
   });
 

--- a/frontend/src/pages/admin-platform-ops.test.tsx
+++ b/frontend/src/pages/admin-platform-ops.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PlatformOperationList } from "@/schemas/platform-ops";
+import { AdminPlatformOpsPage } from "./admin-platform-ops";
+
+const { mockMutateAsync, mockRefetch, mockToastError, mockToastSuccess } =
+  vi.hoisted(() => ({
+    mockMutateAsync: vi.fn(),
+    mockRefetch: vi.fn(),
+    mockToastError: vi.fn(),
+    mockToastSuccess: vi.fn(),
+  }));
+
+const operations: PlatformOperationList = {
+  operations: [
+    {
+      op: "x_search",
+      enabled: false,
+      vendor_service_slug: "platform-x",
+      config: { type: "x_search", max_results_cap: 10 },
+      updated_at: null,
+      updated_by: null,
+    },
+    {
+      op: "speak",
+      enabled: false,
+      vendor_service_slug: "platform-elevenlabs",
+      config: {
+        type: "speak",
+        allowed_voice_ids: ["voice-a"],
+        max_chars: 1000,
+        model_id: "eleven_multilingual_v2",
+      },
+      updated_at: null,
+      updated_by: null,
+    },
+    {
+      op: "call_and_say",
+      enabled: false,
+      vendor_service_slug: "platform-twilio",
+      config: {
+        type: "call_and_say",
+        allowed_destination_prefixes: ["+65"],
+        max_message_chars: 500,
+        voice: "alice",
+        max_calls_per_user_per_day: 3,
+        account_sid: `AC${"a".repeat(32)}`,
+        call_from: "+6512345678",
+      },
+      updated_at: null,
+      updated_by: null,
+    },
+  ],
+};
+
+vi.mock("@/hooks/use-platform-ops", () => ({
+  usePlatformOperations: () => ({
+    data: operations,
+    error: null,
+    isLoading: false,
+    refetch: mockRefetch,
+  }),
+  useUpdatePlatformOperation: () => ({
+    isPending: false,
+    mutateAsync: mockMutateAsync,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mockToastError, success: mockToastSuccess },
+}));
+
+describe("AdminPlatformOpsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutateAsync.mockImplementation(
+      async ({ op, data }: { op: string; data: Record<string, unknown> }) => ({
+        op,
+        ...data,
+        updated_at: "2026-08-25T10:00:00Z",
+        updated_by: "admin-1",
+      }),
+    );
+  });
+
+  it("renders one typed form for each fixed operation", () => {
+    render(<AdminPlatformOpsPage />);
+
+    expect(screen.getByText("X Search")).toBeInTheDocument();
+    expect(screen.getByText("Speak")).toBeInTheDocument();
+    expect(screen.getByText("Call and Say")).toBeInTheDocument();
+    expect(screen.getByLabelText("Maximum Results")).toHaveValue(10);
+    expect(screen.getByLabelText("Allowed Voice IDs")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Allowed Destination Prefixes"),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Account SID")).toHaveValue(
+      `AC${"a".repeat(32)}`,
+    );
+  });
+
+  it("keeps saves dirty-gated and submits the typed operation payload", async () => {
+    render(<AdminPlatformOpsPage />);
+    const user = userEvent.setup();
+    const save = screen.getByRole("button", { name: "Save X Search" });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Maximum Results"), {
+      target: { value: "12" },
+    });
+    await waitFor(() => expect(save).toBeEnabled());
+    await user.click(save);
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        op: "x_search",
+        data: {
+          enabled: false,
+          vendor_service_slug: "platform-x",
+          config: { type: "x_search", max_results_cap: 12 },
+        },
+      }),
+    );
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "X Search configuration saved",
+    );
+  });
+
+  it("edits allowlists as chips instead of raw JSON", async () => {
+    render(<AdminPlatformOpsPage />);
+    const user = userEvent.setup();
+    const voiceInput = screen.getByLabelText("Allowed Voice IDs");
+
+    await user.type(voiceInput, "voice-b{Enter}");
+
+    expect(screen.getByText("voice-b")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove voice ID voice-b" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /json/i })).toBeNull();
+  });
+});

--- a/frontend/src/pages/admin-platform-ops.tsx
+++ b/frontend/src/pages/admin-platform-ops.tsx
@@ -1,0 +1,665 @@
+import {
+  forwardRef,
+  useEffect,
+  useState,
+  type InputHTMLAttributes,
+  type KeyboardEvent,
+} from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Check,
+  PhoneCall,
+  Plus,
+  Search,
+  Volume2,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { ErrorBanner } from "@/components/shared/error-banner";
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormSubmitErrors,
+  useAppForm,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  usePlatformOperations,
+  useUpdatePlatformOperation,
+} from "@/hooks/use-platform-ops";
+import { ApiError } from "@/lib/api-client";
+import {
+  callAndSayUpdateSchema,
+  speakUpdateSchema,
+  xSearchUpdateSchema,
+  type CallAndSayOperation,
+  type CallAndSayUpdate,
+  type PlatformOperation,
+  type SpeakOperation,
+  type SpeakUpdate,
+  type XSearchOperation,
+  type XSearchUpdate,
+} from "@/schemas/platform-ops";
+
+function updateErrorMessage(error: unknown): string {
+  return error instanceof ApiError
+    ? error.message
+    : "Failed to update platform operation";
+}
+
+type NumberInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "max" | "min" | "onChange" | "type" | "value"
+> & {
+  readonly value: number;
+  readonly onChange: (value: number) => void;
+  readonly min: number;
+  readonly max: number;
+};
+
+const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ value, onChange, min, max, ...props }, ref) => (
+    <Input
+      {...props}
+      ref={ref}
+      type="number"
+      min={min}
+      max={max}
+      step={1}
+      value={Number.isFinite(value) ? value : ""}
+      onChange={(event) => onChange(event.target.valueAsNumber)}
+    />
+  ),
+);
+NumberInput.displayName = "NumberInput";
+
+function StringListEditor({
+  inputId,
+  value,
+  onChange,
+  placeholder,
+  itemLabel,
+}: {
+  readonly inputId: string;
+  readonly value: readonly string[];
+  readonly onChange: (value: string[]) => void;
+  readonly placeholder: string;
+  readonly itemLabel: string;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const addDraft = () => {
+    const next = draft.trim();
+    if (!next) return;
+    if (!value.includes(next)) onChange([...value, next]);
+    setDraft("");
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter" && event.key !== ",") return;
+    event.preventDefault();
+    addDraft();
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex min-h-8 flex-wrap gap-1.5">
+        {value.map((item) => (
+          <span
+            key={item}
+            className="inline-flex h-7 max-w-full items-center gap-1 rounded-md border border-border bg-muted px-2 text-[11px] text-foreground"
+          >
+            <span className="truncate font-mono">{item}</span>
+            <button
+              type="button"
+              className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-overlay-strong hover:text-foreground"
+              onClick={() => onChange(value.filter((entry) => entry !== item))}
+              aria-label={`Remove ${itemLabel} ${item}`}
+              title={`Remove ${item}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          id={inputId}
+          value={draft}
+          placeholder={placeholder}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={addDraft}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={addDraft}
+          disabled={!draft.trim()}
+          aria-label={`Add ${itemLabel}`}
+          title={`Add ${itemLabel}`}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function OperationHeader({
+  icon: Icon,
+  title,
+  enabled,
+  onEnabledChange,
+}: {
+  readonly icon: typeof Search;
+  readonly title: string;
+  readonly enabled: boolean;
+  readonly onEnabledChange: (enabled: boolean) => void;
+}) {
+  return (
+    <CardHeader className="border-b border-border/60">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground">
+            <Icon className="h-4 w-4" />
+          </span>
+          <CardTitle>{title}</CardTitle>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-[11px] text-muted-foreground">
+            {enabled ? "Enabled" : "Disabled"}
+          </span>
+          <Switch
+            checked={enabled}
+            onCheckedChange={onEnabledChange}
+            aria-label={`Enable ${title}`}
+          />
+        </div>
+      </div>
+    </CardHeader>
+  );
+}
+
+function XSearchOperationCard({
+  operation,
+}: {
+  readonly operation: XSearchOperation;
+}) {
+  const update = useUpdatePlatformOperation();
+  const form = useAppForm<XSearchUpdate>({
+    resolver: zodResolver(xSearchUpdateSchema),
+    defaultValues: {
+      enabled: operation.enabled,
+      vendor_service_slug: operation.vendor_service_slug,
+      config: operation.config,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      enabled: operation.enabled,
+      vendor_service_slug: operation.vendor_service_slug,
+      config: operation.config,
+    });
+  }, [form, operation]);
+
+  const onSubmit = async (data: XSearchUpdate) => {
+    try {
+      const saved = await update.mutateAsync({ op: "x_search", data });
+      if (saved.op === "x_search") {
+        form.reset({
+          enabled: saved.enabled,
+          vendor_service_slug: saved.vendor_service_slug,
+          config: saved.config,
+        });
+      }
+      toast.success("X Search configuration saved");
+    } catch (error) {
+      toast.error(updateErrorMessage(error));
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <Card className="h-full">
+          <OperationHeader
+            icon={Search}
+            title="X Search"
+            enabled={form.watch("enabled")}
+            onEnabledChange={(enabled) => form.setValue("enabled", enabled)}
+          />
+          <CardContent className="space-y-4 pt-4">
+            <FormField
+              control={form.control}
+              name="vendor_service_slug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Vendor Service Slug</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="config.max_results_cap"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Maximum Results</FormLabel>
+                  <FormControl>
+                    <NumberInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      min={1}
+                      max={25}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormSubmitErrors />
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!form.formState.isDirty || update.isPending}
+              isLoading={update.isPending}
+            >
+              <Check className="h-4 w-4" />
+              Save X Search
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  );
+}
+
+function SpeakOperationCard({
+  operation,
+}: {
+  readonly operation: SpeakOperation;
+}) {
+  const update = useUpdatePlatformOperation();
+  const form = useAppForm<SpeakUpdate>({
+    resolver: zodResolver(speakUpdateSchema),
+    defaultValues: {
+      enabled: operation.enabled,
+      vendor_service_slug: operation.vendor_service_slug,
+      config: operation.config,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      enabled: operation.enabled,
+      vendor_service_slug: operation.vendor_service_slug,
+      config: operation.config,
+    });
+  }, [form, operation]);
+
+  const onSubmit = async (data: SpeakUpdate) => {
+    try {
+      const saved = await update.mutateAsync({ op: "speak", data });
+      if (saved.op === "speak") {
+        form.reset({
+          enabled: saved.enabled,
+          vendor_service_slug: saved.vendor_service_slug,
+          config: saved.config,
+        });
+      }
+      toast.success("Speech configuration saved");
+    } catch (error) {
+      toast.error(updateErrorMessage(error));
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <Card className="h-full">
+          <OperationHeader
+            icon={Volume2}
+            title="Speak"
+            enabled={form.watch("enabled")}
+            onEnabledChange={(enabled) => form.setValue("enabled", enabled)}
+          />
+          <CardContent className="space-y-4 pt-4">
+            <FormField
+              control={form.control}
+              name="vendor_service_slug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Vendor Service Slug</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="config.allowed_voice_ids"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="platform-op-voice-id">
+                    Allowed Voice IDs
+                  </FormLabel>
+                  <StringListEditor
+                    inputId="platform-op-voice-id"
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="Voice ID"
+                    itemLabel="voice ID"
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="config.max_chars"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Maximum Characters</FormLabel>
+                    <FormControl>
+                      <NumberInput
+                        value={field.value}
+                        onChange={field.onChange}
+                        min={1}
+                        max={5000}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="config.model_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Model ID</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormSubmitErrors />
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!form.formState.isDirty || update.isPending}
+              isLoading={update.isPending}
+            >
+              <Check className="h-4 w-4" />
+              Save Speak
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  );
+}
+
+function CallAndSayOperationCard({
+  operation,
+}: {
+  readonly operation: CallAndSayOperation;
+}) {
+  const update = useUpdatePlatformOperation();
+  const form = useAppForm<CallAndSayUpdate>({
+    resolver: zodResolver(callAndSayUpdateSchema),
+    defaultValues: {
+      enabled: operation.enabled,
+      vendor_service_slug: operation.vendor_service_slug,
+      config: operation.config,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      enabled: operation.enabled,
+      vendor_service_slug: operation.vendor_service_slug,
+      config: operation.config,
+    });
+  }, [form, operation]);
+
+  const onSubmit = async (data: CallAndSayUpdate) => {
+    try {
+      const saved = await update.mutateAsync({ op: "call_and_say", data });
+      if (saved.op === "call_and_say") {
+        form.reset({
+          enabled: saved.enabled,
+          vendor_service_slug: saved.vendor_service_slug,
+          config: saved.config,
+        });
+      }
+      toast.success("Call and Say configuration saved");
+    } catch (error) {
+      toast.error(updateErrorMessage(error));
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <Card className="h-full">
+          <OperationHeader
+            icon={PhoneCall}
+            title="Call and Say"
+            enabled={form.watch("enabled")}
+            onEnabledChange={(enabled) => form.setValue("enabled", enabled)}
+          />
+          <CardContent className="space-y-4 pt-4">
+            <FormField
+              control={form.control}
+              name="vendor_service_slug"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Vendor Service Slug</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="config.allowed_destination_prefixes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="platform-op-destination-prefix">
+                    Allowed Destination Prefixes
+                  </FormLabel>
+                  <StringListEditor
+                    inputId="platform-op-destination-prefix"
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="+65"
+                    itemLabel="destination prefix"
+                  />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="config.account_sid"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Account SID</FormLabel>
+                    <FormControl>
+                      <Input {...field} autoComplete="off" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="config.call_from"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Caller ID</FormLabel>
+                    <FormControl>
+                      <Input {...field} inputMode="tel" placeholder="+14155550123" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="config.voice"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Voice</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="config.max_message_chars"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Maximum Message Characters</FormLabel>
+                    <FormControl>
+                      <NumberInput
+                        value={field.value}
+                        onChange={field.onChange}
+                        min={1}
+                        max={1000}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="config.max_calls_per_user_per_day"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Daily Calls Per User</FormLabel>
+                    <FormControl>
+                      <NumberInput
+                        value={field.value}
+                        onChange={field.onChange}
+                        min={1}
+                        max={4_294_967_295}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <FormSubmitErrors />
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!form.formState.isDirty || update.isPending}
+              isLoading={update.isPending}
+            >
+              <Check className="h-4 w-4" />
+              Save Call and Say
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  );
+}
+
+function OperationCard({
+  operation,
+}: {
+  readonly operation: PlatformOperation;
+}) {
+  switch (operation.op) {
+    case "x_search":
+      return <XSearchOperationCard operation={operation} />;
+    case "speak":
+      return <SpeakOperationCard operation={operation} />;
+    case "call_and_say":
+      return <CallAndSayOperationCard operation={operation} />;
+  }
+}
+
+export function AdminPlatformOpsPage() {
+  const { data, error, isLoading, refetch } = usePlatformOperations();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Platform Operations"
+        description="Configure NyxID-owned vendor operations and their server-enforced limits."
+      />
+
+      {error ? (
+        <ErrorBanner
+          message={
+            error instanceof ApiError
+              ? error.message
+              : "Failed to load platform operations"
+          }
+          onRetry={() => void refetch()}
+        />
+      ) : isLoading ? (
+        <div className="grid gap-4 xl:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton
+              key={`platform-operation-${String(index)}`}
+              className="h-[420px] w-full"
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid items-start gap-4 xl:grid-cols-3">
+          {data?.operations.map((operation) => (
+            <OperationCard key={operation.op} operation={operation} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/lazy.ts
+++ b/frontend/src/pages/lazy.ts
@@ -231,6 +231,11 @@ export const AdminIntegrityPage = lazy(() =>
     default: m.AdminIntegrityPage,
   })),
 );
+export const AdminPlatformOpsPage = lazy(() =>
+  import("@/pages/admin-platform-ops").then((m) => ({
+    default: m.AdminPlatformOpsPage,
+  })),
+);
 export const AdminCreditsPage = lazy(() =>
   import("@/pages/admin-credits").then((m) => ({
     default: m.AdminCreditsPage,

--- a/frontend/src/pages/service-list.tsx
+++ b/frontend/src/pages/service-list.tsx
@@ -74,6 +74,7 @@ export function ServiceListPage() {
       base_url: "",
       auth_type: "api_key",
       auth_key_name: "",
+      credential: "",
       service_category: "connection",
       host: "",
       port: "22",
@@ -119,6 +120,7 @@ export function ServiceListPage() {
               base_url: data.base_url ?? "",
               auth_type: data.auth_type ?? "api_key",
               auth_key_name: data.auth_key_name || undefined,
+              credential: data.credential || undefined,
               service_category: data.service_category ?? "connection",
             });
 
@@ -390,6 +392,9 @@ export function ServiceListPage() {
                               if (value !== "body") {
                                 form.setValue("auth_key_name", "");
                               }
+                              if (value === "oidc" || value === "none") {
+                                form.setValue("credential", "");
+                              }
                             }}
                           >
                             <FormControl>
@@ -447,6 +452,28 @@ export function ServiceListPage() {
                               injected. For Lark/Feishu use{" "}
                               <code>app_secret</code>.
                             </p>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+
+                    {authType !== "oidc" && authType !== "none" && (
+                      <FormField
+                        control={form.control}
+                        name="credential"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Master Credential</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="password"
+                                autoComplete="new-password"
+                                placeholder="Vendor credential"
+                                {...field}
+                                value={field.value ?? ""}
+                              />
+                            </FormControl>
                             <FormMessage />
                           </FormItem>
                         )}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -14,7 +14,7 @@ import { AuthLayout } from "@/components/layout/auth-layout";
 import { DashboardLayout } from "@/components/layout/dashboard-layout";
 import { BillingRouteGuard } from "@/components/billing-route-guard";
 import { useAuthStore } from "@/stores/auth-store";
-import { hasAdminRead } from "@/types/api";
+import { canAdminWrite, hasAdminRead } from "@/types/api";
 import { shouldRedirectFromBilling } from "@/lib/billing-availability";
 import { normalizeAdminAuditLogSearch } from "@/lib/admin-audit-log";
 import { normalizeAdminOAuthClientSearch } from "@/lib/admin-oauth-clients";
@@ -68,6 +68,7 @@ import {
   AdminAuditLogPage,
   AdminFeatureFlagsPage,
   AdminIntegrityPage,
+  AdminPlatformOpsPage,
   AdminCreditsPage,
   AdminInviteCodesPage,
   CliAuthPage,
@@ -849,6 +850,18 @@ const adminIntegrityRoute = createRoute({
   component: AdminIntegrityPage,
 });
 
+const adminPlatformOpsRoute = createRoute({
+  path: "platform-ops",
+  getParentRoute: () => adminLayout,
+  beforeLoad: () => {
+    const { user, isLoading } = useAuthStore.getState();
+    if (!isLoading && !canAdminWrite(user)) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
+  component: AdminPlatformOpsPage,
+});
+
 const adminCreditsRoute = createRoute({
   path: "credits",
   getParentRoute: () => adminLayout,
@@ -952,6 +965,7 @@ const routeTree = rootRoute.addChildren([
       adminNodesRoute,
       adminAuditLogRoute,
       adminIntegrityRoute,
+      adminPlatformOpsRoute,
       adminCreditsRoute,
       adminInviteCodesRoute,
       adminFeatureFlagsRoute,

--- a/frontend/src/schemas/platform-ops.test.ts
+++ b/frontend/src/schemas/platform-ops.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  callAndSayUpdateSchema,
+  platformOperationListSchema,
+  speakUpdateSchema,
+  xSearchUpdateSchema,
+} from "./platform-ops";
+
+describe("platform operation schemas", () => {
+  it("accepts the disabled defaults returned for missing rows", () => {
+    expect(
+      platformOperationListSchema.parse({
+        operations: [
+          {
+            op: "speak",
+            enabled: false,
+            vendor_service_slug: "platform-elevenlabs",
+            config: {
+              type: "speak",
+              allowed_voice_ids: [],
+              max_chars: 1000,
+              model_id: "eleven_multilingual_v2",
+            },
+            updated_at: null,
+            updated_by: null,
+          },
+          {
+            op: "call_and_say",
+            enabled: false,
+            vendor_service_slug: "platform-twilio",
+            config: {
+              type: "call_and_say",
+              allowed_destination_prefixes: [],
+              max_message_chars: 500,
+              voice: "alice",
+              max_calls_per_user_per_day: 3,
+              account_sid: "",
+              call_from: "",
+            },
+            updated_at: null,
+            updated_by: null,
+          },
+        ],
+      }).operations,
+    ).toHaveLength(2);
+  });
+
+  it("enforces the server hard caps", () => {
+    expect(
+      xSearchUpdateSchema.safeParse({
+        enabled: true,
+        vendor_service_slug: "platform-x",
+        config: { type: "x_search", max_results_cap: 26 },
+      }).success,
+    ).toBe(false);
+    expect(
+      speakUpdateSchema.safeParse({
+        enabled: true,
+        vendor_service_slug: "platform-elevenlabs",
+        config: {
+          type: "speak",
+          allowed_voice_ids: ["voice-a"],
+          max_chars: 5001,
+          model_id: "eleven_multilingual_v2",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      callAndSayUpdateSchema.safeParse({
+        enabled: true,
+        vendor_service_slug: "platform-twilio",
+        config: {
+          type: "call_and_say",
+          allowed_destination_prefixes: ["+65"],
+          max_message_chars: 1001,
+          voice: "alice",
+          max_calls_per_user_per_day: 3,
+          account_sid: `AC${"0".repeat(32)}`,
+          call_from: "+6512345678",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires a voice allowlist but permits an empty destination allowlist", () => {
+    const speak = speakUpdateSchema.safeParse({
+      enabled: false,
+      vendor_service_slug: "platform-elevenlabs",
+      config: {
+        type: "speak",
+        allowed_voice_ids: [],
+        max_chars: 1000,
+        model_id: "eleven_multilingual_v2",
+      },
+    });
+    const call = callAndSayUpdateSchema.safeParse({
+      enabled: false,
+      vendor_service_slug: "platform-twilio",
+      config: {
+        type: "call_and_say",
+        allowed_destination_prefixes: [],
+        max_message_chars: 500,
+        voice: "alice",
+        max_calls_per_user_per_day: 3,
+        account_sid: `AC${"a".repeat(32)}`,
+        call_from: "+6512345678",
+      },
+    });
+
+    expect(speak.success).toBe(false);
+    expect(call.success).toBe(true);
+  });
+
+  it("rejects duplicate or malformed allowlist values", () => {
+    const duplicateVoices = speakUpdateSchema.safeParse({
+      enabled: true,
+      vendor_service_slug: "platform-elevenlabs",
+      config: {
+        type: "speak",
+        allowed_voice_ids: ["voice-a", "voice-a"],
+        max_chars: 1000,
+        model_id: "eleven_multilingual_v2",
+      },
+    });
+    const malformedPrefix = callAndSayUpdateSchema.safeParse({
+      enabled: true,
+      vendor_service_slug: "platform-twilio",
+      config: {
+        type: "call_and_say",
+        allowed_destination_prefixes: ["65"],
+        max_message_chars: 500,
+        voice: "alice",
+        max_calls_per_user_per_day: 3,
+        account_sid: `AC${"b".repeat(32)}`,
+        call_from: "+6512345678",
+      },
+    });
+
+    expect(duplicateVoices.success).toBe(false);
+    expect(malformedPrefix.success).toBe(false);
+  });
+
+  it("rejects unknown fields and mismatched config types", () => {
+    expect(
+      xSearchUpdateSchema.safeParse({
+        enabled: true,
+        vendor_service_slug: "platform-x",
+        config: { type: "speak", max_results_cap: 10 },
+      }).success,
+    ).toBe(false);
+    expect(
+      xSearchUpdateSchema.safeParse({
+        enabled: true,
+        vendor_service_slug: "platform-x",
+        config: { type: "x_search", max_results_cap: 10 },
+        vendor_body: { query: "caller controlled" },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/frontend/src/schemas/platform-ops.ts
+++ b/frontend/src/schemas/platform-ops.ts
@@ -1,0 +1,192 @@
+import { z } from "zod";
+
+export const PLATFORM_OPERATION_QUERY_KEY = [
+  "admin",
+  "platform-ops",
+] as const;
+
+const vendorServiceSlugSchema = z
+  .string()
+  .min(1, "Vendor service slug is required")
+  .max(128, "Vendor service slug must be at most 128 characters")
+  .regex(
+    /^[a-z0-9-]+$/,
+    "Use only lowercase letters, digits, and hyphens",
+  );
+
+const safeIdentifierSchema = (label: string) =>
+  z
+    .string()
+    .min(1, `${label} is required`)
+    .max(128, `${label} must be at most 128 characters`)
+    .regex(
+      /^[A-Za-z0-9._-]+$/,
+      `${label} may only use letters, digits, periods, hyphens, and underscores`,
+    );
+
+const e164Schema = z
+  .string()
+  .regex(/^\+[1-9][0-9]{0,14}$/, "Must be a valid E.164 number or prefix");
+
+const uniqueStrings = <T extends z.ZodType<string>>(item: T, max: number) =>
+  z
+    .array(item)
+    .max(max, `At most ${String(max)} values are allowed`)
+    .refine(
+      (values) => new Set(values).size === values.length,
+      "Duplicate values are not allowed",
+    );
+
+const operationMetadataSchema = {
+  enabled: z.boolean(),
+  vendor_service_slug: vendorServiceSlugSchema,
+  updated_at: z.string().nullable(),
+  updated_by: z.string().nullable(),
+};
+
+export const xSearchConfigSchema = z
+  .object({
+    type: z.literal("x_search"),
+    max_results_cap: z
+      .number()
+      .int("Maximum results must be an integer")
+      .min(1, "Maximum results must be at least 1")
+      .max(25, "Maximum results cannot exceed 25"),
+  })
+  .strict();
+
+export const speakConfigResponseSchema = z
+  .object({
+    type: z.literal("speak"),
+    allowed_voice_ids: uniqueStrings(safeIdentifierSchema("Voice ID"), 100),
+    max_chars: z
+      .number()
+      .int("Maximum characters must be an integer")
+      .min(1, "Maximum characters must be at least 1")
+      .max(5_000, "Maximum characters cannot exceed 5000"),
+    model_id: safeIdentifierSchema("Model ID"),
+  })
+  .strict();
+
+export const speakConfigSchema = speakConfigResponseSchema.extend({
+  allowed_voice_ids: uniqueStrings(
+    safeIdentifierSchema("Voice ID"),
+    100,
+  ).min(1, "Add at least one allowed voice ID"),
+});
+
+export const callAndSayConfigResponseSchema = z
+  .object({
+    type: z.literal("call_and_say"),
+    allowed_destination_prefixes: uniqueStrings(e164Schema, 100),
+    max_message_chars: z
+      .number()
+      .int("Maximum message characters must be an integer")
+      .min(1, "Maximum message characters must be at least 1")
+      .max(1_000, "Maximum message characters cannot exceed 1000"),
+    voice: safeIdentifierSchema("Voice"),
+    max_calls_per_user_per_day: z
+      .number()
+      .int("Daily call limit must be an integer")
+      .min(1, "Daily call limit must be at least 1")
+      .max(4_294_967_295, "Daily call limit is too large"),
+    account_sid: z.union([
+      z.literal(""),
+      z
+        .string()
+        .regex(
+          /^AC[0-9A-Fa-f]{32}$/,
+          "Must be a Twilio Account SID beginning with AC",
+        ),
+    ]),
+    call_from: z.union([z.literal(""), e164Schema]),
+  })
+  .strict();
+
+export const callAndSayConfigSchema = callAndSayConfigResponseSchema.extend({
+  account_sid: z
+    .string()
+    .regex(
+      /^AC[0-9A-Fa-f]{32}$/,
+      "Must be a Twilio Account SID beginning with AC",
+    ),
+  call_from: e164Schema,
+});
+
+export const xSearchOperationSchema = z
+  .object({
+    op: z.literal("x_search"),
+    ...operationMetadataSchema,
+    config: xSearchConfigSchema,
+  })
+  .strict();
+
+export const speakOperationSchema = z
+  .object({
+    op: z.literal("speak"),
+    ...operationMetadataSchema,
+    config: speakConfigResponseSchema,
+  })
+  .strict();
+
+export const callAndSayOperationSchema = z
+  .object({
+    op: z.literal("call_and_say"),
+    ...operationMetadataSchema,
+    config: callAndSayConfigResponseSchema,
+  })
+  .strict();
+
+export const platformOperationSchema = z.discriminatedUnion("op", [
+  xSearchOperationSchema,
+  speakOperationSchema,
+  callAndSayOperationSchema,
+]);
+
+export const platformOperationListSchema = z
+  .object({
+    operations: z.array(platformOperationSchema),
+  })
+  .strict();
+
+const updateMetadataSchema = {
+  enabled: z.boolean(),
+  vendor_service_slug: vendorServiceSlugSchema,
+};
+
+export const xSearchUpdateSchema = z
+  .object({
+    ...updateMetadataSchema,
+    config: xSearchConfigSchema,
+  })
+  .strict();
+
+export const speakUpdateSchema = z
+  .object({
+    ...updateMetadataSchema,
+    config: speakConfigSchema,
+  })
+  .strict();
+
+export const callAndSayUpdateSchema = z
+  .object({
+    ...updateMetadataSchema,
+    config: callAndSayConfigSchema,
+  })
+  .strict();
+
+export type PlatformOperation = z.infer<typeof platformOperationSchema>;
+export type PlatformOperationList = z.infer<
+  typeof platformOperationListSchema
+>;
+export type XSearchOperation = z.infer<typeof xSearchOperationSchema>;
+export type SpeakOperation = z.infer<typeof speakOperationSchema>;
+export type CallAndSayOperation = z.infer<typeof callAndSayOperationSchema>;
+export type XSearchUpdate = z.infer<typeof xSearchUpdateSchema>;
+export type SpeakUpdate = z.infer<typeof speakUpdateSchema>;
+export type CallAndSayUpdate = z.infer<typeof callAndSayUpdateSchema>;
+
+export type UpdatePlatformOperationVariables =
+  | { readonly op: "x_search"; readonly data: XSearchUpdate }
+  | { readonly op: "speak"; readonly data: SpeakUpdate }
+  | { readonly op: "call_and_say"; readonly data: CallAndSayUpdate };

--- a/frontend/src/schemas/services.test.ts
+++ b/frontend/src/schemas/services.test.ts
@@ -44,6 +44,45 @@ describe("constants", () => {
 });
 
 describe("createServiceSchema", () => {
+  it("accepts a write-only credential for an internal HTTP service", () => {
+    const result = createServiceSchema.safeParse({
+      name: "Platform X",
+      service_type: "http",
+      visibility: "public",
+      base_url: "https://api.x.com",
+      auth_type: "bearer",
+      credential: "vendor-secret",
+      service_category: "internal",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.credential).toBe("vendor-secret");
+    }
+  });
+
+  it("rejects a master credential on a user-credential service", () => {
+    const result = createServiceSchema.safeParse({
+      name: "Platform X",
+      service_type: "http",
+      visibility: "public",
+      base_url: "https://api.x.com",
+      auth_type: "bearer",
+      credential: "vendor-secret",
+      service_category: "connection",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["service_category"],
+          message: "A master credential requires the Internal category",
+        }),
+      );
+    }
+  });
+
   const validData = {
     name: "My Service",
     service_type: "http" as const,

--- a/frontend/src/schemas/services.ts
+++ b/frontend/src/schemas/services.ts
@@ -159,6 +159,7 @@ export const createServiceSchema = z
     auth_type: z.enum(AUTH_TYPES).optional(),
     /// JSON body key for `body` auth. Required when `auth_type === "body"`.
     auth_key_name: optionalString,
+    credential: optionalString,
     service_category: z.enum(SERVICE_CATEGORIES).optional(),
     host: optionalString,
     port: optionalString,
@@ -189,6 +190,14 @@ export const createServiceSchema = z
           code: z.ZodIssueCode.custom,
           path: ["auth_type"],
           message: "Auth type is required",
+        });
+      }
+
+      if (value.credential && value.service_category !== "internal") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["service_category"],
+          message: "A master credential requires the Internal category",
         });
       }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -387,6 +387,8 @@ export type CreateServicePayload =
       /// Required when auth_type is "body" (e.g. "app_secret" for Lark).
       /// Also accepted as an override for other auth types.
       readonly auth_key_name?: string;
+      /** Write-only master credential for an internal service row. */
+      readonly credential?: string;
       readonly service_category?: string;
       readonly anonymous_endpoints?: readonly AnonymousEndpointRule[];
     }


### PR DESCRIPTION
## What this branch achieves

Adds **platform operations**: a first-party NyxID surface of named, server-constructed operations brokering vendor APIs, so callers never touch the vendor request shape — the chrono-llm pattern (`services/assistant_direct.rs`) applied per capability. Spec: `docs/assistant/PLATFORM_OPS_V1_SPEC.md` (already on main).

**Why this shape:** platform services must be scope-limited and non-destructive. The generic operation allowlist matches method+path only and cannot see request bodies — for Twilio/ElevenLabs the danger *is* the body (`To`, `Twiml`, `voice_id`). So NyxID exposes named operations that validate a few typed inputs and compose the upstream request server-side.

## V1 operations (all disabled by default, admin-configured)

- **`x_search`** — X recent search, read-only, results cap
- **`speak`** — ElevenLabs TTS; `voice_id` pinned to an admin allowlist, character cap; returns audio
- **`call_and_say`** — Twilio voice; caller supplies only `to` + `message`. NyxID composes the TwiML (XML-escaped), owns caller-ID and AccountSid, enforces an E.164 prefix allowlist and a per-user daily cap **before** the vendor call. "Send SMS" / "arbitrary call script" are inexpressible — those operations do not exist.

## Surfaces

- `POST /api/v1/platform-ops/{x-search,speak,call-and-say}` — JWT sessions + `nyxid_ag_` keys; delegated/relay/SA tokens rejected; routes added to `delegated_read_denied_path` per repo security rules; metadata-only audit
- `GET/PUT /api/v1/admin/platform-ops` — typed per-op config, hard caps enforced server-side
- MCP tools `nyx__x_search`, `nyx__speak`, `nyx__call_and_say` (absent from tools/list when disabled)
- Admin page `/admin/platform-ops` + write-only credential field on the existing admin services form so vendor rows (`platform-twilio`, `platform-elevenlabs`, `platform-x`) can be provisioned entirely from the UI

## Non-breaking by construction

Purely additive: new model (`platform_operations`), new routes, new tools, new page. Existing-file touches are module registrations and the mandatory auth-middleware path entries (verified additive, 0 behavioural lines removed). Vendor rows resolve via the flag-off server-chosen credential path `chrono-llm-public` already uses.

## Status

- [ ] Final commit (admin-services credential field) landing
- [ ] Reviewer pass (direct code review, iterating with implementer)
- [ ] Rebase onto current main (branch is 10 behind)
- [ ] Local verification: cargo check/clippy/fmt + frontend build (**note: rollup-target PRs get no per-PR CI — ci.yml gates main/dev only; backend suite runs when the rollup PRs into main**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)