### PR TITLE
fix(org): expose member-access services to org members

### DIFF
--- a/backend/src/handlers/keys.rs
+++ b/backend/src/handlers/keys.rs
@@ -265,7 +265,8 @@ async fn resolve_key_read_owner(
             // Members can proxy/use unless the service is admin-only; viewers
             // cannot. Scope has already been enforced above via
             // allows_resource, so if we got here this key is within scope.
-            let allowed = role.can_proxy() && (!svc.admin_only || role.can_admin());
+            let allowed =
+                crate::services::user_service_service::role_can_proxy_service(*role, &svc);
             CredentialSource::Org {
                 org_user_id: org_user_id.clone(),
                 org_name,
@@ -4120,7 +4121,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_key_for_org_requires_admin() {
+    async fn create_org_key_grants_inherited_member_scope_and_requires_admin() {
         let Some(db) = connect_test_database("h_keys_create_org_admin").await else {
             eprintln!("skipping: no local MongoDB");
             return;
@@ -4128,12 +4129,47 @@ mod tests {
         let state = test_app_state(db.clone());
         let admin_id = uuid::Uuid::new_v4().to_string();
         let member_id = uuid::Uuid::new_v4().to_string();
+        let override_member_id = uuid::Uuid::new_v4().to_string();
         let org_id = uuid::Uuid::new_v4().to_string();
         insert_user(&db, &admin_id, UserType::Person).await;
         insert_user(&db, &member_id, UserType::Person).await;
+        insert_user(&db, &override_member_id, UserType::Person).await;
         insert_user(&db, &org_id, UserType::Org).await;
         insert_membership(&db, &org_id, &admin_id, OrgRole::Admin).await;
         insert_membership(&db, &org_id, &member_id, OrgRole::Member).await;
+        insert_membership(&db, &org_id, &override_member_id, OrgRole::Member).await;
+        db.collection::<crate::models::org_membership::OrgMembership>(
+            crate::models::org_membership::COLLECTION_NAME,
+        )
+        .update_one(
+            doc! { "org_user_id": &org_id, "member_user_id": &member_id },
+            doc! { "$set": { "scope_source": "inherit" } },
+        )
+        .await
+        .expect("make member inherit the configured role scope");
+        db.collection::<crate::models::org_membership::OrgMembership>(
+            crate::models::org_membership::COLLECTION_NAME,
+        )
+        .update_one(
+            doc! { "org_user_id": &org_id, "member_user_id": &override_member_id },
+            doc! {
+                "$set": {
+                    "scope_source": "override",
+                    "allowed_service_ids": [],
+                },
+            },
+        )
+        .await
+        .expect("configure an explicit empty member override");
+        crate::services::org_role_scope_service::set_scope(
+            &db,
+            &org_id,
+            OrgRole::Member,
+            Some(Vec::new()),
+            &admin_id,
+        )
+        .await
+        .expect("start with an explicitly configured member role scope");
 
         // Admin should succeed
         let mut body = make_create_key_request(
@@ -4145,14 +4181,74 @@ mod tests {
         );
         body.target_org_id = Some(org_id.clone());
 
-        let result = super::create_key(
+        let Json(created) = super::create_key(
             State(state.clone()),
             test_auth_user(&admin_id),
             TelemetryContext::default(),
             Json(body),
         )
-        .await;
-        assert!(result.is_ok(), "admin should create org key");
+        .await
+        .expect("admin should create org key");
+        assert!(!created.admin_only);
+
+        let Json(member_keys) = super::list_keys(State(state.clone()), test_auth_user(&member_id))
+            .await
+            .expect("member should list newly created org services");
+        let member_service = member_keys
+            .keys
+            .iter()
+            .find(|key| key.id == created.id)
+            .expect("new org service should be visible to an inheriting member");
+        assert!(matches!(
+            &member_service.credential_source,
+            crate::handlers::user_services_handler::CredentialSourceResponse::Org {
+                role: crate::handlers::user_services_handler::OrgRoleResponse::Member,
+                allowed: true,
+                ..
+            }
+        ));
+
+        let member_target = crate::services::proxy_service::resolve_proxy_target_from_user_service(
+            &state.db,
+            &state.encryption_keys,
+            &state.node_ws_manager,
+            &member_id,
+            Some(&created.slug),
+            created.catalog_service_id.as_deref(),
+            None,
+        )
+        .await
+        .expect("member proxy resolution should not fail")
+        .expect("new org service should resolve for an inheriting member");
+        assert_eq!(member_target.user_service_id, created.id);
+
+        let Json(override_member_keys) =
+            super::list_keys(State(state.clone()), test_auth_user(&override_member_id))
+                .await
+                .expect("override member should still be able to list keys");
+        assert!(
+            override_member_keys
+                .keys
+                .iter()
+                .all(|key| key.id != created.id),
+            "automatic role-scope expansion must not rewrite a per-member override"
+        );
+        let override_proxy_result =
+            crate::services::proxy_service::resolve_proxy_target_from_user_service(
+                &state.db,
+                &state.encryption_keys,
+                &state.node_ws_manager,
+                &override_member_id,
+                Some(&created.slug),
+                created.catalog_service_id.as_deref(),
+                None,
+            )
+            .await;
+        match override_proxy_result {
+            Err(AppError::OrgRoleInsufficient(_)) => {}
+            Err(other) => panic!("expected scoped denial, got {other:?}"),
+            Ok(_) => panic!("explicitly scoped-out member resolved the org service"),
+        }
 
         // Member should be rejected
         let mut body2 = make_create_key_request(
@@ -4594,7 +4690,7 @@ mod tests {
     // ---- list_keys integration tests ----
 
     #[tokio::test]
-    async fn list_keys_includes_org_keys() {
+    async fn list_keys_keeps_admin_only_org_keys_visible_to_members() {
         let Some(db) = connect_test_database("h_keys_list_org_keys").await else {
             eprintln!("skipping: no local MongoDB");
             return;
@@ -4607,15 +4703,58 @@ mod tests {
         insert_user(&db, &org_id, UserType::Org).await;
         insert_membership(&db, &org_id, &user_id, OrgRole::Member).await;
         insert_key_fixture(&db, &org_id, &service_id, "org-svc", "Org Service").await;
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id },
+                doc! { "$set": { "admin_only": true } },
+            )
+            .await
+            .expect("enable admin-only policy");
+
+        let Json(response) = super::list_keys(State(state.clone()), test_auth_user(&user_id))
+            .await
+            .unwrap();
+
+        let restricted = response
+            .keys
+            .iter()
+            .find(|key| key.id == service_id)
+            .expect("admin-only org keys should remain visible to members");
+        assert!(restricted.admin_only);
+        assert!(matches!(
+            &restricted.credential_source,
+            crate::handlers::user_services_handler::CredentialSourceResponse::Org {
+                role: crate::handlers::user_services_handler::OrgRoleResponse::Member,
+                allowed: false,
+                ..
+            }
+        ));
+
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id },
+                doc! { "$set": { "admin_only": false } },
+            )
+            .await
+            .expect("disable admin-only policy");
 
         let Json(response) = super::list_keys(State(state), test_auth_user(&user_id))
             .await
             .unwrap();
-
-        assert!(
-            response.keys.iter().any(|k| k.id == service_id),
-            "org keys should be visible to members"
-        );
+        let unrestricted = response
+            .keys
+            .iter()
+            .find(|key| key.id == service_id)
+            .expect("org key should remain visible after disabling the policy");
+        assert!(!unrestricted.admin_only);
+        assert!(matches!(
+            &unrestricted.credential_source,
+            crate::handlers::user_services_handler::CredentialSourceResponse::Org {
+                role: crate::handlers::user_services_handler::OrgRoleResponse::Member,
+                allowed: true,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/backend/src/services/llm_gateway_service.rs
+++ b/backend/src/services/llm_gateway_service.rs
@@ -6,6 +6,7 @@ use crate::errors::{AppError, AppResult};
 use crate::models::downstream_service::{
     COLLECTION_NAME as DOWNSTREAM_SERVICES, DownstreamService,
 };
+use crate::models::org_membership::OrgRole;
 use crate::models::provider_config::{COLLECTION_NAME as PROVIDER_CONFIGS, ProviderConfig};
 use crate::models::user_api_key::{COLLECTION_NAME as USER_API_KEYS, UserApiKey};
 use crate::models::user_provider_token::{
@@ -107,6 +108,7 @@ pub async fn get_llm_status(
                 credential_owners.push(CredentialOwner::Org {
                     org_user_id: m.org_user_id,
                     effective_scope,
+                    role: m.role,
                 });
             }
         }
@@ -237,6 +239,7 @@ enum CredentialOwner {
     Org {
         org_user_id: String,
         effective_scope: Option<Vec<String>>,
+        role: OrgRole,
     },
 }
 
@@ -248,15 +251,20 @@ impl CredentialOwner {
         }
     }
 
-    fn allows(&self, user_service_id: &str) -> bool {
+    fn allows(&self, user_service: &crate::models::user_service::UserService) -> bool {
         match self {
             CredentialOwner::Personal(_) => true,
             CredentialOwner::Org {
-                effective_scope, ..
-            } => crate::services::org_role_scope_service::scope_allows(
                 effective_scope,
-                user_service_id,
-            ),
+                role,
+                ..
+            } => {
+                user_service_service::role_can_proxy_service(*role, user_service)
+                    && crate::services::org_role_scope_service::scope_allows(
+                        effective_scope,
+                        &user_service.id,
+                    )
+            }
         }
     }
 }
@@ -295,7 +303,7 @@ async fn lookup_user_service_status(
     else {
         return Ok(LlmStatusRank::NotConnected);
     };
-    if !owner.allows(&us.id) {
+    if !owner.allows(&us) {
         return Ok(LlmStatusRank::NotConnected);
     }
     let Some(api_key_id) = us.api_key_id.as_deref() else {
@@ -882,6 +890,33 @@ impl LlmTranslator for GoogleAiTranslator {
 mod tests {
     use super::*;
     use mongodb::bson::Bson;
+
+    #[test]
+    fn org_credential_owner_rejects_admin_only_service_for_member() {
+        let mut service = crate::test_utils::test_user_service(
+            "service-id",
+            "org-id",
+            "llm-openai",
+            "endpoint-id",
+            None,
+            None,
+        );
+        service.admin_only = true;
+
+        let member = CredentialOwner::Org {
+            org_user_id: "org-id".to_string(),
+            effective_scope: None,
+            role: OrgRole::Member,
+        };
+        let admin = CredentialOwner::Org {
+            org_user_id: "org-id".to_string(),
+            effective_scope: None,
+            role: OrgRole::Admin,
+        };
+
+        assert!(!member.allows(&service));
+        assert!(admin.allows(&service));
+    }
 
     #[test]
     fn build_llm_service_filter_targets_llm_service_slugs() {

--- a/backend/src/services/mcp_service.rs
+++ b/backend/src/services/mcp_service.rs
@@ -1097,15 +1097,18 @@ async fn load_user_tools_inner(
             let org_pinned: Vec<UserService> = db
                 .collection::<UserService>(USER_SERVICES)
                 .find(doc! {
-                    "user_id": &m.org_user_id,
-                    "is_active": true,
-                    "service_type": "http",
-                    "node_id": { "$type": "string", "$ne": "" },
+                        "user_id": &m.org_user_id,
+                        "is_active": true,
+                        "service_type": "http",
+                        "node_id": { "$type": "string", "$ne": "" },
                 })
                 .await?
                 .try_collect()
                 .await?;
             for svc in org_pinned {
+                if !crate::services::user_service_service::role_can_proxy_service(m.role, &svc) {
+                    continue;
+                }
                 if !crate::services::org_role_scope_service::scope_allows(&effective_scope, &svc.id)
                 {
                     continue;
@@ -1563,6 +1566,9 @@ async fn load_callable_user_services(
             .await?;
 
         for svc in org_svcs {
+            if !crate::services::user_service_service::role_can_proxy_service(m.role, &svc) {
+                continue;
+            }
             if !crate::services::org_role_scope_service::scope_allows(&effective_scope, &svc.id) {
                 continue;
             }
@@ -5479,6 +5485,97 @@ mod tests {
         assert_eq!(unavailable["executable"], false);
         assert_eq!(unavailable["source"], "user_service");
         assert_eq!(unavailable["is_generic_proxy"], true);
+    }
+
+    #[tokio::test]
+    async fn callable_service_loader_tracks_admin_only_toggle_for_member() {
+        use crate::models::org_membership::{COLLECTION_NAME as ORG_MEMBERSHIPS, OrgRole};
+
+        let Some(db) = connect_test_database("mcp_admin_only_member_discovery").await else {
+            eprintln!("skipping MCP admin-only discovery test: no local MongoDB available");
+            return;
+        };
+
+        let member_id = uuid::Uuid::new_v4().to_string();
+        let org_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let endpoint_id = uuid::Uuid::new_v4().to_string();
+        let service = test_user_service(
+            &service_id,
+            &org_id,
+            "admin-only-org-service",
+            &endpoint_id,
+            None,
+            None,
+        );
+        db.collection::<UserService>(USER_SERVICES)
+            .insert_one(service)
+            .await
+            .expect("insert admin-only org service");
+        db.collection::<crate::models::org_membership::OrgMembership>(ORG_MEMBERSHIPS)
+            .insert_one(crate::test_utils::test_membership(
+                &org_id,
+                &member_id,
+                OrgRole::Member,
+                None,
+            ))
+            .await
+            .expect("insert member membership");
+
+        let visible_while_disabled = load_callable_user_services(
+            &db,
+            &NodeWsManager::new(30, 100),
+            &member_id,
+            false,
+            NodeScope::Unrestricted,
+        )
+        .await
+        .expect("load member-callable services");
+        assert_eq!(visible_while_disabled.len(), 1);
+        assert_eq!(visible_while_disabled[0].service.id, service_id);
+
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id },
+                doc! { "$set": { "admin_only": true } },
+            )
+            .await
+            .expect("enable admin-only policy");
+
+        let hidden_while_enabled = load_callable_user_services(
+            &db,
+            &NodeWsManager::new(30, 100),
+            &member_id,
+            false,
+            NodeScope::Unrestricted,
+        )
+        .await
+        .expect("reload member-callable services after enabling policy");
+
+        assert!(
+            hidden_while_enabled.is_empty(),
+            "admin-only org services must not be advertised as callable to regular members"
+        );
+
+        db.collection::<UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id },
+                doc! { "$set": { "admin_only": false } },
+            )
+            .await
+            .expect("disable admin-only policy");
+
+        let visible_again = load_callable_user_services(
+            &db,
+            &NodeWsManager::new(30, 100),
+            &member_id,
+            false,
+            NodeScope::Unrestricted,
+        )
+        .await
+        .expect("reload member-callable services after disabling policy");
+        assert_eq!(visible_again.len(), 1);
+        assert_eq!(visible_again[0].service.id, service_id);
     }
 
     #[tokio::test]

--- a/backend/src/services/oauth_resource_service.rs
+++ b/backend/src/services/oauth_resource_service.rs
@@ -161,8 +161,7 @@ fn owner_access_can_grant_user_service(
         org_service::OwnerAccess::Direct => true,
         org_service::OwnerAccess::AsOrgAdmin { .. } => access.allows_resource(&service.id),
         org_service::OwnerAccess::AsOrgMember { role, .. } => {
-            role.can_proxy()
-                && (!service.admin_only || role.can_admin())
+            crate::services::user_service_service::role_can_proxy_service(*role, service)
                 && access.allows_resource(&service.id)
         }
         org_service::OwnerAccess::Forbidden => false,

--- a/backend/src/services/org_role_scope_service.rs
+++ b/backend/src/services/org_role_scope_service.rs
@@ -154,6 +154,37 @@ pub fn scope_allows(effective: &Option<Vec<String>>, svc_id: &str) -> bool {
     }
 }
 
+/// Add a service to an explicitly restricted role scope.
+///
+/// Missing scope rows and rows whose `allowed_service_ids` is null already
+/// grant full access, so this deliberately leaves them unchanged. Membership
+/// overrides are stored separately and are never expanded here.
+pub async fn add_service_to_configured_role_scope(
+    db: &mongodb::Database,
+    org_user_id: &str,
+    role: OrgRole,
+    service_id: &str,
+    actor_id: &str,
+) -> AppResult<()> {
+    db.collection::<OrgRoleScope>(COLLECTION_NAME)
+        .update_one(
+            doc! {
+                "org_user_id": org_user_id,
+                "role": role.as_str(),
+                "allowed_service_ids": { "$type": "array" },
+            },
+            doc! {
+                "$addToSet": { "allowed_service_ids": service_id },
+                "$set": {
+                    "updated_at": bson::DateTime::from_chrono(Utc::now()),
+                    "updated_by": actor_id,
+                },
+            },
+        )
+        .await?;
+    Ok(())
+}
+
 pub async fn delete_all_for_org(db: &mongodb::Database, org_user_id: &str) -> AppResult<()> {
     db.collection::<OrgRoleScope>(COLLECTION_NAME)
         .delete_many(doc! { "org_user_id": org_user_id })
@@ -361,5 +392,99 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn add_service_only_expands_the_matching_configured_array_scope() {
+        let Some(db) = connect_test_database("org_role_scope_add_service").await else {
+            eprintln!("skipping org role scope service test: no local MongoDB available");
+            return;
+        };
+        let org_id = Uuid::new_v4().to_string();
+        let other_org_id = Uuid::new_v4().to_string();
+        let missing_scope_org_id = Uuid::new_v4().to_string();
+        let actor_id = Uuid::new_v4().to_string();
+        let new_actor_id = Uuid::new_v4().to_string();
+
+        set_scope(
+            &db,
+            &org_id,
+            OrgRole::Member,
+            Some(vec!["existing-service".to_string()]),
+            &actor_id,
+        )
+        .await
+        .expect("set member scope");
+        set_scope(&db, &org_id, OrgRole::Admin, Some(Vec::new()), &actor_id)
+            .await
+            .expect("set admin scope");
+        set_scope(&db, &other_org_id, OrgRole::Member, None, &actor_id)
+            .await
+            .expect("set unrestricted member scope");
+
+        for _ in 0..2 {
+            add_service_to_configured_role_scope(
+                &db,
+                &org_id,
+                OrgRole::Member,
+                "new-service",
+                &new_actor_id,
+            )
+            .await
+            .expect("add service to configured member scope");
+        }
+        add_service_to_configured_role_scope(
+            &db,
+            &missing_scope_org_id,
+            OrgRole::Member,
+            "new-service",
+            &new_actor_id,
+        )
+        .await
+        .expect("missing scope should be a no-op");
+        add_service_to_configured_role_scope(
+            &db,
+            &other_org_id,
+            OrgRole::Member,
+            "new-service",
+            &new_actor_id,
+        )
+        .await
+        .expect("unrestricted scope should be a no-op");
+
+        let member = get_scope(&db, &org_id, OrgRole::Member)
+            .await
+            .expect("get member scope")
+            .expect("stored member scope");
+        assert_eq!(
+            member.allowed_service_ids,
+            Some(vec![
+                "existing-service".to_string(),
+                "new-service".to_string(),
+            ])
+        );
+        assert_eq!(member.updated_by, new_actor_id);
+
+        let admin = get_scope(&db, &org_id, OrgRole::Admin)
+            .await
+            .expect("get admin scope")
+            .expect("stored admin scope");
+        assert_eq!(admin.allowed_service_ids, Some(Vec::new()));
+        assert_eq!(admin.updated_by, actor_id);
+
+        let unrestricted = get_scope(&db, &other_org_id, OrgRole::Member)
+            .await
+            .expect("get unrestricted scope")
+            .expect("stored unrestricted scope");
+        assert_eq!(unrestricted.allowed_service_ids, None);
+        assert_eq!(unrestricted.updated_by, actor_id);
+
+        assert!(
+            get_scope(&db, &missing_scope_org_id, OrgRole::Member)
+                .await
+                .expect("get missing member scope")
+                .is_none(),
+            "adding a service must not create a role-scope row"
+        );
     }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1310,7 +1310,7 @@ fn admin_only_allows_role(
     user_service: &UserService,
     role: crate::models::org_membership::OrgRole,
 ) -> bool {
-    !user_service.admin_only || role.can_admin()
+    crate::services::user_service_service::role_can_proxy_service(role, user_service)
 }
 
 async fn lookup_service_pool_member(
@@ -4968,6 +4968,28 @@ mod tests {
                 .map(|r| r.org_user_id.as_str()),
             Some(org_id.as_str())
         );
+
+        db.collection::<crate::models::user_service::UserService>(USER_SERVICES)
+            .update_one(
+                doc! { "_id": &service_id },
+                doc! { "$set": { "admin_only": false } },
+            )
+            .await
+            .expect("disable admin-only policy");
+
+        let member_resolved = resolve_proxy_target_from_user_service(
+            &db,
+            &test_encryption_keys(),
+            &node_manager,
+            &member_id,
+            Some("admin-svc"),
+            None,
+            None,
+        )
+        .await
+        .expect("member resolution should succeed after disabling admin-only")
+        .expect("member should resolve the org service after disabling admin-only");
+        assert_eq!(member_resolved.user_service_id, service_id);
     }
 
     // ---- agent credential override resolution (issue #788) ----

--- a/backend/src/services/user_service_service.rs
+++ b/backend/src/services/user_service_service.rs
@@ -80,6 +80,38 @@ fn ensure_user_managed_service(service: &UserService) -> AppResult<()> {
     Ok(())
 }
 
+/// Whether an organization role can execute a service after applying the
+/// service's admin-only policy. Personal service access does not use this
+/// predicate because admin-only applies only to organization membership.
+pub(crate) fn role_can_proxy_service(role: OrgRole, service: &UserService) -> bool {
+    role.can_proxy() && (!service.admin_only || role.can_admin())
+}
+
+#[cfg(test)]
+mod access_policy_tests {
+    use super::*;
+
+    #[test]
+    fn admin_only_execution_policy_distinguishes_members_from_admins() {
+        let mut service = crate::test_utils::test_user_service(
+            "service-id",
+            "org-id",
+            "service",
+            "endpoint-id",
+            None,
+            None,
+        );
+
+        assert!(role_can_proxy_service(OrgRole::Member, &service));
+        assert!(!role_can_proxy_service(OrgRole::Viewer, &service));
+
+        service.admin_only = true;
+        assert!(!role_can_proxy_service(OrgRole::Member, &service));
+        assert!(!role_can_proxy_service(OrgRole::Viewer, &service));
+        assert!(role_can_proxy_service(OrgRole::Admin, &service));
+    }
+}
+
 /// Return endpoint ids whose target URL is owned by platform auto-provisioning.
 /// The URL remains stored normally for proxy resolution; callers use this set
 /// only when constructing user-facing endpoint responses.
@@ -499,8 +531,7 @@ async fn list_user_services_with_sources_impl(
             }
             // Viewer can see but not proxy. Admin-only services are also
             // visible to members, but not executable by them.
-            let allowed =
-                scope_allowed && m.role.can_proxy() && (!svc.admin_only || m.role.can_admin());
+            let allowed = scope_allowed && role_can_proxy_service(m.role, &svc);
 
             out.push(UserServiceWithSource {
                 service: svc,
@@ -910,6 +941,17 @@ pub async fn create_user_service_with_id(
         .insert_one(&service)
         .await?;
 
+    if !service.admin_only {
+        crate::services::org_role_scope_service::add_service_to_configured_role_scope(
+            db,
+            user_id,
+            OrgRole::Member,
+            &service.id,
+            actor_user_id,
+        )
+        .await?;
+    }
+
     Ok(service)
 }
 
@@ -1196,6 +1238,17 @@ pub async fn update_user_service(
 
     if result.matched_count == 0 {
         return Err(AppError::NotFound("User service not found".to_string()));
+    }
+
+    if admin_only == Some(false) {
+        crate::services::org_role_scope_service::add_service_to_configured_role_scope(
+            db,
+            user_id,
+            OrgRole::Member,
+            service_id,
+            actor_user_id,
+        )
+        .await?;
     }
 
     // Audit per-user default header mutations (NyxID#356). Names only —
@@ -2027,6 +2080,70 @@ mod tests {
             inject_delegation_token: true,
             delegation_token_scope: "llm:proxy".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn update_user_service_round_trips_admin_only_policy() {
+        let Some(db) = connect_test_database("user_service_admin_only_update").await else {
+            eprintln!("skipping user service admin-only update test: no local MongoDB available");
+            return;
+        };
+
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        db.collection::<UserService>(COLLECTION_NAME)
+            .insert_one(test_user_service(
+                &service_id,
+                &user_id,
+                "org-service",
+                "endpoint-id",
+                None,
+                None,
+            ))
+            .await
+            .expect("insert user service");
+        crate::services::org_role_scope_service::set_scope(
+            &db,
+            &user_id,
+            OrgRole::Member,
+            Some(Vec::new()),
+            &user_id,
+        )
+        .await
+        .expect("set restricted member role scope");
+
+        for expected in [true, false] {
+            update_user_service(
+                &db,
+                &user_id,
+                &user_id,
+                &service_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(expected),
+            )
+            .await
+            .expect("update admin-only policy");
+
+            let stored = get_user_service(&db, &user_id, &service_id)
+                .await
+                .expect("reload updated service");
+            assert_eq!(stored.admin_only, expected);
+        }
+
+        let member_scope =
+            crate::services::org_role_scope_service::get_scope(&db, &user_id, OrgRole::Member)
+                .await
+                .expect("get member role scope")
+                .expect("stored member role scope");
+        assert_eq!(member_scope.allowed_service_ids, Some(vec![service_id]));
     }
 
     #[tokio::test]

--- a/cli/src/commands/service.rs
+++ b/cli/src/commands/service.rs
@@ -46,6 +46,18 @@ pub(crate) fn display_status(svc: &Value) -> &'static str {
     credential_status
 }
 
+/// Render the service policy reported by `GET /keys` without deriving it
+/// from the caller's current execution permission. Organization members must
+/// still be able to identify an admin-only service even though its
+/// `credential_source.allowed` value is false for them.
+pub(crate) fn display_access_policy(svc: &Value) -> &'static str {
+    if svc["admin_only"].as_bool().unwrap_or(false) {
+        "admin-only"
+    } else {
+        "members"
+    }
+}
+
 /// Parse one or more `--default-header NAME=VALUE[:overridable]` flag values
 /// into a JSON-shaped list that the backend `validate_headers` helper will
 /// then normalize and persist. NyxID#356.
@@ -978,11 +990,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
                             let label = svc["label"].as_str().unwrap_or("-");
                             let endpoint = display_endpoint(svc, "endpoint_url", None);
                             let status = display_status(svc);
-                            let access = if svc["admin_only"].as_bool().unwrap_or(false) {
-                                "admin-only"
-                            } else {
-                                "members"
-                            };
+                            let access = display_access_policy(svc);
                             let node = svc["node_id"].as_str().unwrap_or("--");
                             table.add_row([id, slug, label, endpoint, status, access, node]);
                         }
@@ -1038,14 +1046,7 @@ pub async fn run(command: ServiceCommands) -> Result<()> {
                     eprintln!("Type:       {svc_type}");
                     eprintln!("Status:     {status}");
                     eprintln!("Active:     {is_active}");
-                    eprintln!(
-                        "Access:     {}",
-                        if svc["admin_only"].as_bool().unwrap_or(false) {
-                            "admin-only"
-                        } else {
-                            "members"
-                        }
-                    );
+                    eprintln!("Access:     {}", display_access_policy(&svc));
                     eprintln!();
                     eprintln!("Endpoint:   {endpoint}");
                     eprintln!("Auth:       {auth_method} / {auth_key}");
@@ -2595,6 +2596,29 @@ mod tests {
     }
 
     #[test]
+    fn access_policy_exposes_both_admin_only_states() {
+        let member_access = serde_json::json!({
+            "admin_only": false,
+            "credential_source": {
+                "type": "org",
+                "role": "member",
+                "allowed": true,
+            },
+        });
+        assert_eq!(display_access_policy(&member_access), "members");
+
+        let admin_only = serde_json::json!({
+            "admin_only": true,
+            "credential_source": {
+                "type": "org",
+                "role": "member",
+                "allowed": false,
+            },
+        });
+        assert_eq!(display_access_policy(&admin_only), "admin-only");
+    }
+
+    #[test]
     fn test_format_credential_lines() {
         let lines1 = format_credential_lines("node_managed", Some("abc-123"), "home-assistant");
         assert_eq!(
@@ -3327,6 +3351,36 @@ mod command_tests {
         })
         .await
         .expect("empty list should succeed");
+    }
+
+    #[tokio::test]
+    async fn list_table_accepts_visible_admin_only_org_service() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/keys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "keys": [{
+                    "id": "svc-org",
+                    "slug": "org-service",
+                    "label": "Org Service",
+                    "endpoint_url": "https://org.example.test",
+                    "admin_only": true,
+                    "credential_source": {
+                        "type": "org",
+                        "role": "member",
+                        "allowed": false
+                    }
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        run(ServiceCommands::List {
+            auth: mock_auth_with_output(server.uri(), OutputFormat::Table),
+        })
+        .await
+        .expect("admin-only org service should remain listable");
     }
 
     #[tokio::test]

--- a/docs/ORG_MODEL.md
+++ b/docs/ORG_MODEL.md
@@ -76,6 +76,8 @@ effective = if scope_source == Override { m.allowed_service_ids }
             else { org_role_scopes.get(org_user_id, role).allowed_service_ids }
 ```
 
+Creating an org service with admin-only execution disabled automatically adds its `UserService.id` to an explicitly configured Member role scope. Disabling admin-only execution later does the same, so inheriting members can discover and execute the service immediately. Admin-only creation does not grant Member scope. Per-member overrides remain fixed and are never expanded automatically.
+
 Enforcement runs at proxy time (members cannot call services outside their effective scope), at write time (admins cannot edit services outside their effective scope), and on every secondary read path that resolves org-inherited credentials (catalog, LLM gateway, MCP, approvals). Deleting an org-owned service automatically prunes its id from every role scope and every membership override so stale ids cannot linger.
 
 ### Org user vs. person user

--- a/frontend/src/pages/key-detail.test.tsx
+++ b/frontend/src/pages/key-detail.test.tsx
@@ -555,6 +555,49 @@ describe("KeyDetailPage — edit flows", () => {
     hooks.updateUserService.mock.calls[0]![1].onSuccess();
     expect(mockToastSuccess).toHaveBeenCalledWith("Custom User-Agent saved");
   });
+
+  it("keeps the admin-only explanation stable while toggling the policy", async () => {
+    const user = userEvent.setup();
+    hooks.key.data = makeKey({
+      admin_only: false,
+      credential_source: {
+        type: "org",
+        org_id: "org-1",
+        org_name: "Acme Org",
+        avatar_url: null,
+        role: "admin",
+        allowed: true,
+      },
+    });
+
+    render(<KeyDetailPage />);
+    await user.click(screen.getByRole("tab", { name: "Advanced" }));
+
+    const explanation =
+      "When enabled, regular organization members cannot proxy this service. Organization admins retain access.";
+    expect(screen.getByText(explanation)).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("switch", { name: "Admin-only execution" }),
+    );
+
+    expect(hooks.updateUserService).toHaveBeenCalledWith(
+      { serviceId: "key-1", admin_only: true },
+      expect.any(Object),
+    );
+    expect(screen.getByText(explanation)).toBeInTheDocument();
+  });
+
+  it("does not offer the organization policy for a personal service", async () => {
+    const user = userEvent.setup();
+
+    render(<KeyDetailPage />);
+    await user.click(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(
+      screen.queryByRole("switch", { name: "Admin-only execution" }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("KeyDetailPage — delete flow", () => {

--- a/frontend/src/pages/key-detail.tsx
+++ b/frontend/src/pages/key-detail.tsx
@@ -1847,9 +1847,8 @@ function AccessPolicySection({
               Admin-only execution
             </Label>
             <p className="text-[11px] text-muted-foreground">
-              {adminOnly
-                ? "Only org admins can proxy this service."
-                : "Org members with service scope can proxy this service."}
+              When enabled, regular organization members cannot proxy this
+              service. Organization admins retain access.
             </p>
           </div>
           <Switch
@@ -2592,13 +2591,15 @@ export function KeyDetailPage() {
               readOnly={readOnly}
             />
 
-            <div className="grid gap-4 lg:grid-cols-2">
-              <AccessPolicySection
-                serviceId={keyInfo.id}
-                adminOnly={keyInfo.admin_only ?? false}
-                readOnly={readOnly}
-              />
-            </div>
+            {isOrgSource && (
+              <div className="grid gap-4 lg:grid-cols-2">
+                <AccessPolicySection
+                  serviceId={keyInfo.id}
+                  adminOnly={keyInfo.admin_only ?? false}
+                  readOnly={readOnly}
+                />
+              </div>
+            )}
 
             {!isSsh && (
               <>


### PR DESCRIPTION
## Summary

- Apply Admin-only execution consistently to proxy resolution, `/keys`, CLI output, MCP discovery, OAuth resources, and LLM readiness.
- Add a member-access org service to an existing array-valued Member role scope when an admin creates the service or sets `admin_only=false`. Keep missing and null role scopes and per-member overrides unchanged.
- Keep the frontend explanation static and show the control only for org-owned services.

## Rollout note

This PR does not bulk-add historical services to Member role scopes. After deployment, submit `admin_only=false` once for an existing service that the role scope omits. In the frontend, toggle Admin-only execution on and then back off.

## Test Plan

- [x] `cargo test -p nyxid create_org_key_grants_inherited_member_scope_and_requires_admin -- --nocapture`
- [x] `cargo test -p nyxid admin_only -- --nocapture`
- [x] `cargo test -p nyxid add_service_only_expands_the_matching_configured_array_scope -- --nocapture`
- [x] `cargo test -p nyxid-cli admin_only -- --nocapture`
- [x] `npm test -- src/pages/key-detail.test.tsx`
- [x] `npm run build`
- [x] `npm run lint` with 0 errors and 27 pre-existing warnings
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] Reproduced the live pre-deploy failure with a read-only non-admin CLI check: `api-elevenlabs` is absent from the returned org services

## Checklist

- [x] Code follows the project architecture rules
- [x] No hardcoded secrets or credentials
- [x] Error messages do not leak internal details
- [x] Organization scope behavior is documented in `docs/ORG_MODEL.md`