### PR TITLE
fix(frontend): accept account:read and sandbox:execute delegation token scopes

### DIFF
--- a/frontend/src/pages/service-edit.tsx
+++ b/frontend/src/pages/service-edit.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useService, useUpdateService } from "@/hooks/use-services";
 import { useDeveloperApps } from "@/hooks/use-developer-apps";
 import {
+  DELEGATION_TOKEN_SCOPES,
   updateServiceSchema,
   type UpdateServiceFormData,
   VISIBILITY_OPTIONS,
@@ -1108,7 +1109,8 @@ export function ServiceEditPage() {
                               <p className="text-xs text-muted-foreground">
                                 Space-separated scopes for the delegation token.
                                 Defaults to &quot;llm:proxy&quot; if left empty.
-                                Available scopes: llm:proxy, proxy:*, llm:status
+                                Available scopes:{" "}
+                                {DELEGATION_TOKEN_SCOPES.join(", ")}
                               </p>
                               <FormMessage />
                             </FormItem>

--- a/frontend/src/schemas/services.test.ts
+++ b/frontend/src/schemas/services.test.ts
@@ -230,6 +230,32 @@ describe("updateServiceSchema", () => {
     }
   });
 
+  it("accepts every delegation token scope the backend allows", () => {
+    // Backend source of truth: SERVICE_DELEGATION_SCOPES in backend/src/mw/auth.rs.
+    for (const delegation_token_scope of [
+      "llm:proxy",
+      "proxy:*",
+      "llm:status",
+      "account:read",
+      "sandbox:execute",
+      "proxy:* sandbox:execute",
+    ]) {
+      expect(
+        updateServiceSchema.safeParse({ ...validData, delegation_token_scope })
+          .success,
+      ).toBe(true);
+    }
+  });
+
+  it("rejects a delegation token scope the backend does not allow", () => {
+    expect(
+      updateServiceSchema.safeParse({
+        ...validData,
+        delegation_token_scope: "proxy:* sandbox:admin",
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts update with identity propagation fields", () => {
     const result = updateServiceSchema.safeParse({
       ...validData,

--- a/frontend/src/schemas/services.ts
+++ b/frontend/src/schemas/services.ts
@@ -52,8 +52,15 @@ export type ServiceCategory = (typeof SERVICE_CATEGORIES)[number];
 
 const optionalString = z.string().optional().or(z.literal(""));
 
-// Mirrors the backend whitelist in handlers/services.rs validate_delegation_scope.
-const DELEGATION_TOKEN_SCOPES = ["llm:proxy", "proxy:*", "llm:status"];
+// Mirrors SERVICE_DELEGATION_SCOPES in backend/src/mw/auth.rs, the allowlist
+// enforced by both handlers/services.rs and services/user_service_service.rs.
+export const DELEGATION_TOKEN_SCOPES = [
+  "llm:proxy",
+  "proxy:*",
+  "llm:status",
+  "account:read",
+  "sandbox:execute",
+];
 const urlField = z.string().refine(isValidHttpUrl, "Must be a valid URL");
 
 export const sshServiceConfigSchema = z


### PR DESCRIPTION
## Summary

The service edit form rejected `sandbox:execute` and `account:read` in **Delegation Token Scope**, even though the backend accepts both. The frontend allowlist was a hand-maintained copy of the backend's and had gone stale.

- `frontend/src/schemas/services.ts` held `["llm:proxy", "proxy:*", "llm:status"]`. The backend's `SERVICE_DELEGATION_SCOPES` (`backend/src/mw/auth.rs:273`) has five entries. `account:read` and `sandbox:execute` were added by `5c89e104` ("fix: support sandbox execution delegation (#1337)"), which updated `auth.rs`, `user_service_service.rs`, the CLI, and the docs, and never touched `frontend/`.
- Anyone using the form got `Each scope must be one of: llm:proxy, proxy:*, llm:status`. `PUT /api/v1/services/{id}` and `PUT /api/v1/user-services/{id}` would both have accepted the value, and `nyxid service update --delegation-token-scope 'proxy:* sandbox:execute'` already works today, so the web UI was the only blocked path.
- The **Available scopes** help text listed the same three by hand. It now renders the one exported list, so the next backend scope shows up in both places from a single edit.

Why it matters beyond the form. aevatar's code-execution admission contract (ADR-0050) requires `forward_access_token=true && inject_delegation_token=true && scope ⊇ {proxy:*, sandbox:execute}` on the `chrono-sandbox` route. NyxID itself never reads `sandbox:execute`; its own proxy gate is `proxy` or `proxy:*` via `scope_allows_rest_proxy`. So `sandbox:execute` is a downstream admission marker that NyxID stores and forwards, and it was unsettable from the UI.

Two commits, failing test first.

| Commit | Change |
|---|---|
| `4e78f9b6` | `test(frontend)`: pin the allowlist to the backend's, red on `account:read` and `sandbox:execute` |
| `39376009` | `fix(frontend)`: widen the allowlist, render the help text from it |

## Verification

Run from `frontend/`.

**Repro, before the fix** (`4e78f9b6` alone):

```
 FAIL  src/schemas/services.test.ts > updateServiceSchema > accepts every delegation token scope the backend allows
AssertionError: expected false to be true // Object.is equality
 ❯ src/schemas/services.test.ts:246:9
Tests  1 failed | 35 passed (36)
```

**After the fix** (`39376009`):

```
$ npx vitest run src/schemas/services.test.ts
Test Files  1 passed (1)
     Tests  36 passed (36)
```

**Full suite:**

```
$ npm run test
Test Files  291 passed (291)
     Tests  2886 passed (2886)
```

**Type check and production build:**

```
$ npx tsc --noEmit -p tsconfig.app.json    # exit 0
$ npm run build                            # built, credential-accept footprint assertion passed
```

**Backend side, confirming the target list:**

```
$ cargo test -p nyxid --bin nyxid-server validate_identity_config_accepts
test validate_identity_config_accepts_all_valid_scopes ... ok
test result: ok. 5 passed; 0 failed
```

Pre-commit hook (`scripts/pre-commit`, eslint) ran on both commits and passed. The 27 eslint warnings it prints are pre-existing on `main` and untouched here.

## Risks and judgment calls

**I did not drive the authenticated page in a browser.** The edit form is behind admin auth and needs the backend plus MongoDB. What I verified instead is the exact enforcement point, `updateServiceSchema` executed directly, plus the wiring that connects it to the form (`service-edit.tsx:66`, `resolver: zodResolver(updateServiceSchema)`) and a clean production build. There is no second validation layer between the input and that schema. Reviewers who want a screenshot should say so.

**Exporting `DELEGATION_TOKEN_SCOPES` is a deliberate widening of the module surface.** It removes the third hand-maintained copy in the help text. The alternative was to leave the copy and edit two literals; that is what let this drift in the first place.

**The Rust and TypeScript lists are still duplicated with nothing enforcing agreement.** The new test pins the TypeScript side and names `backend/src/mw/auth.rs` in a comment, so a future divergence fails a frontend test rather than surfacing as a support question. It does not read the Rust file. A real cross-language check would need build plumbing that this repo does not have, and it did not seem worth introducing for a five-element list.

**Scope check.** `account:read` was already backend-legal and is now settable in the form. That is the same drift, not a new grant. It stays governed by the delegated-read rules in `mw/auth.rs` (`delegated_read_denied_path`, exact-scope, GET-only, no WebSocket upgrade).

## Related

Found while investigating #1502. This does **not** close it. `chrono-sandbox` rows are auto-provisioned, and `ensure_user_managed_service` (`backend/src/services/user_service_service.rs:74-81`) rejects writes where `source == auto_provision` with a 403. That is the `PUT -> 403` in the aevatarAI/aevatar#3530 production log. The per-caller alias work in #1502 is still required to unblock that. This PR only makes the scope settable once there is a writable row to set it on.

Related: #1502, aevatarAI/aevatar#3530.
