### PR TITLE
fix(frontend): remove routine credential pills from service cards

### DIFF
--- a/frontend/src/pages/keys.test.tsx
+++ b/frontend/src/pages/keys.test.tsx
@@ -167,6 +167,36 @@ describe("KeysPage", () => {
     expect(screen.getByText("/proxy/s/openai")).toBeInTheDocument();
   });
 
+  it("omits oauth2 and api_key credential pills from service cards", () => {
+    state.keys = [
+      makeKey({
+        id: "oauth-service",
+        label: "OAuth Service",
+        slug: "oauth-service",
+        credential_type: "oauth2",
+      }),
+      makeKey({
+        id: "api-key-service",
+        label: "API Key Service",
+        slug: "api-key-service",
+        credential_type: "api_key",
+      }),
+      makeKey({
+        id: "bearer-service",
+        label: "Bearer Service",
+        slug: "bearer-service",
+        credential_type: "bearer",
+      }),
+    ];
+
+    render(<KeysPage />);
+
+    expect(screen.queryByText("oauth2")).not.toBeInTheDocument();
+    expect(screen.queryByText("api_key")).not.toBeInTheDocument();
+    expect(screen.getByText("bearer")).toBeInTheDocument();
+    expect(screen.getAllByText("Direct")).toHaveLength(3);
+  });
+
   it("shows the empty state with an Add Your First Service CTA when there are no services", async () => {
     state.keys = [];
 

--- a/frontend/src/pages/keys.tsx
+++ b/frontend/src/pages/keys.tsx
@@ -211,16 +211,20 @@ function KeyCardContent({
             <Badge variant="warning">Credential Missing</Badge>
           )}
           {isSsh && <Badge variant="secondary">SSH</Badge>}
-          {/* Auth-method pill — moved to top so it aligns across cards */}
-          <Badge variant="secondary">
-            {keyInfo.auto_connected
-              ? autoAuthLabel
-              : isSsh
-                ? hasSshCertificateAuth
-                  ? "certificate"
-                  : "ssh tunnel"
-                : keyInfo.credential_type}
-          </Badge>
+          {(keyInfo.auto_connected ||
+            isSsh ||
+            (keyInfo.credential_type !== "oauth2" &&
+              keyInfo.credential_type !== "api_key")) && (
+            <Badge variant="secondary">
+              {keyInfo.auto_connected
+                ? autoAuthLabel
+                : isSsh
+                  ? hasSshCertificateAuth
+                    ? "certificate"
+                    : "ssh tunnel"
+                  : keyInfo.credential_type}
+            </Badge>
+          )}
           {/* Routing pill — moved to top so it aligns across cards.
               When routed via a node, the badge becomes a real Link so the
               user can jump straight to the node detail page (deferred Wave B


### PR DESCRIPTION
## Summary

- Remove the raw `oauth2` and `api_key` credential-type pills from External Services grid cards.
- Preserve credential data, OAuth reconnect behavior, status badges, `Direct`/node routing, and specialized credential labels such as SSH and platform-managed modes.
- Add focused regression coverage for the hidden values and retained non-target badges.

## Test Plan

- [x] Full frontend suite passes (`npm run test`: 291 files, 2,893 tests)
- [x] Frontend lint passes with 0 errors (`npm run lint`; 27 pre-existing warnings)
- [x] Production frontend build passes (`npm run build`)
- [x] New test verifies `oauth2` and `api_key` are absent while `bearer` and `Direct` remain

## Checklist

- [x] Code follows the project's architecture rules
- [x] No hardcoded secrets or credentials
- [x] Error handling and API contracts are unchanged
- [x] Documentation is not required for this presentation-only change
