### PR TITLE
fix(approvals): keep approval settings out of app lifecycle; exempt auto-connected services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, dev]
+    # Rollup PRs must be gated with the same CI coverage as main/dev PRs.
+    branches: [main, dev, 'rollup-*']
   push:
     # `main` is intentionally not listed here -- pushes to main are gated
     # through publish-images.yml, which calls this workflow via workflow_call.

--- a/backend/src/billing_integration_tests.rs
+++ b/backend/src/billing_integration_tests.rs
@@ -530,9 +530,11 @@ async fn billing_route_coverage_smoke() {
         .insert_one(NotificationChannel {
             id: Uuid::new_v4().to_string(),
             user_id: owner_id.clone(),
-            telegram_chat_id: None,
-            telegram_username: None,
-            telegram_enabled: false,
+            // Global approval protection is enforced only while a delivery
+            // channel is active; a linked Telegram chat keeps it enforced here.
+            telegram_chat_id: Some(4242),
+            telegram_username: Some("billing-smoke".to_string()),
+            telegram_enabled: true,
             telegram_link_code: None,
             telegram_link_code_expires_at: None,
             approval_timeout_secs: 300,

--- a/backend/src/handlers/device_tokens.rs
+++ b/backend/src/handlers/device_tokens.rs
@@ -3,7 +3,6 @@ use axum::{
     extract::{Path, State},
 };
 use chrono::Utc;
-use futures::TryStreamExt;
 use mongodb::Collection;
 use mongodb::bson::{self, Document, doc};
 use serde::{Deserialize, Serialize};
@@ -92,9 +91,9 @@ pub async fn register_device(
         .filter(|prev| *prev != body.token.as_str());
 
     // Ensure one push token belongs to one user at a time (prevents account-switch leakage).
-    detach_token_from_other_users(&state.db, &collection, &user_id, &body.token, bson_now).await?;
+    detach_token_from_other_users(&collection, &user_id, &body.token, bson_now).await?;
     if let Some(prev) = resolved_prev {
-        detach_token_from_other_users(&state.db, &collection, &user_id, prev, bson_now).await?;
+        detach_token_from_other_users(&collection, &user_id, prev, bson_now).await?;
     }
 
     // Rotation path: replace `previous_token` with the new token on the same device record.
@@ -385,12 +384,6 @@ pub async fn remove_device(
 
     // Disable push only if this update still has no remaining devices.
     // The conditional filter prevents racing with a concurrent device registration.
-    // Also auto-disable approval_required if Telegram is not connected either,
-    // to prevent the user from being locked out of their own services.
-    let should_auto_disable_approval =
-        should_auto_disable_approval_after_last_push_device_removed(&channel);
-    let set_on_empty = disable_push_update_doc(should_auto_disable_approval);
-
     collection
         .update_one(
             doc! {
@@ -398,15 +391,13 @@ pub async fn remove_device(
                 "push_enabled": true,
                 "push_devices.0": { "$exists": false },
             },
-            doc! { "$set": set_on_empty },
+            doc! { "$set": disable_push_update_doc() },
         )
         .await?;
 
-    let approval_auto_disabled = channel
-        .push_devices
-        .iter()
-        .all(|device| device.device_id == device_id)
-        && should_auto_disable_approval;
+    let updated_channel = notification_service::get_or_create_channel(&state.db, &user_id).await?;
+    let approval_suspended = updated_channel.approval_required
+        && !notification_service::has_active_notification_channel(&updated_channel);
 
     audit_service::log_for_user(
         state.db.clone(),
@@ -414,7 +405,7 @@ pub async fn remove_device(
         "push_device_removed",
         Some(serde_json::json!({
             "device_id": device_id,
-            "approval_auto_disabled": approval_auto_disabled,
+            "approval_suspended": approval_suspended,
         })),
     );
 
@@ -431,8 +422,8 @@ pub async fn remove_device(
         );
     }
 
-    let message = if approval_auto_disabled && channel.approval_required {
-        "Device removed. Approval protection has been disabled because no notification channels remain.".to_string()
+    let message = if approval_suspended {
+        "Device removed. Approval protection is suspended until a notification channel is available; it resumes automatically.".to_string()
     } else {
         "Device removed".to_string()
     };
@@ -483,20 +474,14 @@ pub async fn remove_current_device(
                 "push_enabled": true,
                 "push_devices.0": { "$exists": false },
             },
-            doc! {
-                "$set": disable_push_update_doc(
-                    should_auto_disable_approval_after_last_push_device_removed(&channel)
-                )
-            },
+            doc! { "$set": disable_push_update_doc() },
         )
         .await?;
 
-    let approval_auto_disabled = token_was_present
-        && channel
-            .push_devices
-            .iter()
-            .all(|device| device.token == body.token)
-        && should_auto_disable_approval_after_last_push_device_removed(&channel);
+    let updated_channel = notification_service::get_or_create_channel(&state.db, &user_id).await?;
+    let approval_suspended = token_was_present
+        && updated_channel.approval_required
+        && !notification_service::has_active_notification_channel(&updated_channel);
 
     audit_service::log_for_user(
         state.db.clone(),
@@ -505,7 +490,7 @@ pub async fn remove_current_device(
         Some(serde_json::json!({
             "platform": body.platform,
             "token_removed": token_was_present,
-            "approval_auto_disabled": approval_auto_disabled,
+            "approval_suspended": approval_suspended,
         })),
     );
 
@@ -523,8 +508,8 @@ pub async fn remove_current_device(
         );
     }
 
-    let message = if approval_auto_disabled {
-        "Current device removed. Approval protection has been disabled because no notification channels remain.".to_string()
+    let message = if approval_suspended {
+        "Current device removed. Approval protection is suspended until a notification channel is available; it resumes automatically.".to_string()
     } else {
         "Current device removed".to_string()
     };
@@ -533,7 +518,6 @@ pub async fn remove_current_device(
 }
 
 async fn detach_token_from_other_users(
-    db: &mongodb::Database,
     collection: &Collection<NotificationChannel>,
     user_id: &str,
     token: &str,
@@ -543,8 +527,6 @@ async fn detach_token_from_other_users(
         "user_id": { "$ne": user_id },
         "push_devices.token": token,
     };
-    let affected_channels: Vec<NotificationChannel> =
-        collection.find(filter.clone()).await?.try_collect().await?;
     let removed = collection
         .update_many(
             filter,
@@ -576,56 +558,6 @@ async fn detach_token_from_other_users(
                 },
             )
             .await?;
-
-        // Avoid leaving approvals enabled for users who no longer have any
-        // active notification channels after token detachment. This is the
-        // lockout-prevention exception to the rule that registration never
-        // changes approval settings. Audit each actual auto-disable with
-        // metadata only; the push token itself is never recorded.
-        for channel in affected_channels.iter().filter(|channel| {
-            channel.approval_required
-                && !channel.push_devices.is_empty()
-                && channel
-                    .push_devices
-                    .iter()
-                    .all(|device| device.token == token)
-                && !telegram_channel_is_active(channel)
-        }) {
-            let result = collection
-                .update_one(
-                    doc! {
-                        "_id": &channel.id,
-                        "approval_required": true,
-                        "push_devices.0": { "$exists": false },
-                        "$or": [
-                            { "telegram_enabled": { "$ne": true } },
-                            { "telegram_chat_id": bson::Bson::Null },
-                        ],
-                    },
-                    doc! {
-                        "$set": {
-                            "approval_required": false,
-                            "updated_at": bson::DateTime::from_chrono(Utc::now()),
-                        }
-                    },
-                )
-                .await?;
-            if result.modified_count > 0 {
-                audit_service::log_async(
-                    db.clone(),
-                    Some(channel.user_id.clone()),
-                    "approval_auto_disabled_after_push_token_detach".to_string(),
-                    Some(serde_json::json!({
-                        "reason": "no_notification_channels",
-                        "detached_by_user_id": user_id,
-                    })),
-                    None,
-                    None,
-                    None,
-                    None,
-                );
-            }
-        }
     }
 
     Ok(())
@@ -776,25 +708,11 @@ fn ensure_platform_matches(existing: &DeviceToken, requested_platform: &str) -> 
     Ok(())
 }
 
-fn telegram_channel_is_active(channel: &NotificationChannel) -> bool {
-    channel.telegram_enabled && channel.telegram_chat_id.is_some()
-}
-
-fn should_auto_disable_approval_after_last_push_device_removed(
-    channel: &NotificationChannel,
-) -> bool {
-    channel.approval_required && !telegram_channel_is_active(channel)
-}
-
-fn disable_push_update_doc(disable_approval: bool) -> Document {
-    let mut update = doc! {
+fn disable_push_update_doc() -> Document {
+    doc! {
         "push_enabled": false,
         "updated_at": bson::DateTime::from_chrono(Utc::now()),
-    };
-    if disable_approval {
-        update.insert("approval_required", false);
     }
-    update
 }
 
 #[cfg(test)]
@@ -1011,7 +929,7 @@ mod tests {
     }
 
     #[test]
-    fn auto_disables_approval_when_last_push_device_is_removed_without_telegram() {
+    fn approval_preference_is_preserved_when_last_push_device_is_removed() {
         let channel = NotificationChannel {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: uuid::Uuid::new_v4().to_string(),
@@ -1029,13 +947,14 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        assert!(should_auto_disable_approval_after_last_push_device_removed(
+        assert!(channel.approval_required);
+        assert!(!notification_service::has_active_notification_channel(
             &channel
         ));
     }
 
     #[test]
-    fn keeps_approval_when_telegram_channel_is_active() {
+    fn active_telegram_channel_keeps_approval_enforced() {
         let channel = NotificationChannel {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: uuid::Uuid::new_v4().to_string(),
@@ -1053,7 +972,9 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        assert!(!should_auto_disable_approval_after_last_push_device_removed(&channel));
+        assert!(notification_service::has_active_notification_channel(
+            &channel
+        ));
     }
 
     #[tokio::test]
@@ -1179,8 +1100,101 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn detaching_last_device_auto_disables_previous_owner_approval() {
-        let Some(db) = connect_test_database("device_detach_auto_disable_approval").await else {
+    async fn logout_login_round_trip_preserves_approval_and_resumes_enforcement() {
+        let Some(db) = connect_test_database("device_logout_login_approval").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let channel_id = uuid::Uuid::new_v4().to_string();
+        let old_device = DeviceToken {
+            device_id: "logout-device".to_string(),
+            platform: "fcm".to_string(),
+            token: "logout-token".to_string(),
+            device_name: None,
+            app_id: None,
+            registered_at: Utc::now(),
+            last_used_at: None,
+        };
+        let collection = db.collection::<NotificationChannel>(COLLECTION_NAME);
+        collection
+            .insert_one(NotificationChannel {
+                id: channel_id.clone(),
+                user_id: user_id.clone(),
+                telegram_chat_id: None,
+                telegram_username: None,
+                telegram_enabled: false,
+                telegram_link_code: None,
+                telegram_link_code_expires_at: None,
+                approval_timeout_secs: 30,
+                grant_expiry_days: 30,
+                approval_required: true,
+                push_enabled: true,
+                push_devices: vec![old_device],
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        // This is the database work performed by remove_current_device on logout.
+        collection
+            .update_one(
+                doc! { "_id": &channel_id },
+                doc! {
+                    "$pull": { "push_devices": { "token": "logout-token" } },
+                    "$set": disable_push_update_doc(),
+                },
+            )
+            .await
+            .unwrap();
+        let after_logout = notification_service::get_or_create_channel(&db, &user_id)
+            .await
+            .unwrap();
+        assert!(after_logout.approval_required);
+        assert!(!notification_service::has_active_notification_channel(
+            &after_logout
+        ));
+        assert!(
+            !crate::services::approval_service::user_requires_approval(&db, &user_id)
+                .await
+                .unwrap()
+        );
+
+        let new_device = DeviceToken {
+            device_id: "login-device".to_string(),
+            platform: "fcm".to_string(),
+            token: "login-token".to_string(),
+            device_name: None,
+            app_id: None,
+            registered_at: Utc::now(),
+            last_used_at: None,
+        };
+        collection
+            .update_one(
+                doc! { "_id": &channel_id },
+                new_device_update_doc(&new_device, bson::DateTime::from_chrono(Utc::now()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let after_login = notification_service::get_or_create_channel(&db, &user_id)
+            .await
+            .unwrap();
+        assert!(after_login.approval_required);
+        assert!(notification_service::has_active_notification_channel(
+            &after_login
+        ));
+        assert!(
+            crate::services::approval_service::user_requires_approval(&db, &user_id)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn detaching_last_device_preserves_previous_owner_approval_preference() {
+        let Some(db) = connect_test_database("device_detach_preserves_approval").await else {
             eprintln!("skipping: no MongoDB");
             return;
         };
@@ -1222,13 +1236,8 @@ mod tests {
             .await
             .unwrap();
 
-        let audit_written = crate::services::audit_service::notify_on_audit_write_for_user(
-            "approval_auto_disabled_after_push_token_detach",
-            previous_user_id.clone(),
-        );
         let collection = db.collection::<NotificationChannel>(COLLECTION_NAME);
         detach_token_from_other_users(
-            &db,
             &collection,
             &registering_user_id,
             "detached-token",
@@ -1242,10 +1251,14 @@ mod tests {
             .await
             .unwrap()
             .expect("previous owner channel");
-        assert!(!saved.approval_required);
-        tokio::time::timeout(std::time::Duration::from_secs(5), audit_written)
-            .await
-            .expect("approval auto-disable audit timeout")
-            .expect("approval auto-disable audit writer dropped");
+        assert!(saved.approval_required);
+        assert!(!notification_service::has_active_notification_channel(
+            &saved
+        ));
+        assert!(
+            !crate::services::approval_service::user_requires_approval(&db, &previous_user_id)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/backend/src/handlers/device_tokens.rs
+++ b/backend/src/handlers/device_tokens.rs
@@ -3,6 +3,7 @@ use axum::{
     extract::{Path, State},
 };
 use chrono::Utc;
+use futures::TryStreamExt;
 use mongodb::Collection;
 use mongodb::bson::{self, Document, doc};
 use serde::{Deserialize, Serialize};
@@ -91,9 +92,9 @@ pub async fn register_device(
         .filter(|prev| *prev != body.token.as_str());
 
     // Ensure one push token belongs to one user at a time (prevents account-switch leakage).
-    detach_token_from_other_users(&collection, &user_id, &body.token, bson_now).await?;
+    detach_token_from_other_users(&state.db, &collection, &user_id, &body.token, bson_now).await?;
     if let Some(prev) = resolved_prev {
-        detach_token_from_other_users(&collection, &user_id, prev, bson_now).await?;
+        detach_token_from_other_users(&state.db, &collection, &user_id, prev, bson_now).await?;
     }
 
     // Rotation path: replace `previous_token` with the new token on the same device record.
@@ -106,19 +107,12 @@ pub async fn register_device(
         ensure_platform_matches(existing, &body.platform)?;
 
         let device_id = existing.device_id.clone();
-        let mut update_doc = doc! {
-            "push_devices.$.token": &body.token,
-            "push_devices.$.platform": &body.platform,
-            "push_devices.$.registered_at": bson_now,
-            "updated_at": bson_now,
-        };
-
-        if let Some(ref name) = body.device_name {
-            update_doc.insert("push_devices.$.device_name", name);
-        }
-        if let Some(ref app_id) = body.app_id {
-            update_doc.insert("push_devices.$.app_id", app_id);
-        }
+        let update_doc = device_metadata_update_doc(
+            bson_now,
+            Some((&body.token, &body.platform)),
+            body.device_name.as_deref(),
+            body.app_id.as_deref(),
+        );
 
         collection
             .update_one(
@@ -161,17 +155,12 @@ pub async fn register_device(
 
         // Update existing device metadata
         let device_id = existing.device_id.clone();
-        let mut update_doc = doc! {
-            "push_devices.$.registered_at": bson_now,
-            "updated_at": bson_now,
-        };
-
-        if let Some(ref name) = body.device_name {
-            update_doc.insert("push_devices.$.device_name", name);
-        }
-        if let Some(ref app_id) = body.app_id {
-            update_doc.insert("push_devices.$.app_id", app_id);
-        }
+        let update_doc = device_metadata_update_doc(
+            bson_now,
+            None,
+            body.device_name.as_deref(),
+            body.app_id.as_deref(),
+        );
 
         collection
             .update_one(
@@ -228,17 +217,7 @@ pub async fn register_device(
                 "push_devices.9": { "$exists": false },
                 "push_devices.token": { "$ne": &body.token },
             },
-            doc! {
-                "$push": {
-                    "push_devices": bson::to_bson(&device_token)
-                        .map_err(|e| AppError::Internal(format!("BSON serialize failed: {e}")))?
-                },
-                "$set": {
-                    "push_enabled": true,
-                    "approval_required": true,
-                    "updated_at": bson_now,
-                }
-            },
+            new_device_update_doc(&device_token, bson_now)?,
         )
         .await?;
 
@@ -254,16 +233,12 @@ pub async fn register_device(
             ensure_platform_matches(existing, &body.platform)?;
 
             // Token already exists (likely concurrent request) -- refresh metadata and return it.
-            let mut update_doc = doc! {
-                "push_devices.$.registered_at": bson_now,
-                "updated_at": bson_now,
-            };
-            if let Some(ref name) = body.device_name {
-                update_doc.insert("push_devices.$.device_name", name);
-            }
-            if let Some(ref app_id) = body.app_id {
-                update_doc.insert("push_devices.$.app_id", app_id);
-            }
+            let update_doc = device_metadata_update_doc(
+                bson_now,
+                None,
+                body.device_name.as_deref(),
+                body.app_id.as_deref(),
+            );
 
             collection
                 .update_one(
@@ -427,7 +402,11 @@ pub async fn remove_device(
         )
         .await?;
 
-    let approval_auto_disabled = channel.push_devices.len() == 1 && should_auto_disable_approval;
+    let approval_auto_disabled = channel
+        .push_devices
+        .iter()
+        .all(|device| device.device_id == device_id)
+        && should_auto_disable_approval;
 
     audit_service::log_for_user(
         state.db.clone(),
@@ -512,7 +491,11 @@ pub async fn remove_current_device(
         )
         .await?;
 
-    let approval_auto_disabled = channel.push_devices.len() == 1
+    let approval_auto_disabled = token_was_present
+        && channel
+            .push_devices
+            .iter()
+            .all(|device| device.token == body.token)
         && should_auto_disable_approval_after_last_push_device_removed(&channel);
 
     audit_service::log_for_user(
@@ -521,7 +504,7 @@ pub async fn remove_current_device(
         "push_device_removed_on_logout",
         Some(serde_json::json!({
             "platform": body.platform,
-            "token_removed": true,
+            "token_removed": token_was_present,
             "approval_auto_disabled": approval_auto_disabled,
         })),
     );
@@ -550,17 +533,21 @@ pub async fn remove_current_device(
 }
 
 async fn detach_token_from_other_users(
+    db: &mongodb::Database,
     collection: &Collection<NotificationChannel>,
     user_id: &str,
     token: &str,
     now: bson::DateTime,
 ) -> AppResult<()> {
+    let filter = doc! {
+        "user_id": { "$ne": user_id },
+        "push_devices.token": token,
+    };
+    let affected_channels: Vec<NotificationChannel> =
+        collection.find(filter.clone()).await?.try_collect().await?;
     let removed = collection
         .update_many(
-            doc! {
-                "user_id": { "$ne": user_id },
-                "push_devices.token": token,
-            },
+            filter,
             doc! {
                 "$pull": {
                     "push_devices": { "token": token }
@@ -591,26 +578,54 @@ async fn detach_token_from_other_users(
             .await?;
 
         // Avoid leaving approvals enabled for users who no longer have any
-        // active notification channels after token detachment.
-        collection
-            .update_many(
-                doc! {
-                    "user_id": { "$ne": user_id },
-                    "approval_required": true,
-                    "push_devices.0": { "$exists": false },
-                    "$or": [
-                        { "telegram_enabled": { "$ne": true } },
-                        { "telegram_chat_id": bson::Bson::Null },
-                    ],
-                },
-                doc! {
-                    "$set": {
-                        "approval_required": false,
-                        "updated_at": bson::DateTime::from_chrono(Utc::now()),
-                    }
-                },
-            )
-            .await?;
+        // active notification channels after token detachment. This is the
+        // lockout-prevention exception to the rule that registration never
+        // changes approval settings. Audit each actual auto-disable with
+        // metadata only; the push token itself is never recorded.
+        for channel in affected_channels.iter().filter(|channel| {
+            channel.approval_required
+                && !channel.push_devices.is_empty()
+                && channel
+                    .push_devices
+                    .iter()
+                    .all(|device| device.token == token)
+                && !telegram_channel_is_active(channel)
+        }) {
+            let result = collection
+                .update_one(
+                    doc! {
+                        "_id": &channel.id,
+                        "approval_required": true,
+                        "push_devices.0": { "$exists": false },
+                        "$or": [
+                            { "telegram_enabled": { "$ne": true } },
+                            { "telegram_chat_id": bson::Bson::Null },
+                        ],
+                    },
+                    doc! {
+                        "$set": {
+                            "approval_required": false,
+                            "updated_at": bson::DateTime::from_chrono(Utc::now()),
+                        }
+                    },
+                )
+                .await?;
+            if result.modified_count > 0 {
+                audit_service::log_async(
+                    db.clone(),
+                    Some(channel.user_id.clone()),
+                    "approval_auto_disabled_after_push_token_detach".to_string(),
+                    Some(serde_json::json!({
+                        "reason": "no_notification_channels",
+                        "detached_by_user_id": user_id,
+                    })),
+                    None,
+                    None,
+                    None,
+                    None,
+                );
+            }
+        }
     }
 
     Ok(())
@@ -640,6 +655,42 @@ async fn remove_duplicate_token_entries(
         )
         .await?;
     Ok(())
+}
+
+fn device_metadata_update_doc(
+    now: bson::DateTime,
+    token_and_platform: Option<(&str, &str)>,
+    device_name: Option<&str>,
+    app_id: Option<&str>,
+) -> Document {
+    let mut update = doc! {
+        "push_devices.$.registered_at": now,
+        "updated_at": now,
+    };
+    if let Some((token, platform)) = token_and_platform {
+        update.insert("push_devices.$.token", token);
+        update.insert("push_devices.$.platform", platform);
+    }
+    if let Some(name) = device_name {
+        update.insert("push_devices.$.device_name", name);
+    }
+    if let Some(app_id) = app_id {
+        update.insert("push_devices.$.app_id", app_id);
+    }
+    update
+}
+
+fn new_device_update_doc(device_token: &DeviceToken, now: bson::DateTime) -> AppResult<Document> {
+    Ok(doc! {
+        "$push": {
+            "push_devices": bson::to_bson(device_token)
+                .map_err(|e| AppError::Internal(format!("BSON serialize failed: {e}")))?
+        },
+        "$set": {
+            "push_enabled": true,
+            "updated_at": now,
+        }
+    })
 }
 
 // --- Validation ---
@@ -749,6 +800,7 @@ fn disable_push_update_doc(disable_approval: bool) -> Document {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::connect_test_database;
 
     #[test]
     fn validate_valid_fcm() {
@@ -1002,5 +1054,198 @@ mod tests {
         };
 
         assert!(!should_auto_disable_approval_after_last_push_device_removed(&channel));
+    }
+
+    #[tokio::test]
+    async fn registration_paths_leave_approval_required_untouched() {
+        let Some(db) = connect_test_database("device_registration_approval_untouched").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+
+        let old_device = DeviceToken {
+            device_id: "old-device".to_string(),
+            platform: "fcm".to_string(),
+            token: "old-token".to_string(),
+            device_name: None,
+            app_id: None,
+            registered_at: Utc::now(),
+            last_used_at: None,
+        };
+        let new_device = DeviceToken {
+            device_id: "new-device".to_string(),
+            platform: "fcm".to_string(),
+            token: "new-token".to_string(),
+            device_name: Some("new device".to_string()),
+            app_id: None,
+            registered_at: Utc::now(),
+            last_used_at: None,
+        };
+
+        for approval_required in [false, true] {
+            let paths = [
+                (
+                    "rotation",
+                    device_metadata_update_doc(
+                        bson::DateTime::from_chrono(Utc::now()),
+                        Some(("new-token", "fcm")),
+                        None,
+                        None,
+                    ),
+                    true,
+                ),
+                (
+                    "refresh",
+                    device_metadata_update_doc(
+                        bson::DateTime::from_chrono(Utc::now()),
+                        None,
+                        Some("refreshed"),
+                        None,
+                    ),
+                    true,
+                ),
+                (
+                    "concurrent-registration-recovery",
+                    device_metadata_update_doc(
+                        bson::DateTime::from_chrono(Utc::now()),
+                        None,
+                        None,
+                        Some("app-id"),
+                    ),
+                    true,
+                ),
+                (
+                    "new-device",
+                    new_device_update_doc(&new_device, bson::DateTime::from_chrono(Utc::now()))
+                        .unwrap(),
+                    false,
+                ),
+            ];
+
+            for (path, update, has_existing_device) in paths {
+                let update = if has_existing_device {
+                    doc! { "$set": update }
+                } else {
+                    update
+                };
+                let channel_id = uuid::Uuid::new_v4().to_string();
+                let user_id = uuid::Uuid::new_v4().to_string();
+                db.collection::<NotificationChannel>(COLLECTION_NAME)
+                    .insert_one(NotificationChannel {
+                        id: channel_id.clone(),
+                        user_id,
+                        telegram_chat_id: None,
+                        telegram_username: None,
+                        telegram_enabled: false,
+                        telegram_link_code: None,
+                        telegram_link_code_expires_at: None,
+                        approval_timeout_secs: 30,
+                        grant_expiry_days: 30,
+                        approval_required,
+                        push_enabled: has_existing_device,
+                        push_devices: if has_existing_device {
+                            vec![old_device.clone()]
+                        } else {
+                            vec![]
+                        },
+                        created_at: Utc::now(),
+                        updated_at: Utc::now(),
+                    })
+                    .await
+                    .unwrap();
+
+                let filter = if has_existing_device {
+                    doc! { "_id": &channel_id, "push_devices.token": "old-token" }
+                } else {
+                    doc! { "_id": &channel_id }
+                };
+                db.collection::<NotificationChannel>(COLLECTION_NAME)
+                    .update_one(filter, update)
+                    .await
+                    .unwrap_or_else(|error| panic!("{path} update failed: {error}"));
+
+                let saved = db
+                    .collection::<NotificationChannel>(COLLECTION_NAME)
+                    .find_one(doc! { "_id": &channel_id })
+                    .await
+                    .unwrap()
+                    .expect("registration channel");
+                assert_eq!(
+                    saved.approval_required, approval_required,
+                    "{path} path changed approval_required"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn detaching_last_device_auto_disables_previous_owner_approval() {
+        let Some(db) = connect_test_database("device_detach_auto_disable_approval").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let previous_user_id = uuid::Uuid::new_v4().to_string();
+        let registering_user_id = uuid::Uuid::new_v4().to_string();
+        let channel_id = uuid::Uuid::new_v4().to_string();
+        let device = DeviceToken {
+            device_id: "detached-device".to_string(),
+            platform: "fcm".to_string(),
+            token: "detached-token".to_string(),
+            device_name: None,
+            app_id: None,
+            registered_at: Utc::now(),
+            last_used_at: None,
+        };
+        let duplicate_device = DeviceToken {
+            device_id: "duplicate-device".to_string(),
+            ..device.clone()
+        };
+        db.collection::<NotificationChannel>(COLLECTION_NAME)
+            .insert_one(NotificationChannel {
+                id: channel_id.clone(),
+                user_id: previous_user_id.clone(),
+                telegram_chat_id: None,
+                telegram_username: None,
+                telegram_enabled: false,
+                telegram_link_code: None,
+                telegram_link_code_expires_at: None,
+                approval_timeout_secs: 30,
+                grant_expiry_days: 30,
+                approval_required: true,
+                push_enabled: true,
+                // `$pull` removes every matching token. Duplicate legacy rows
+                // must still count as losing the previous owner's last channel.
+                push_devices: vec![device, duplicate_device],
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let audit_written = crate::services::audit_service::notify_on_audit_write_for_user(
+            "approval_auto_disabled_after_push_token_detach",
+            previous_user_id.clone(),
+        );
+        let collection = db.collection::<NotificationChannel>(COLLECTION_NAME);
+        detach_token_from_other_users(
+            &db,
+            &collection,
+            &registering_user_id,
+            "detached-token",
+            bson::DateTime::from_chrono(Utc::now()),
+        )
+        .await
+        .unwrap();
+
+        let saved = collection
+            .find_one(doc! { "_id": &channel_id })
+            .await
+            .unwrap()
+            .expect("previous owner channel");
+        assert!(!saved.approval_required);
+        tokio::time::timeout(std::time::Duration::from_secs(5), audit_written)
+            .await
+            .expect("approval auto-disable audit timeout")
+            .expect("approval auto-disable audit writer dropped");
     }
 }

--- a/backend/src/handlers/device_tokens.rs
+++ b/backend/src/handlers/device_tokens.rs
@@ -287,10 +287,11 @@ pub async fn register_device(
         state.db.clone(),
         &auth_user,
         "push_device_registered",
-        Some(serde_json::json!({
-            "device_id": device_id,
-            "platform": body.platform,
-        })),
+        Some(push_device_registered_audit_metadata(
+            &channel,
+            &device_id,
+            &body.platform,
+        )),
     );
 
     // Telemetry: notification.device_registered (new-device path).
@@ -622,6 +623,19 @@ fn new_device_update_doc(device_token: &DeviceToken, now: bson::DateTime) -> App
             "push_enabled": true,
             "updated_at": now,
         }
+    })
+}
+
+fn push_device_registered_audit_metadata(
+    channel: &NotificationChannel,
+    device_id: &str,
+    platform: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "device_id": device_id,
+        "platform": platform,
+        "approval_resumed": channel.approval_required
+            && !notification_service::has_active_notification_channel(channel),
     })
 }
 
@@ -975,6 +989,48 @@ mod tests {
         assert!(notification_service::has_active_notification_channel(
             &channel
         ));
+    }
+
+    #[test]
+    fn new_push_device_audit_reports_approval_resumption_without_token() {
+        let channel = NotificationChannel {
+            id: uuid::Uuid::new_v4().to_string(),
+            user_id: uuid::Uuid::new_v4().to_string(),
+            telegram_chat_id: None,
+            telegram_username: None,
+            telegram_enabled: false,
+            telegram_link_code: None,
+            telegram_link_code_expires_at: None,
+            approval_timeout_secs: 30,
+            grant_expiry_days: 30,
+            approval_required: true,
+            push_enabled: false,
+            push_devices: vec![],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let metadata = push_device_registered_audit_metadata(&channel, "device-id", "fcm");
+
+        assert_eq!(metadata["approval_resumed"], true);
+        assert_eq!(metadata["device_id"], "device-id");
+        assert_eq!(metadata["platform"], "fcm");
+        assert!(metadata.get("token").is_none());
+
+        let mut already_active = channel.clone();
+        already_active.telegram_enabled = true;
+        already_active.telegram_chat_id = Some(1234);
+        assert_eq!(
+            push_device_registered_audit_metadata(&already_active, "device-id", "fcm")["approval_resumed"],
+            false
+        );
+
+        let mut approval_off = channel;
+        approval_off.approval_required = false;
+        assert_eq!(
+            push_device_registered_audit_metadata(&approval_off, "device-id", "fcm")["approval_resumed"],
+            false
+        );
     }
 
     #[tokio::test]

--- a/backend/src/handlers/llm_gateway.rs
+++ b/backend/src/handlers/llm_gateway.rs
@@ -288,6 +288,7 @@ pub async fn llm_proxy_request(
     // always None -- and then fall through to the legacy delegation path
     // with the "Provider ... connection required" error, even though the
     // user has a perfectly valid UserService linked by catalog_service_id.
+    let mut is_auto_connected_for_approval = false;
     let (target, resolved_via_user_service, master_credential, owner_for_approval) =
         match proxy_service::resolve_proxy_target_from_user_service(
             &state.db,
@@ -301,6 +302,7 @@ pub async fn llm_proxy_request(
         .await?
         {
             Some(resolution) => {
+                is_auto_connected_for_approval = resolution.is_auto_connected;
                 let effective_owner = resolution
                     .org_routing
                     .as_ref()
@@ -350,6 +352,7 @@ pub async fn llm_proxy_request(
             Some(&body_bytes)
         },
         owner_for_approval.as_deref(),
+        is_auto_connected_for_approval,
     )
     .await?;
 
@@ -649,6 +652,7 @@ pub async fn gateway_request(
     // resolutions the owner is the org's user_id, otherwise it falls
     // through to the actor.
     let mut effective_owner_for_approval: Option<String> = None;
+    let mut is_auto_connected_for_approval = false;
     // See `llm_proxy_request` for why we pass `None` as the slug here
     // instead of `provider_slug` -- the URL's provider slug does not
     // match UserService.slug, which is user-chosen at provision time.
@@ -665,6 +669,7 @@ pub async fn gateway_request(
         .await?
         {
             Some(resolution) => {
+                is_auto_connected_for_approval = resolution.is_auto_connected;
                 effective_owner_for_approval = Some(
                     resolution
                         .org_routing
@@ -767,6 +772,7 @@ pub async fn gateway_request(
             Some(&body_bytes)
         },
         effective_owner_for_approval.as_deref(),
+        is_auto_connected_for_approval,
     )
     .await?;
 
@@ -1611,6 +1617,7 @@ async fn preflight_llm_deny_before_resolution(
     .unwrap_or_else(|| proxy_service::ApprovalResolutionHint {
         service_id: service_id.to_string(),
         service_owner_id: approval_owner_user_id.clone(),
+        is_auto_connected: false,
     });
 
     let operation = operation_descriptor::build_llm_descriptor(method_str, path, body);
@@ -1620,6 +1627,7 @@ async fn preflight_llm_deny_before_resolution(
         &hint.service_owner_id,
         &hint.service_id,
         &operation,
+        hint.is_auto_connected,
     )
     .await?;
 
@@ -1642,6 +1650,7 @@ async fn check_llm_approval(
     method_str: &str,
     body: Option<&[u8]>,
     service_owner_user_id: Option<&str>,
+    is_auto_connected: bool,
 ) -> AppResult<()> {
     let approval_owner_user_id = auth_user.effective_approval_owner_user_id();
     let owner_for_resolution = service_owner_user_id.unwrap_or(&approval_owner_user_id);
@@ -1655,6 +1664,7 @@ async fn check_llm_approval(
         auth_user.approval_requester_type(),
         &auth_user.approval_requester_id(),
         auth_user.auth_method == crate::mw::auth::AuthMethod::Session,
+        is_auto_connected,
     )
     .await?;
 

--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -1581,6 +1581,7 @@ async fn authorize_mcp_operation(
         auth.approval_requester_type(),
         &auth.approval_requester_id(),
         auth.auth_method == AuthMethod::Session,
+        target.is_auto_connected,
     )
     .await
     .map_err(|e| {
@@ -2897,6 +2898,8 @@ async fn handle_mcp_ssh_exec(
             service_name: service.name,
             service_slug: service.slug,
             service_owner_user_id,
+            // SSH services are not auto-provisioned.
+            is_auto_connected: false,
         },
         &operation,
         request_id.clone(),

--- a/backend/src/handlers/notifications.rs
+++ b/backend/src/handlers/notifications.rs
@@ -21,6 +21,7 @@ pub struct NotificationSettingsResponse {
     pub telegram_username: Option<String>,
     pub telegram_enabled: bool,
     pub approval_required: bool,
+    pub approval_suspended: bool,
     pub approval_timeout_secs: u32,
     pub grant_expiry_days: u32,
     pub push_enabled: bool,
@@ -149,10 +150,7 @@ pub async fn update_settings(
         ));
     }
 
-    let resulting_approval_required = body.approval_required.unwrap_or(channel.approval_required);
-    if resulting_approval_required
-        && !has_enabled_notification_channel_after_update(&channel, &body)
-    {
+    if explicitly_enables_approval_without_active_channel(&channel, &body) {
         return Err(AppError::BadRequest(
             "Approval protection requires at least one enabled notification channel. Keep Telegram or push notifications enabled, or disable approval protection first.".to_string(),
         ));
@@ -197,6 +195,8 @@ pub async fn update_settings(
         Some(serde_json::json!({
             "telegram_enabled": updated.telegram_enabled,
             "approval_required": updated.approval_required,
+            "approval_suspended": updated.approval_required
+                && !notification_service::has_active_notification_channel(&updated),
             "approval_timeout_secs": updated.approval_timeout_secs,
             "grant_expiry_days": updated.grant_expiry_days,
             "push_enabled": updated.push_enabled,
@@ -282,11 +282,8 @@ pub async fn telegram_disconnect(
     let user_id = auth_user.user_id.to_string();
     let channel = notification_service::get_or_create_channel(&state.db, &user_id).await?;
 
-    // Auto-disable approval_required if no other notification channel remains
-    let no_push_channel = channel.push_devices.is_empty() || !channel.push_enabled;
-
     let now = bson::DateTime::from_chrono(Utc::now());
-    let mut set_doc = doc! {
+    let set_doc = doc! {
         "telegram_chat_id": bson::Bson::Null,
         "telegram_username": bson::Bson::Null,
         "telegram_enabled": false,
@@ -294,9 +291,6 @@ pub async fn telegram_disconnect(
         "telegram_link_code_expires_at": bson::Bson::Null,
         "updated_at": now,
     };
-    if no_push_channel {
-        set_doc.insert("approval_required", false);
-    }
 
     state
         .db
@@ -304,14 +298,16 @@ pub async fn telegram_disconnect(
         .update_one(doc! { "_id": &channel.id }, doc! { "$set": set_doc })
         .await?;
 
-    let approval_disabled = no_push_channel && channel.approval_required;
+    let updated_channel = notification_service::get_or_create_channel(&state.db, &user_id).await?;
+    let approval_suspended = updated_channel.approval_required
+        && !notification_service::has_active_notification_channel(&updated_channel);
 
     audit_service::log_for_user(
         state.db.clone(),
         &auth_user,
         "telegram_disconnected",
-        if approval_disabled {
-            Some(serde_json::json!({ "approval_auto_disabled": true }))
+        if approval_suspended {
+            Some(serde_json::json!({ "approval_suspended": true }))
         } else {
             None
         },
@@ -335,8 +331,8 @@ pub async fn telegram_disconnect(
         );
     }
 
-    let message = if approval_disabled {
-        "Telegram disconnected. Approval protection has been disabled because no notification channels remain.".to_string()
+    let message = if approval_suspended {
+        "Telegram disconnected. Approval protection is suspended until a notification channel is available; it resumes automatically.".to_string()
     } else {
         "Telegram disconnected".to_string()
     };
@@ -355,6 +351,8 @@ fn to_settings_response(channel: &NotificationChannel) -> NotificationSettingsRe
         telegram_username: channel.telegram_username.clone(),
         telegram_enabled: channel.telegram_enabled,
         approval_required: channel.approval_required,
+        approval_suspended: channel.approval_required
+            && !notification_service::has_active_notification_channel(channel),
         approval_timeout_secs: channel.approval_timeout_secs,
         grant_expiry_days: channel.grant_expiry_days,
         push_enabled: channel.push_enabled,
@@ -372,6 +370,15 @@ fn has_enabled_notification_channel_after_update(
 
     (telegram_enabled && channel.telegram_chat_id.is_some())
         || (push_enabled && !channel.push_devices.is_empty())
+}
+
+fn explicitly_enables_approval_without_active_channel(
+    channel: &NotificationChannel,
+    body: &UpdateNotificationSettingsRequest,
+) -> bool {
+    !channel.approval_required
+        && body.approval_required == Some(true)
+        && !has_enabled_notification_channel_after_update(channel, body)
 }
 
 #[cfg(test)]
@@ -420,13 +427,13 @@ mod tests {
             push_enabled: Some(true),
         };
 
-        assert!(has_enabled_notification_channel_after_update(
+        assert!(!explicitly_enables_approval_without_active_channel(
             &channel, &body
         ));
     }
 
     #[test]
-    fn rejects_disabling_last_channel_while_approval_stays_enabled() {
+    fn allows_disabling_last_channel_while_approval_preference_stays_enabled() {
         let mut channel = make_channel();
         channel.push_enabled = true;
         channel.approval_required = true;
@@ -444,13 +451,17 @@ mod tests {
 
         let body = UpdateNotificationSettingsRequest {
             telegram_enabled: None,
-            approval_required: None,
+            // The web form submits all values, including an unchanged `true`.
+            approval_required: Some(true),
             approval_timeout_secs: None,
             grant_expiry_days: None,
             push_enabled: Some(false),
         };
 
         assert!(!has_enabled_notification_channel_after_update(
+            &channel, &body
+        ));
+        assert!(!explicitly_enables_approval_without_active_channel(
             &channel, &body
         ));
     }
@@ -484,6 +495,25 @@ mod tests {
         assert!(!has_enabled_notification_channel_after_update(
             &channel, &body
         ));
+        assert!(!explicitly_enables_approval_without_active_channel(
+            &channel, &body
+        ));
+    }
+
+    #[test]
+    fn rejects_explicit_approval_enable_without_active_channel() {
+        let channel = make_channel();
+        let body = UpdateNotificationSettingsRequest {
+            telegram_enabled: None,
+            approval_required: Some(true),
+            approval_timeout_secs: None,
+            grant_expiry_days: None,
+            push_enabled: None,
+        };
+
+        assert!(explicitly_enables_approval_without_active_channel(
+            &channel, &body
+        ));
     }
 
     // --- Pure function tests: to_settings_response ---
@@ -497,6 +527,7 @@ mod tests {
         assert!(resp.telegram_username.is_none());
         assert!(!resp.telegram_enabled);
         assert!(!resp.approval_required);
+        assert!(!resp.approval_suspended);
         assert_eq!(resp.approval_timeout_secs, 30);
         assert_eq!(resp.grant_expiry_days, 30);
         assert!(!resp.push_enabled);
@@ -551,6 +582,7 @@ mod tests {
         let resp = to_settings_response(&channel);
 
         assert!(resp.approval_required);
+        assert!(resp.approval_suspended);
         assert_eq!(resp.approval_timeout_secs, 120);
         assert_eq!(resp.grant_expiry_days, 7);
     }
@@ -713,6 +745,7 @@ mod tests {
             telegram_username: Some("alice".to_string()),
             telegram_enabled: true,
             approval_required: false,
+            approval_suspended: false,
             approval_timeout_secs: 60,
             grant_expiry_days: 14,
             push_enabled: true,
@@ -725,6 +758,7 @@ mod tests {
         assert_eq!(json["telegram_username"], "alice");
         assert_eq!(json["telegram_enabled"], true);
         assert_eq!(json["approval_required"], false);
+        assert_eq!(json["approval_suspended"], false);
         assert_eq!(json["approval_timeout_secs"], 60);
         assert_eq!(json["grant_expiry_days"], 14);
         assert_eq!(json["push_enabled"], true);
@@ -740,6 +774,7 @@ mod tests {
             telegram_username: None,
             telegram_enabled: false,
             approval_required: false,
+            approval_suspended: false,
             approval_timeout_secs: 30,
             grant_expiry_days: 30,
             push_enabled: false,

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -555,6 +555,10 @@ struct PreResolved {
     /// lookups so the failover list reflects the org's bindings, not
     /// just the calling member's personal bindings.
     effective_owner_id: String,
+    /// Whether the resolved UserService is platform-managed and
+    /// auto-connected. This suppresses only the implicit global approval
+    /// fallback; explicit per-service policies remain in force.
+    is_auto_connected: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1021,6 +1025,7 @@ async fn proxy_request_inner(
                         .as_ref()
                         .map(|r| r.org_user_id.clone())
                         .unwrap_or_else(|| user_id_str.clone()),
+                    is_auto_connected: resolved.is_auto_connected,
                 }),
                 TargetMode::CallerAddressed,
                 Vec::new(),
@@ -1082,6 +1087,7 @@ async fn proxy_request_inner(
                     .as_ref()
                     .map(|r| r.org_user_id.clone())
                     .unwrap_or_else(|| user_id_str.clone()),
+                is_auto_connected: resolved.is_auto_connected,
             }),
             TargetMode::CallerAddressed,
             Vec::new(),
@@ -1250,6 +1256,7 @@ async fn proxy_request_by_slug_inner(
                         .as_ref()
                         .map(|r| r.org_user_id.clone())
                         .unwrap_or_else(|| user_id_str.clone()),
+                    is_auto_connected: resolved.is_auto_connected,
                 }),
                 TargetMode::CallerAddressed,
                 Vec::new(),
@@ -1311,6 +1318,7 @@ async fn proxy_request_by_slug_inner(
                     .as_ref()
                     .map(|r| r.org_user_id.clone())
                     .unwrap_or_else(|| user_id_str.clone()),
+                is_auto_connected: resolved.is_auto_connected,
             }),
             TargetMode::CallerAddressed,
             Vec::new(),
@@ -1708,12 +1716,14 @@ async fn preflight_proxy_deny_before_resolution(
         Some(proxy_service::ApprovalResolutionHint {
             service_id: service_id.to_string(),
             service_owner_id: approval_owner_user_id.clone(),
+            is_auto_connected: false,
         })
     } else if let Some(slug) = slug {
         let service = proxy_service::resolve_service_by_slug(&state.db, slug).await?;
         Some(proxy_service::ApprovalResolutionHint {
             service_id: service.id,
             service_owner_id: approval_owner_user_id.clone(),
+            is_auto_connected: false,
         })
     } else {
         None
@@ -1730,6 +1740,7 @@ async fn preflight_proxy_deny_before_resolution(
         &hint.service_owner_id,
         &hint.service_id,
         &operation,
+        hint.is_auto_connected,
     )
     .await?;
 
@@ -1804,6 +1815,7 @@ async fn execute_proxy_inner(
     // Captured outside the resolution match so the downstream approval
     // block can apply the org-aware cascade.
     let mut effective_owner_for_approval: Option<String> = None;
+    let mut is_auto_connected_for_approval = false;
 
     // Resolve target and node routing.
     //
@@ -1822,6 +1834,7 @@ async fn execute_proxy_inner(
         catalog_service_slug,
     ) = if let Some(mut pre) = pre_resolved {
         effective_owner_for_approval = Some(pre.effective_owner_id.clone());
+        is_auto_connected_for_approval = pre.is_auto_connected;
         // New UserService path: target already resolved.
         // Use the resolved service's effective owner (the org's user_id
         // for org-routed calls, the actor for personal) when looking up
@@ -2216,6 +2229,7 @@ async fn execute_proxy_inner(
         auth_user.approval_requester_type(),
         &auth_user.approval_requester_id(),
         auth_user.auth_method == crate::mw::auth::AuthMethod::Session,
+        is_auto_connected_for_approval,
     )
     .await?;
 

--- a/backend/src/handlers/ssh_tunnel.rs
+++ b/backend/src/handlers/ssh_tunnel.rs
@@ -1068,6 +1068,9 @@ pub(crate) async fn authorize_ssh_access_for_operation(
         auth_user.approval_requester_type(),
         &auth_user.approval_requester_id(),
         auth_user.auth_method == AuthMethod::Session,
+        // SSH services are not auto-provisioned today, so there is no
+        // auto-connected source to exempt from the global fallback here.
+        false,
     )
     .await?;
 

--- a/backend/src/models/notification_channel.rs
+++ b/backend/src/models/notification_channel.rs
@@ -71,8 +71,9 @@ pub struct NotificationChannel {
     #[serde(default = "default_grant_expiry_days")]
     pub grant_expiry_days: u32,
 
-    /// Whether approval is required for proxy/LLM requests using this user's
-    /// credentials. When false, all requests are auto-approved (legacy behavior).
+    /// The user's global approval-protection preference. Enforcement is suspended
+    /// while no active notification channel is available and resumes when one returns.
+    /// Explicit per-service approval configuration is evaluated independently.
     #[serde(default)]
     pub approval_required: bool,
 

--- a/backend/src/models/service_approval_config.rs
+++ b/backend/src/models/service_approval_config.rs
@@ -104,8 +104,10 @@ pub struct ApprovalRule {
 /// services (set `approval_required = false`). Conversely, when global is false,
 /// they can require approval for specific high-risk services.
 ///
-/// If no config exists for a (user, service) pair, the global
-/// `notification_channels.approval_required` setting applies.
+/// If no config exists for a (user, service) pair, the active global
+/// `notification_channels.approval_required` setting applies. That global default
+/// is suspended without a notification channel and exempted for auto-connected
+/// services; this explicit configuration remains authoritative in both cases.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ServiceApprovalConfig {
     /// UUID v4 string

--- a/backend/src/services/approval_service.rs
+++ b/backend/src/services/approval_service.rs
@@ -39,7 +39,8 @@ pub async fn resolve_approval_mode(
     Ok(per_service.map(|c| c.approval_mode).unwrap_or_default())
 }
 
-/// Check whether a user has the global approval system enabled.
+/// Check whether the user's global approval preference is currently enforceable.
+/// A stored opt-in is suspended while the user has no active notification channel.
 pub async fn user_requires_approval(db: &Database, user_id: &str) -> AppResult<bool> {
     Ok(user_global_approval_setting(db, user_id)
         .await?
@@ -62,7 +63,7 @@ pub async fn user_requires_approval(db: &Database, user_id: &str) -> AppResult<b
 ///    `primary_owner_user_id` is the org's user_id; grants live under the
 ///    org so the next call from the same actor reuses it.
 /// 2. Otherwise -- personal service, OR org-owned without an org policy --
-///    the actor's per-service or global setting applies (existing behavior).
+///    the actor's per-service config or active global setting applies.
 ///    The request `primary_owner_user_id` is the actor.
 /// 3. For an auto-connected `UserService`, the global setting is not an
 ///    implicit fallback. An explicit actor/org config still wins as above.
@@ -303,7 +304,8 @@ async fn user_global_approval_setting(db: &Database, user_id: &str) -> AppResult
         .collection::<NotificationChannel>(CHANNELS)
         .find_one(doc! { "user_id": user_id })
         .await?;
-    Ok(channel.map(|c| c.approval_required))
+    Ok(channel
+        .map(|c| c.approval_required && notification_service::has_active_notification_channel(&c)))
 }
 
 /// Pure resolution helper kept for unit-testable semantics. Used to be the
@@ -2596,9 +2598,9 @@ mod tests {
         NotificationChannel {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: user_id.to_string(),
-            telegram_chat_id: None,
-            telegram_username: None,
-            telegram_enabled: false,
+            telegram_chat_id: Some(1234),
+            telegram_username: Some("test".to_string()),
+            telegram_enabled: true,
             telegram_link_code: None,
             telegram_link_code_expires_at: None,
             approval_timeout_secs: 30,
@@ -2761,6 +2763,75 @@ mod tests {
 
         let result = user_requires_approval(&db, &user_id).await.unwrap();
         assert!(result);
+    }
+
+    #[tokio::test]
+    async fn suspended_global_approval_fails_open_and_resumes_when_channel_returns() {
+        let Some(db) = connect_test_database("appr_svc_suspended_global").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let mut channel = make_channel(&user_id, true);
+        channel.telegram_chat_id = None;
+        channel.telegram_username = None;
+        channel.telegram_enabled = false;
+        insert_channel(&db, &channel).await;
+
+        let operation = test_operation();
+        let suspended = evaluate_and_check(
+            &db,
+            &user_id,
+            &user_id,
+            &service_id,
+            &operation,
+            Some("api_key"),
+            "agent-1",
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            suspended,
+            ApprovalOutcome::Allowed { required: false }
+        ));
+        assert_eq!(
+            db.collection::<ApprovalRequest>(REQUESTS)
+                .count_documents(doc! {})
+                .await
+                .unwrap(),
+            0
+        );
+
+        db.collection::<NotificationChannel>(CHANNELS)
+            .update_one(
+                doc! { "_id": &channel.id },
+                doc! {
+                    "$set": {
+                        "telegram_enabled": true,
+                        "telegram_chat_id": 1234_i64,
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        let resumed = evaluate_and_check(
+            &db,
+            &user_id,
+            &user_id,
+            &service_id,
+            &operation,
+            Some("api_key"),
+            "agent-1",
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(resumed, ApprovalOutcome::NeedsApproval(_)));
     }
 
     // --- check_approval ---
@@ -3518,7 +3589,11 @@ mod tests {
             return;
         };
         let actor_id = uuid::Uuid::new_v4().to_string();
-        insert_channel(&db, &make_channel(&actor_id, true)).await;
+        let mut suspended_channel = make_channel(&actor_id, true);
+        suspended_channel.telegram_chat_id = None;
+        suspended_channel.telegram_username = None;
+        suspended_channel.telegram_enabled = false;
+        insert_channel(&db, &suspended_channel).await;
 
         let cases = [
             (false, None, ApprovalEffect::AutoAllow, false),

--- a/backend/src/services/approval_service.rs
+++ b/backend/src/services/approval_service.rs
@@ -64,6 +64,8 @@ pub async fn user_requires_approval(db: &Database, user_id: &str) -> AppResult<b
 /// 2. Otherwise -- personal service, OR org-owned without an org policy --
 ///    the actor's per-service or global setting applies (existing behavior).
 ///    The request `primary_owner_user_id` is the actor.
+/// 3. For an auto-connected `UserService`, the global setting is not an
+///    implicit fallback. An explicit actor/org config still wins as above.
 ///
 /// This is the cleanest semantic: the resource owner's policy is
 /// authoritative when set, and falls back to the actor's preference when
@@ -110,6 +112,7 @@ pub async fn resolve_org_aware_approval(
     service_owner_user_id: &str,
     service_id: &str,
     descriptor: &OperationDescriptor,
+    is_auto_connected: bool,
 ) -> AppResult<ApprovalResolution> {
     // Step 1: if the resolved service is org-owned and the org has a
     // policy, use it. We detect "org-owned" by looking up the owner's
@@ -158,7 +161,16 @@ pub async fn resolve_org_aware_approval(
             decision.grant_scope,
         )
     } else {
-        let required = user_requires_approval(db, actor_user_id).await?;
+        // Auto-connected services are platform-managed and deliberately have
+        // no user credential. The global notification setting is an implicit
+        // fallback, so it must not turn these services into approval gates.
+        // Explicit actor/org ServiceApprovalConfig rows are handled above and
+        // still apply verbatim.
+        let required = if is_auto_connected {
+            false
+        } else {
+            user_requires_approval(db, actor_user_id).await?
+        };
         (
             required,
             ApprovalMode::default(),
@@ -187,6 +199,7 @@ pub async fn evaluate_deny_only(
     service_owner_user_id: &str,
     service_id: &str,
     descriptor: &OperationDescriptor,
+    is_auto_connected: bool,
 ) -> AppResult<bool> {
     let resolution = resolve_org_aware_approval(
         db,
@@ -194,6 +207,7 @@ pub async fn evaluate_deny_only(
         service_owner_user_id,
         service_id,
         descriptor,
+        is_auto_connected,
     )
     .await?;
     Ok(resolution.effect == ApprovalEffect::Deny)
@@ -209,6 +223,7 @@ pub async fn evaluate_and_check(
     requester_type: Option<&str>,
     requester_id: &str,
     bypass_approval_flow: bool,
+    is_auto_connected: bool,
 ) -> AppResult<ApprovalOutcome> {
     let resolution = resolve_org_aware_approval(
         db,
@@ -216,6 +231,7 @@ pub async fn evaluate_and_check(
         service_owner_user_id,
         service_id,
         descriptor,
+        is_auto_connected,
     )
     .await?;
 
@@ -3360,10 +3376,16 @@ mod tests {
         insert_config(&db, &actor_config).await;
 
         let operation = test_operation();
-        let resolution =
-            resolve_org_aware_approval(&db, &actor_id, &org_user_id, &service_id, &operation)
-                .await
-                .unwrap();
+        let resolution = resolve_org_aware_approval(
+            &db,
+            &actor_id,
+            &org_user_id,
+            &service_id,
+            &operation,
+            false,
+        )
+        .await
+        .unwrap();
         assert!(resolution.required);
         assert_eq!(resolution.mode, ApprovalMode::Grant);
         assert_eq!(resolution.primary_owner_user_id, actor_id);
@@ -3392,10 +3414,16 @@ mod tests {
         insert_config(&db, &org_config).await;
 
         let operation = test_operation();
-        let resolution =
-            resolve_org_aware_approval(&db, &actor_id, &org_user_id, &service_id, &operation)
-                .await
-                .unwrap();
+        let resolution = resolve_org_aware_approval(
+            &db,
+            &actor_id,
+            &org_user_id,
+            &service_id,
+            &operation,
+            false,
+        )
+        .await
+        .unwrap();
         assert!(resolution.required);
         assert_eq!(resolution.mode, ApprovalMode::Grant);
         assert_eq!(resolution.primary_owner_user_id, org_user_id);
@@ -3424,13 +3452,144 @@ mod tests {
 
         let operation = test_operation();
         let resolution =
-            resolve_org_aware_approval(&db, &actor_id, &actor_id, &service_id, &operation)
+            resolve_org_aware_approval(&db, &actor_id, &actor_id, &service_id, &operation, false)
                 .await
                 .unwrap();
         assert!(resolution.required);
         assert_eq!(resolution.mode, ApprovalMode::default());
         assert_eq!(resolution.primary_owner_user_id, actor_id);
         assert!(!resolution.from_org_policy);
+    }
+
+    #[tokio::test]
+    async fn resolve_org_aware_approval_skips_global_default_for_auto_connected_service() {
+        let Some(db) = connect_test_database("appr_svc_auto_global_default").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        insert_channel(&db, &make_channel(&actor_id, true)).await;
+
+        let resolution = resolve_org_aware_approval(
+            &db,
+            &actor_id,
+            &actor_id,
+            &service_id,
+            &test_operation(),
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(!resolution.required);
+        assert_eq!(resolution.effect, ApprovalEffect::AutoAllow);
+
+        let outcome = evaluate_and_check(
+            &db,
+            &actor_id,
+            &actor_id,
+            &service_id,
+            &test_operation(),
+            Some("api_key"),
+            "agent-1",
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            outcome,
+            ApprovalOutcome::Allowed { required: false }
+        ));
+        assert_eq!(
+            db.collection::<ApprovalRequest>(REQUESTS)
+                .count_documents(doc! {})
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_org_aware_approval_keeps_explicit_actor_config_for_auto_connected_service() {
+        let Some(db) = connect_test_database("appr_svc_auto_explicit_config").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        insert_channel(&db, &make_channel(&actor_id, true)).await;
+
+        let cases = [
+            (false, None, ApprovalEffect::AutoAllow, false),
+            (true, None, ApprovalEffect::RequireApproval, true),
+            (
+                false,
+                Some(ApprovalEffect::Deny),
+                ApprovalEffect::Deny,
+                false,
+            ),
+        ];
+        for (approval_required, default_effect, expected_effect, expected_required) in cases {
+            let service_id = uuid::Uuid::new_v4().to_string();
+            let mut config = make_service_config(
+                &actor_id,
+                &service_id,
+                approval_required,
+                ApprovalMode::PerRequest,
+            );
+            config.default_effect = default_effect;
+            insert_config(&db, &config).await;
+
+            let resolution = resolve_org_aware_approval(
+                &db,
+                &actor_id,
+                &actor_id,
+                &service_id,
+                &test_operation(),
+                true,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(resolution.required, expected_required);
+            assert_eq!(resolution.effect, expected_effect);
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_org_aware_approval_keeps_explicit_org_config_for_auto_connected_service() {
+        let Some(db) = connect_test_database("appr_svc_auto_explicit_org_config").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        let org_user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        db.collection::<User>(USERS)
+            .insert_one(test_user(&org_user_id, UserType::Org))
+            .await
+            .unwrap();
+
+        let mut org_config =
+            make_service_config(&org_user_id, &service_id, false, ApprovalMode::PerRequest);
+        org_config.default_effect = Some(ApprovalEffect::Deny);
+        insert_config(&db, &org_config).await;
+
+        let resolution = resolve_org_aware_approval(
+            &db,
+            &actor_id,
+            &org_user_id,
+            &service_id,
+            &test_operation(),
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(!resolution.required);
+        assert_eq!(resolution.effect, ApprovalEffect::Deny);
+        assert!(resolution.from_org_policy);
     }
 
     // --- list_grants ---

--- a/backend/src/services/exact_service_approval_service.rs
+++ b/backend/src/services/exact_service_approval_service.rs
@@ -1914,6 +1914,8 @@ mod tests {
             operation_digest: &binding.operation_digest,
             operation_generation: binding.operation_generation,
         }
+    }
+
     #[tokio::test]
     async fn exact_auto_connected_global_default_is_not_required() {
         let Some(db) = crate::test_utils::connect_test_database("exact_auto_global_default").await

--- a/backend/src/services/exact_service_approval_service.rs
+++ b/backend/src/services/exact_service_approval_service.rs
@@ -235,6 +235,7 @@ pub async fn create_request(
         Some(&caller.requester_type),
         &caller.requester_id,
         false,
+        approval_target.is_auto_connected,
     )
     .await?
     {
@@ -1206,6 +1207,7 @@ struct ApprovalTarget {
     service_name: String,
     service_slug: String,
     service_owner_user_id: String,
+    is_auto_connected: bool,
 }
 
 async fn approval_target(
@@ -1237,6 +1239,7 @@ async fn approval_target(
         service_name: service.service_name.clone(),
         service_slug: service.service_slug.clone(),
         service_owner_user_id: hint.service_owner_id,
+        is_auto_connected: hint.is_auto_connected,
     })
 }
 
@@ -1469,6 +1472,7 @@ async fn approval_policy_is_live(
             Some(&caller.requester_type),
             &caller.requester_id,
             false,
+            target.is_auto_connected,
         )
         .await?,
         approval_service::ApprovalOutcome::NeedsApproval(pending)
@@ -1723,6 +1727,82 @@ mod tests {
         }
     }
 
+    fn caller_for(user_id: &str) -> ExactServiceApprovalCaller {
+        let mut value = caller();
+        value.actor_user_id = user_id.to_string();
+        value.proxy_resolution_user_id = user_id.to_string();
+        value.approval_owner_user_id = user_id.to_string();
+        value
+    }
+
+    fn exact_test_service(
+        user_service_id: &str,
+        owner_id: &str,
+        catalog_service_id: &str,
+        slug: &str,
+    ) -> mcp_service::McpToolService {
+        mcp_service::McpToolService {
+            service_id: catalog_service_id.to_string(),
+            service_name: "Exact test service".to_string(),
+            service_slug: slug.to_string(),
+            description: None,
+            service_category: "user_service".to_string(),
+            endpoints: Vec::new(),
+            durable_endpoint_metadata: HashMap::new(),
+            source: mcp_service::McpToolSource::UserManaged {
+                user_service_id: user_service_id.to_string(),
+                catalog_service_id: Some(catalog_service_id.to_string()),
+                effective_owner_id: owner_id.to_string(),
+                node_id: None,
+                has_server_credential: true,
+            },
+            executable: true,
+            is_generic_proxy: false,
+            invalid_openapi_contract: false,
+            recommended_skills: Vec::new(),
+            proxy_operation_policy: None,
+        }
+    }
+
+    async fn insert_exact_test_service(
+        db: &Database,
+        owner_id: &str,
+        user_service_id: &str,
+        catalog_service_id: &str,
+        slug: &str,
+        source: Option<&str>,
+    ) {
+        let endpoint_id = uuid::Uuid::new_v4().to_string();
+        db.collection::<crate::models::user_endpoint::UserEndpoint>(
+            crate::models::user_endpoint::COLLECTION_NAME,
+        )
+        .insert_one(crate::test_utils::test_user_endpoint(
+            &endpoint_id,
+            owner_id,
+            "Exact test service",
+            "https://exact.invalid",
+            None,
+            Some(catalog_service_id),
+        ))
+        .await
+        .unwrap();
+        let mut service = crate::test_utils::test_user_service(
+            user_service_id,
+            owner_id,
+            slug,
+            &endpoint_id,
+            Some(catalog_service_id),
+            None,
+        );
+        service.source = source.map(str::to_string);
+        db.collection::<crate::models::user_service::UserService>(
+            crate::models::user_service::COLLECTION_NAME,
+        )
+        .insert_one(service)
+        .await
+        .unwrap();
+    }
+
     fn create() -> ExactServiceApprovalCreate {
         ExactServiceApprovalCreate {
             user_service_id: "service-alpha".to_string(),
@@ -1834,6 +1914,147 @@ mod tests {
             operation_digest: &binding.operation_digest,
             operation_generation: binding.operation_generation,
         }
+    #[tokio::test]
+    async fn exact_auto_connected_global_default_is_not_required() {
+        let Some(db) = crate::test_utils::connect_test_database("exact_auto_global_default").await
+        else {
+            return;
+        };
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        let user_service_id = uuid::Uuid::new_v4().to_string();
+        let catalog_service_id = uuid::Uuid::new_v4().to_string();
+        let slug = "exact-auto-global";
+        insert_exact_test_service(
+            &db,
+            &actor_id,
+            &user_service_id,
+            &catalog_service_id,
+            slug,
+            Some(crate::models::user_service::AUTO_PROVISION_SOURCE),
+        )
+        .await;
+        let channel = crate::models::notification_channel::NotificationChannel {
+            id: uuid::Uuid::new_v4().to_string(),
+            user_id: actor_id.clone(),
+            telegram_chat_id: Some(1234),
+            telegram_username: Some("exact-test".to_string()),
+            telegram_enabled: true,
+            telegram_link_code: None,
+            telegram_link_code_expires_at: None,
+            approval_timeout_secs: 30,
+            grant_expiry_days: 30,
+            approval_required: true,
+            push_enabled: false,
+            push_devices: Vec::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        db.collection::<crate::models::notification_channel::NotificationChannel>(
+            crate::models::notification_channel::COLLECTION_NAME,
+        )
+        .insert_one(channel)
+        .await
+        .unwrap();
+
+        let service = exact_test_service(&user_service_id, &actor_id, &catalog_service_id, slug);
+        let caller = caller_for(&actor_id);
+        let target = approval_target(
+            &crate::test_utils::test_app_state(db.clone()),
+            &caller,
+            &service,
+        )
+        .await
+        .unwrap();
+        let outcome = approval_service::evaluate_and_check(
+            &db,
+            &actor_id,
+            &target.service_owner_user_id,
+            &target.service_id,
+            &crate::services::operation_descriptor::build_mcp_descriptor("POST", "/items", None),
+            Some("delegated"),
+            "exact-client",
+            false,
+            target.is_auto_connected,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            outcome,
+            approval_service::ApprovalOutcome::Allowed { required: false }
+        ));
+        assert_eq!(
+            db.collection::<ApprovalRequest>(REQUESTS)
+                .count_documents(doc! {})
+                .await
+                .unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_auto_connected_explicit_per_service_config_still_requires_approval() {
+        let Some(db) = crate::test_utils::connect_test_database("exact_auto_explicit_config").await
+        else {
+            return;
+        };
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        let user_service_id = uuid::Uuid::new_v4().to_string();
+        let catalog_service_id = uuid::Uuid::new_v4().to_string();
+        let slug = "exact-auto-explicit";
+        insert_exact_test_service(
+            &db,
+            &actor_id,
+            &user_service_id,
+            &catalog_service_id,
+            slug,
+            Some(crate::models::user_service::AUTO_PROVISION_SOURCE),
+        )
+        .await;
+        let now = Utc::now();
+        db.collection::<crate::models::service_approval_config::ServiceApprovalConfig>(
+            crate::models::service_approval_config::COLLECTION_NAME,
+        )
+        .insert_one(
+            crate::models::service_approval_config::ServiceApprovalConfig {
+                id: uuid::Uuid::new_v4().to_string(),
+                user_id: actor_id.clone(),
+                service_id: catalog_service_id.clone(),
+                service_name: "Exact test service".to_string(),
+                approval_required: true,
+                approval_mode: ApprovalMode::PerRequest,
+                rules: Vec::new(),
+                default_effect: None,
+                created_at: now,
+                updated_at: now,
+            },
+        )
+        .await
+        .unwrap();
+
+        let service = exact_test_service(&user_service_id, &actor_id, &catalog_service_id, slug);
+        let caller = caller_for(&actor_id);
+        let state = crate::test_utils::test_app_state(db.clone());
+        let target = approval_target(&state, &caller, &service).await.unwrap();
+        let outcome = approval_service::evaluate_and_check(
+            &db,
+            &actor_id,
+            &target.service_owner_user_id,
+            &target.service_id,
+            &crate::services::operation_descriptor::build_mcp_descriptor("POST", "/items", None),
+            Some("delegated"),
+            "exact-client",
+            false,
+            target.is_auto_connected,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            outcome,
+            approval_service::ApprovalOutcome::NeedsApproval(pending)
+                if pending.resolution.mode == ApprovalMode::PerRequest
+        ));
     }
 
     fn approval_request(

--- a/backend/src/services/mcp_approval.rs
+++ b/backend/src/services/mcp_approval.rs
@@ -47,6 +47,7 @@ pub(crate) async fn approval_target_for_tool(
         .unwrap_or_else(|| proxy_service::ApprovalResolutionHint {
             service_id: downstream_service_id.clone(),
             service_owner_id: effective_approval_owner_user_id.to_string(),
+            is_auto_connected: false,
         }),
     };
 
@@ -206,6 +207,7 @@ mod tests {
                     &target.service_owner_user_id,
                     &target.service_id,
                     &operation,
+                    target.is_auto_connected,
                 )
                 .await
                 .unwrap(),

--- a/backend/src/services/mcp_approval.rs
+++ b/backend/src/services/mcp_approval.rs
@@ -9,6 +9,7 @@ pub(crate) struct McpApprovalTarget {
     pub(crate) service_name: String,
     pub(crate) service_slug: String,
     pub(crate) service_owner_user_id: String,
+    pub(crate) is_auto_connected: bool,
 }
 
 /// Resolve the approval policy identity for a loaded MCP service.
@@ -54,6 +55,7 @@ pub(crate) async fn approval_target_for_tool(
         service_name: service.service_name.clone(),
         service_slug: service.service_slug.clone(),
         service_owner_user_id: hint.service_owner_id,
+        is_auto_connected: hint.is_auto_connected,
     })
 }
 
@@ -70,6 +72,7 @@ mod tests {
     use crate::models::user::{COLLECTION_NAME as USERS, User, UserType};
     use crate::models::user_endpoint::{COLLECTION_NAME as USER_ENDPOINTS, UserEndpoint};
     use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
+    use mongodb::bson::doc;
 
     fn loaded_user_service(id: &str, owner_id: &str, slug: &str) -> mcp_service::McpToolService {
         mcp_service::McpToolService {
@@ -209,5 +212,47 @@ mod tests {
                 "approval target must yield denied_by_policy for org_owned={org_owned}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn auto_provisioned_mcp_target_carries_auto_connected_hint() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("mcp_auto_connected_approval_target").await
+        else {
+            eprintln!(
+                "skipping MCP auto-connected approval target test: no local MongoDB available"
+            );
+            return;
+        };
+
+        let actor_id = uuid::Uuid::new_v4().to_string();
+        let catalog_id = uuid::Uuid::new_v4().to_string();
+        let user_service_id = uuid::Uuid::new_v4().to_string();
+        let slug = "auto-mcp-service";
+        insert_deny_fixture(
+            &db,
+            &actor_id,
+            &actor_id,
+            &catalog_id,
+            &user_service_id,
+            slug,
+            false,
+        )
+        .await;
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &user_service_id },
+                doc! { "$set": { "source": crate::models::user_service::AUTO_PROVISION_SOURCE } },
+            )
+            .await
+            .unwrap();
+
+        let service = loaded_user_service(&user_service_id, &actor_id, slug);
+        let target = approval_target_for_tool(&db, &actor_id, &service)
+            .await
+            .unwrap();
+
+        assert_eq!(target.service_id, catalog_id);
+        assert!(target.is_auto_connected);
     }
 }

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -5993,6 +5993,65 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn discover_services_excludes_auto_provisioned_user_service() {
+        let Some(db) = connect_test_database("mcp_discover_auto_user_service").await else {
+            eprintln!("skipping MCP auto-provision discovery test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let catalog_id = uuid::Uuid::new_v4().to_string();
+        let user_service_id = uuid::Uuid::new_v4().to_string();
+        let endpoint_id = uuid::Uuid::new_v4().to_string();
+
+        let mut catalog = dummy_service();
+        catalog.id = catalog_id.clone();
+        catalog.slug = "auto-provisioned-catalog".to_string();
+        catalog.requires_user_credential = false;
+        db.collection::<DownstreamService>(DOWNSTREAM_SERVICES)
+            .insert_one(catalog)
+            .await
+            .expect("insert auto catalog service");
+
+        db.collection::<UserEndpoint>(USER_ENDPOINTS)
+            .insert_one(test_user_endpoint(
+                &endpoint_id,
+                &user_id,
+                "Auto service",
+                "https://auto.example.com",
+                None,
+                Some(&catalog_id),
+            ))
+            .await
+            .expect("insert auto endpoint");
+        let mut user_service = test_user_service(
+            &user_service_id,
+            &user_id,
+            "auto-service",
+            &endpoint_id,
+            Some(&catalog_id),
+            None,
+        );
+        user_service.source = Some(crate::models::user_service::AUTO_PROVISION_SOURCE.to_string());
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(user_service)
+            .await
+            .expect("insert auto user service");
+
+        let discovered = discover_services(&db, &user_id, None, Some("connection"))
+            .await
+            .expect("discover services");
+        let discovered_ids: Vec<&str> = discovered["services"]
+            .as_array()
+            .expect("services array")
+            .iter()
+            .filter_map(|service| service["service_id"].as_str())
+            .collect();
+        assert!(!discovered_ids.contains(&catalog_id.as_str()));
+        assert!(!discovered_ids.contains(&user_service_id.as_str()));
+    }
+
     // -- generate_tool_definitions tests --
 
     #[test]
@@ -8072,6 +8131,7 @@ mod tests {
                 membership_id: "membership".to_string(),
             }),
             pool_selection: None,
+            is_auto_connected: false,
         }
     }
 

--- a/backend/src/services/notification_service.rs
+++ b/backend/src/services/notification_service.rs
@@ -20,6 +20,14 @@ pub struct NotificationResult {
     pub telegram_message_id: Option<i64>,
 }
 
+/// Return whether at least one notification channel can currently receive an
+/// approval request. This is a delivery fact, separate from the user's stored
+/// approval preference.
+pub fn has_active_notification_channel(channel: &NotificationChannel) -> bool {
+    (channel.telegram_enabled && channel.telegram_chat_id.is_some())
+        || (channel.push_enabled && !channel.push_devices.is_empty())
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DeviceNotificationTemplate {
     BindSuccess,
@@ -1040,27 +1048,6 @@ async fn remove_stale_device_tokens(db: &Database, channel_id: &str, device_ids:
                         },
                     )
                     .await;
-
-                let _ = db
-                    .collection::<NotificationChannel>(COLLECTION_NAME)
-                    .update_one(
-                        doc! {
-                            "_id": channel_id,
-                            "approval_required": true,
-                            "push_devices.0": { "$exists": false },
-                            "$or": [
-                                { "telegram_enabled": { "$ne": true } },
-                                { "telegram_chat_id": bson::Bson::Null },
-                            ],
-                        },
-                        doc! {
-                            "$set": {
-                                "approval_required": false,
-                                "updated_at": bson::DateTime::from_chrono(chrono::Utc::now()),
-                            }
-                        },
-                    )
-                    .await;
             }
         }
         Err(e) => tracing::warn!("Failed to remove stale device tokens: {e}"),
@@ -1491,6 +1478,43 @@ mod tests {
         let updated = get_or_create_channel(&db, &user_id).await.unwrap();
         assert!(updated.push_devices.is_empty());
         assert!(!updated.push_enabled);
+    }
+
+    #[tokio::test]
+    async fn remove_stale_device_tokens_preserves_approval_preference() {
+        let Some(db) = connect_test_database("notif_svc_rm_stale_approval").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let channel = get_or_create_channel(&db, &user_id).await.unwrap();
+        let device = make_device("dev-only", "fcm", "token-only");
+        let device_doc = bson::to_bson(&device).unwrap();
+        db.collection::<NotificationChannel>(COLLECTION_NAME)
+            .update_one(
+                doc! { "_id": &channel.id },
+                doc! {
+                    "$set": {
+                        "approval_required": true,
+                        "push_enabled": true,
+                        "push_devices": [device_doc],
+                    }
+                },
+            )
+            .await
+            .unwrap();
+
+        remove_stale_device_tokens(&db, &channel.id, &["dev-only".to_string()]).await;
+
+        let updated = get_or_create_channel(&db, &user_id).await.unwrap();
+        assert!(updated.approval_required);
+        assert!(updated.push_devices.is_empty());
+        assert!(!updated.push_enabled);
+        assert!(
+            !crate::services::approval_service::user_requires_approval(&db, &user_id)
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1283,12 +1283,18 @@ pub struct UserServiceResolution {
     /// Set when a slug resolved through a `ServicePool` before selecting
     /// the concrete `UserService` member.
     pub pool_selection: Option<service_pool_service::PoolSelection>,
+    /// True when the resolved UserService is a platform-managed,
+    /// credential-free auto-provisioned catalog service. Approval resolution
+    /// uses this only to suppress the implicit global default; explicit
+    /// per-service policies remain authoritative.
+    pub is_auto_connected: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApprovalResolutionHint {
     pub service_id: String,
     pub service_owner_id: String,
+    pub is_auto_connected: bool,
 }
 
 /// Audit metadata for proxy calls that resolved through an org membership
@@ -2188,6 +2194,7 @@ async fn legacy_approval_hint(
         return Ok(Some(ApprovalResolutionHint {
             service_id: service_id.to_string(),
             service_owner_id: actor_user_id.to_string(),
+            is_auto_connected: false,
         }));
     }
 
@@ -2196,6 +2203,7 @@ async fn legacy_approval_hint(
         return Ok(Some(ApprovalResolutionHint {
             service_id: service.id,
             service_owner_id: actor_user_id.to_string(),
+            is_auto_connected: false,
         }));
     }
 
@@ -2209,6 +2217,7 @@ fn approval_hint_from_user_service(user_service: &UserService) -> ApprovalResolu
             .clone()
             .unwrap_or_else(|| user_service.id.clone()),
         service_owner_id: user_service.user_id.clone(),
+        is_auto_connected: user_service.source.as_deref() == Some(AUTO_PROVISION_SOURCE),
     }
 }
 
@@ -2447,6 +2456,7 @@ async fn finish_resolution(
             master_credential: false,
             org_routing,
             pool_selection,
+            is_auto_connected: user_service.source.as_deref() == Some(AUTO_PROVISION_SOURCE),
         });
     }
 
@@ -2509,6 +2519,7 @@ async fn finish_resolution(
             master_credential: true,
             org_routing,
             pool_selection,
+            is_auto_connected: user_service.source.as_deref() == Some(AUTO_PROVISION_SOURCE),
         });
     }
 
@@ -2601,6 +2612,7 @@ async fn finish_resolution(
             master_credential: false,
             org_routing,
             pool_selection,
+            is_auto_connected: user_service.source.as_deref() == Some(AUTO_PROVISION_SOURCE),
         });
     }
 
@@ -2662,6 +2674,7 @@ async fn finish_resolution(
         master_credential: false,
         org_routing,
         pool_selection,
+        is_auto_connected: user_service.source.as_deref() == Some(AUTO_PROVISION_SOURCE),
     })
 }
 

--- a/backend/src/services/telegram_poller.rs
+++ b/backend/src/services/telegram_poller.rs
@@ -222,18 +222,12 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
         return;
     }
 
-    // Update the channel with the Telegram details and auto-enable approval
+    // Link Telegram without changing the user's global approval preference.
+    // Approval protection is enabled only through the explicit notification
+    // settings endpoint; linking a delivery channel must not opt the user in.
     let now = bson::DateTime::from_chrono(chrono::Utc::now());
     let update = doc! {
-        "$set": {
-            "telegram_chat_id": chat_id,
-            "telegram_username": &username,
-            "telegram_enabled": true,
-            "approval_required": true,
-            "telegram_link_code": bson::Bson::Null,
-            "telegram_link_code_expires_at": bson::Bson::Null,
-            "updated_at": now,
-        }
+        "$set": telegram_link_update_fields(chat_id, &username, now)
     };
 
     match collection
@@ -245,7 +239,7 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
                 &state.http_client,
                 bot_token,
                 chat_id,
-                "Your Telegram account has been linked to NyxID. Global approval protection has been enabled, and services without per-service overrides will now send approval requests here.",
+                "Your Telegram account has been linked to NyxID. Approval protection remains controlled by your notification settings.",
             )
             .await;
 
@@ -256,7 +250,6 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
                 Some(serde_json::json!({
                     "telegram_username": username,
                     "telegram_chat_id": chat_id,
-                    "approval_auto_enabled": true,
                 })),
                 None,
                 None,
@@ -274,6 +267,21 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
             )
             .await;
         }
+    }
+}
+
+fn telegram_link_update_fields(
+    chat_id: i64,
+    username: &Option<String>,
+    now: bson::DateTime,
+) -> bson::Document {
+    doc! {
+        "telegram_chat_id": chat_id,
+        "telegram_username": username,
+        "telegram_enabled": true,
+        "telegram_link_code": bson::Bson::Null,
+        "telegram_link_code_expires_at": bson::Bson::Null,
+        "updated_at": now,
     }
 }
 
@@ -333,5 +341,21 @@ mod tests {
             decision_callback_message(&error),
             "Server error, please try again"
         );
+    }
+
+    #[test]
+    fn telegram_link_update_preserves_approval_preference() {
+        let update =
+            telegram_link_update_fields(1234, &Some("nyx".to_string()), bson::DateTime::now());
+
+        assert!(!update.contains_key("approval_required"));
+        for approval_required in [false, true] {
+            let mut persisted = doc! { "approval_required": approval_required };
+            persisted.extend(update.clone());
+            assert_eq!(
+                persisted.get_bool("approval_required").unwrap(),
+                approval_required
+            );
+        }
     }
 }

--- a/backend/src/services/telegram_poller.rs
+++ b/backend/src/services/telegram_poller.rs
@@ -3,7 +3,10 @@ use mongodb::bson::{self, doc};
 use crate::AppState;
 use crate::errors::AppError;
 use crate::models::notification_channel::{COLLECTION_NAME as CHANNELS, NotificationChannel};
-use crate::services::{approval_service, audit_service, telegram_service};
+use crate::services::{approval_service, audit_service, notification_service, telegram_service};
+
+const TELEGRAM_LINKED_APPROVAL_ACTIVE_MESSAGE: &str = "Your Telegram account has been linked to NyxID. Approval protection is now active and approval requests will be delivered here.";
+const TELEGRAM_LINKED_APPROVAL_OFF_MESSAGE: &str = "Your Telegram account has been linked to NyxID. Approval protection is off — enable it in NyxID notification settings when you want requests delivered here.";
 
 /// Run the Telegram long polling loop (development mode fallback).
 ///
@@ -229,6 +232,7 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
     let update = doc! {
         "$set": telegram_link_update_fields(chat_id, &username, now)
     };
+    let link_outcome = telegram_link_outcome(&channel);
 
     match collection
         .update_one(doc! { "_id": &channel.id }, update)
@@ -239,7 +243,7 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
                 &state.http_client,
                 bot_token,
                 chat_id,
-                "Your Telegram account has been linked to NyxID. Approval protection remains controlled by your notification settings.",
+                link_outcome.message,
             )
             .await;
 
@@ -247,10 +251,11 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
                 state.db.clone(),
                 Some(channel.user_id.clone()),
                 "telegram_linked".to_string(),
-                Some(serde_json::json!({
-                    "telegram_username": username,
-                    "telegram_chat_id": chat_id,
-                })),
+                Some(telegram_link_audit_metadata(
+                    username.as_deref(),
+                    chat_id,
+                    link_outcome,
+                )),
                 None,
                 None,
                 None,
@@ -268,6 +273,36 @@ async fn handle_link_message(state: &AppState, message: telegram_service::Telegr
             .await;
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TelegramLinkOutcome {
+    message: &'static str,
+    approval_resumed: bool,
+}
+
+fn telegram_link_outcome(channel: &NotificationChannel) -> TelegramLinkOutcome {
+    TelegramLinkOutcome {
+        message: if channel.approval_required {
+            TELEGRAM_LINKED_APPROVAL_ACTIVE_MESSAGE
+        } else {
+            TELEGRAM_LINKED_APPROVAL_OFF_MESSAGE
+        },
+        approval_resumed: channel.approval_required
+            && !notification_service::has_active_notification_channel(channel),
+    }
+}
+
+fn telegram_link_audit_metadata(
+    username: Option<&str>,
+    chat_id: i64,
+    outcome: TelegramLinkOutcome,
+) -> serde_json::Value {
+    serde_json::json!({
+        "telegram_username": username,
+        "telegram_chat_id": chat_id,
+        "approval_resumed": outcome.approval_resumed,
+    })
 }
 
 fn telegram_link_update_fields(
@@ -309,6 +344,25 @@ fn decision_callback_message(error: &AppError) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn notification_channel(approval_required: bool) -> NotificationChannel {
+        NotificationChannel {
+            id: uuid::Uuid::new_v4().to_string(),
+            user_id: uuid::Uuid::new_v4().to_string(),
+            telegram_chat_id: None,
+            telegram_username: None,
+            telegram_enabled: false,
+            telegram_link_code: Some("NYXID-TEST".to_string()),
+            telegram_link_code_expires_at: None,
+            approval_timeout_secs: 30,
+            grant_expiry_days: 30,
+            approval_required,
+            push_enabled: false,
+            push_devices: vec![],
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
 
     #[test]
     fn decision_callback_message_maps_expired_forbidden() {
@@ -357,5 +411,47 @@ mod tests {
                 approval_required
             );
         }
+    }
+
+    #[test]
+    fn telegram_link_reports_approval_resumption() {
+        let outcome = telegram_link_outcome(&notification_channel(true));
+        let metadata = telegram_link_audit_metadata(Some("nyx"), 1234, outcome);
+
+        assert_eq!(outcome.message, TELEGRAM_LINKED_APPROVAL_ACTIVE_MESSAGE);
+        assert!(outcome.approval_resumed);
+        assert_eq!(metadata["approval_resumed"], true);
+    }
+
+    #[test]
+    fn telegram_link_reports_approval_off_without_resumption() {
+        let outcome = telegram_link_outcome(&notification_channel(false));
+        let metadata = telegram_link_audit_metadata(None, 1234, outcome);
+
+        assert_eq!(outcome.message, TELEGRAM_LINKED_APPROVAL_OFF_MESSAGE);
+        assert!(!outcome.approval_resumed);
+        assert_eq!(metadata["approval_resumed"], false);
+    }
+
+    #[test]
+    fn telegram_link_does_not_report_resumption_when_another_channel_is_active() {
+        let mut channel = notification_channel(true);
+        channel.push_enabled = true;
+        channel
+            .push_devices
+            .push(crate::models::notification_channel::DeviceToken {
+                device_id: "existing-device".to_string(),
+                platform: "fcm".to_string(),
+                token: "existing-token".to_string(),
+                device_name: None,
+                app_id: None,
+                registered_at: chrono::Utc::now(),
+                last_used_at: None,
+            });
+
+        let outcome = telegram_link_outcome(&channel);
+
+        assert_eq!(outcome.message, TELEGRAM_LINKED_APPROVAL_ACTIVE_MESSAGE);
+        assert!(!outcome.approval_resumed);
     }
 }

--- a/cli/src/commands/notification.rs
+++ b/cli/src/commands/notification.rs
@@ -15,20 +15,12 @@ pub async fn run(command: NotificationCommands) -> Result<()> {
                     println!("{}", serde_json::to_string_pretty(&settings)?);
                 }
                 OutputFormat::Table => {
-                    let push = settings["push_enabled"]
-                        .as_bool()
-                        .map(|b| b.to_string())
-                        .unwrap_or_else(|| "-".to_string());
-                    let telegram = settings["telegram_enabled"]
-                        .as_bool()
-                        .map(|b| b.to_string())
-                        .unwrap_or_else(|| "-".to_string());
+                    let push = optional_bool_display(&settings, "push_enabled");
+                    let telegram = optional_bool_display(&settings, "telegram_enabled");
                     let telegram_connected =
                         settings["telegram_connected"].as_bool().unwrap_or(false);
-                    let approval = settings["approval_required"]
-                        .as_bool()
-                        .map(|b| b.to_string())
-                        .unwrap_or_else(|| "-".to_string());
+                    let approval = optional_bool_display(&settings, "approval_required");
+                    let approval_suspended = optional_bool_display(&settings, "approval_suspended");
 
                     eprintln!("Notification Settings");
                     eprintln!();
@@ -36,6 +28,7 @@ pub async fn run(command: NotificationCommands) -> Result<()> {
                     eprintln!("Telegram Enabled:    {telegram}");
                     eprintln!("Telegram Connected:  {telegram_connected}");
                     eprintln!("Approval Required:   {approval}");
+                    eprintln!("Approval Suspended:  {approval_suspended}");
                 }
             }
             Ok(())
@@ -123,6 +116,13 @@ pub async fn run(command: NotificationCommands) -> Result<()> {
     }
 }
 
+fn optional_bool_display(value: &Value, key: &str) -> String {
+    value[key]
+        .as_bool()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,7 +137,8 @@ mod tests {
             .and(path("/api/v1/notifications/settings"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "push_enabled": true, "telegram_enabled": false,
-                "telegram_connected": false, "approval_required": true
+                "telegram_connected": false, "approval_required": true,
+                "approval_suspended": true
             })))
             .expect(1)
             .mount(&server)
@@ -213,7 +214,8 @@ mod tests {
             .and(path("/api/v1/notifications/settings"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "push_enabled": false, "telegram_enabled": true,
-                "telegram_connected": true, "approval_required": false
+                "telegram_connected": true, "approval_required": true,
+                "approval_suspended": false
             })))
             .mount(&server)
             .await;
@@ -226,6 +228,41 @@ mod tests {
         })
         .await
         .expect("settings table should succeed");
+    }
+
+    #[tokio::test]
+    async fn settings_table_output_supports_older_server_without_suspension_field() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/notifications/settings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "push_enabled": true, "telegram_enabled": false,
+                "telegram_connected": false, "approval_required": true
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        run(NotificationCommands::Settings {
+            auth: crate::test_support::mock_auth_with_output(
+                server.uri(),
+                crate::cli::OutputFormat::Table,
+            ),
+        })
+        .await
+        .expect("older-server settings table should succeed");
+    }
+
+    #[test]
+    fn settings_table_formats_suspension_and_supports_older_servers() {
+        let current = serde_json::json!({ "approval_suspended": true });
+        let older = serde_json::json!({});
+
+        assert_eq!(
+            optional_bool_display(&current, "approval_suspended"),
+            "true"
+        );
+        assert_eq!(optional_bool_display(&older, "approval_suspended"), "-");
     }
 
     #[tokio::test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -3517,7 +3517,7 @@ Forward any HTTP request to a registered downstream service. NyxID resolves the 
 
 **Streaming:** If the client sends `Accept: text/event-stream` or the upstream responds with `Content-Type: text/event-stream`, NyxID forwards the SSE stream without buffering and strips `content-length`.
 
-**Transaction Approval:** If the resource owner has `approval_required` enabled and the request uses a non-session auth method (API key, delegated token, service account, or access token), the proxy checks for an existing approval grant. If no grant exists, an approval request is created (with Telegram notification if configured) and the **HTTP connection is held open** until the user approves/rejects or the configured timeout expires. If approved, the request proceeds and the downstream response is returned. If rejected or timed out, a `403 Forbidden` is returned. Direct browser sessions (session cookie auth) bypass approval.
+**Transaction Approval:** If the resource owner has `approval_required` enabled, has at least one active notification channel, and the request uses a non-session auth method (API key, delegated token, service account, or access token), the proxy checks for an existing approval grant. If no grant exists, an approval request is created (with Telegram notification if configured) and the **HTTP connection is held open** until the user approves/rejects or the configured timeout expires. If approved, the request proceeds and the downstream response is returned. If rejected or timed out, a `403 Forbidden` is returned. The implicit global default is suspended while the owner has no active notification channel and never applies to auto-connected (auto-provisioned, credential-free) services. Explicit per-service `ServiceApprovalConfig` rows apply regardless of channel availability or the auto-connected exemption. Direct browser sessions (session cookie auth) bypass approval.
 
 **Limits:** Request body is limited to 10 MB for proxy requests.
 
@@ -3693,7 +3693,7 @@ Three access modes are available:
 
 Streaming is supported for providers that expose SSE-compatible streaming APIs. When the request sets `"stream": true`, NyxID returns `text/event-stream` and forwards or translates provider SSE events on the fly.
 
-**Transaction Approval:** The same blocking approval flow applies to LLM gateway endpoints as to the proxy. If the resource owner has `approval_required` enabled and the request uses a non-session auth method (API key, delegated token, service account, or access token), the connection is held open until the user approves/rejects or the timeout expires. See the [Proxy](#proxy) section for details.
+**Transaction Approval:** The same blocking approval flow applies to LLM gateway endpoints as to the proxy. If the resource owner has `approval_required` enabled, has at least one active notification channel, and the request uses a non-session auth method (API key, delegated token, service account, or access token), the connection is held open until the user approves/rejects or the timeout expires. The implicit global default is suspended while the owner has no active notification channel and never applies to auto-connected (auto-provisioned, credential-free) services. Explicit per-service `ServiceApprovalConfig` rows apply regardless of channel availability or the auto-connected exemption. See the [Proxy](#proxy) section for details.
 
 #### GET /api/v1/llm/status
 
@@ -7136,11 +7136,16 @@ Authorization: Bearer <access_token>
   "telegram_connected": true,
   "telegram_username": "johndoe",
   "telegram_enabled": true,
+  "push_enabled": true,
+  "push_device_count": 1,
   "approval_required": true,
+  "approval_suspended": false,
   "approval_timeout_secs": 30,
   "grant_expiry_days": 30
 }
 ```
+
+The global `approval_required` preference is enforced only while at least one Telegram or push notification channel is active. `approval_suspended` is `true` when the stored preference remains on but no channel is currently available; enforcement resumes automatically when a channel becomes active again.
 
 **curl:**
 
@@ -7174,8 +7179,23 @@ All fields are optional. Only provided fields are updated.
 - `approval_timeout_secs`: 10..=300
 - `grant_expiry_days`: 1..=365
 - `telegram_enabled: true` requires a linked Telegram account
+- `approval_required: true` (turning it on from off) requires an active Telegram or push channel; an already-enabled preference may keep its value while channels are disabled (protection is suspended)
 
-**Response (200):** Same shape as GET response.
+**Response (200):**
+
+```json
+{
+  "telegram_connected": true,
+  "telegram_username": "johndoe",
+  "telegram_enabled": true,
+  "push_enabled": true,
+  "push_device_count": 1,
+  "approval_required": true,
+  "approval_suspended": false,
+  "approval_timeout_secs": 60,
+  "grant_expiry_days": 14
+}
+```
 
 **curl:**
 
@@ -7230,6 +7250,8 @@ Clears the linked Telegram account and disables Telegram notifications.
 }
 ```
 
+If approval protection remains enabled but no active channel remains, the message is `Telegram disconnected. Approval protection is suspended until a notification channel is available; it resumes automatically.`
+
 **curl:**
 
 ```bash
@@ -7251,7 +7273,7 @@ Authorization: Bearer <access_token>
 Content-Type: application/json
 ```
 
-Register or refresh a device token for push notifications. If a device with the same `token` already exists, its metadata is updated (token refresh). The first registered device automatically enables push notifications.
+Register or refresh a device token for push notifications. If a device with the same `token` already exists, its metadata is updated (token refresh). The first registered device automatically enables push notifications. Registration never changes the stored `approval_required` preference; if protection was suspended, it resumes from that existing preference when the push channel becomes active.
 
 **Request Body:**
 
@@ -7357,6 +7379,8 @@ Remove a registered push notification device. If no devices remain after removal
   "message": "Device removed"
 }
 ```
+
+If approval protection remains enabled but no active channel remains, the message is `Device removed. Approval protection is suspended until a notification channel is available; it resumes automatically.`
 
 **Errors:**
 - `1003 not_found` -- Device not found
@@ -7568,7 +7592,7 @@ Authorization: Bearer <access_token>
 
 **Auth:** Required (human-only -- rejects delegated tokens and service account tokens).
 
-Returns all per-service approval configurations for the current user. These override the global `approval_required` setting on a per-service basis.
+Returns all per-service approval configurations for the current user. These override the global `approval_required` setting on a per-service basis (only the global fallback is subject to channel suspension and the auto-connected exemption).
 
 **Response (200):**
 
@@ -7603,7 +7627,7 @@ Content-Type: application/json
 
 **Auth:** Required (human-only).
 
-Creates or updates a per-service approval override. When set, this value takes precedence over the global `notification_channels.approval_required` setting for the specified service.
+Creates or updates a per-service approval override. When set, this value takes precedence over the global `notification_channels.approval_required` setting for the specified service (only the global fallback is subject to channel suspension and the auto-connected exemption).
 
 **Request:**
 
@@ -7649,7 +7673,7 @@ Authorization: Bearer <access_token>
 
 **Auth:** Required (human-only).
 
-Removes the per-service approval override, reverting to the global `approval_required` setting for this service.
+Removes the per-service approval override, reverting to the global `approval_required` setting for this service (the global fallback is subject to channel suspension and the auto-connected exemption).
 
 **Response (200):**
 

--- a/frontend/src/components/dashboard/notification-setup-card.tsx
+++ b/frontend/src/components/dashboard/notification-setup-card.tsx
@@ -48,8 +48,9 @@ export function NotificationSetupCard() {
   const pushReady =
     settings?.push_enabled && (pushDevices?.devices.length ?? 0) > 0;
   const approvalEnabled = settings?.approval_required ?? false;
+  const approvalSuspended = settings?.approval_suspended ?? false;
   const hasChannel = telegramReady || pushReady;
-  const allDone = hasChannel && approvalEnabled;
+  const allDone = hasChannel && approvalEnabled && !approvalSuspended;
 
   const handleDismiss = useCallback(() => {
     localStorage.setItem(DISMISSED_KEY, "true");
@@ -158,6 +159,22 @@ export function NotificationSetupCard() {
                 >
                   Manage settings
                 </Link>
+              </p>
+            </div>
+          )}
+
+          {approvalSuspended && (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+              <div className="flex items-center gap-2">
+                <Shield className="h-4 w-4 text-amber-500" />
+                <span className="text-[13px] font-medium">
+                  Approval protection is suspended
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Your approval preference remains on. Connect or re-enable
+                Telegram or push notifications and protection will resume
+                automatically.
               </p>
             </div>
           )}

--- a/frontend/src/components/dashboard/notification-setup-card.tsx
+++ b/frontend/src/components/dashboard/notification-setup-card.tsx
@@ -241,9 +241,9 @@ export function NotificationSetupCard() {
 
             {!hasChannel && (
               <p className="text-xs text-muted-foreground">
-                Connect Telegram or download the mobile app to enable approval
-                protection. Approval is enabled automatically when you set up a
-                channel.
+                Connect Telegram or download the mobile app to receive approval
+                requests. Then explicitly enable approval protection in this
+                card or Approval Settings.
               </p>
             )}
           </div>

--- a/frontend/src/components/shared/approval-setup-wizard.tsx
+++ b/frontend/src/components/shared/approval-setup-wizard.tsx
@@ -39,7 +39,7 @@ export function ApprovalSetupWizard({
     {
       label: "Turn on approval protection",
       description:
-        "Enable the global approval toggle. Programmatic proxy, LLM gateway, and SSH requests will require your approval.",
+        "Enable the global approval toggle. Requests will require your approval by default; auto-connected services remain available unless you add an explicit per-service policy.",
       done: approvalEnabled,
     },
   ];
@@ -56,7 +56,9 @@ export function ApprovalSetupWizard({
           </p>
           <p className="text-xs text-muted-foreground">
             Programmatic proxy, LLM gateway, and SSH requests require your
-            approval. You can approve via Telegram, the mobile app, or the{" "}
+            approval by default. Auto-connected services remain available
+            unless you add an explicit per-service policy. You can approve via
+            Telegram, the mobile app, or the{" "}
             <Link
               to="/approvals/history"
               className="underline underline-offset-2 hover:text-foreground"

--- a/frontend/src/components/shared/approval-setup-wizard.tsx
+++ b/frontend/src/components/shared/approval-setup-wizard.tsx
@@ -18,10 +18,12 @@ export function ApprovalSetupWizard({
   hasChannel,
   channelEnabled,
   approvalEnabled,
+  approvalSuspended,
 }: {
   readonly hasChannel: boolean;
   readonly channelEnabled: boolean;
   readonly approvalEnabled: boolean;
+  readonly approvalSuspended: boolean;
 }) {
   const steps: readonly SetupStep[] = [
     {
@@ -44,7 +46,23 @@ export function ApprovalSetupWizard({
     },
   ];
 
-  const allDone = steps.every((s) => s.done);
+  const allDone = steps.every((s) => s.done) && !approvalSuspended;
+
+  if (approvalSuspended) {
+    return (
+      <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+        <Info className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+        <div className="space-y-0.5">
+          <p className="text-[12px] font-medium">Approval protection is suspended</p>
+          <p className="text-xs text-muted-foreground">
+            Your approval preference is still on, but no enabled notification
+            channel is available. Connect or re-enable Telegram or push
+            notifications and protection will resume automatically.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (allDone) {
     return (

--- a/frontend/src/lib/mock-data.ts
+++ b/frontend/src/lib/mock-data.ts
@@ -508,6 +508,7 @@ const MOCK_NOTIFICATION_SETTINGS = {
   push_enabled: true,
   push_device_count: 1,
   approval_required: true,
+  approval_suspended: false,
   approval_timeout_secs: 300,
   grant_expiry_days: 30,
 };

--- a/frontend/src/pages/notification-settings.tsx
+++ b/frontend/src/pages/notification-settings.tsx
@@ -625,9 +625,11 @@ export function NotificationSettingsPage() {
             <CardHeader>
               <CardTitle>Approval Preferences</CardTitle>
               <CardDescription>
-                Configure approval settings. When enabled, every request
-                requires approval by default (per-request mode). You can
-                opt specific services into time-based grants below.
+                Configure approval settings. When enabled, requests require
+                approval by default (per-request mode). Auto-connected
+                services remain available unless you add an explicit
+                per-service policy. You can opt specific services into
+                time-based grants below.
               </CardDescription>
             </CardHeader>
             <CardContent>

--- a/frontend/src/pages/notification-settings.tsx
+++ b/frontend/src/pages/notification-settings.tsx
@@ -483,6 +483,7 @@ export function NotificationSettingsPage() {
               Boolean(settings?.push_enabled)
             }
             approvalEnabled={Boolean(settings?.approval_required)}
+            approvalSuspended={Boolean(settings?.approval_suspended)}
           />
 
           {/* Telegram Connection Card */}

--- a/frontend/src/types/approvals.ts
+++ b/frontend/src/types/approvals.ts
@@ -5,6 +5,7 @@ export interface NotificationSettings {
   readonly push_enabled: boolean;
   readonly push_device_count: number;
   readonly approval_required: boolean;
+  readonly approval_suspended: boolean;
   readonly approval_timeout_secs: number;
   readonly grant_expiry_days: number;
 }

--- a/mobile/src/features/account/AccountSettingsScreen.tsx
+++ b/mobile/src/features/account/AccountSettingsScreen.tsx
@@ -299,9 +299,9 @@ export function AccountSettingsScreen({ navigation }: Props) {
       );
       return;
     }
-    const willDisableApproval = isLastChannel("push") && notifSettings?.approval_required;
-    const message = willDisableApproval
-      ? "This is your only notification channel. Disabling it will also turn off approval protection."
+    const willSuspendApproval = isLastChannel("push") && notifSettings?.approval_required;
+    const message = willSuspendApproval
+      ? "This is your only notification channel. Approval protection will be suspended until a channel is available, then resume automatically."
       : "You will no longer receive push notifications for approval requests.";
 
     Alert.alert("Disable Push Notifications", message, [
@@ -316,7 +316,6 @@ export function AccountSettingsScreen({ navigation }: Props) {
           notifMutation.mutate(
             {
               push_enabled: false,
-              ...(willDisableApproval && { approval_required: false }),
             },
             emitPreferenceToggledOnSuccess("push_enabled", false),
           );
@@ -333,10 +332,10 @@ export function AccountSettingsScreen({ navigation }: Props) {
       );
       return;
     }
-    const willDisableApproval = isLastChannel("telegram") && notifSettings?.approval_required;
+    const willSuspendApproval = isLastChannel("telegram") && notifSettings?.approval_required;
     const willDisconnect = true; // disabling always disconnects
-    const message = willDisableApproval
-      ? "This is your only notification channel. Disabling it will disconnect Telegram and turn off approval protection."
+    const message = willSuspendApproval
+      ? "This is your only notification channel. Disabling it will disconnect Telegram and suspend approval protection until a channel is available."
       : "This will disconnect your Telegram account and stop all Telegram notifications.";
 
     Alert.alert("Disable Telegram", message, [
@@ -345,8 +344,7 @@ export function AccountSettingsScreen({ navigation }: Props) {
         text: "Disable",
         style: "destructive",
         onPress: async () => {
-          // Disable notifications + approval in one call, then
-          // disconnect. Only emit after BOTH land -- the earlier design
+          // Disable notifications in one call, then disconnect. Only emit after BOTH land -- the earlier design
           // emitted before the settings update, which overcounted
           // completed toggles on offline/error.
           //
@@ -360,7 +358,6 @@ export function AccountSettingsScreen({ navigation }: Props) {
           try {
             await mobileApi.updateNotificationSettings({
               telegram_enabled: false,
-              ...(willDisableApproval && { approval_required: false }),
             });
             settingsOk = true;
           } catch {
@@ -586,7 +583,9 @@ export function AccountSettingsScreen({ navigation }: Props) {
               </View>
               {notifSettings && (
                 <Text style={styles.channelHint}>
-                  Either Push or Telegram must stay enabled to receive approval requests.
+                  {notifSettings.approval_suspended
+                    ? "Approval protection is suspended until a notification channel is available; it resumes automatically."
+                    : "Push or Telegram delivers requests when approval protection is on."}
                 </Text>
               )}
             </>

--- a/mobile/src/lib/api/errorMessages.ts
+++ b/mobile/src/lib/api/errorMessages.ts
@@ -53,7 +53,7 @@ const BAD_REQUEST_OVERRIDES: Array<{ pattern: string; message: string }> = [
   {
     pattern: "at least one enabled notification channel",
     message:
-      "Either Push or Telegram must stay enabled to receive approval requests.",
+      "Connect and enable Push or Telegram before turning on approval protection.",
   },
 ];
 

--- a/mobile/src/lib/api/types.ts
+++ b/mobile/src/lib/api/types.ts
@@ -77,6 +77,7 @@ export type NotificationSettings = {
   telegram_username: string | null;
   telegram_enabled: boolean;
   approval_required: boolean;
+  approval_suspended: boolean;
   approval_timeout_secs: number;
   grant_expiry_days: number;
   push_enabled: boolean;


### PR DESCRIPTION
## What this resolves

Two reported NyxID permissions/approvals problems:

1. **Installing the NyxID mobile app overwrote users' approval defaults.** Root cause: `register_device` (`backend/src/handlers/device_tokens.rs`) did `$set { approval_required: true }` on the user's global notification channel whenever a *new* push device registered. A fresh install always produces a brand-new APNs/FCM token with no `previous_token`, so every install, reinstall, and new phone silently turned global approval protection **on**. The Telegram link flow (`telegram_poller.rs`, shared by webhook mode) had the same auto-enable, and sign-out / device removal / stale-token sweep / account-switch detach auto-*disabled* it — the setting was being clobbered in both directions by app lifecycle events.
2. **Auto-connected services demanded approval.** Auto-connected services (`UserService.source == "auto_provision"`, the platform-managed credential-free catalog services) were subject to the implicit global default like any other service, so once (1) flipped the global flag, even internal services started generating approval prompts.

## What changed

**Auto-connected exemption (resolution layer).** `approval_service::resolve_org_aware_approval` takes an `is_auto_connected` input that suppresses **only the implicit global fallback**. Explicit user/org `ServiceApprovalConfig` rows — including `deny` — still apply verbatim. The fact is derived from the resolved `UserService` and plumbed through every enforcement path: HTTP proxy (pre-resolved, slug, legacy hint), LLM gateway (both paths + deny preflight), MCP transport (`McpApprovalTarget.is_auto_connected` in `services/mcp_approval.rs`), the exact-service approval flow (`exact_service_approval_service.rs`, both call sites), and SSH (documented as never auto-provisioned). MCP discovery already excluded auto-provisioned services from the connect surface; that now has a regression test.

**`approval_required` is a pure user preference.** No lifecycle path mutates it any more: device registration (new / rotation / refresh / concurrent recovery), sign-out, device removal, account-switch token detach, stale-token sweep, Telegram link, Telegram disconnect. Only `PUT /api/v1/notifications/settings` writes it.

**Computed suspension instead of stored auto-disable.** Enforcement of the global default now requires at least one *active* notification channel (`telegram_enabled && telegram_chat_id` or `push_enabled && push_devices`). When the stored preference is on but no channel exists, protection is **suspended** (fail-open, exactly as the old auto-disable behaved) and **resumes automatically** when a channel returns — so a sign-out/sign-in round trip, a reinstall, or a Telegram re-link preserves the user's explicit choice instead of erasing it. Surfaced as `approval_suspended` on the settings response, in the web notification settings/setup card/wizard, the mobile account screen, `nyxid notification settings`, and audit metadata (`approval_suspended`, `approval_resumed`). The settings endpoint still refuses turning approval **on** with no channel; it now allows disabling the last channel while keeping the preference (suspended).

**CI trigger.** `ci.yml` only ran on PRs into `main`/`dev`, so PRs into rollup branches got no checks. `pull_request.branches` now includes `'rollup-*'`; because the workflow file changed, this PR runs the full pipeline.

## Design decisions

- **No data migration** for users whose `approval_required` was flipped on by past installs: we cannot distinguish them from users who chose it, and silently disabling a protective setting is worse. They can toggle it off in settings, and the prompt noise from auto-connected services is gone regardless.
- Explicit per-service configs are honored for auto-connected services and enforce regardless of channel availability (pre-existing behavior, unchanged).
- Exact-service approval requests for an auto-connected service under the global default now resolve `Allowed` and surface the existing `exact_service_approval_not_required` conflict; an exact approval created *before* deploy for such a service re-evaluates as not-required at redemption and fails safe (`selector_revoked`), after which the caller re-requests and proceeds without a prompt.

## Verification

Local (rebased on the rollup tip): `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, focused backend suites for every touched module against a replica-set MongoDB, full `cargo test -p nyxid-cli` (incl. wizard-bundle freshness), frontend `lint` + `test` + `build`, mobile `tsc --noEmit`. Pre-rebase, the full backend suite passed 5013/5013 and frontend 2631/2631. CI on this PR runs the full pipeline (all jobs forced by the workflow change).

Docs: `docs/API.md` updated for the settings response (`approval_suspended`, `push_enabled`, `push_device_count`), validation rules, transaction-approval semantics, device registration invariance, and disconnect/removal messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
