### PR TITLE
feat(platform-ops): gate the platform-services surface behind experimental:platform-services (default off)

### DIFF
--- a/backend/src/handlers/admin_platform_ops.rs
+++ b/backend/src/handlers/admin_platform_ops.rs
@@ -72,6 +72,8 @@ pub async fn list_platform_operations(
     State(state): State<AppState>,
     auth_user: AuthUser,
 ) -> AppResult<Json<AdminPlatformOperationListResponse>> {
+    // Deliberately ungated: administrators can stage per-operation configuration
+    // while the caller-facing platform-services feature flag remains disabled.
     require_admin(&state, &auth_user).await?;
     let configured = platform_operation_service::list_configured_operations(&state.db).await?;
     let operations = platform_operation_service::PLATFORM_OPERATION_NAMES
@@ -92,6 +94,8 @@ pub async fn update_platform_operation(
     Path(op): Path<String>,
     Json(body): Json<UpdatePlatformOperationRequest>,
 ) -> AppResult<Json<AdminPlatformOperationResponse>> {
+    // Deliberately ungated: administrators can stage per-operation configuration
+    // while the caller-facing platform-services feature flag remains disabled.
     require_admin(&state, &auth_user).await?;
     let op = platform_operation_service::parse_operation_name(&op)?;
     let operation = platform_operation_service::upsert_operation(

--- a/backend/src/handlers/mcp_transport.rs
+++ b/backend/src/handlers/mcp_transport.rs
@@ -23,9 +23,10 @@ use crate::services::platform_operation_service::{
     CallAndSayRequest, SpeakRequest, XSearchRequest,
 };
 use crate::services::{
-    approval_service, audit_service, connect_link_service, mcp_service, notification_service,
-    operation_descriptor, oracle_pool_service, oracle_session_service, oracle_task_service,
-    platform_operation_service, proxy_service, ssh_service, user_service_service,
+    approval_service, audit_service, connect_link_service, feature_flag_service, mcp_service,
+    notification_service, operation_descriptor, oracle_pool_service, oracle_session_service,
+    oracle_task_service, platform_operation_service, proxy_service, ssh_service,
+    user_service_service,
 };
 use crate::telemetry::{TelemetryContext, TelemetryEvent, emit_event};
 
@@ -662,6 +663,25 @@ fn platform_operations_allowed(auth: &McpAuthContext) -> bool {
     ) || (auth.auth_method == AuthMethod::ApiKey && auth.is_agent_api_key)
 }
 
+/// Resolve the caller-facing feature gate for platform operations. Resolution
+/// failures fail closed so a rollout cannot accidentally publish or execute a
+/// surface while its flag state is unavailable.
+async fn platform_services_flag_enabled(state: &AppState, auth: &McpAuthContext) -> bool {
+    match feature_flag_service::resolve_personal_features(&state.db, &auth.user_id).await {
+        Ok(features) => features
+            .iter()
+            .any(|key| key == feature_flag_service::PLATFORM_SERVICES_FLAG_KEY),
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                user_id = %auth.user_id,
+                "Failed to resolve platform-services feature flag for MCP"
+            );
+            false
+        }
+    }
+}
+
 fn mcp_service_scope(auth: &McpAuthContext) -> mcp_service::ServiceScope<'_> {
     if auth.allow_all_services {
         mcp_service::ServiceScope::Unrestricted
@@ -1196,20 +1216,21 @@ async fn handle_tools_list(
     };
 
     let services = catalog.services;
-    let platform_operations = if platform_operations_allowed(auth) {
-        match platform_operation_service::list_enabled_operations(&state.db).await {
-            Ok(operations) => operations,
-            Err(error) => {
-                tracing::error!(
-                    error = %error,
-                    "Failed to load enabled platform operations for MCP discovery"
-                );
-                Vec::new()
+    let platform_operations =
+        if platform_operations_allowed(auth) && platform_services_flag_enabled(state, auth).await {
+            match platform_operation_service::list_enabled_operations(&state.db).await {
+                Ok(operations) => operations,
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        "Failed to load enabled platform operations for MCP discovery"
+                    );
+                    Vec::new()
+                }
             }
-        }
-    } else {
-        Vec::new()
-    };
+        } else {
+            Vec::new()
+        };
 
     // Session-backed clients get meta-tools + activated service tools only.
     // Stateless (API-key) clients with no session get the full tool list up front.
