### PR TITLE
feat(platform-ops): admin-managed vendor provisioning, bind-time contract validation, and structural flag gating

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -2054,6 +2054,29 @@ pub async fn ensure_indexes(db: &Database) -> Result<(), mongodb::error::Error> 
         )
         .await?;
 
+    // ── platform_vendor_templates ──
+    // Vendor keys and canonical slugs are the stable admin-facing identities;
+    // inactive templates remain available for audit/history, so uniqueness is
+    // enforced across all rows.
+    let platform_vendor_templates =
+        db.collection::<Document>(crate::models::platform_vendor_template::COLLECTION_NAME);
+    platform_vendor_templates
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "vendor": 1 })
+                .options(IndexOptions::builder().unique(true).build())
+                .build(),
+        )
+        .await?;
+    platform_vendor_templates
+        .create_index(
+            IndexModel::builder()
+                .keys(doc! { "slug": 1 })
+                .options(IndexOptions::builder().unique(true).build())
+                .build(),
+        )
+        .await?;
+
     // ── feature_flag_overrides ──
     // One override per (org, flag, target scope). target_key is null for
     // org-scope rows, the role string for role scope, the member_user_id for

--- a/backend/src/errors/mod.rs
+++ b/backend/src/errors/mod.rs
@@ -73,6 +73,9 @@ pub enum AppError {
     #[error("Platform operation vendor is unavailable")]
     PlatformOperationUnavailable,
 
+    #[error("{0}")]
+    PlatformVendorProvisioningInvalid(String),
+
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
@@ -531,6 +534,7 @@ impl AppError {
             Self::BadRequest(_) | Self::ValidationError(_) => StatusCode::BAD_REQUEST,
             Self::RequestBodyTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
             Self::PlatformOperationUnavailable => StatusCode::BAD_GATEWAY,
+            Self::PlatformVendorProvisioningInvalid(_) => StatusCode::BAD_REQUEST,
             Self::Unauthorized(_) | Self::AuthenticationFailed(_) | Self::TokenExpired => {
                 StatusCode::UNAUTHORIZED
             }
@@ -683,6 +687,7 @@ impl AppError {
             Self::BadRequest(_) => 1000,
             Self::RequestBodyTooLarge { .. } => 11700,
             Self::PlatformOperationUnavailable => 11800,
+            Self::PlatformVendorProvisioningInvalid(_) => 11801,
             Self::Unauthorized(_) => 1001,
             Self::Forbidden(_) => 1002,
             Self::NotFound(_) => 1003,
@@ -875,6 +880,7 @@ impl AppError {
             Self::BadRequest(_) => "bad_request",
             Self::RequestBodyTooLarge { .. } => "request_body_too_large",
             Self::PlatformOperationUnavailable => "platform_operation_unavailable",
+            Self::PlatformVendorProvisioningInvalid(_) => "platform_vendor_provisioning_invalid",
             Self::Unauthorized(_) => "unauthorized",
             Self::Forbidden(_) => "forbidden",
             Self::NotFound(_) => "not_found",

--- a/backend/src/handlers/admin_platform_ops.rs
+++ b/backend/src/handlers/admin_platform_ops.rs
@@ -1,7 +1,10 @@
 use axum::{
     Json,
     extract::{Path, State},
+    http::StatusCode,
 };
+use futures::TryStreamExt;
+use mongodb::bson::doc;
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -11,12 +14,81 @@ use crate::models::platform_operation::{
     CallAndSayConfig, PlatformOperation, PlatformOperationConfig, PlatformOperationName,
     SpeakConfig, XSearchConfig,
 };
+use crate::models::platform_vendor_template::PlatformVendorTemplate;
 use crate::mw::auth::AuthUser;
-use crate::services::{audit_service, platform_operation_service};
+use crate::services::{
+    audit_service, platform_operation_service, platform_vendor_template_service,
+};
 
 #[derive(Debug, Serialize)]
 pub struct AdminPlatformOperationListResponse {
     pub operations: Vec<AdminPlatformOperationResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminPlatformVendorRequirementListResponse {
+    pub vendors: Vec<AdminPlatformVendorRequirementResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminPlatformVendorRequirementResponse {
+    pub id: String,
+    pub vendor: String,
+    pub display_name: String,
+    pub operation: Option<String>,
+    pub slug: String,
+    pub base_url: String,
+    pub auth_method: String,
+    pub auth_key_name: Option<String>,
+    pub service_category: String,
+    pub visibility: String,
+    pub credential_label: String,
+    pub credential_note: String,
+    pub capability_summary: String,
+    pub restriction_summary: String,
+    pub is_active: bool,
+    pub is_seeded: bool,
+    pub existing_service: Option<AdminPlatformVendorServiceResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminPlatformVendorTemplateListResponse {
+    pub vendors: Vec<AdminPlatformVendorRequirementResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlatformVendorTemplateRequest {
+    pub vendor: String,
+    pub display_name: String,
+    pub slug: String,
+    pub base_url: String,
+    pub auth_method: String,
+    #[serde(default)]
+    pub auth_key_name: Option<String>,
+    pub credential_label: String,
+    pub credential_note: String,
+    #[serde(default)]
+    pub operation: Option<String>,
+    pub capability_summary: String,
+    pub restriction_summary: String,
+    #[serde(default = "default_template_active")]
+    pub is_active: bool,
+}
+
+fn default_template_active() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminPlatformVendorServiceResponse {
+    pub id: String,
+    pub name: String,
+    pub auth_method: String,
+    pub auth_key_name: String,
+    pub service_category: String,
+    pub visibility: String,
+    pub is_active: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -67,6 +139,104 @@ pub struct UpdatePlatformOperationRequest {
     pub config: PlatformOperationConfig,
 }
 
+/// GET /api/v1/admin/platform-ops/vendor-requirements
+pub async fn get_vendor_requirements(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AppResult<Json<AdminPlatformVendorRequirementListResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let templates = platform_vendor_template_service::list_templates(&state.db, false).await?;
+    let services = list_active_vendor_services(&state.db, &templates).await?;
+    Ok(Json(vendor_requirements_response(&templates, &services)))
+}
+
+/// GET /api/v1/admin/platform-ops/vendor-templates
+pub async fn list_vendor_templates(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AppResult<Json<AdminPlatformVendorTemplateListResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let templates = platform_vendor_template_service::list_templates(&state.db, true).await?;
+    let services = list_active_vendor_services(&state.db, &templates).await?;
+    Ok(Json(AdminPlatformVendorTemplateListResponse {
+        vendors: vendor_requirements_response(&templates, &services).vendors,
+    }))
+}
+
+/// POST /api/v1/admin/platform-ops/vendor-templates
+pub async fn create_vendor_template(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Json(body): Json<PlatformVendorTemplateRequest>,
+) -> AppResult<Json<AdminPlatformVendorRequirementResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let template = platform_vendor_template_service::create_template(
+        &state.db,
+        body.into(),
+        &auth_user.user_id.to_string(),
+    )
+    .await?;
+    audit_service::log_for_user(
+        state.db.clone(),
+        &auth_user,
+        "admin_platform_vendor_template_created",
+        Some(serde_json::json!({ "vendor": template.vendor, "slug": template.slug })),
+    );
+    Ok(Json(vendor_template_response(&template, None)))
+}
+
+/// PUT /api/v1/admin/platform-ops/vendor-templates/{template_id}
+pub async fn update_vendor_template(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(template_id): Path<String>,
+    Json(body): Json<PlatformVendorTemplateRequest>,
+) -> AppResult<Json<AdminPlatformVendorRequirementResponse>> {
+    require_admin(&state, &auth_user).await?;
+    let template = platform_vendor_template_service::update_template(
+        &state.db,
+        &template_id,
+        body.into(),
+        &auth_user.user_id.to_string(),
+    )
+    .await?;
+    let services = list_active_vendor_services(&state.db, std::slice::from_ref(&template)).await?;
+    audit_service::log_for_user(
+        state.db.clone(),
+        &auth_user,
+        "admin_platform_vendor_template_updated",
+        Some(serde_json::json!({ "vendor": template.vendor, "slug": template.slug })),
+    );
+    Ok(Json(vendor_template_response(
+        &template,
+        services
+            .iter()
+            .find(|service| service.slug == template.slug),
+    )))
+}
+
+/// DELETE /api/v1/admin/platform-ops/vendor-templates/{template_id}
+pub async fn disable_vendor_template(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(template_id): Path<String>,
+) -> AppResult<StatusCode> {
+    require_admin(&state, &auth_user).await?;
+    platform_vendor_template_service::disable_template(
+        &state.db,
+        &template_id,
+        &auth_user.user_id.to_string(),
+    )
+    .await?;
+    audit_service::log_for_user(
+        state.db.clone(),
+        &auth_user,
+        "admin_platform_vendor_template_disabled",
+        Some(serde_json::json!({ "template_id": template_id })),
+    );
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// GET /api/v1/admin/platform-ops
 pub async fn list_platform_operations(
     State(state): State<AppState>,
@@ -100,6 +270,7 @@ pub async fn update_platform_operation(
     let op = platform_operation_service::parse_operation_name(&op)?;
     let operation = platform_operation_service::upsert_operation(
         &state.db,
+        &state.encryption_keys,
         op,
         body.enabled,
         body.vendor_service_slug,
@@ -120,6 +291,99 @@ pub async fn update_platform_operation(
     );
 
     Ok(Json(platform_operation_response(op, Some(operation))))
+}
+
+async fn list_active_vendor_services(
+    db: &mongodb::Database,
+    templates: &[PlatformVendorTemplate],
+) -> AppResult<Vec<crate::models::downstream_service::DownstreamService>> {
+    let slugs = templates
+        .iter()
+        .map(|template| template.slug.as_str())
+        .collect::<Vec<_>>();
+    if slugs.is_empty() {
+        return Ok(Vec::new());
+    }
+    db.collection::<crate::models::downstream_service::DownstreamService>(
+        crate::models::downstream_service::COLLECTION_NAME,
+    )
+    .find(doc! { "slug": { "$in": slugs }, "is_active": true })
+    .await?
+    .try_collect()
+    .await
+    .map_err(crate::errors::AppError::DatabaseError)
+}
+
+fn vendor_requirements_response(
+    templates: &[PlatformVendorTemplate],
+    services: &[crate::models::downstream_service::DownstreamService],
+) -> AdminPlatformVendorRequirementListResponse {
+    let vendors = templates
+        .iter()
+        .map(|template| {
+            vendor_template_response(
+                template,
+                services
+                    .iter()
+                    .find(|service| service.slug == template.slug),
+            )
+        })
+        .collect();
+    AdminPlatformVendorRequirementListResponse { vendors }
+}
+
+fn vendor_template_response(
+    template: &PlatformVendorTemplate,
+    service: Option<&crate::models::downstream_service::DownstreamService>,
+) -> AdminPlatformVendorRequirementResponse {
+    AdminPlatformVendorRequirementResponse {
+        id: template.id.clone(),
+        vendor: template.vendor.clone(),
+        display_name: template.display_name.clone(),
+        operation: template.operation.clone(),
+        slug: template.slug.clone(),
+        base_url: template.base_url.clone(),
+        auth_method: template.auth_method.clone(),
+        auth_key_name: template.auth_key_name.clone(),
+        service_category: "internal".to_string(),
+        visibility: "public".to_string(),
+        credential_label: template.credential_label.clone(),
+        credential_note: template.credential_note.clone(),
+        capability_summary: template.capability_summary.clone(),
+        restriction_summary: template.restriction_summary.clone(),
+        is_active: template.is_active,
+        is_seeded: template.is_seeded,
+        existing_service: service.map(|service| AdminPlatformVendorServiceResponse {
+            id: service.id.clone(),
+            name: service.name.clone(),
+            auth_method: service.auth_method.clone(),
+            auth_key_name: service.auth_key_name.clone(),
+            service_category: service.service_category.clone(),
+            visibility: service.visibility.clone(),
+            is_active: service.is_active,
+        }),
+    }
+}
+
+impl From<PlatformVendorTemplateRequest>
+    for platform_vendor_template_service::PlatformVendorTemplateInput
+{
+    fn from(request: PlatformVendorTemplateRequest) -> Self {
+        Self {
+            vendor: request.vendor,
+            display_name: request.display_name,
+            slug: request.slug,
+            base_url: request.base_url,
+            auth_method: request.auth_method,
+            auth_key_name: request.auth_key_name,
+            credential_label: request.credential_label,
+            credential_note: request.credential_note,
+            operation: request.operation,
+            capability_summary: request.capability_summary,
+            restriction_summary: request.restriction_summary,
+            is_active: request.is_active,
+        }
+    }
 }
 
 fn platform_operation_response(
@@ -185,6 +449,62 @@ impl From<PlatformOperationConfig> for AdminPlatformOperationConfigResponse {
 mod tests {
     use super::*;
     use crate::models::platform_operation::COLLECTION_NAME as PLATFORM_OPERATIONS;
+    use crate::services::platform_operation_service::DEFAULT_PLATFORM_VENDOR_TEMPLATES;
+
+    fn seeded_templates() -> Vec<PlatformVendorTemplate> {
+        let now = chrono::Utc::now();
+        DEFAULT_PLATFORM_VENDOR_TEMPLATES
+            .iter()
+            .enumerate()
+            .map(|(index, seed)| PlatformVendorTemplate {
+                id: format!("template-{index}"),
+                vendor: seed.vendor.to_string(),
+                display_name: seed.display_name.to_string(),
+                slug: seed.slug.to_string(),
+                base_url: seed.base_url.to_string(),
+                auth_method: seed.auth_method.to_string(),
+                auth_key_name: seed.auth_key_name.map(str::to_string),
+                credential_label: seed.credential_label.to_string(),
+                credential_note: seed.credential_note.to_string(),
+                operation: seed.operation.map(str::to_string),
+                capability_summary: seed.capability_summary.to_string(),
+                restriction_summary: seed.restriction_summary.to_string(),
+                is_active: true,
+                is_seeded: true,
+                created_at: now,
+                updated_at: now,
+                updated_by: "system".to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn vendor_requirements_response_exposes_the_provisioning_contract() {
+        let response = vendor_requirements_response(&seeded_templates(), &[]);
+        assert_eq!(response.vendors.len(), 4);
+
+        let elevenlabs = response
+            .vendors
+            .iter()
+            .find(|vendor| vendor.vendor == "elevenlabs")
+            .expect("ElevenLabs requirement");
+        assert_eq!(elevenlabs.operation.as_deref(), Some("speak"));
+        assert_eq!(elevenlabs.slug, "platform-elevenlabs");
+        assert_eq!(elevenlabs.base_url, "https://api.elevenlabs.io");
+        assert_eq!(elevenlabs.auth_method, "header");
+        assert_eq!(elevenlabs.auth_key_name.as_deref(), Some("xi-api-key"));
+        assert_eq!(elevenlabs.service_category, "internal");
+        assert_eq!(elevenlabs.visibility, "public");
+
+        let duffel = response
+            .vendors
+            .iter()
+            .find(|vendor| vendor.vendor == "duffel")
+            .expect("Duffel requirement");
+        assert_eq!(duffel.operation, None);
+        assert_eq!(duffel.slug, "platform-duffel");
+        assert_eq!(duffel.auth_method, "bearer");
+    }
 
     #[test]
     fn missing_rows_render_as_disabled_defaults() {
@@ -220,8 +540,30 @@ mod tests {
             return;
         };
 
+        let encryption_keys = crate::test_utils::test_encryption_keys();
+        let mut vendor = crate::models::downstream_service::test_helpers::dummy_service();
+        vendor.id = uuid::Uuid::new_v4().to_string();
+        vendor.slug = "platform-x".to_string();
+        vendor.base_url = "https://api.x.com".to_string();
+        vendor.auth_method = "bearer".to_string();
+        vendor.auth_key_name = "Authorization".to_string();
+        vendor.service_category = "internal".to_string();
+        vendor.visibility = "public".to_string();
+        vendor.requires_user_credential = false;
+        vendor.credential_encrypted = encryption_keys
+            .encrypt(b"x-bearer-token")
+            .await
+            .expect("encrypt vendor credential");
+        db.collection::<crate::models::downstream_service::DownstreamService>(
+            crate::models::downstream_service::COLLECTION_NAME,
+        )
+        .insert_one(vendor)
+        .await
+        .expect("insert platform vendor row");
+
         let operation = platform_operation_service::upsert_operation(
             &db,
+            &encryption_keys,
             PlatformOperationName::XSearch,
             true,
             "platform-x".to_string(),

--- a/backend/src/handlers/endpoints.rs
+++ b/backend/src/handlers/endpoints.rs
@@ -11,7 +11,7 @@ use crate::mw::auth::AuthUser;
 use crate::services::service_endpoint_service::{
     EndpointInput, EndpointUpdate, validate_request_content_type, validate_response_contract,
 };
-use crate::services::{openapi_parser, service_endpoint_service};
+use crate::services::{catalog_spec_sync, openapi_parser, service_endpoint_service};
 
 use super::services_helpers::{fetch_service, require_admin_or_creator, require_http_service};
 
@@ -196,6 +196,11 @@ pub async fn create_endpoint(
     let service = fetch_service(&state, &service_id).await?;
     require_http_service(&service)?;
     require_admin_or_creator(&state, &auth_user, &service.created_by).await?;
+    if catalog_spec_sync::is_platform_vendor_service(&service) {
+        return Err(AppError::BadRequest(
+            "Platform vendor rows cannot publish endpoint tools".to_string(),
+        ));
+    }
 
     validate_endpoint_name(&body.name)?;
     validate_method(&body.method)?;
@@ -248,6 +253,11 @@ pub async fn update_endpoint(
     let service = fetch_service(&state, &service_id).await?;
     require_http_service(&service)?;
     require_admin_or_creator(&state, &auth_user, &service.created_by).await?;
+    if catalog_spec_sync::is_platform_vendor_service(&service) {
+        return Err(AppError::BadRequest(
+            "Platform vendor rows cannot publish endpoint tools".to_string(),
+        ));
+    }
 
     if let Some(ref name) = body.name {
         validate_endpoint_name(name)?;
@@ -332,6 +342,11 @@ pub async fn discover_endpoints(
     let service = fetch_service(&state, &service_id).await?;
     require_http_service(&service)?;
     require_admin_or_creator(&state, &auth_user, &service.created_by).await?;
+    if catalog_spec_sync::is_platform_vendor_service(&service) {
+        return Err(AppError::BadRequest(
+            "Platform vendor rows cannot publish endpoint tools".to_string(),
+        ));
+    }
 
     let api_spec_url = service.openapi_spec_url.ok_or_else(|| {
         AppError::BadRequest("Service has no openapi_spec_url configured".to_string())

--- a/backend/src/handlers/platform_ops.rs
+++ b/backend/src/handlers/platform_ops.rs
@@ -3,8 +3,9 @@ use std::time::Instant;
 use axum::{
     Json,
     body::Body,
-    extract::State,
+    extract::{Request, State},
     http::{StatusCode, header},
+    middleware::Next,
     response::{IntoResponse, Response},
 };
 use chrono::Utc;
@@ -31,6 +32,19 @@ async fn require_platform_ops_enabled(state: &AppState, auth_user: &AuthUser) ->
         ));
     }
     Ok(())
+}
+
+/// Structural feature gate for every route in the `/platform-ops` nest.
+/// Handler-level checks remain as belt-and-braces protection for direct calls
+/// and tests, but a newly mounted route inherits this middleware automatically.
+pub async fn platform_services_feature_gate(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    request: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    require_platform_ops_enabled(&state, &auth_user).await?;
+    Ok(next.run(request).await)
 }
 
 pub async fn x_search(

--- a/backend/src/handlers/services.rs
+++ b/backend/src/handlers/services.rs
@@ -967,7 +967,13 @@ pub async fn create_service(
             (enc, None)
         };
 
-        let docs_metadata = api_docs_service::discover_service_docs(base_url, None, None).await;
+        let docs_metadata = api_docs_service::discover_service_docs_for_category(
+            &service_category,
+            base_url,
+            None,
+            None,
+        )
+        .await;
 
         (
             base_url.to_string(),
@@ -1205,11 +1211,7 @@ pub async fn create_service(
     // Auto-run endpoint discovery when the new service already carries a
     // spec URL so MCP tools and workflow operations appear without a
     // manual discover-endpoints call (#1290 follow-up).
-    if new_service
-        .openapi_spec_url
-        .as_deref()
-        .is_some_and(|url| !url.is_empty())
-    {
+    if catalog_spec_sync::should_auto_sync_service_endpoints(&new_service) {
         catalog_spec_sync::spawn_spec_endpoint_sync(state.db.clone(), id.clone());
     }
 
@@ -1382,6 +1384,12 @@ pub async fn update_service(
 ) -> AppResult<Json<ServiceResponse>> {
     let service = fetch_service(&state, &service_id).await?;
     require_admin_or_creator(&state, &auth_user, &service.created_by).await?;
+    let is_platform_vendor = catalog_spec_sync::is_platform_vendor_service(&service);
+    if is_platform_vendor && (body.openapi_spec_url.is_some() || body.asyncapi_spec_url.is_some()) {
+        return Err(AppError::BadRequest(
+            "Platform vendor rows cannot configure OpenAPI or AsyncAPI specs".to_string(),
+        ));
+    }
     let mut platform_price_changed = false;
     if let Some(billing) = body.billing.as_mut() {
         let current_pricing = service
@@ -1611,14 +1619,18 @@ pub async fn update_service(
             } else {
                 service.asyncapi_spec_url.clone()
             };
-            http_docs_refresh = Some(
-                api_docs_service::discover_service_docs(
-                    docs_base_url,
-                    explicit_openapi,
-                    explicit_asyncapi,
+            http_docs_refresh = if is_platform_vendor {
+                None
+            } else {
+                Some(
+                    api_docs_service::discover_service_docs(
+                        docs_base_url,
+                        explicit_openapi,
+                        explicit_asyncapi,
+                    )
+                    .await,
                 )
-                .await,
-            );
+            };
         }
         "ssh" => {
             let has_http_only_updates = body.base_url.is_some()
@@ -2120,11 +2132,7 @@ pub async fn update_service(
     // so setting openapi_spec_url is enough to surface MCP tools and
     // workflow operations without a manual discover-endpoints call
     // (#1290 follow-up).
-    if updated
-        .openapi_spec_url
-        .as_deref()
-        .is_some_and(|url| !url.is_empty())
-    {
+    if catalog_spec_sync::should_auto_sync_service_endpoints(&updated) {
         catalog_spec_sync::spawn_spec_endpoint_sync(state.db.clone(), service_id.clone());
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -529,6 +529,12 @@ async fn main() {
         .await
         .expect("Failed to seed default services");
 
+    // Seed the admin-managed platform vendor provisioning templates. Existing
+    // rows are never overwritten so operators can edit or disable templates.
+    services::platform_vendor_template_service::seed_default_templates(&db, "system")
+        .await
+        .expect("Failed to seed platform vendor templates");
+
     // Materialize ServiceEndpoint rows for seeded catalog services from the
     // hosted overlay specs so /api/v1/mcp/config publishes concrete
     // service_id + endpoint_id operations for workflow consumers (#1290).
@@ -1217,7 +1223,7 @@ async fn main() {
 
     // Build router — public OAuth routes get open CORS (per RFC 9207),
     // private API routes get restricted CORS (FRONTEND_URL only).
-    let (public_oauth, private_api) = routes::build_router();
+    let (public_oauth, private_api) = routes::build_router_with_state(state.clone());
 
     let csrf_state = state.clone();
     let private_api = private_api.layer(cors).layer(axum_mw::from_fn_with_state(

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -61,6 +61,7 @@ pub mod org_role_scope;
 pub mod platform_op_usage;
 pub mod platform_operation;
 pub mod platform_settings;
+pub mod platform_vendor_template;
 pub mod provider_config;
 pub mod pushed_authorization_request;
 pub mod refresh_token;

--- a/backend/src/models/platform_vendor_template.rs
+++ b/backend/src/models/platform_vendor_template.rs
@@ -1,0 +1,36 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const COLLECTION_NAME: &str = "platform_vendor_templates";
+
+/// Admin-managed provisioning metadata. This record is intentionally not the
+/// runtime operation contract: operation binding always checks the code-owned
+/// contract in `platform_operation_service`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlatformVendorTemplate {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub vendor: String,
+    pub display_name: String,
+    pub slug: String,
+    pub base_url: String,
+    pub auth_method: String,
+    #[serde(default)]
+    pub auth_key_name: Option<String>,
+    pub credential_label: String,
+    pub credential_note: String,
+    #[serde(default)]
+    pub operation: Option<String>,
+    #[serde(default)]
+    pub capability_summary: String,
+    #[serde(default)]
+    pub restriction_summary: String,
+    pub is_active: bool,
+    #[serde(default)]
+    pub is_seeded: bool,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub created_at: DateTime<Utc>,
+    #[serde(with = "bson::serde_helpers::chrono_datetime_as_bson_datetime")]
+    pub updated_at: DateTime<Utc>,
+    pub updated_by: String,
+}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -424,7 +424,26 @@ fn oauth_public_cors() -> CorsLayer {
 /// The caller must attach separate CORS layers to each before merging.
 /// Public OAuth endpoints allow any origin (per RFC 9207) while private
 /// API endpoints restrict origin to FRONTEND_URL.
+///
+/// The no-state builder remains for integration tests and compatibility
+/// callers that attach application state themselves; production uses
+/// `build_router_with_state` so the platform-operations feature gate can be
+/// installed at the router boundary.
+#[allow(dead_code)]
 pub fn build_router() -> (Router<AppState>, Router<AppState>) {
+    build_router_internal(None)
+}
+
+/// Build the production router with state-aware middleware attached to the
+/// caller-facing platform-operations nest. Admin platform-ops routes remain
+/// deliberately ungated so operators can stage templates and configuration.
+pub fn build_router_with_state(state: AppState) -> (Router<AppState>, Router<AppState>) {
+    build_router_internal(Some(state))
+}
+
+fn build_router_internal(
+    platform_gate_state: Option<AppState>,
+) -> (Router<AppState>, Router<AppState>) {
     let mfa_routes = Router::new()
         .route("/setup", post(handlers::mfa::setup))
         .route("/confirm", post(handlers::mfa::confirm))
@@ -771,6 +790,20 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
         .route(
             "/platform-ops",
             get(handlers::admin_platform_ops::list_platform_operations),
+        )
+        .route(
+            "/platform-ops/vendor-requirements",
+            get(handlers::admin_platform_ops::get_vendor_requirements),
+        )
+        .route(
+            "/platform-ops/vendor-templates",
+            get(handlers::admin_platform_ops::list_vendor_templates)
+                .post(handlers::admin_platform_ops::create_vendor_template),
+        )
+        .route(
+            "/platform-ops/vendor-templates/{template_id}",
+            put(handlers::admin_platform_ops::update_vendor_template)
+                .delete(handlers::admin_platform_ops::disable_vendor_template),
         )
         .route(
             "/platform-ops/{op}",
@@ -1565,10 +1598,20 @@ pub fn build_router() -> (Router<AppState>, Router<AppState>) {
     let platform_operation_routes = Router::new()
         .route("/x-search", post(handlers::platform_ops::x_search))
         .route("/speak", post(handlers::platform_ops::speak))
-        .route("/call-and-say", post(handlers::platform_ops::call_and_say))
-        .layer(middleware::from_fn(reject_delegated_tokens))
-        .layer(middleware::from_fn(reject_service_account_tokens))
-        .layer(middleware::from_fn(reject_relay_tokens));
+        .route("/call-and-say", post(handlers::platform_ops::call_and_say));
+    let platform_operation_routes = match platform_gate_state {
+        Some(state) => platform_operation_routes.layer(middleware::from_fn_with_state(
+            state,
+            handlers::platform_ops::platform_services_feature_gate,
+        )),
+        None => platform_operation_routes,
+    }
+    // Every current and future caller-facing operation inherits the flag gate
+    // at the nest boundary. Admin routes are mounted separately below and
+    // intentionally stay ungated for staged provisioning.
+    .layer(middleware::from_fn(reject_delegated_tokens))
+    .layer(middleware::from_fn(reject_service_account_tokens))
+    .layer(middleware::from_fn(reject_relay_tokens));
 
     let api_v1_platform_operations = Router::new().nest("/platform-ops", platform_operation_routes);
 

--- a/backend/src/services/api_docs_service.rs
+++ b/backend/src/services/api_docs_service.rs
@@ -59,6 +59,33 @@ pub struct ServiceDocumentationMetadata {
     pub streaming_supported: bool,
 }
 
+impl ServiceDocumentationMetadata {
+    fn empty() -> Self {
+        Self {
+            openapi_spec_url: None,
+            asyncapi_spec_url: None,
+            streaming_supported: false,
+        }
+    }
+}
+
+pub async fn discover_service_docs_for_category(
+    service_category: &str,
+    base_url: &str,
+    explicit_openapi_spec_url: Option<String>,
+    explicit_asyncapi_spec_url: Option<String>,
+) -> ServiceDocumentationMetadata {
+    if service_category == "internal" {
+        return ServiceDocumentationMetadata::empty();
+    }
+    discover_service_docs(
+        base_url,
+        explicit_openapi_spec_url,
+        explicit_asyncapi_spec_url,
+    )
+    .await
+}
+
 pub async fn discover_service_docs(
     base_url: &str,
     explicit_openapi_spec_url: Option<String>,
@@ -1052,8 +1079,8 @@ mod tests {
     use super::{
         CachedSpecEntry, MAX_SPEC_CACHE_ENTRIES, ServiceDocumentationMetadata, SpecCacheTestGuard,
         build_asyncapi_document, cache_spec, catalog_csp, detect_streaming_from_openapi,
-        fetch_spec_json, get_cached_spec, render_scalar_html, scalar_docs_csp,
-        validate_spec_fetch_target,
+        discover_service_docs_for_category, fetch_spec_json, get_cached_spec, render_scalar_html,
+        scalar_docs_csp, validate_spec_fetch_target,
     };
     use crate::errors::AppError;
     use std::sync::Arc;
@@ -1306,6 +1333,17 @@ mod tests {
     }
 
     // ---- is_auto_discovered_openapi_spec_url ----
+
+    #[tokio::test]
+    async fn internal_services_never_auto_discover_documentation() {
+        let metadata =
+            discover_service_docs_for_category("internal", "https://api.elevenlabs.io", None, None)
+                .await;
+
+        assert_eq!(metadata.openapi_spec_url, None);
+        assert_eq!(metadata.asyncapi_spec_url, None);
+        assert!(!metadata.streaming_supported);
+    }
 
     #[test]
     fn auto_discovered_openapi_matches_probe_paths() {

--- a/backend/src/services/catalog_service.rs
+++ b/backend/src/services/catalog_service.rs
@@ -17,7 +17,7 @@ use crate::models::service_provider_requirement::{
 };
 use crate::models::user::{COLLECTION_NAME as USERS, User};
 use crate::models::user_service::{COLLECTION_NAME as USER_SERVICES, UserService};
-use crate::services::{org_service, role_service};
+use crate::services::{catalog_spec_sync, org_service, role_service};
 
 /// A catalog entry combining DownstreamService + ProviderConfig info.
 pub struct CatalogEntry {
@@ -308,6 +308,11 @@ pub async fn list_catalog(
                     ],
                 },
                 legacy_service_category_filter(&["connection", "internal"]),
+                {
+                    "$nor": [
+                        { "service_category": "internal", "slug": { "$regex": "^platform-" } },
+                    ],
+                },
                 visibility_filter(user_id),
             ],
         },
@@ -326,6 +331,11 @@ pub async fn list_catalog_all(
         "is_active": true,
         "$and": [
             legacy_service_category_filter(&["connection", "internal"]),
+            {
+                "$nor": [
+                    { "service_category": "internal", "slug": { "$regex": "^platform-" } },
+                ],
+            },
             visibility_filter(user_id),
         ],
     };
@@ -452,6 +462,10 @@ pub async fn get_downstream_service_by_slug(
         .await?
         .ok_or_else(|| AppError::NotFound("Catalog entry not found".to_string()))?;
 
+    if catalog_spec_sync::is_platform_vendor_service(&svc) {
+        return Err(AppError::NotFound("Catalog entry not found".to_string()));
+    }
+
     enforce_catalog_read_access(db, user_id, &svc).await?;
 
     Ok(svc)
@@ -552,6 +566,10 @@ pub async fn get_catalog_entry(
         .find_one(doc! { "slug": slug, "is_active": true })
         .await?
         .ok_or_else(|| AppError::NotFound("Catalog entry not found".to_string()))?;
+
+    if catalog_spec_sync::is_platform_vendor_service(&svc) {
+        return Err(AppError::NotFound("Catalog entry not found".to_string()));
+    }
 
     enforce_catalog_read_access(db, user_id, &svc).await?;
 

--- a/backend/src/services/catalog_spec_sync.rs
+++ b/backend/src/services/catalog_spec_sync.rs
@@ -42,6 +42,9 @@ pub async fn sync_seeded_service_endpoints(db: &mongodb::Database) -> AppResult<
         else {
             continue; // Service not seeded on this deployment
         };
+        if is_platform_vendor_service(&service) {
+            continue;
+        }
 
         let inputs = match seeded_endpoint_inputs(slug) {
             Ok(inputs) => inputs,
@@ -90,6 +93,7 @@ pub async fn sync_spec_backed_service_endpoints(db: &mongodb::Database) -> AppRe
         .find(doc! {
             "is_active": true,
             "service_type": "http",
+            "service_category": { "$ne": "internal" },
             "openapi_spec_url": { "$type": "string", "$ne": "" },
         })
         .await?
@@ -119,11 +123,7 @@ pub fn spawn_spec_endpoint_sync(db: mongodb::Database, service_id: String) {
                 return;
             }
         };
-        if service
-            .openapi_spec_url
-            .as_deref()
-            .is_none_or(str::is_empty)
-        {
+        if !should_auto_sync_service_endpoints(&service) {
             return;
         }
         sync_service_endpoints_from_spec_url(&db, &service).await;
@@ -134,6 +134,9 @@ pub fn spawn_spec_endpoint_sync(db: mongodb::Database, service_id: String) {
 /// failure instead of erroring so callers (startup sweep, admin handlers)
 /// are never blocked by a broken spec URL.
 async fn sync_service_endpoints_from_spec_url(db: &mongodb::Database, service: &DownstreamService) {
+    if !should_auto_sync_service_endpoints(service) {
+        return;
+    }
     let Some(spec_url) = service.openapi_spec_url.as_deref() else {
         return;
     };
@@ -196,6 +199,24 @@ async fn sync_service_endpoints_from_spec_url(db: &mongodb::Database, service: &
     }
 }
 
+pub fn should_auto_sync_service_endpoints(service: &DownstreamService) -> bool {
+    service.is_active
+        && service.service_type == "http"
+        && service.service_category != "internal"
+        && service
+            .openapi_spec_url
+            .as_deref()
+            .is_some_and(|url| !url.is_empty())
+}
+
+/// Platform vendor rows are credential stores, not catalog surfaces. Their
+/// reserved slug namespace lets hosted catalog overlays continue to hydrate
+/// intentional internal services such as LLM catalogs without publishing
+/// tools for operator-managed vendor credentials.
+pub fn is_platform_vendor_service(service: &DownstreamService) -> bool {
+    service.service_category == "internal" && service.slug.starts_with("platform-")
+}
+
 /// Parse and validate the hosted overlay for a slug into endpoint inputs.
 fn seeded_endpoint_inputs(slug: &str) -> AppResult<Vec<EndpointInput>> {
     let spec = catalog_spec_registry::spec_for_slug(slug).ok_or_else(|| {
@@ -236,6 +257,17 @@ fn endpoint_inputs_from_spec(spec: &serde_json::Value) -> AppResult<Vec<Endpoint
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn internal_services_are_never_auto_materialized_as_tools() {
+        let mut service = crate::models::downstream_service::test_helpers::dummy_service();
+        service.slug = "platform-elevenlabs".to_string();
+        service.service_category = "internal".to_string();
+        service.openapi_spec_url = Some("https://api.elevenlabs.io/openapi.json".to_string());
+
+        assert!(!should_auto_sync_service_endpoints(&service));
+        assert!(is_platform_vendor_service(&service));
+    }
 
     #[test]
     fn every_hydrated_slug_produces_valid_endpoint_inputs() {

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -29,8 +29,8 @@ use crate::services::content_type::{
 };
 use crate::services::node_ws_manager::NodeWsManager;
 use crate::services::{
-    api_docs_service, connect_link_service, connection_service, node_routing_service,
-    openapi_parser, operation_descriptor, proxy_service,
+    api_docs_service, catalog_spec_sync, connect_link_service, connection_service,
+    node_routing_service, openapi_parser, operation_descriptor, proxy_service,
 };
 
 // ---------------------------------------------------------------------------
@@ -950,6 +950,9 @@ async fn load_user_tools_inner(
         "is_active": true,
         "requires_user_credential": false,
         "service_category": { "$ne": "provider" },
+        "$nor": [
+            { "service_category": "internal", "slug": { "$regex": "^platform-" } },
+        ],
     };
     auto_services_filter.extend(legacy_http_service_type_filter());
 
@@ -974,7 +977,10 @@ async fn load_user_tools_inner(
     let mut valid_platform_services: Vec<(&DownstreamService, bool)> = Vec::new();
 
     for svc in &connected_services {
-        if svc.service_type != "http" || svc.service_category == "provider" {
+        if svc.service_type != "http"
+            || svc.service_category == "provider"
+            || catalog_spec_sync::is_platform_vendor_service(svc)
+        {
             continue;
         }
         let mut executable = true;
@@ -1213,15 +1219,24 @@ async fn load_user_tools_inner(
             .catalog_service_id
             .as_deref()
             .and_then(|id| catalog_policy_by_id.get(id).copied());
+        let platform_vendor_catalog =
+            catalog_policy.is_some_and(catalog_spec_sync::is_platform_vendor_service);
         let user_endpoint = endpoints_by_id.get(us.endpoint_id.as_str()).copied();
         let endpoint_label = user_endpoint
             .map(|ep| ep.label.as_str())
             .unwrap_or(&us.slug);
 
         let user_spec_url = user_endpoint.and_then(|ep| ep.openapi_spec_url.as_deref());
-        let (published, is_generic, invalid_openapi_contract) = if let Some(catalog_id) =
-            us.catalog_service_id.as_deref()
-        {
+        let (published, is_generic, invalid_openapi_contract) = if platform_vendor_catalog {
+            (
+                ParsedMcpEndpoints {
+                    endpoints: Vec::new(),
+                    durable_metadata: HashMap::new(),
+                },
+                false,
+                false,
+            )
+        } else if let Some(catalog_id) = us.catalog_service_id.as_deref() {
             // Catalog-backed: the instance's user-mounted spec is a
             // deliberate per-instance override and takes precedence over
             // the template's registered ServiceEndpoint rows. A broken or
@@ -4452,6 +4467,9 @@ pub async fn discover_services(
     let mut filter = doc! {
         "is_active": true,
         "service_category": { "$ne": "provider" },
+        "$nor": [
+            { "service_category": "internal", "slug": { "$regex": "^platform-" } },
+        ],
     };
     filter.extend(legacy_http_service_type_filter());
     if let Some(cat) = category {

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -88,6 +88,7 @@ pub mod org_slug;
 pub mod par_service;
 pub mod platform_operation_service;
 pub mod platform_settings_service;
+pub mod platform_vendor_template_service;
 pub mod provider_service;
 pub mod provider_token_exchange_service;
 pub mod proxy_authorization;

--- a/backend/src/services/platform_operation_service.rs
+++ b/backend/src/services/platform_operation_service.rs
@@ -834,7 +834,7 @@ async fn resolve_vendor_target(
     let service = assistant_service::resolve_admin_service_by_slug(db, slug)
         .await
         .map_err(|error| vendor_configuration_failed(op, error))?;
-    validate_vendor_binding_shape(requirement, slug, Some(&service))
+    validate_vendor_binding_shape(requirement, slug, Some(&service), false)
         .map_err(|error| vendor_configuration_failed(op, error))?;
     let authorized = proxy_service::authorize_master_credential_server_chosen(db, &service)
         .await
@@ -879,7 +879,7 @@ async fn validate_vendor_binding(
         None => collection.find_one(doc! { "slug": slug }).await?,
     };
     let requirement = vendor_requirement_for_operation(op);
-    validate_vendor_binding_shape(requirement, slug, service.as_ref())?;
+    validate_vendor_binding_shape(requirement, slug, service.as_ref(), true)?;
     let service = service.expect("validated vendor binding must have a service row");
 
     if service.credential_encrypted.is_empty() {
@@ -899,10 +899,16 @@ async fn validate_vendor_binding(
     validate_vendor_credential(requirement, &service, credential.as_slice())
 }
 
+/// `enforce_base_url` is true only at provisioning time. The canonical base URL is a
+/// template default and a bind-time guard against typos -- it is deliberately NOT a
+/// runtime gate, so an operator may legitimately point a vendor row at a regional
+/// endpoint, an egress proxy, or a test double. The security-bearing checks (auth
+/// shape, category, visibility, credential) are enforced on every path.
 fn validate_vendor_binding_shape(
     requirement: &PlatformOperationVendorContract,
     slug: &str,
     service: Option<&DownstreamService>,
+    enforce_base_url: bool,
 ) -> AppResult<()> {
     let op = operation_name(requirement.operation);
     let Some(service) = service else {
@@ -916,7 +922,7 @@ fn validate_vendor_binding_shape(
             requirement.slug
         )));
     }
-    if service.base_url.trim_end_matches('/') != requirement.base_url {
+    if enforce_base_url && service.base_url.trim_end_matches('/') != requirement.base_url {
         return Err(AppError::PlatformVendorProvisioningInvalid(format!(
             "{op} requires base_url '{}'; row '{}' has '{}'",
             requirement.base_url, service.slug, service.base_url
@@ -1287,12 +1293,12 @@ mod tests {
         ];
 
         for (expected, slug, service) in cases {
-            let error = validate_vendor_binding_shape(requirement, slug, service.as_ref())
+            let error = validate_vendor_binding_shape(requirement, slug, service.as_ref(), true)
                 .expect_err("mismatched vendor row must be rejected");
             assert_eq!(provisioning_message(error), expected);
         }
 
-        validate_vendor_binding_shape(requirement, SPEAK_VENDOR_SLUG, Some(&valid))
+        validate_vendor_binding_shape(requirement, SPEAK_VENDOR_SLUG, Some(&valid), true)
             .expect("valid vendor row shape");
         let error = validate_vendor_credential(requirement, &valid, b"")
             .expect_err("empty credential must be rejected");

--- a/backend/src/services/platform_operation_service.rs
+++ b/backend/src/services/platform_operation_service.rs
@@ -10,6 +10,9 @@ use zeroize::Zeroizing;
 
 use crate::crypto::aes::EncryptionKeys;
 use crate::errors::{AppError, AppResult};
+use crate::models::downstream_service::{
+    COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
+};
 use crate::models::platform_op_usage::{COLLECTION_NAME as PLATFORM_OP_USAGE, PlatformOpUsage};
 use crate::models::platform_operation::{
     COLLECTION_NAME as PLATFORM_OPERATIONS, CallAndSayConfig, PlatformOperation,
@@ -33,6 +36,132 @@ pub const PLATFORM_OPERATION_NAMES: [PlatformOperationName; 3] = [
     PlatformOperationName::Speak,
     PlatformOperationName::CallAndSay,
 ];
+
+/// Runtime-enforced operation contract. Keep this registry code-owned: admin
+/// templates are provisioning metadata and must never be able to weaken these
+/// checks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlatformOperationVendorContract {
+    pub operation: PlatformOperationName,
+    pub slug: &'static str,
+    pub base_url: &'static str,
+    pub auth_method: &'static str,
+    pub auth_key_name: Option<&'static str>,
+}
+
+pub const PLATFORM_OPERATION_VENDOR_CONTRACTS: [PlatformOperationVendorContract; 3] = [
+    PlatformOperationVendorContract {
+        operation: PlatformOperationName::CallAndSay,
+        slug: CALL_AND_SAY_VENDOR_SLUG,
+        base_url: "https://api.twilio.com",
+        auth_method: "basic",
+        auth_key_name: None,
+    },
+    PlatformOperationVendorContract {
+        operation: PlatformOperationName::Speak,
+        slug: SPEAK_VENDOR_SLUG,
+        base_url: "https://api.elevenlabs.io",
+        auth_method: "header",
+        auth_key_name: Some("xi-api-key"),
+    },
+    PlatformOperationVendorContract {
+        operation: PlatformOperationName::XSearch,
+        slug: X_SEARCH_VENDOR_SLUG,
+        base_url: "https://api.x.com",
+        auth_method: "bearer",
+        auth_key_name: None,
+    },
+];
+
+/// Seed data for the admin-managed template collection. Duffel deliberately
+/// has no operation binding yet; a future operation adds a code contract and
+/// sets this row's `operation` to that operation name before it can be bound.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SeededPlatformVendorTemplate {
+    pub vendor: &'static str,
+    pub display_name: &'static str,
+    pub slug: &'static str,
+    pub base_url: &'static str,
+    pub auth_method: &'static str,
+    pub auth_key_name: Option<&'static str>,
+    pub credential_label: &'static str,
+    pub credential_note: &'static str,
+    pub operation: Option<&'static str>,
+    pub capability_summary: &'static str,
+    pub restriction_summary: &'static str,
+}
+
+pub const DEFAULT_PLATFORM_VENDOR_TEMPLATES: [SeededPlatformVendorTemplate; 4] = [
+    SeededPlatformVendorTemplate {
+        vendor: "twilio",
+        display_name: "Twilio",
+        slug: CALL_AND_SAY_VENDOR_SLUG,
+        base_url: "https://api.twilio.com",
+        auth_method: "basic",
+        auth_key_name: None,
+        credential_label: "Auth token",
+        credential_note: "Use the Auth Token paired with the Account SID configured on Call and Say.",
+        operation: Some("call_and_say"),
+        capability_summary: "Places server-constructed voice calls through call_and_say.",
+        restriction_summary: "Does not expose Twilio's general API or import its OpenAPI operations.",
+    },
+    SeededPlatformVendorTemplate {
+        vendor: "elevenlabs",
+        display_name: "ElevenLabs",
+        slug: SPEAK_VENDOR_SLUG,
+        base_url: "https://api.elevenlabs.io",
+        auth_method: "header",
+        auth_key_name: Some("xi-api-key"),
+        credential_label: "API key",
+        credential_note: "Use a restricted ElevenLabs API key with text-to-speech access.",
+        operation: Some("speak"),
+        capability_summary: "Synthesizes speech through the server-constructed speak operation.",
+        restriction_summary: "Does not expose voice cloning or import ElevenLabs vendor tools.",
+    },
+    SeededPlatformVendorTemplate {
+        vendor: "x",
+        display_name: "X",
+        slug: X_SEARCH_VENDOR_SLUG,
+        base_url: "https://api.x.com",
+        auth_method: "bearer",
+        auth_key_name: None,
+        credential_label: "Bearer token",
+        credential_note: "Use an app bearer token with read access to recent search.",
+        operation: Some("x_search"),
+        capability_summary: "Searches recent posts through the bounded x_search operation.",
+        restriction_summary: "Does not publish, modify accounts, or expose X's general API.",
+    },
+    SeededPlatformVendorTemplate {
+        vendor: "duffel",
+        display_name: "Duffel",
+        slug: "platform-duffel",
+        base_url: "https://api.duffel.com",
+        auth_method: "bearer",
+        auth_key_name: None,
+        credential_label: "Access token",
+        credential_note: "Store a server-side Duffel access token for a future platform operation.",
+        operation: None,
+        capability_summary: "Pre-provisions the credential row; no Duffel platform operation is shipped yet.",
+        restriction_summary: "Does not expose Duffel endpoints or publish any executable vendor tools.",
+    },
+];
+
+pub fn vendor_requirement_for_operation(
+    op: PlatformOperationName,
+) -> &'static PlatformOperationVendorContract {
+    PLATFORM_OPERATION_VENDOR_CONTRACTS
+        .iter()
+        .find(|contract| contract.operation == op)
+        .expect("every shipped platform operation must bind one vendor contract")
+}
+
+pub fn vendor_contract_for_operation_name(
+    name: &str,
+) -> Option<&'static PlatformOperationVendorContract> {
+    PLATFORM_OPERATION_VENDOR_CONTRACTS
+        .iter()
+        .find(|contract| operation_name(contract.operation) == name)
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -128,11 +257,7 @@ pub fn default_operation_config(op: PlatformOperationName) -> PlatformOperationC
 }
 
 pub fn default_vendor_service_slug(op: PlatformOperationName) -> &'static str {
-    match op {
-        PlatformOperationName::XSearch => X_SEARCH_VENDOR_SLUG,
-        PlatformOperationName::Speak => SPEAK_VENDOR_SLUG,
-        PlatformOperationName::CallAndSay => CALL_AND_SAY_VENDOR_SLUG,
-    }
+    vendor_requirement_for_operation(op).slug
 }
 
 pub fn validate_operation_config(
@@ -509,6 +634,7 @@ pub async fn list_enabled_operations(db: &mongodb::Database) -> AppResult<Vec<Pl
 
 pub async fn upsert_operation(
     db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
     op: PlatformOperationName,
     enabled: bool,
     vendor_service_slug: String,
@@ -516,6 +642,7 @@ pub async fn upsert_operation(
     updated_by: &str,
 ) -> AppResult<PlatformOperation> {
     validate_operation_config(op, &vendor_service_slug, &config)?;
+    validate_vendor_binding(db, encryption_keys, op, &vendor_service_slug).await?;
 
     let config = bson::to_bson(&config).map_err(|error| {
         AppError::Internal(format!(
@@ -564,8 +691,6 @@ pub async fn execute_x_search(
         encryption_keys,
         PlatformOperationName::XSearch,
         &operation.vendor_service_slug,
-        "bearer",
-        None,
     )
     .await?;
     let url = format!(
@@ -599,8 +724,6 @@ pub async fn execute_speak(
         encryption_keys,
         PlatformOperationName::Speak,
         &operation.vendor_service_slug,
-        "header",
-        Some("xi-api-key"),
     )
     .await?;
     let url = format!(
@@ -664,8 +787,6 @@ pub async fn execute_call_and_say(
         encryption_keys,
         PlatformOperationName::CallAndSay,
         &operation.vendor_service_slug,
-        "basic",
-        None,
     )
     .await?;
 
@@ -708,28 +829,16 @@ async fn resolve_vendor_target(
     encryption_keys: &EncryptionKeys,
     op: PlatformOperationName,
     slug: &str,
-    expected_auth_method: &str,
-    expected_auth_key_name: Option<&str>,
 ) -> AppResult<VendorTarget> {
+    let requirement = vendor_requirement_for_operation(op);
     let service = assistant_service::resolve_admin_service_by_slug(db, slug)
         .await
+        .map_err(|error| vendor_configuration_failed(op, error))?;
+    validate_vendor_binding_shape(requirement, slug, Some(&service))
         .map_err(|error| vendor_configuration_failed(op, error))?;
     let authorized = proxy_service::authorize_master_credential_server_chosen(db, &service)
         .await
         .map_err(|error| vendor_configuration_failed(op, error))?;
-    if service.auth_method != expected_auth_method
-        || expected_auth_key_name
-            .is_some_and(|expected| !service.auth_key_name.eq_ignore_ascii_case(expected))
-    {
-        tracing::error!(
-            op = operation_name(op),
-            service_slug = %service.slug,
-            auth_method = %service.auth_method,
-            auth_key_name = %service.auth_key_name,
-            "Platform operation vendor row has an invalid authentication shape"
-        );
-        return Err(AppError::PlatformOperationUnavailable);
-    }
     let decrypted = Zeroizing::new(
         authorized
             .decrypt(encryption_keys)
@@ -753,6 +862,133 @@ async fn resolve_vendor_target(
         auth_key_name: service.auth_key_name,
         credential,
     })
+}
+
+async fn validate_vendor_binding(
+    db: &mongodb::Database,
+    encryption_keys: &EncryptionKeys,
+    op: PlatformOperationName,
+    slug: &str,
+) -> AppResult<()> {
+    let collection = db.collection::<DownstreamService>(DOWNSTREAM_SERVICES);
+    let service = match collection
+        .find_one(doc! { "slug": slug, "is_active": true })
+        .await?
+    {
+        Some(service) => Some(service),
+        None => collection.find_one(doc! { "slug": slug }).await?,
+    };
+    let requirement = vendor_requirement_for_operation(op);
+    validate_vendor_binding_shape(requirement, slug, service.as_ref())?;
+    let service = service.expect("validated vendor binding must have a service row");
+
+    if service.credential_encrypted.is_empty() {
+        return validate_vendor_credential(requirement, &service, b"");
+    }
+    let credential = Zeroizing::new(
+        encryption_keys
+            .decrypt(&service.credential_encrypted)
+            .await
+            .map_err(|_| {
+                AppError::PlatformVendorProvisioningInvalid(format!(
+                    "{} requires a readable credential; row '{}' cannot be decrypted and must be replaced",
+                    operation_name(op), service.slug
+                ))
+            })?,
+    );
+    validate_vendor_credential(requirement, &service, credential.as_slice())
+}
+
+fn validate_vendor_binding_shape(
+    requirement: &PlatformOperationVendorContract,
+    slug: &str,
+    service: Option<&DownstreamService>,
+) -> AppResult<()> {
+    let op = operation_name(requirement.operation);
+    let Some(service) = service else {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires vendor row '{slug}'; no row with that slug exists"
+        )));
+    };
+    if slug != requirement.slug {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires canonical vendor_service_slug '{}'; requested row slug is '{slug}'",
+            requirement.slug
+        )));
+    }
+    if service.base_url.trim_end_matches('/') != requirement.base_url {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires base_url '{}'; row '{}' has '{}'",
+            requirement.base_url, service.slug, service.base_url
+        )));
+    }
+    if !service.is_active {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires an active vendor row; row '{}' is inactive",
+            service.slug
+        )));
+    }
+    if service.auth_method != requirement.auth_method {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires auth_method '{}'; row '{}' has '{}'",
+            requirement.auth_method, service.slug, service.auth_method
+        )));
+    }
+    if let Some(expected) = requirement.auth_key_name
+        && !service.auth_key_name.eq_ignore_ascii_case(expected)
+    {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires auth_key_name '{expected}'; row '{}' has '{}'",
+            service.slug, service.auth_key_name
+        )));
+    }
+    if service.service_category != "internal" {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires service_category 'internal'; row '{}' has '{}'",
+            service.slug, service.service_category
+        )));
+    }
+    if service.visibility != "public" {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires visibility 'public'; row '{}' has '{}'",
+            service.slug, service.visibility
+        )));
+    }
+    if service.provider_config_id.is_some() {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires provider_config_id to be absent; row '{}' has '{}'",
+            service.slug,
+            service.provider_config_id.as_deref().unwrap_or_default()
+        )));
+    }
+    if service.service_type != "http" {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires service_type 'http'; row '{}' has '{}'",
+            service.slug, service.service_type
+        )));
+    }
+    if service.requires_user_credential {
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires requires_user_credential false; row '{}' has true",
+            service.slug
+        )));
+    }
+    Ok(())
+}
+
+fn validate_vendor_credential(
+    requirement: &PlatformOperationVendorContract,
+    service: &DownstreamService,
+    credential: &[u8],
+) -> AppResult<()> {
+    if credential.is_empty() {
+        let op = operation_name(requirement.operation);
+        return Err(AppError::PlatformVendorProvisioningInvalid(format!(
+            "{op} requires a non-empty credential; row '{}' has an empty credential",
+            service.slug
+        )));
+    }
+    Ok(())
 }
 
 fn vendor_configuration_failed(op: PlatformOperationName, error: AppError) -> AppError {
@@ -901,6 +1137,7 @@ fn is_duplicate_key_error(error: &mongodb::error::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::downstream_service::test_helpers::dummy_service;
 
     fn speak_config() -> SpeakConfig {
         SpeakConfig {
@@ -919,6 +1156,150 @@ mod tests {
             account_sid: format!("AC{}", "1".repeat(32)),
             call_from: "+16505550100".to_string(),
         }
+    }
+
+    fn valid_speak_vendor_service() -> crate::models::downstream_service::DownstreamService {
+        let mut service = dummy_service();
+        service.slug = SPEAK_VENDOR_SLUG.to_string();
+        service.base_url = "https://api.elevenlabs.io".to_string();
+        service.auth_method = "header".to_string();
+        service.auth_key_name = "xi-api-key".to_string();
+        service.service_category = "internal".to_string();
+        service.visibility = "public".to_string();
+        service.requires_user_credential = false;
+        service.credential_encrypted = vec![1];
+        service
+    }
+
+    fn provisioning_message(error: AppError) -> String {
+        let AppError::PlatformVendorProvisioningInvalid(message) = error else {
+            panic!("expected a platform vendor provisioning error, got {error:?}");
+        };
+        message
+    }
+
+    #[test]
+    fn operation_contracts_and_seeded_templates_are_consistent() {
+        assert_eq!(PLATFORM_OPERATION_VENDOR_CONTRACTS.len(), 3);
+        for contract in PLATFORM_OPERATION_VENDOR_CONTRACTS {
+            assert_eq!(
+                vendor_requirement_for_operation(contract.operation),
+                &contract
+            );
+            assert_eq!(
+                default_vendor_service_slug(contract.operation),
+                contract.slug
+            );
+        }
+
+        for template in DEFAULT_PLATFORM_VENDOR_TEMPLATES {
+            let Some(operation) = template.operation else {
+                // Duffel is intentionally a credential template until a code
+                // operation is shipped; there is no contract to cross-check.
+                continue;
+            };
+            let operation = parse_operation_name(operation).expect("seeded operation name");
+            let contract = vendor_requirement_for_operation(operation);
+            assert_eq!(template.auth_method, contract.auth_method);
+            assert_eq!(template.auth_key_name, contract.auth_key_name);
+        }
+    }
+
+    #[test]
+    fn bind_validation_names_every_vendor_row_mismatch() {
+        let requirement = vendor_requirement_for_operation(PlatformOperationName::Speak);
+        let valid = valid_speak_vendor_service();
+
+        let cases: Vec<(
+            &str,
+            &str,
+            Option<crate::models::downstream_service::DownstreamService>,
+        )> = vec![
+            (
+                "speak requires canonical vendor_service_slug 'platform-elevenlabs'; requested row slug is 'platform-other'",
+                "platform-other",
+                Some(crate::models::downstream_service::DownstreamService {
+                    slug: "platform-other".to_string(),
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires base_url 'https://api.elevenlabs.io'; row 'platform-elevenlabs' has 'https://wrong.example'",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    base_url: "https://wrong.example".to_string(),
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires vendor row 'platform-elevenlabs'; no row with that slug exists",
+                SPEAK_VENDOR_SLUG,
+                None,
+            ),
+            (
+                "speak requires an active vendor row; row 'platform-elevenlabs' is inactive",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    is_active: false,
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires auth_method 'header'; row 'platform-elevenlabs' has 'bearer'",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    auth_method: "bearer".to_string(),
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires auth_key_name 'xi-api-key'; row 'platform-elevenlabs' has 'X-API-Key'",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    auth_key_name: "X-API-Key".to_string(),
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires service_category 'internal'; row 'platform-elevenlabs' has 'connection'",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    service_category: "connection".to_string(),
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires visibility 'public'; row 'platform-elevenlabs' has 'private'",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    visibility: "private".to_string(),
+                    ..valid.clone()
+                }),
+            ),
+            (
+                "speak requires provider_config_id to be absent; row 'platform-elevenlabs' has 'provider-1'",
+                SPEAK_VENDOR_SLUG,
+                Some(crate::models::downstream_service::DownstreamService {
+                    provider_config_id: Some("provider-1".to_string()),
+                    ..valid.clone()
+                }),
+            ),
+        ];
+
+        for (expected, slug, service) in cases {
+            let error = validate_vendor_binding_shape(requirement, slug, service.as_ref())
+                .expect_err("mismatched vendor row must be rejected");
+            assert_eq!(provisioning_message(error), expected);
+        }
+
+        validate_vendor_binding_shape(requirement, SPEAK_VENDOR_SLUG, Some(&valid))
+            .expect("valid vendor row shape");
+        let error = validate_vendor_credential(requirement, &valid, b"")
+            .expect_err("empty credential must be rejected");
+        assert_eq!(
+            provisioning_message(error),
+            "speak requires a non-empty credential; row 'platform-elevenlabs' has an empty credential"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/services/platform_vendor_template_service.rs
+++ b/backend/src/services/platform_vendor_template_service.rs
@@ -1,0 +1,396 @@
+use chrono::Utc;
+use futures::TryStreamExt;
+use mongodb::bson::doc;
+use mongodb::options::ReturnDocument;
+use uuid::Uuid;
+
+use crate::errors::{AppError, AppResult};
+use crate::models::platform_vendor_template::{COLLECTION_NAME, PlatformVendorTemplate};
+use crate::services::platform_operation_service::{
+    DEFAULT_PLATFORM_VENDOR_TEMPLATES, SeededPlatformVendorTemplate,
+    vendor_contract_for_operation_name,
+};
+use crate::services::url_validation::validate_base_url;
+
+const MAX_VENDOR_KEY_LENGTH: usize = 64;
+const MAX_VENDOR_SLUG_LENGTH: usize = 100;
+const MAX_DISPLAY_NAME_LENGTH: usize = 200;
+const MAX_CREDENTIAL_LABEL_LENGTH: usize = 120;
+const MAX_HELP_LENGTH: usize = 4_096;
+
+pub async fn list_templates(
+    db: &mongodb::Database,
+    include_inactive: bool,
+) -> AppResult<Vec<PlatformVendorTemplate>> {
+    let filter = if include_inactive {
+        doc! {}
+    } else {
+        doc! { "is_active": true }
+    };
+    db.collection::<PlatformVendorTemplate>(COLLECTION_NAME)
+        .find(filter)
+        .await?
+        .try_collect()
+        .await
+        .map_err(AppError::DatabaseError)
+}
+
+pub async fn seed_default_templates(db: &mongodb::Database, actor: &str) -> AppResult<()> {
+    let collection = db.collection::<PlatformVendorTemplate>(COLLECTION_NAME);
+    let now = Utc::now();
+    for seed in DEFAULT_PLATFORM_VENDOR_TEMPLATES {
+        let template = seeded_template(seed, now, actor);
+        let document = mongodb::bson::to_document(&template).map_err(|error| {
+            AppError::Internal(format!(
+                "Failed to serialize platform vendor template: {error}"
+            ))
+        })?;
+        collection
+            .update_one(
+                doc! { "vendor": seed.vendor },
+                doc! { "$setOnInsert": document },
+            )
+            .upsert(true)
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn create_template(
+    db: &mongodb::Database,
+    input: PlatformVendorTemplateInput,
+    actor: &str,
+) -> AppResult<PlatformVendorTemplate> {
+    let input = normalize_input(input);
+    validate_input(&input)?;
+    let now = Utc::now();
+    let template = PlatformVendorTemplate {
+        id: Uuid::new_v4().to_string(),
+        vendor: input.vendor,
+        display_name: input.display_name,
+        slug: input.slug,
+        base_url: input.base_url,
+        auth_method: input.auth_method,
+        auth_key_name: input.auth_key_name,
+        credential_label: input.credential_label,
+        credential_note: input.credential_note,
+        operation: input.operation,
+        capability_summary: input.capability_summary,
+        restriction_summary: input.restriction_summary,
+        is_active: input.is_active,
+        is_seeded: false,
+        created_at: now,
+        updated_at: now,
+        updated_by: actor.to_string(),
+    };
+    db.collection::<PlatformVendorTemplate>(COLLECTION_NAME)
+        .insert_one(&template)
+        .await
+        .map_err(|error| {
+            if error.to_string().contains("duplicate key") {
+                AppError::Conflict(
+                    "A vendor template with this key or slug already exists".to_string(),
+                )
+            } else {
+                AppError::DatabaseError(error)
+            }
+        })?;
+    Ok(template)
+}
+
+pub async fn update_template(
+    db: &mongodb::Database,
+    id: &str,
+    input: PlatformVendorTemplateInput,
+    actor: &str,
+) -> AppResult<PlatformVendorTemplate> {
+    let input = normalize_input(input);
+    validate_input(&input)?;
+    let now = Utc::now();
+    let set = doc! {
+        "vendor": input.vendor,
+        "display_name": input.display_name,
+        "slug": input.slug,
+        "base_url": input.base_url,
+        "auth_method": input.auth_method,
+        "auth_key_name": input.auth_key_name,
+        "credential_label": input.credential_label,
+        "credential_note": input.credential_note,
+        "operation": input.operation,
+        "capability_summary": input.capability_summary,
+        "restriction_summary": input.restriction_summary,
+        "is_active": input.is_active,
+        "updated_at": bson::DateTime::from_chrono(now),
+        "updated_by": actor,
+    };
+    db.collection::<PlatformVendorTemplate>(COLLECTION_NAME)
+        .find_one_and_update(doc! { "_id": id }, doc! { "$set": set })
+        .return_document(ReturnDocument::After)
+        .await
+        .map_err(|error| {
+            if error.to_string().contains("duplicate key") {
+                AppError::Conflict(
+                    "A vendor template with this key or slug already exists".to_string(),
+                )
+            } else {
+                AppError::DatabaseError(error)
+            }
+        })?
+        .ok_or_else(|| AppError::NotFound("Vendor template not found".to_string()))
+}
+
+pub async fn disable_template(db: &mongodb::Database, id: &str, actor: &str) -> AppResult<()> {
+    let result = db
+        .collection::<PlatformVendorTemplate>(COLLECTION_NAME)
+        .update_one(
+            doc! { "_id": id, "is_active": true },
+            doc! {
+                "$set": {
+                    "is_active": false,
+                    "updated_at": bson::DateTime::from_chrono(Utc::now()),
+                    "updated_by": actor,
+                }
+            },
+        )
+        .await?;
+    if result.matched_count == 0 {
+        return Err(AppError::NotFound(
+            "Active vendor template not found".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct PlatformVendorTemplateInput {
+    pub vendor: String,
+    pub display_name: String,
+    pub slug: String,
+    pub base_url: String,
+    pub auth_method: String,
+    pub auth_key_name: Option<String>,
+    pub credential_label: String,
+    pub credential_note: String,
+    pub operation: Option<String>,
+    pub capability_summary: String,
+    pub restriction_summary: String,
+    pub is_active: bool,
+}
+
+fn normalize_input(mut input: PlatformVendorTemplateInput) -> PlatformVendorTemplateInput {
+    input.vendor = input.vendor.trim().to_string();
+    input.display_name = input.display_name.trim().to_string();
+    input.slug = input.slug.trim().to_string();
+    input.base_url = input.base_url.trim().to_string();
+    input.auth_method = input.auth_method.trim().to_string();
+    input.auth_key_name = input
+        .auth_key_name
+        .and_then(|value| (!value.trim().is_empty()).then(|| value.trim().to_string()));
+    input.credential_label = input.credential_label.trim().to_string();
+    input.credential_note = input.credential_note.trim().to_string();
+    input.operation = input
+        .operation
+        .and_then(|value| (!value.trim().is_empty()).then(|| value.trim().to_string()));
+    input.capability_summary = input.capability_summary.trim().to_string();
+    input.restriction_summary = input.restriction_summary.trim().to_string();
+    input
+}
+
+fn validate_input(input: &PlatformVendorTemplateInput) -> AppResult<()> {
+    let vendor = input.vendor.trim();
+    if vendor.is_empty()
+        || vendor.len() > MAX_VENDOR_KEY_LENGTH
+        || !vendor.bytes().enumerate().all(|(index, byte)| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || (index > 0 && (byte == b'_' || byte == b'-'))
+        })
+    {
+        return Err(AppError::ValidationError(
+            "vendor must use lowercase letters, digits, underscores, and hyphens".to_string(),
+        ));
+    }
+    if input.display_name.trim().is_empty() || input.display_name.len() > MAX_DISPLAY_NAME_LENGTH {
+        return Err(AppError::ValidationError(
+            "display_name must be between 1 and 200 characters".to_string(),
+        ));
+    }
+    let slug = input.slug.trim();
+    if slug.len() < 9
+        || slug.len() > MAX_VENDOR_SLUG_LENGTH
+        || !slug.starts_with("platform-")
+        || !slug
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(AppError::ValidationError(
+            "slug must start with platform- and use lowercase letters, digits, and hyphens"
+                .to_string(),
+        ));
+    }
+    validate_base_url(input.base_url.trim())?;
+    if !matches!(input.auth_method.as_str(), "header" | "bearer" | "basic") {
+        return Err(AppError::ValidationError(
+            "auth_method must be one of: header, bearer, basic".to_string(),
+        ));
+    }
+    if input.auth_method == "header"
+        && input
+            .auth_key_name
+            .as_deref()
+            .is_none_or(|name| name.trim().is_empty())
+    {
+        return Err(AppError::ValidationError(
+            "auth_key_name is required for header auth_method".to_string(),
+        ));
+    }
+    if input.credential_label.trim().is_empty()
+        || input.credential_label.len() > MAX_CREDENTIAL_LABEL_LENGTH
+    {
+        return Err(AppError::ValidationError(
+            "credential_label must be between 1 and 120 characters".to_string(),
+        ));
+    }
+    for (label, value) in [
+        ("credential_note", &input.credential_note),
+        ("capability_summary", &input.capability_summary),
+        ("restriction_summary", &input.restriction_summary),
+    ] {
+        if value.trim().is_empty() || value.len() > MAX_HELP_LENGTH {
+            return Err(AppError::ValidationError(format!(
+                "{label} must be between 1 and {MAX_HELP_LENGTH} characters"
+            )));
+        }
+    }
+    if let Some(operation) = input
+        .operation
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        && let Some(contract) = vendor_contract_for_operation_name(operation)
+    {
+        if input.slug != contract.slug {
+            return Err(AppError::ValidationError(format!(
+                "operation '{operation}' requires canonical slug '{}'; template has '{}'",
+                contract.slug, input.slug
+            )));
+        }
+        if input.base_url.trim_end_matches('/') != contract.base_url {
+            return Err(AppError::ValidationError(format!(
+                "operation '{operation}' requires canonical base_url '{}'; template has '{}'",
+                contract.base_url, input.base_url
+            )));
+        }
+        if input.auth_method != contract.auth_method {
+            return Err(AppError::ValidationError(format!(
+                "operation '{operation}' requires auth_method '{}'; template has '{}'",
+                contract.auth_method, input.auth_method
+            )));
+        }
+        if contract.auth_key_name != input.auth_key_name.as_deref() {
+            return Err(AppError::ValidationError(format!(
+                "operation '{operation}' requires auth_key_name {:?}; template has {:?}",
+                contract.auth_key_name, input.auth_key_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn seeded_template(
+    seed: SeededPlatformVendorTemplate,
+    now: chrono::DateTime<Utc>,
+    actor: &str,
+) -> PlatformVendorTemplate {
+    PlatformVendorTemplate {
+        id: Uuid::new_v4().to_string(),
+        vendor: seed.vendor.to_string(),
+        display_name: seed.display_name.to_string(),
+        slug: seed.slug.to_string(),
+        base_url: seed.base_url.to_string(),
+        auth_method: seed.auth_method.to_string(),
+        auth_key_name: seed.auth_key_name.map(str::to_string),
+        credential_label: seed.credential_label.to_string(),
+        credential_note: seed.credential_note.to_string(),
+        operation: seed.operation.map(str::to_string),
+        capability_summary: seed.capability_summary.to_string(),
+        restriction_summary: seed.restriction_summary.to_string(),
+        is_active: true,
+        is_seeded: true,
+        created_at: now,
+        updated_at: now,
+        updated_by: actor.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::platform_operation_service::{
+        DEFAULT_PLATFORM_VENDOR_TEMPLATES, vendor_requirement_for_operation,
+    };
+
+    #[test]
+    fn seeded_templates_match_code_contracts() {
+        for seed in DEFAULT_PLATFORM_VENDOR_TEMPLATES {
+            let Some(operation) = seed.operation else {
+                // Duffel is intentionally a credential template until a code
+                // operation is shipped; there is no contract to cross-check.
+                continue;
+            };
+            let operation =
+                crate::services::platform_operation_service::parse_operation_name(operation)
+                    .expect("seeded operation name");
+            let contract = vendor_requirement_for_operation(operation);
+            assert_eq!(seed.auth_method, contract.auth_method);
+            assert_eq!(seed.auth_key_name, contract.auth_key_name);
+        }
+    }
+
+    #[test]
+    fn contradictory_operation_template_is_rejected() {
+        let mut input = PlatformVendorTemplateInput {
+            vendor: "bad-elevenlabs".to_string(),
+            display_name: "Bad ElevenLabs".to_string(),
+            slug: "platform-elevenlabs".to_string(),
+            base_url: "https://api.elevenlabs.io".to_string(),
+            auth_method: "bearer".to_string(),
+            auth_key_name: None,
+            credential_label: "API key".to_string(),
+            credential_note: "note".to_string(),
+            operation: Some("speak".to_string()),
+            capability_summary: "capability".to_string(),
+            restriction_summary: "restriction".to_string(),
+            is_active: true,
+        };
+        let error = validate_input(&input).expect_err("contradictory template must be rejected");
+        assert!(error.to_string().contains("requires auth_method 'header'"));
+        input.auth_method = "header".to_string();
+        input.auth_key_name = Some("xi-api-key".to_string());
+        validate_input(&input).expect("matching template shape");
+    }
+
+    #[test]
+    fn operation_template_cannot_override_canonical_identity() {
+        let input = PlatformVendorTemplateInput {
+            vendor: "alternate-elevenlabs".to_string(),
+            display_name: "Alternate ElevenLabs".to_string(),
+            slug: "platform-alternate-elevenlabs".to_string(),
+            base_url: "https://api.elevenlabs.io".to_string(),
+            auth_method: "header".to_string(),
+            auth_key_name: Some("xi-api-key".to_string()),
+            credential_label: "API key".to_string(),
+            credential_note: "note".to_string(),
+            operation: Some("speak".to_string()),
+            capability_summary: "capability".to_string(),
+            restriction_summary: "restriction".to_string(),
+            is_active: true,
+        };
+        let error = validate_input(&input).expect_err("operation identity must be canonical");
+        assert!(
+            error
+                .to_string()
+                .contains("requires canonical slug 'platform-elevenlabs'")
+        );
+    }
+}

--- a/backend/src/services/unified_key_service.rs
+++ b/backend/src/services/unified_key_service.rs
@@ -24,8 +24,9 @@ use crate::models::user_service::{AUTO_PROVISION_SOURCE, UserService};
 use crate::models::ws_frame_injection::WsFrameInjection;
 use crate::services::{
     audit_service::{self, AuditActor},
-    node_service, oauth_revocation, ssh_service, user_api_key_service, user_credentials_service,
-    user_endpoint_service, user_service_service, user_token_service, ws_frame_injector,
+    catalog_spec_sync, node_service, oauth_revocation, ssh_service, user_api_key_service,
+    user_credentials_service, user_endpoint_service, user_service_service, user_token_service,
+    ws_frame_injector,
 };
 
 const MAX_SERVICE_SLUG_LEN: usize = 80;
@@ -820,6 +821,12 @@ async fn create_key_inner(
             .find_one(doc! { "slug": slug, "is_active": true })
             .await?
             .ok_or_else(|| AppError::NotFound(format!("Catalog service '{slug}' not found")))?;
+
+        if catalog_spec_sync::is_platform_vendor_service(&svc) {
+            return Err(AppError::NotFound(format!(
+                "Catalog service '{slug}' not found"
+            )));
+        }
 
         let is_ssh = svc.service_type == "ssh";
         let provider = if let Some(ref pid) = svc.provider_config_id {

--- a/frontend/src/components/admin-platform-ops/platform-vendor-dialog.tsx
+++ b/frontend/src/components/admin-platform-ops/platform-vendor-dialog.tsx
@@ -1,0 +1,306 @@
+import { useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CheckCircle2, ShieldX, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormSubmitErrors,
+  useAppForm,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useProvisionPlatformVendor } from "@/hooks/use-platform-ops";
+import {
+  platformVendorProvisionSchema,
+  type PlatformVendor,
+  type PlatformVendorProvision,
+  type PlatformVendorRequirement,
+} from "@/schemas/platform-ops";
+
+const OPERATION_LABELS = {
+  x_search: "X Search",
+  speak: "Speak",
+  call_and_say: "Call and Say",
+} as const;
+
+function LockedField({
+  id,
+  label,
+  value,
+}: {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      <Input id={id} value={value} disabled className="font-mono" />
+    </div>
+  );
+}
+
+export function PlatformVendorDialog({
+  open,
+  onOpenChange,
+  requirements,
+}: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly requirements: readonly PlatformVendorRequirement[];
+}) {
+  const provision = useProvisionPlatformVendor();
+  const firstVendor = requirements[0]?.vendor ?? "twilio";
+  const form = useAppForm<PlatformVendorProvision>({
+    resolver: zodResolver(platformVendorProvisionSchema),
+    defaultValues: { vendor: firstVendor, credential: "", note: "" },
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.reset({ vendor: firstVendor, credential: "", note: "" });
+    }
+  }, [firstVendor, form, open]);
+
+  const selectedVendor = form.watch("vendor");
+  const requirement =
+    requirements.find((item) => item.vendor === selectedVendor) ??
+    requirements[0];
+  const existingService = requirement?.existing_service ?? undefined;
+
+  const closeDialog = () => {
+    form.reset({ vendor: firstVendor, credential: "", note: "" });
+    onOpenChange(false);
+  };
+
+  const onSubmit = async (data: PlatformVendorProvision) => {
+    if (!requirement) return;
+    try {
+      await provision.mutateAsync({
+        requirement,
+        data,
+        replaceServiceId: existingService?.id,
+      });
+      toast.success(
+        existingService
+          ? `${requirement.display_name} vendor row replaced`
+          : `${requirement.display_name} vendor row added`,
+      );
+      closeDialog();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to provision platform vendor row",
+      );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) onOpenChange(true);
+        else closeDialog();
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>
+            {existingService ? "Replace platform vendor" : "Add platform vendor"}
+          </DialogTitle>
+          <DialogDescription>
+            Create a server-owned credential row from the operation contract.
+            Credentials are write-only and vendor API tools remain unpublished.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="vendor"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Vendor</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(value) => field.onChange(value as PlatformVendor)}
+                  >
+                    <FormControl>
+                      <SelectTrigger aria-label="Vendor">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {requirements.map((item) => (
+                        <SelectItem key={item.vendor} value={item.vendor}>
+                          {item.display_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {requirement ? (
+              <>
+                <div className="flex items-center justify-between gap-3 border-y border-border/50 py-2.5">
+                  <div>
+                    <p className="text-[10px] font-semibold uppercase tracking-[1.5px] text-text-tertiary">
+                      Bound operation
+                    </p>
+                    <p className="mt-1 text-[12px] text-foreground">
+                      {requirement.operation
+                        ? OPERATION_LABELS[
+                            requirement.operation as keyof typeof OPERATION_LABELS
+                          ] ?? requirement.operation
+                        : "No operation shipped yet"}
+                    </p>
+                  </div>
+                  <Badge variant={requirement.operation ? "info" : "secondary"}>
+                    {requirement.operation ?? "Pre-provisioned"}
+                  </Badge>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <LockedField
+                    id="platform-vendor-slug"
+                    label="Slug"
+                    value={requirement.slug}
+                  />
+                  <LockedField
+                    id="platform-vendor-base-url"
+                    label="Base URL"
+                    value={requirement.base_url}
+                  />
+                  <LockedField
+                    id="platform-vendor-auth-method"
+                    label="Auth method"
+                    value={requirement.auth_method}
+                  />
+                  <LockedField
+                    id="platform-vendor-auth-key-name"
+                    label="Auth key name"
+                    value={requirement.auth_key_name ?? "Not required"}
+                  />
+                  <LockedField
+                    id="platform-vendor-category"
+                    label="Category"
+                    value={requirement.service_category}
+                  />
+                  <LockedField
+                    id="platform-vendor-visibility"
+                    label="Visibility"
+                    value={requirement.visibility}
+                  />
+                </div>
+
+                <div className="space-y-2 rounded-xl border border-border/50 bg-white/[0.02] px-4 py-3">
+                  <div className="flex gap-2.5 text-[12px] text-muted-foreground">
+                    <CheckCircle2 className="mt-0.5 size-3.5 shrink-0 text-success" />
+                    <span>{requirement.capability_summary}</span>
+                  </div>
+                  <div className="flex gap-2.5 text-[12px] text-muted-foreground">
+                    <ShieldX className="mt-0.5 size-3.5 shrink-0 text-warning" />
+                    <span>{requirement.restriction_summary}</span>
+                  </div>
+                </div>
+
+                {existingService ? (
+                  <div className="flex gap-3 rounded-xl border border-warning/20 bg-warning/[0.05] px-4 py-3">
+                    <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warning" />
+                    <p className="text-[12px] text-muted-foreground">
+                      This action deactivates <strong>{existingService.name}</strong> and
+                      creates a corrected row with the same slug. No other service rows
+                      are changed.
+                    </p>
+                  </div>
+                ) : null}
+
+                <FormField
+                  control={form.control}
+                  name="credential"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{requirement.credential_label}</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="password"
+                          autoComplete="new-password"
+                          spellCheck={false}
+                        />
+                      </FormControl>
+                      <p className="text-[11px] text-muted-foreground">
+                        {requirement.credential_note}
+                      </p>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="note"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Operator note (optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder="Scope, owner, or rotation context"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            ) : null}
+
+            <FormSubmitErrors />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={closeDialog}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={!requirement || !form.formState.isDirty || provision.isPending}
+                isLoading={provision.isPending}
+              >
+                {existingService ? "Replace vendor row" : "Add vendor row"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin-platform-ops/platform-vendor-template-manager.tsx
+++ b/frontend/src/components/admin-platform-ops/platform-vendor-template-manager.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Ban, Check, Pencil, Plus, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormSubmitErrors,
+  useAppForm,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  useCreatePlatformVendorTemplate,
+  useDisablePlatformVendorTemplate,
+  usePlatformVendorTemplates,
+  useUpdatePlatformVendorTemplate,
+} from "@/hooks/use-platform-ops";
+import { ApiError } from "@/lib/api-client";
+import {
+  platformVendorTemplateFormSchema,
+  type PlatformVendorRequirement,
+  type PlatformVendorTemplateForm,
+} from "@/schemas/platform-ops";
+
+const OPERATION_OPTIONS = [
+  { value: "x_search", label: "X Search" },
+  { value: "speak", label: "Speak" },
+  { value: "call_and_say", label: "Call and Say" },
+] as const;
+
+const EMPTY_FORM: PlatformVendorTemplateForm = {
+  vendor: "",
+  display_name: "",
+  slug: "platform-",
+  base_url: "https://",
+  auth_method: "bearer",
+  auth_key_name: null,
+  credential_label: "Access token",
+  credential_note: "",
+  operation: null,
+  capability_summary: "",
+  restriction_summary: "",
+  is_active: true,
+};
+
+function templateToForm(template: PlatformVendorRequirement): PlatformVendorTemplateForm {
+  return {
+    vendor: template.vendor,
+    display_name: template.display_name,
+    slug: template.slug,
+    base_url: template.base_url,
+    auth_method: template.auth_method,
+    auth_key_name: template.auth_key_name,
+    credential_label: template.credential_label,
+    credential_note: template.credential_note,
+    operation: template.operation,
+    capability_summary: template.capability_summary,
+    restriction_summary: template.restriction_summary,
+    is_active: template.is_active,
+  };
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof ApiError || error instanceof Error
+    ? error.message
+    : fallback;
+}
+
+export function PlatformVendorTemplateManager({
+  open,
+  onOpenChange,
+}: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const templates = usePlatformVendorTemplates();
+  const create = useCreatePlatformVendorTemplate();
+  const update = useUpdatePlatformVendorTemplate();
+  const disable = useDisablePlatformVendorTemplate();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const form = useAppForm<PlatformVendorTemplateForm>({
+    resolver: zodResolver(platformVendorTemplateFormSchema),
+    defaultValues: EMPTY_FORM,
+  });
+
+  const editing = templates.data?.vendors.find((template) => template.id === editingId);
+
+  useEffect(() => {
+    if (open && !editingId) form.reset(EMPTY_FORM);
+  }, [editingId, form, open]);
+
+  const close = () => {
+    setEditingId(null);
+    form.reset(EMPTY_FORM);
+    onOpenChange(false);
+  };
+
+  const startEdit = (template: PlatformVendorRequirement) => {
+    setEditingId(template.id);
+    form.reset(templateToForm(template));
+  };
+
+  const onSubmit = async (data: PlatformVendorTemplateForm) => {
+    try {
+      if (editingId) {
+        await update.mutateAsync({ id: editingId, data });
+        toast.success("Vendor template updated");
+      } else {
+        await create.mutateAsync(data);
+        toast.success("Vendor template added");
+      }
+      setEditingId(null);
+      form.reset(EMPTY_FORM);
+    } catch (error) {
+      toast.error(errorMessage(error, "Failed to save vendor template"));
+    }
+  };
+
+  const onDisable = async (template: PlatformVendorRequirement) => {
+    try {
+      await disable.mutateAsync(template.id);
+      toast.success(`${template.display_name} template disabled`);
+      if (editingId === template.id) {
+        setEditingId(null);
+        form.reset(EMPTY_FORM);
+      }
+    } catch (error) {
+      toast.error(errorMessage(error, "Failed to disable vendor template"));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => (nextOpen ? onOpenChange(true) : close())}>
+      <DialogContent className="max-w-3xl" scrollMode="body">
+        <DialogHeader>
+          <DialogTitle>Vendor templates</DialogTitle>
+          <DialogDescription>
+            Manage the provisioning forms operators see. A template controls display
+            metadata only; operation binding still enforces the server contract.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-auto space-y-5 overflow-y-auto pr-1">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[1.5px] text-text-tertiary">
+              Current templates
+            </p>
+            {templates.error ? (
+              <p className="text-sm text-destructive">{errorMessage(templates.error, "Failed to load vendor templates")}</p>
+            ) : (
+              <div className="divide-y divide-border/50 rounded-lg border border-border/60">
+                {templates.data?.vendors.map((template) => (
+                  <div key={template.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-medium">{template.display_name}</span>
+                        <Badge variant={template.is_active ? "success" : "secondary"}>
+                          {template.is_active ? "Active" : "Disabled"}
+                        </Badge>
+                        {template.is_seeded ? <Badge variant="secondary">Seeded</Badge> : null}
+                      </div>
+                      <p className="truncate font-mono text-[11px] text-muted-foreground">{template.vendor} · {template.slug}</p>
+                    </div>
+                    <div className="flex shrink-0 gap-1.5">
+                      <Button type="button" variant="outline" size="sm" onClick={() => startEdit(template)}>
+                        <Pencil className="size-3.5" />
+                        Edit
+                      </Button>
+                      {template.is_active ? (
+                        <Button type="button" variant="ghost" size="sm" onClick={() => void onDisable(template)} disabled={disable.isPending}>
+                          <Ban className="size-3.5" />
+                          Disable
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+                {!templates.isLoading && !templates.data?.vendors.length ? (
+                  <p className="px-3 py-4 text-sm text-muted-foreground">No templates yet.</p>
+                ) : null}
+              </div>
+            )}
+          </div>
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <div className="flex items-center justify-between border-y border-border/50 py-3">
+                <div>
+                  <p className="text-sm font-medium">{editing ? `Edit ${editing.display_name}` : "Add a template"}</p>
+                  <p className="text-xs text-muted-foreground">Use a stable `platform-` slug for rows created from this form.</p>
+                </div>
+                {editing ? (
+                  <Button type="button" variant="ghost" size="sm" onClick={() => { setEditingId(null); form.reset(EMPTY_FORM); }}>
+                    <RotateCcw className="size-3.5" />
+                    New template
+                  </Button>
+                ) : <Plus className="size-4 text-muted-foreground" />}
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <FormField control={form.control} name="vendor" render={({ field }) => <FormItem><FormLabel>Vendor key</FormLabel><FormControl><Input {...field} placeholder="acme" /></FormControl><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="display_name" render={({ field }) => <FormItem><FormLabel>Display name</FormLabel><FormControl><Input {...field} placeholder="Acme Voice" /></FormControl><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="slug" render={({ field }) => <FormItem><FormLabel>Canonical slug</FormLabel><FormControl><Input {...field} className="font-mono" /></FormControl><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="base_url" render={({ field }) => <FormItem><FormLabel>Base URL</FormLabel><FormControl><Input {...field} type="url" /></FormControl><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="auth_method" render={({ field }) => <FormItem><FormLabel>Auth method</FormLabel><Select value={field.value} onValueChange={(value) => field.onChange(value)}><FormControl><SelectTrigger><SelectValue /></SelectTrigger></FormControl><SelectContent><SelectItem value="bearer">Bearer</SelectItem><SelectItem value="header">Header</SelectItem><SelectItem value="basic">Basic</SelectItem></SelectContent></Select><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="auth_key_name" render={({ field }) => <FormItem><FormLabel>Required auth key name</FormLabel><FormControl><Input value={field.value ?? ""} onChange={(event) => field.onChange(event.target.value || null)} placeholder="Optional for bearer/basic" /></FormControl><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="credential_label" render={({ field }) => <FormItem><FormLabel>Credential label</FormLabel><FormControl><Input {...field} /></FormControl><FormMessage /></FormItem>} />
+                <FormField control={form.control} name="operation" render={({ field }) => <FormItem><FormLabel>Served operation</FormLabel><Select value={field.value ?? "none"} onValueChange={(value) => field.onChange(value === "none" ? null : value)}><FormControl><SelectTrigger><SelectValue /></SelectTrigger></FormControl><SelectContent><SelectItem value="none">No operation yet</SelectItem>{OPERATION_OPTIONS.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}</SelectContent></Select><FormMessage /></FormItem>} />
+              </div>
+
+              <FormField control={form.control} name="credential_note" render={({ field }) => <FormItem><FormLabel>Credential help text</FormLabel><FormControl><Input {...field} /></FormControl><FormMessage /></FormItem>} />
+              <FormField control={form.control} name="capability_summary" render={({ field }) => <FormItem><FormLabel>Capability summary</FormLabel><FormControl><Input {...field} /></FormControl><FormMessage /></FormItem>} />
+              <FormField control={form.control} name="restriction_summary" render={({ field }) => <FormItem><FormLabel>Restriction summary</FormLabel><FormControl><Input {...field} /></FormControl><FormMessage /></FormItem>} />
+              <FormField control={form.control} name="is_active" render={({ field }) => <FormItem className="flex items-center justify-between rounded-lg border border-border/60 px-3 py-2"><div><FormLabel>Available to operators</FormLabel><p className="text-xs text-muted-foreground">Disabled templates stay visible here but cannot provision new rows.</p></div><FormControl><Switch checked={field.value} onCheckedChange={field.onChange} /></FormControl></FormItem>} />
+              <FormSubmitErrors />
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={close}>Close</Button>
+                <Button type="submit" variant="primary" disabled={!form.formState.isDirty || create.isPending || update.isPending} isLoading={create.isPending || update.isPending}>
+                  <Check className="size-4" />
+                  {editing ? "Save template" : "Add template"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/use-platform-ops.test.tsx
+++ b/frontend/src/hooks/use-platform-ops.test.tsx
@@ -4,21 +4,46 @@ import type { PropsWithChildren } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   PLATFORM_OPERATION_QUERY_KEY,
+  type PlatformVendorRequirement,
   type PlatformOperationList,
 } from "@/schemas/platform-ops";
 import {
   usePlatformOperations,
+  usePlatformVendorRequirements,
+  useProvisionPlatformVendor,
   useUpdatePlatformOperation,
 } from "./use-platform-ops";
 
-const { mockGet, mockPut } = vi.hoisted(() => ({
+const { mockDelete, mockGet, mockPost, mockPut } = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
   mockGet: vi.fn(),
+  mockPost: vi.fn(),
   mockPut: vi.fn(),
 }));
 
 vi.mock("@/lib/api-client", () => ({
-  api: { get: mockGet, put: mockPut },
+  api: { delete: mockDelete, get: mockGet, post: mockPost, put: mockPut },
 }));
+
+const elevenLabsRequirement: PlatformVendorRequirement = {
+  id: "template-elevenlabs",
+  vendor: "elevenlabs",
+  display_name: "ElevenLabs",
+  operation: "speak",
+  slug: "platform-elevenlabs",
+  base_url: "https://api.elevenlabs.io",
+  auth_method: "header",
+  auth_key_name: "xi-api-key",
+  service_category: "internal",
+  visibility: "public",
+  credential_label: "API key",
+  credential_note: "Use a restricted key.",
+  capability_summary: "Serves speak.",
+  restriction_summary: "Does not expose vendor tools.",
+  is_active: true,
+  is_seeded: true,
+  existing_service: null,
+};
 
 const xSearchOperation = {
   op: "x_search" as const,
@@ -58,6 +83,59 @@ describe("platform operation hooks", () => {
 
     expect(mockGet).toHaveBeenCalledWith("/admin/platform-ops");
     expect(result.current.data?.operations).toEqual([xSearchOperation]);
+  });
+
+  it("loads and parses vendor requirements", async () => {
+    mockGet.mockResolvedValue({ vendors: [elevenLabsRequirement] });
+    const { Wrapper } = createHarness();
+    const { result } = renderHook(() => usePlatformVendorRequirements(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/admin/platform-ops/vendor-requirements",
+    );
+    expect(result.current.data?.vendors).toEqual([elevenLabsRequirement]);
+  });
+
+  it("replaces a vendor row in one mutation while preserving its contract", async () => {
+    mockDelete.mockResolvedValue(undefined);
+    mockPost.mockResolvedValue({ id: "new-service-id" });
+    const { Wrapper } = createHarness();
+    const { result } = renderHook(() => useProvisionPlatformVendor(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        requirement: elevenLabsRequirement,
+        data: {
+          vendor: "elevenlabs",
+          credential: "write-only-key",
+          note: "Restricted to TTS",
+        },
+        replaceServiceId: "old-service-id",
+      });
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith("/services/old-service-id");
+    expect(mockPost).toHaveBeenCalledWith("/services", {
+      name: "Platform ElevenLabs",
+      slug: "platform-elevenlabs",
+      service_type: "http",
+      base_url: "https://api.elevenlabs.io",
+      auth_method: "header",
+      auth_key_name: "xi-api-key",
+      credential: "write-only-key",
+      service_category: "internal",
+      visibility: "public",
+      auth_notes: "Restricted to TTS",
+    });
+    expect(mockDelete.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPost.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it("rejects an invalid response instead of exposing untyped data", async () => {

--- a/frontend/src/hooks/use-platform-ops.ts
+++ b/frontend/src/hooks/use-platform-ops.ts
@@ -2,12 +2,21 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import {
   PLATFORM_OPERATION_QUERY_KEY,
+  PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY,
+  PLATFORM_VENDOR_TEMPLATES_QUERY_KEY,
   platformOperationListSchema,
   platformOperationSchema,
+  platformVendorRequirementSchema,
+  platformVendorRequirementListSchema,
+  type PlatformVendorRequirementList,
+  type PlatformVendorTemplateForm,
+  type PlatformVendorTemplateInput,
+  type ProvisionPlatformVendorVariables,
   type PlatformOperation,
   type PlatformOperationList,
   type UpdatePlatformOperationVariables,
 } from "@/schemas/platform-ops";
+import type { DownstreamService } from "@/types/api";
 
 export function usePlatformOperations() {
   return useQuery({
@@ -45,6 +54,133 @@ export function useUpdatePlatformOperation() {
           };
         },
       );
+    },
+  });
+}
+
+export function usePlatformVendorRequirements() {
+  return useQuery({
+    queryKey: PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY,
+    queryFn: async (): Promise<PlatformVendorRequirementList> => {
+      const response = await api.get<unknown>(
+        "/admin/platform-ops/vendor-requirements",
+      );
+      return platformVendorRequirementListSchema.parse(response);
+    },
+  });
+}
+
+export function usePlatformVendorTemplates() {
+  return useQuery({
+    queryKey: PLATFORM_VENDOR_TEMPLATES_QUERY_KEY,
+    queryFn: async (): Promise<PlatformVendorRequirementList> => {
+      const response = await api.get<unknown>(
+        "/admin/platform-ops/vendor-templates",
+      );
+      return platformVendorRequirementListSchema.parse(response);
+    },
+  });
+}
+
+export function useCreatePlatformVendorTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: PlatformVendorTemplateInput) => {
+      const response = await api.post<unknown>(
+        "/admin/platform-ops/vendor-templates",
+        data,
+      );
+      return platformVendorRequirementSchema.parse(response);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: PLATFORM_VENDOR_TEMPLATES_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY });
+    },
+  });
+}
+
+export function useUpdatePlatformVendorTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      data,
+    }: {
+      readonly id: string;
+      readonly data: PlatformVendorTemplateForm;
+    }) => {
+      const response = await api.put<unknown>(
+        `/admin/platform-ops/vendor-templates/${id}`,
+        data,
+      );
+      return platformVendorRequirementSchema.parse(response);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: PLATFORM_VENDOR_TEMPLATES_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY });
+    },
+  });
+}
+
+export function useDisablePlatformVendorTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await api.delete<void>(`/admin/platform-ops/vendor-templates/${id}`);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: PLATFORM_VENDOR_TEMPLATES_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY });
+    },
+  });
+}
+
+export function useProvisionPlatformVendor() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      requirement,
+      data,
+      replaceServiceId,
+    }: ProvisionPlatformVendorVariables): Promise<DownstreamService> => {
+      if (data.vendor !== requirement.vendor) {
+        throw new Error("Selected vendor does not match its requirement");
+      }
+      if (replaceServiceId) {
+        await api.delete<void>(`/services/${replaceServiceId}`);
+      }
+
+      try {
+        return await api.post<DownstreamService>("/services", {
+          name: `Platform ${requirement.display_name}`,
+          slug: requirement.slug,
+          service_type: "http",
+          base_url: requirement.base_url,
+          auth_method: requirement.auth_method,
+          ...(requirement.auth_key_name
+            ? { auth_key_name: requirement.auth_key_name }
+            : {}),
+          credential: data.credential,
+          service_category: requirement.service_category,
+          visibility: requirement.visibility,
+          ...(data.note ? { auth_notes: data.note } : {}),
+        });
+      } catch (error) {
+        if (replaceServiceId) {
+          const detail = error instanceof Error ? ` ${error.message}` : "";
+          throw new Error(
+            `The existing row was deactivated, but the corrected row could not be created.${detail}`,
+          );
+        }
+        throw error;
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["services"] });
+      void queryClient.invalidateQueries({
+        queryKey: PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY,
+      });
     },
   });
 }

--- a/frontend/src/pages/admin-platform-ops.test.tsx
+++ b/frontend/src/pages/admin-platform-ops.test.tsx
@@ -1,16 +1,77 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PlatformOperationList } from "@/schemas/platform-ops";
+import type {
+  PlatformOperationList,
+  PlatformVendorRequirementList,
+} from "@/schemas/platform-ops";
 import { AdminPlatformOpsPage } from "./admin-platform-ops";
 
-const { mockMutateAsync, mockRefetch, mockToastError, mockToastSuccess } =
+const {
+  mockMutateAsync,
+  mockProvisionAsync,
+  mockRefetch,
+  mockToastError,
+  mockToastSuccess,
+} =
   vi.hoisted(() => ({
     mockMutateAsync: vi.fn(),
+    mockProvisionAsync: vi.fn(),
     mockRefetch: vi.fn(),
     mockToastError: vi.fn(),
     mockToastSuccess: vi.fn(),
   }));
+
+const vendorRequirements: PlatformVendorRequirementList = {
+  vendors: [
+    {
+      id: "template-twilio",
+      vendor: "twilio",
+      display_name: "Twilio",
+      operation: "call_and_say",
+      slug: "platform-twilio",
+      base_url: "https://api.twilio.com",
+      auth_method: "basic",
+      auth_key_name: null,
+      service_category: "internal",
+      visibility: "public",
+      credential_label: "Auth token",
+      credential_note: "Use the Twilio Auth Token.",
+      capability_summary: "Serves call_and_say.",
+      restriction_summary: "Does not expose general Twilio tools.",
+      is_active: true,
+      is_seeded: true,
+      existing_service: null,
+    },
+    {
+      id: "template-elevenlabs",
+      vendor: "elevenlabs",
+      display_name: "ElevenLabs",
+      operation: "speak",
+      slug: "platform-elevenlabs",
+      base_url: "https://api.elevenlabs.io",
+      auth_method: "header",
+      auth_key_name: "xi-api-key",
+      service_category: "internal",
+      visibility: "public",
+      credential_label: "API key",
+      credential_note: "Use a restricted ElevenLabs API key.",
+      capability_summary: "Serves speak.",
+      restriction_summary: "Does not expose voice cloning or vendor tools.",
+      is_active: true,
+      is_seeded: true,
+      existing_service: {
+        id: "existing-elevenlabs-id",
+        name: "Broken ElevenLabs",
+        auth_method: "header",
+        auth_key_name: "X-API-Key",
+        service_category: "internal",
+        visibility: "public",
+        is_active: true,
+      },
+    },
+  ],
+};
 
 const operations: PlatformOperationList = {
   operations: [
@@ -65,6 +126,16 @@ vi.mock("@/hooks/use-platform-ops", () => ({
     isPending: false,
     mutateAsync: mockMutateAsync,
   }),
+  usePlatformVendorRequirements: () => ({
+    data: vendorRequirements,
+    error: null,
+    isLoading: false,
+    refetch: mockRefetch,
+  }),
+  useProvisionPlatformVendor: () => ({
+    isPending: false,
+    mutateAsync: mockProvisionAsync,
+  }),
 }));
 
 vi.mock("sonner", () => ({
@@ -82,6 +153,7 @@ describe("AdminPlatformOpsPage", () => {
         updated_by: "admin-1",
       }),
     );
+    mockProvisionAsync.mockResolvedValue({ id: "replacement-id" });
   });
 
   it("renders one typed form for each fixed operation", () => {
@@ -139,5 +211,52 @@ describe("AdminPlatformOpsPage", () => {
       screen.getByRole("button", { name: "Remove voice ID voice-b" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("textbox", { name: /json/i })).toBeNull();
+  });
+
+  it("prefills locked vendor fields and replaces a broken row in one action", async () => {
+    render(<AdminPlatformOpsPage />);
+    const user = userEvent.setup();
+
+    await user.click(
+      screen.getByRole("button", { name: "Add platform vendor" }),
+    );
+    await user.click(screen.getByRole("combobox", { name: "Vendor" }));
+    await user.click(screen.getByRole("option", { name: "ElevenLabs" }));
+
+    expect(screen.getByLabelText("Slug")).toHaveValue(
+      "platform-elevenlabs",
+    );
+    expect(screen.getByLabelText("Slug")).toBeDisabled();
+    expect(screen.getByLabelText("Base URL")).toHaveValue(
+      "https://api.elevenlabs.io",
+    );
+    expect(screen.getByLabelText("Auth method")).toHaveValue("header");
+    expect(screen.getByLabelText("Auth key name")).toHaveValue("xi-api-key");
+    expect(screen.getByText("Serves speak.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Does not expose voice cloning or vendor tools."),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("API key"), "write-only-key");
+    await user.type(
+      screen.getByLabelText("Operator note (optional)"),
+      "Restricted to TTS",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Replace vendor row" }),
+    );
+
+    await waitFor(() =>
+      expect(mockProvisionAsync).toHaveBeenCalledWith({
+        requirement: vendorRequirements.vendors[1],
+        data: {
+          vendor: "elevenlabs",
+          credential: "write-only-key",
+          note: "Restricted to TTS",
+        },
+        replaceServiceId: "existing-elevenlabs-id",
+      }),
+    );
+    expect(screen.queryByDisplayValue("write-only-key")).toBeNull();
   });
 });

--- a/frontend/src/pages/admin-platform-ops.tsx
+++ b/frontend/src/pages/admin-platform-ops.tsx
@@ -8,12 +8,17 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Check,
+  KeyRound,
   PhoneCall,
   Plus,
   Search,
+  Settings2,
   Volume2,
   X,
 } from "lucide-react";
+import { PlatformVendorDialog } from "@/components/admin-platform-ops/platform-vendor-dialog";
+import { PlatformVendorTemplateManager } from "@/components/admin-platform-ops/platform-vendor-template-manager";
+import { AddCtaButton } from "@/components/shared/add-cta-button";
 import { toast } from "sonner";
 import { ErrorBanner } from "@/components/shared/error-banner";
 import { PageHeader } from "@/components/shared/page-header";
@@ -40,6 +45,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import {
   usePlatformOperations,
+  usePlatformVendorRequirements,
   useUpdatePlatformOperation,
 } from "@/hooks/use-platform-ops";
 import { ApiError } from "@/lib/api-client";
@@ -626,14 +632,75 @@ function OperationCard({
 }
 
 export function AdminPlatformOpsPage() {
-  const { data, error, isLoading, refetch } = usePlatformOperations();
-
+  const [vendorDialogOpen, setVendorDialogOpen] = useState(false);
+  const [templateManagerOpen, setTemplateManagerOpen] = useState(false);
+  const {
+    data,
+    error,
+    isLoading,
+    refetch: refetchOperations,
+  } = usePlatformOperations();
+  const {
+    data: vendorRequirements,
+    error: vendorRequirementsError,
+    isLoading: vendorRequirementsLoading,
+    refetch: refetchVendorRequirements,
+  } = usePlatformVendorRequirements();
   return (
     <div className="space-y-6">
       <PageHeader
         title="Platform Operations"
         description="Configure NyxID-owned vendor operations and their server-enforced limits."
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={() => setTemplateManagerOpen(true)}
+            >
+              <Settings2 className="size-4" />
+              Manage templates
+            </Button>
+            <AddCtaButton
+              label="Add platform vendor"
+              icon={KeyRound}
+              onClick={() => setVendorDialogOpen(true)}
+              disabled={
+                vendorRequirementsLoading ||
+                !vendorRequirements ||
+                !!vendorRequirementsError ||
+                vendorRequirements.vendors.length === 0
+              }
+            />
+          </div>
+        }
       />
+
+      <PlatformVendorDialog
+        open={vendorDialogOpen}
+        onOpenChange={setVendorDialogOpen}
+        requirements={vendorRequirements?.vendors ?? []}
+      />
+      {templateManagerOpen ? (
+        <PlatformVendorTemplateManager
+          open={templateManagerOpen}
+          onOpenChange={setTemplateManagerOpen}
+        />
+      ) : null}
+
+      {vendorRequirementsError ? (
+        <ErrorBanner
+          message={
+            vendorRequirementsError instanceof ApiError
+              ? vendorRequirementsError.message
+              : "Failed to load platform vendor provisioning data"
+          }
+          onRetry={() => {
+            void refetchVendorRequirements();
+          }}
+        />
+      ) : null}
 
       {error ? (
         <ErrorBanner
@@ -642,7 +709,7 @@ export function AdminPlatformOpsPage() {
               ? error.message
               : "Failed to load platform operations"
           }
-          onRetry={() => void refetch()}
+          onRetry={() => void refetchOperations()}
         />
       ) : isLoading ? (
         <div className="grid gap-4 xl:grid-cols-3">

--- a/frontend/src/schemas/platform-ops.test.ts
+++ b/frontend/src/schemas/platform-ops.test.ts
@@ -2,11 +2,121 @@ import { describe, expect, it } from "vitest";
 import {
   callAndSayUpdateSchema,
   platformOperationListSchema,
+  platformVendorProvisionSchema,
+  platformVendorRequirementListSchema,
+  platformVendorTemplateFormSchema,
   speakUpdateSchema,
   xSearchUpdateSchema,
 } from "./platform-ops";
 
 describe("platform operation schemas", () => {
+  it("parses the four-vendor provisioning contract", () => {
+    const result = platformVendorRequirementListSchema.parse({
+      vendors: [
+        {
+          id: "template-elevenlabs",
+          vendor: "elevenlabs",
+          display_name: "ElevenLabs",
+          operation: "speak",
+          slug: "platform-elevenlabs",
+          base_url: "https://api.elevenlabs.io",
+          auth_method: "header",
+          auth_key_name: "xi-api-key",
+          service_category: "internal",
+          visibility: "public",
+          credential_label: "API key",
+          credential_note: "Use a restricted key.",
+          capability_summary: "Serves speak.",
+          restriction_summary: "Does not expose vendor tools.",
+          is_active: true,
+          is_seeded: true,
+          existing_service: null,
+        },
+        {
+          id: "template-duffel",
+          vendor: "duffel",
+          display_name: "Duffel",
+          operation: null,
+          slug: "platform-duffel",
+          base_url: "https://api.duffel.com",
+          auth_method: "bearer",
+          auth_key_name: null,
+          service_category: "internal",
+          visibility: "public",
+          credential_label: "Access token",
+          credential_note: "Provision ahead of an operation.",
+          capability_summary: "No operation is shipped yet.",
+          restriction_summary: "Does not expose vendor tools.",
+          is_active: true,
+          is_seeded: true,
+          existing_service: null,
+        },
+      ],
+    });
+
+    expect(result.vendors[0]?.auth_key_name).toBe("xi-api-key");
+    expect(result.vendors[1]?.operation).toBeNull();
+  });
+
+  it("requires a write-only credential and bounds the optional note", () => {
+    expect(
+      platformVendorProvisionSchema.safeParse({
+        vendor: "x",
+        credential: "",
+        note: "",
+      }).success,
+    ).toBe(false);
+    expect(
+      platformVendorProvisionSchema.safeParse({
+        vendor: "x",
+        credential: "secret",
+        note: "n".repeat(4097),
+      }).success,
+    ).toBe(false);
+    expect(
+      platformVendorProvisionSchema.safeParse({
+        vendor: "x",
+        credential: "secret",
+        note: "Read-only app token",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts extensible vendor templates and rejects an invalid template shape", () => {
+    const template = platformVendorTemplateFormSchema.safeParse({
+      vendor: "acme_voice",
+      display_name: "Acme Voice",
+      slug: "platform-acme-voice",
+      base_url: "https://api.acme.example",
+      auth_method: "header",
+      auth_key_name: "X-Acme-Key",
+      credential_label: "API key",
+      credential_note: "Use a restricted production key.",
+      operation: null,
+      capability_summary: "Provides the Acme voice operation.",
+      restriction_summary: "Does not expose the vendor catalog.",
+      is_active: true,
+    });
+    expect(template.success).toBe(true);
+
+    expect(
+      platformVendorTemplateFormSchema.safeParse({
+        vendor: "Acme",
+        display_name: "Acme Voice",
+        slug: "platform-acme-voice",
+        base_url: "https://api.acme.example",
+        auth_method: "bearer",
+        auth_key_name: null,
+        credential_label: "Access token",
+        credential_note: "note",
+        operation: null,
+        capability_summary: "capability",
+        restriction_summary: "restriction",
+        is_active: true,
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts the disabled defaults returned for missing rows", () => {
     expect(
       platformOperationListSchema.parse({

--- a/frontend/src/schemas/platform-ops.ts
+++ b/frontend/src/schemas/platform-ops.ts
@@ -4,6 +4,105 @@ export const PLATFORM_OPERATION_QUERY_KEY = [
   "admin",
   "platform-ops",
 ] as const;
+export const PLATFORM_VENDOR_REQUIREMENTS_QUERY_KEY = [
+  "admin",
+  "platform-ops",
+  "vendor-requirements",
+] as const;
+export const PLATFORM_VENDOR_TEMPLATES_QUERY_KEY = [
+  "admin",
+  "platform-ops",
+  "vendor-templates",
+] as const;
+
+export const platformVendorSchema = z
+  .string()
+  .trim()
+  .min(1, "Vendor key is required")
+  .max(64, "Vendor key must be at most 64 characters")
+  .regex(
+    /^[a-z0-9][a-z0-9_-]*$/,
+    "Use lowercase letters, digits, underscores, and hyphens",
+  );
+
+const existingPlatformVendorServiceSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    auth_method: z.string(),
+    auth_key_name: z.string(),
+    service_category: z.string(),
+    visibility: z.string(),
+    is_active: z.literal(true),
+  })
+  .strict();
+
+export const platformVendorRequirementSchema = z
+  .object({
+    id: z.string().min(1),
+    vendor: platformVendorSchema,
+    display_name: z.string().min(1),
+    operation: z.string().min(1).nullable(),
+    slug: z.string().regex(/^platform-[a-z0-9-]+$/),
+    base_url: z.url(),
+    auth_method: z.enum(["header", "bearer", "basic"]),
+    auth_key_name: z.string().min(1).nullable(),
+    service_category: z.literal("internal"),
+    visibility: z.literal("public"),
+    credential_label: z.string().min(1),
+    credential_note: z.string().min(1),
+    capability_summary: z.string().min(1),
+    restriction_summary: z.string().min(1),
+    is_active: z.boolean(),
+    is_seeded: z.boolean(),
+    existing_service: existingPlatformVendorServiceSchema.nullable(),
+  })
+  .strict();
+
+export const platformVendorRequirementListSchema = z
+  .object({
+    vendors: z.array(platformVendorRequirementSchema),
+  })
+  .strict();
+
+export const platformVendorProvisionSchema = z
+  .object({
+    vendor: platformVendorSchema,
+    credential: z
+      .string()
+      .trim()
+      .min(1, "Credential is required")
+      .max(16_384, "Credential is too large"),
+    note: z
+      .string()
+      .trim()
+      .max(4_096, "Operator note must be at most 4096 characters"),
+  })
+  .strict();
+
+export const platformVendorTemplateFormSchema = z
+  .object({
+    vendor: platformVendorSchema,
+    display_name: z.string().trim().min(1).max(200),
+    slug: z
+      .string()
+      .trim()
+      .regex(
+        /^platform-[a-z0-9-]+$/,
+        "Slug must start with platform- and use lowercase letters, digits, and hyphens",
+      )
+      .max(100),
+    base_url: z.url(),
+    auth_method: z.enum(["header", "bearer", "basic"]),
+    auth_key_name: z.string().trim().max(256).nullable(),
+    credential_label: z.string().trim().min(1).max(120),
+    credential_note: z.string().trim().min(1).max(4_096),
+    operation: z.string().trim().max(64).nullable(),
+    capability_summary: z.string().trim().min(1).max(4_096),
+    restriction_summary: z.string().trim().min(1).max(4_096),
+    is_active: z.boolean(),
+  })
+  .strict();
 
 const vendorServiceSlugSchema = z
   .string()
@@ -190,3 +289,27 @@ export type UpdatePlatformOperationVariables =
   | { readonly op: "x_search"; readonly data: XSearchUpdate }
   | { readonly op: "speak"; readonly data: SpeakUpdate }
   | { readonly op: "call_and_say"; readonly data: CallAndSayUpdate };
+
+export type PlatformVendor = z.infer<typeof platformVendorSchema>;
+export type PlatformVendorRequirement = z.infer<
+  typeof platformVendorRequirementSchema
+>;
+export type PlatformVendorRequirementList = z.infer<
+  typeof platformVendorRequirementListSchema
+>;
+export type PlatformVendorProvision = z.infer<
+  typeof platformVendorProvisionSchema
+>;
+export type PlatformVendorTemplateForm = z.infer<
+  typeof platformVendorTemplateFormSchema
+>;
+
+export interface ProvisionPlatformVendorVariables {
+  readonly requirement: PlatformVendorRequirement;
+  readonly data: PlatformVendorProvision;
+  readonly replaceServiceId?: string;
+}
+
+export type PlatformVendorTemplateInput = z.infer<
+  typeof platformVendorTemplateFormSchema
+>;


### PR DESCRIPTION
Fixes a systemic provisioning defect found while activating ElevenLabs in production.

## The problem

Each platform operation requires its vendor row to have an exact auth shape, declared in code (`resolve_vendor_target`): `speak` → `header`+`xi-api-key`, `call_and_say` → `basic`, `x_search` → `bearer`. **Provisioning had no access to that contract.** A real ElevenLabs row was created via the admin form and broke two ways:

- the form's "API Key" type hardcodes `auth_key_name: X-API-Key`; ElevenLabs needs `xi-api-key` → every call 401s
- creation **auto-attached** `openapi_spec_url`, publishing **387 raw vendor tools** (incl. voice cloning) as executable MCP tools from what should be credential storage

The only runtime signal was an opaque **502**, indistinguishable from a genuine upstream outage. Auth fields are immutable, so a wrong row can't be repaired — only recreated. Every future vendor repeats this; Twilio was already known to fail the same way in a different field.

## What this adds

- **Vendor templates as admin-managed data** (`platform_vendor_template`) — slug, base URL, auth shape, credential label, served operation. The four (Twilio/ElevenLabs/X/Duffel) ship as **seeded defaults, not a hardcoded ceiling**; operators add more with no code change.
- **Templates never become a second source of truth.** The code contract stays authoritative; bind-time validation compares the actual row against *code*. A seeded template contradicting its operation's contract **fails a test** (`seeded_templates_match_code_contracts`, `contradictory_operation_template_is_rejected`).
- **Bind-time validation with actionable errors** — e.g. `"speak requires auth_key_name 'xi-api-key'; row 'platform-elevenlabs' has 'X-API-Key'"` — moving failure from runtime-opaque to provisioning-explicit.
- **Platform vendor rows cannot configure specs**; no auto-discovery, no endpoint rows. Closes the 387-tool exposure at source.
- **Structural flag gating** — `platform_services_feature_gate` is router-level middleware on the `/platform-ops` nest, so every current *and future* caller-facing operation inherits the flag without a per-handler line. Per-handler calls retained as belt-and-braces. Admin routes stay deliberately ungated so operators can stage before exposure.
- **Guided "Add platform vendor" UI** + template manager; credential write-only; generic create dialog unchanged for BYOK rows.

## Verification

`cargo fmt --check` clean · **clippy 0 issues** · frontend build green · new backend tests pass locally (bind-validation per mismatch case with asserted messages, anti-drift, requirements endpoint). Reviewed directly: production uses `build_router_with_state` so the gate is always installed (the `None` branch is test-only); all shared-file changes verified additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)