@@ -1762,7 +1783,7 @@ async fn handle_platform_x_search(
     arguments: &serde_json::Value,
     request_id: Option<serde_json::Value>,
 ) -> Response {
-    if !platform_operations_allowed(auth) {
+    if !platform_operations_allowed(auth) || !platform_services_flag_enabled(state, auth).await {
         return tool_result(request_id, "Platform operation is not available", true);
     }
     let request = match parse_platform_operation_arguments::<XSearchRequest>(arguments) {
@@ -1803,7 +1824,7 @@ async fn handle_platform_speak(
     arguments: &serde_json::Value,
     request_id: Option<serde_json::Value>,
 ) -> Response {
-    if !platform_operations_allowed(auth) {
+    if !platform_operations_allowed(auth) || !platform_services_flag_enabled(state, auth).await {
         return tool_result(request_id, "Platform operation is not available", true);
     }
     let request = match parse_platform_operation_arguments::<SpeakRequest>(arguments) {
@@ -1848,7 +1869,7 @@ async fn handle_platform_call_and_say(
     arguments: &serde_json::Value,
     request_id: Option<serde_json::Value>,
 ) -> Response {
-    if !platform_operations_allowed(auth) {
+    if !platform_operations_allowed(auth) || !platform_services_flag_enabled(state, auth).await {
         return tool_result(request_id, "Platform operation is not available", true);
     }
     let request = match parse_platform_operation_arguments::<CallAndSayRequest>(arguments) {
@@ -3311,6 +3332,10 @@ mod tests {
     use crate::models::org_membership::{
         COLLECTION_NAME as ORG_MEMBERSHIPS, OrgMembership, OrgRole,
     };
+    use crate::models::platform_operation::{
+        COLLECTION_NAME as PLATFORM_OPERATIONS, PlatformOperation, PlatformOperationConfig,
+        PlatformOperationName, XSearchConfig,
+    };
     use crate::models::service_approval_config::{
         ApprovalMode, COLLECTION_NAME as SERVICE_APPROVAL_CONFIGS, ServiceApprovalConfig,
     };
@@ -3423,6 +3448,167 @@ mod tests {
                 method,
             )));
         }
+    }
+
+    async fn enable_platform_services_for_mcp_tests(db: &mongodb::Database) {
+        crate::services::feature_flag_service::set_platform_override(
+            db,
+            crate::services::feature_flag_service::PLATFORM_SERVICES_FLAG_KEY,
+            &crate::services::feature_flag_service::FlagTarget::Global,
+            true,
+            "mcp-test-actor",
+        )
+        .await
+        .expect("enable platform-services flag for MCP test");
+    }
+
+    fn enabled_x_search_operation() -> PlatformOperation {
+        PlatformOperation {
+            id: uuid::Uuid::new_v4().to_string(),
+            op: PlatformOperationName::XSearch,
+            enabled: true,
+            vendor_service_slug: "platform-x".to_string(),
+            config: PlatformOperationConfig::XSearch(XSearchConfig {
+                max_results_cap: 10,
+            }),
+            updated_at: chrono::Utc::now(),
+            updated_by: "mcp-test-actor".to_string(),
+        }
+    }
+
+    fn tools_list_request() -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: Some(serde_json::json!(1)),
+            method: "tools/list".to_string(),
+            params: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_list_hides_platform_operations_when_flag_is_off() {
+        let Some(db) = connect_test_database("mcp_platform_ops_flag_off").await else {
+            eprintln!("skipping MCP platform operation flag test: no local MongoDB available");
+            return;
+        };
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_one(enabled_x_search_operation())
+            .await
+            .expect("insert enabled platform operation");
+        let state = test_app_state(db);
+        let auth = McpAuthContext::user("user-1".to_string(), AuthMethod::Session);
+        let response = handle_tools_list(&state, &auth, None, &tools_list_request()).await;
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("read MCP tools/list response");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("decode MCP tools/list response");
+        let tools = payload["result"]["tools"]
+            .as_array()
+            .expect("tools/list result contains tools");
+        assert!(!tools.iter().any(|tool| tool["name"] == "nyx__x_search"));
+        assert!(!tools.iter().any(|tool| tool["name"] == "nyx__speak"));
+        assert!(!tools.iter().any(|tool| tool["name"] == "nyx__call_and_say"));
+    }
+
+    #[tokio::test]
+    async fn mcp_tools_list_publishes_platform_operations_when_flag_is_on() {
+        let Some(db) = connect_test_database("mcp_platform_ops_flag_on").await else {
+            eprintln!("skipping MCP platform operation flag test: no local MongoDB available");
+            return;
+        };
+        enable_platform_services_for_mcp_tests(&db).await;
+        db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
+            .insert_one(enabled_x_search_operation())
+            .await
+            .expect("insert enabled platform operation");
+        let state = test_app_state(db);
+        let auth = McpAuthContext::user("user-1".to_string(), AuthMethod::Session);
+        let response = handle_tools_list(&state, &auth, None, &tools_list_request()).await;
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("read MCP tools/list response");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("decode MCP tools/list response");
+        let tools = payload["result"]["tools"]
+            .as_array()
+            .expect("tools/list result contains tools");
+        assert!(tools.iter().any(|tool| tool["name"] == "nyx__x_search"));
+    }
+
+    #[tokio::test]
+    async fn mcp_platform_operations_reject_guessed_names_when_flag_is_off() {
+        let Some(db) = connect_test_database("mcp_platform_ops_dispatch_off").await else {
+            eprintln!("skipping MCP platform operation flag test: no local MongoDB available");
+            return;
+        };
+        let state = test_app_state(db);
+        let auth = McpAuthContext::user("user-1".to_string(), AuthMethod::Session);
+
+        let responses = [
+            handle_platform_x_search(
+                &state,
+                &auth,
+                &serde_json::json!({}),
+                Some(serde_json::json!(1)),
+            )
+            .await,
+            handle_platform_speak(
+                &state,
+                &auth,
+                &serde_json::json!({}),
+                Some(serde_json::json!(2)),
+            )
+            .await,
+            handle_platform_call_and_say(
+                &state,
+                &auth,
+                &serde_json::json!({}),
+                Some(serde_json::json!(3)),
+            )
+            .await,
+        ];
+        for response in responses {
+            let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+                .await
+                .expect("read MCP tool response");
+            let payload: serde_json::Value =
+                serde_json::from_slice(&body).expect("decode MCP tool response");
+            assert_eq!(payload["result"]["isError"], true);
+            assert_eq!(
+                payload["result"]["content"][0]["text"],
+                "Platform operation is not available"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_platform_dispatch_preserves_argument_validation_when_flag_is_on() {
+        let Some(db) = connect_test_database("mcp_platform_ops_dispatch_on").await else {
+            eprintln!("skipping MCP platform operation flag test: no local MongoDB available");
+            return;
+        };
+        enable_platform_services_for_mcp_tests(&db).await;
+        let state = test_app_state(db);
+        let auth = McpAuthContext::user("user-1".to_string(), AuthMethod::Session);
+        let response = handle_platform_x_search(
+            &state,
+            &auth,
+            &serde_json::json!({}),
+            Some(serde_json::json!(1)),
+        )
+        .await;
+        let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .expect("read MCP tool response");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&body).expect("decode MCP tool response");
+        assert_eq!(payload["result"]["isError"], true);
+        assert!(
+            payload["result"]["content"][0]["text"]
+                .as_str()
+                .is_some_and(|text| text.starts_with("Invalid platform operation arguments:"))
+        );
     }
 
     #[tokio::test]

--- a/backend/src/handlers/platform_ops.rs
+++ b/backend/src/handlers/platform_ops.rs
@@ -17,13 +17,28 @@ use crate::mw::auth::{AuthMethod, AuthUser};
 use crate::services::platform_operation_service::{
     CallAndSayRequest, SpeakRequest, XSearchRequest,
 };
-use crate::services::{audit_service, platform_operation_service};
+use crate::services::{audit_service, feature_flag_service, platform_operation_service};
+
+async fn require_platform_ops_enabled(state: &AppState, auth_user: &AuthUser) -> AppResult<()> {
+    let enabled =
+        feature_flag_service::resolve_personal_features(&state.db, &auth_user.user_id.to_string())
+            .await?
+            .into_iter()
+            .any(|key| key == feature_flag_service::PLATFORM_SERVICES_FLAG_KEY);
+    if !enabled {
+        return Err(AppError::NotFound(
+            "Platform operation route not found.".to_string(),
+        ));
+    }
+    Ok(())
+}
 
 pub async fn x_search(
     State(state): State<AppState>,
     auth_user: AuthUser,
     Json(request): Json<XSearchRequest>,
 ) -> AppResult<Response> {
+    require_platform_ops_enabled(&state, &auth_user).await?;
     ensure_platform_operation_caller(&state, &auth_user).await?;
     enforce_agent_rate_limit(&state, &auth_user)?;
 
@@ -57,6 +72,7 @@ pub async fn speak(
     auth_user: AuthUser,
     Json(request): Json<SpeakRequest>,
 ) -> AppResult<Response> {
+    require_platform_ops_enabled(&state, &auth_user).await?;
     ensure_platform_operation_caller(&state, &auth_user).await?;
     enforce_agent_rate_limit(&state, &auth_user)?;
 
@@ -101,6 +117,7 @@ pub async fn call_and_say(
     auth_user: AuthUser,
     Json(request): Json<CallAndSayRequest>,
 ) -> AppResult<Response> {
+    require_platform_ops_enabled(&state, &auth_user).await?;
     ensure_platform_operation_caller(&state, &auth_user).await?;
     enforce_agent_rate_limit(&state, &auth_user)?;
 
@@ -305,6 +322,18 @@ mod tests {
             .expect("create platform operation usage index");
     }
 
+    async fn enable_platform_services_for_tests(db: &mongodb::Database) {
+        crate::services::feature_flag_service::set_platform_override(
+            db,
+            crate::services::feature_flag_service::PLATFORM_SERVICES_FLAG_KEY,
+            &crate::services::feature_flag_service::FlagTarget::Global,
+            true,
+            USER_ID,
+        )
+        .await
+        .expect("enable platform-services flag for test");
+    }
+
     async fn spawn_twilio(status: StatusCode) -> (String, tokio::task::JoinHandle<()>) {
         let app = Router::new().route(
             "/2010-04-01/Accounts/{account_sid}/Calls.json",
@@ -328,12 +357,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn platform_services_flag_off_returns_not_found_for_all_http_operations() {
+        let Some(db) =
+            crate::test_utils::connect_test_database("platform_ops_flag_default_off").await
+        else {
+            eprintln!("skipping platform operation handler test: no local MongoDB available");
+            return;
+        };
+        let state = crate::test_utils::test_app_state(db);
+        let auth_user = crate::test_utils::test_auth_user(USER_ID);
+
+        let x_search_result = x_search(
+            State(state.clone()),
+            auth_user.clone(),
+            Json(XSearchRequest {
+                query: "nyxid".to_string(),
+                max_results: None,
+            }),
+        )
+        .await;
+        assert!(matches!(x_search_result, Err(AppError::NotFound(_))));
+
+        let speak_result = speak(
+            State(state.clone()),
+            auth_user.clone(),
+            Json(SpeakRequest {
+                text: "Hello".to_string(),
+                voice_id: "voice".to_string(),
+            }),
+        )
+        .await;
+        assert!(matches!(speak_result, Err(AppError::NotFound(_))));
+
+        let call_result = call_and_say(
+            State(state),
+            auth_user,
+            Json(CallAndSayRequest {
+                to: "+6512345678".to_string(),
+                message: "Hello".to_string(),
+            }),
+        )
+        .await;
+        assert!(matches!(call_result, Err(AppError::NotFound(_))));
+    }
+
+    #[tokio::test]
     async fn disabled_operation_returns_not_found() {
         let Some(db) = crate::test_utils::connect_test_database("platform_ops_disabled").await
         else {
             eprintln!("skipping platform operation handler test: no local MongoDB available");
             return;
         };
+        enable_platform_services_for_tests(&db).await;
         db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
             .insert_one(operation(
                 PlatformOperationName::XSearch,
@@ -364,6 +439,7 @@ mod tests {
             eprintln!("skipping platform operation handler test: no local MongoDB available");
             return;
         };
+        enable_platform_services_for_tests(&db).await;
         db.collection::<PlatformOperation>(PLATFORM_OPERATIONS)
             .insert_one(operation(
                 PlatformOperationName::XSearch,
@@ -395,6 +471,7 @@ mod tests {
             eprintln!("skipping platform operation handler test: no local MongoDB available");
             return;
         };
+        enable_platform_services_for_tests(&db).await;
         ensure_usage_index(&db).await;
         let state = crate::test_utils::test_app_state(db.clone());
         let (base_url, server) = spawn_twilio(StatusCode::CREATED).await;
@@ -440,6 +517,7 @@ mod tests {
             eprintln!("skipping platform operation handler test: no local MongoDB available");
             return;
         };
+        enable_platform_services_for_tests(&db).await;
         ensure_usage_index(&db).await;
         let state = crate::test_utils::test_app_state(db.clone());
         let (base_url, server) = spawn_twilio(StatusCode::INTERNAL_SERVER_ERROR).await;

--- a/backend/src/services/feature_flag_service.rs
+++ b/backend/src/services/feature_flag_service.rs
@@ -116,12 +116,24 @@ const DIRECT_CHAT_ENGINE_FLAG: FeatureFlagDef = FeatureFlagDef {
     default_enabled: false,
 };
 
+/// Operator gate for the first-party platform-services operation surface.
+/// Disabled by default; per-operation `enabled` rows remain a separate,
+/// narrower layer below this caller-facing feature gate.
+pub const PLATFORM_SERVICES_FLAG_KEY: &str = "experimental:platform-services";
+
+const PLATFORM_SERVICES_FLAG: FeatureFlagDef = FeatureFlagDef {
+    key: PLATFORM_SERVICES_FLAG_KEY,
+    description: "Exposes constrained first-party platform service operations.",
+    default_enabled: false,
+};
+
 #[cfg(not(test))]
 pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
     AI_ASSISTANT_FLAG,
     BILLING_FLAG,
     AEVATAR_CHAT_WIRE_LOG_FLAG,
     DIRECT_CHAT_ENGINE_FLAG,
+    PLATFORM_SERVICES_FLAG,
 ];
 
 /// Test builds carry a placeholder flag so the resolution / override pipeline
@@ -132,6 +144,7 @@ pub const FEATURE_FLAGS: &[FeatureFlagDef] = &[
     BILLING_FLAG_TEST,
     AEVATAR_CHAT_WIRE_LOG_FLAG,
     DIRECT_CHAT_ENGINE_FLAG,
+    PLATFORM_SERVICES_FLAG,
     FeatureFlagDef {
         key: "example_ui",
         description: "Test-only placeholder flag.",
@@ -1278,6 +1291,7 @@ mod tests {
                 "experimental:billing",
                 "experimental:aevatar-chat-wire-log",
                 "experimental:direct-chat-engine",
+                "experimental:platform-services",
             ]
         );
         assert_eq!(
@@ -1289,6 +1303,12 @@ mod tests {
                 .expect("wire-log flag is registered")
                 .default_enabled,
             "the wire-log diagnostic must default to off"
+        );
+        assert!(
+            !find_flag(PLATFORM_SERVICES_FLAG_KEY)
+                .expect("platform-services flag is registered")
+                .default_enabled,
+            "the platform-services surface must default to off"
         );
     }
 


### PR DESCRIPTION
Gates the entire platform-operations consumer surface behind one feature flag, **disabled for every user by default**.

- `PLATFORM_SERVICES_FLAG_KEY = "experimental:platform-services"`, `default_enabled: false` in **both** prod and test registries (billing's test-ON precedent deliberately not copied — default-off is itself pinned by a registry test; existing tests opt in via explicit `set_platform_override`).
- `require_platform_ops_enabled` runs **first** in `x_search`/`speak`/`call_and_say` — an unflagged caller gets a plain not-found 404 before any token-class distinction.
- MCP gated on **both** paths: `tools/list` omits the three `nyx__` tools, and dispatch independently rejects guessed names. Flag-resolution failures fail closed.
- Admin `GET/PUT /api/v1/admin/platform-ops*` deliberately ungated (commented) so operators stage config before exposure.
- Layering: flag (who sees the surface) → per-op `enabled` (what's live) → per-op config (how bounded).
- Additive only; shared files touched: flag registry + MCP transport thread-through. Reviewed directly, zero findings. fmt/check/clippy green locally; backend suite runs when the rollup PRs into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)