### PR TITLE
refactor(assistant): remove plan.resolve and the untyped completions pass-through

### DIFF
--- a/.github/workflows/aevatar-chat-drift.yml
+++ b/.github/workflows/aevatar-chat-drift.yml
@@ -1,0 +1,46 @@
+# Weekly check that Aevatar feature/integrate has not moved a watched chat
+# path after the SHA pinned in
+# tests/fixtures/assistant/aevatar-chat-contract-pin.json.
+#
+# A red run means a contract-owned upstream file changed. Review the receipt
+# artifact, then re-pin only after an owner decides the new SHA. This job
+# never edits the pin.
+
+name: Aevatar Chat Drift
+
+on:
+  schedule:
+    - cron: "37 3 * * 1" # Mondays 03:37 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    name: Watched chat path drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check watched Aevatar chat paths
+        run: |
+          set -o pipefail
+          python3 scripts/check-aevatar-chat-drift.py \
+            --pin tests/fixtures/assistant/aevatar-chat-contract-pin.json \
+            --remote https://github.com/aevatarAI/aevatar.git \
+            --branch feature/integrate \
+            --json | tee aevatar-chat-drift-receipt.json
+
+      - name: Upload drift receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aevatar-chat-drift-receipt
+          path: aevatar-chat-drift-receipt.json
+          if-no-files-found: warn

--- a/.github/workflows/aevatar-chat-drift.yml
+++ b/.github/workflows/aevatar-chat-drift.yml
@@ -5,6 +5,9 @@
 # A red run means a contract-owned upstream file changed. Review the receipt
 # artifact, then re-pin only after an owner decides the new SHA. This job
 # never edits the pin.
+#
+# Pull requests that touch the checker, its tests, the pin, or this workflow
+# run the offline unit tests only.
 
 name: Aevatar Chat Drift
 
@@ -12,13 +15,36 @@ on:
   schedule:
     - cron: "37 3 * * 1" # Mondays 03:37 UTC
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/check-aevatar-chat-drift.py"
+      - "scripts/tests/**"
+      - "scripts/__init__.py"
+      - "tests/fixtures/assistant/aevatar-chat-contract-pin.json"
+      - ".github/workflows/aevatar-chat-drift.yml"
 
 permissions:
   contents: read
 
 jobs:
+  unit-tests:
+    name: Drift checker unit tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run drift checker unit tests
+        run: python3 -m unittest scripts.tests.test_check_aevatar_chat_drift
+
   drift-check:
     name: Watched chat path drift
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ keys/
 *~
 .DS_Store
 
+# ─── Python ───
+__pycache__/
+*.pyc
+
 # ─── Logs ───
 *.log
 logs/

--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -1118,25 +1118,6 @@ pub async fn get_state(
     .await)
 }
 
-/// `POST /api/v1/assistant/completions` -- OpenAI-compatible SSE stream.
-pub async fn completions(
-    State(state): State<AppState>,
-    auth_user: AuthUser,
-    request: Request<Body>,
-) -> AppResult<Response> {
-    let mut echoes = upstream_echo_collector(&state, &auth_user, request.headers()).await;
-    let response = forward(
-        &state,
-        &auth_user,
-        assistant_service::completions_path(),
-        request,
-        Vec::new(),
-        ForwardEcho::enabled(None, None, echoes.as_mut()),
-    )
-    .await?;
-    Ok(attach_wire_log(&state, &auth_user, None, response, echoes.as_deref()).await)
-}
-
 /// Bounds caller chat bodies: a 32k-char prompt is at most 128 KiB of UTF-8,
 /// with additional room for JSON escaping.
 const MAX_ASSISTANT_CHAT_REQUEST_BYTES: usize = 256 * 1024;

--- a/backend/src/handlers/assistant_actions.rs
+++ b/backend/src/handlers/assistant_actions.rs
@@ -17,12 +17,11 @@ pub const ASSISTANT_ACTIONS_REVISION: &str = "nyxid-assistant-actions.v8";
 /// `ReadRequiredString(..., 128)` bound on the revision field.
 const MAX_REVISION_PARAM_CHARS: usize = 128;
 
-/// Mirrors Aevatar `PinnedActionsByRevision` on `origin/feature/integrate`
-/// (the superset of `origin/dev`'s `{v4…v7}`). Action-name order is Aevatar's
-/// listed order; it is not a prefix of the current default array (v7 skips
-/// `service.reauthorize` at index 1). `aevatar-nyxid-actions.v1` is Aevatar's
-/// own composition namespace and is not a NyxID-published revision.
-const PINNED_ACTIONS_BY_REVISION: &[(&str, &[&str])] = &[
+/// Legacy action subsets served when a caller requests a specific NyxID
+/// revision. The bare endpoint always serves the additive default manifest;
+/// current Aevatar uses `schema_version`, not this revision label, as its
+/// registry-wide compatibility gate.
+const PUBLISHED_ACTIONS_BY_REVISION: &[(&str, &[&str])] = &[
     ("nyxid-assistant-actions.v4", &["service.connect"]),
     (
         "nyxid-assistant-actions.v5",
@@ -100,13 +99,10 @@ const SERVICE_REAUTHORIZE_DESCRIPTION: &str = "Ask the user's browser to re-auth
 const KEY_CREATE_DESCRIPTION: &str = "Ask the user's browser to create a scoped NyxID API key for the named platform and allowed services. Use when the user wants a new agent identity bounded to specific user-service IDs. NyxID owns key creation and one-time key display, and reports only a safe key reference. Never request, expose, or repeat key material in chat.";
 const KEY_ROTATE_DESCRIPTION: &str = "Ask the user's browser to rotate one exact NyxID API key. Use when the user needs a replacement credential for the identified key. NyxID commits an authoritative predecessor-successor relation, displays replacement key material once in the browser, and reports only the replacement key reference. Never request, expose, or repeat key material in chat.";
 
-// Wave-2 descriptors below are published DORMANT: they are deliberately absent
-// from every Aevatar revision pin, so every current composition skips them at
-// registry load (upstream `Load_ShouldIgnoreUnknownActionWhenExecutableActionsArePresent`).
-// They become executable only when a future revision pins them; until that
-// revision bump they may still be amended. Do not edit the four shipped
-// descriptors above - their schemas are pinned byte-for-byte by
-// `JsonNode.DeepEquals` in deployed compositions.
+// Descriptors below are published additively. Aevatar skips unknown or
+// divergent descriptors per action. schema_version is the only registry-wide
+// gate. The four byte-compared descriptors above require a coordinated
+// consumer contract change.
 const KEY_UPDATE_DESCRIPTION: &str = "Ask the user's browser to update the display metadata of one exact NyxID API key - its name, platform, or description. Use when the user wants to relabel or reclassify an existing agent key without changing what it can reach. NyxID owns the journey and reports only the safe key reference. Never request, expose, or repeat key material in chat.";
 const KEY_DELETE_DESCRIPTION: &str = "Ask the user's browser to permanently delete one exact NyxID API key. Use when the user wants to retire an agent identity entirely. Deletion is destructive and confirmed in the browser every time; NyxID reports only the safe key reference. Never request, expose, or repeat key material in chat.";
 const KEY_EXTEND_SCOPE_DESCRIPTION: &str = "Ask the user's browser to widen one exact NyxID API key's allowed services by the listed user-service IDs. Use when a task needs the key to reach a service it cannot reach today. Widening is confirmed in the browser and never remembered; NyxID reports only the safe key reference. Never request, expose, or repeat key material in chat.";
@@ -295,7 +291,6 @@ static MANIFEST_BODY: LazyLock<String> = LazyLock::new(|| {
                 tier: "v1",
                 remember_eligible: false,
             },
-            // ---- Wave 2 (dormant until a future revision pins them) ----
             AssistantActionDescriptor {
                 action: "key.update",
                 description: KEY_UPDATE_DESCRIPTION,
@@ -1142,7 +1137,7 @@ static MANIFEST_BODY: LazyLock<String> = LazyLock::new(|| {
 /// (revision, action) and `JsonNode.DeepEquals`s it; current bytes only
 /// pass for revisions that pin the live descriptor.
 static PINNED_REVISION_BODIES: LazyLock<HashMap<&'static str, String>> = LazyLock::new(|| {
-    PINNED_ACTIONS_BY_REVISION
+    PUBLISHED_ACTIONS_BY_REVISION
         .iter()
         .map(|(revision, action_names)| {
             (*revision, compose_revision_manifest(revision, action_names))
@@ -1226,10 +1221,7 @@ pub async fn get_assistant_actions(Query(query): Query<AssistantActionsQuery>) -
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{HashMap as StdHashMap, HashSet},
-        sync::Arc,
-    };
+    use std::{collections::HashSet, sync::Arc};
 
     use axum::{
         Extension,
@@ -1238,24 +1230,20 @@ mod tests {
         middleware,
         response::Response,
     };
-    use serde::Deserialize;
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
     use super::{
-        ASSISTANT_ACTIONS_REVISION, ASSISTANT_ACTIONS_SCHEMA_VERSION, PINNED_ACTIONS_BY_REVISION,
-        manifest_body, resolve_assistant_actions_body,
+        ASSISTANT_ACTIONS_REVISION, ASSISTANT_ACTIONS_SCHEMA_VERSION,
+        PUBLISHED_ACTIONS_BY_REVISION, manifest_body, resolve_assistant_actions_body,
     };
     use crate::config::TrustedProxyRange;
     use crate::mw::rate_limit::{GlobalRateLimiter, PerIpRateLimiter, rate_limit_middleware};
 
     const MAXIMUM_REGISTRY_BYTES: usize = 1_048_576;
-    /// Names the manifest may contain. The first 14 mirror the Aevatar
-    /// parser's `SupportedActions` contract; the Wave-2 block extends the
-    /// rail with dormant verbs the upstream loader provably skips until a
-    /// future revision pins them (it validates only that `action` is a
-    /// string of at most 128 chars before skipping). Names outside this
-    /// list still fail the conformance test below.
+    /// Names the NyxID manifest may contain. Fourteen are known to the pinned
+    /// Aevatar consumer; it ignores the remaining well-formed descriptors.
+    /// Names outside this list still fail the conformance test below.
     const SUPPORTED_ACTIONS: &[&str] = &[
         "service.connect",
         "service.reauthorize",
@@ -1300,7 +1288,7 @@ mod tests {
         "external_key.add_gcp_service_account",
         "openclaw.connect",
         "device.onboard",
-        "// Wave 2 (dormant; not pinned by any Aevatar revision yet)",
+        "// Additive descriptors",
         "key.update",
         "key.delete",
         "key.extend_scope",
@@ -1317,9 +1305,7 @@ mod tests {
         "provider.disconnect",
     ];
 
-    /// The composition the deployed v8 pin executes. Everything else in the
-    /// manifest is dormant and must stay non-remembered until pinned.
-    const V8_PINNED_ACTIONS: &[&str] = &[
+    const V8_PREFIX_ACTIONS: &[&str] = &[
         "service.connect",
         "service.reauthorize",
         "key.create",
@@ -2508,151 +2494,68 @@ mod tests {
         }
     }
 
-    /// Aevatar `KeyCreateParamsSchema` (the pre-least-scope constant).
-    /// Independent of NyxID's live descriptor so a serving regression that
-    /// copies current `key.create` bytes into v5 cannot hide behind a shared
-    /// helper.
-    fn aevatar_key_create_params_schema_pre_least_scope() -> Value {
-        json!({
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["name", "platform", "allowedServiceIds"],
-            "properties": {
-                "name": { "type": "string" },
-                "platform": { "type": "string" },
-                "allowedServiceIds": {
-                    "type": "array",
-                    "items": { "type": "string" }
-                }
-            }
-        })
+    fn current_remember_eligible(action: &str) -> bool {
+        action == "service.connect"
     }
 
-    /// Mirrors `ValidatePinnedContract`'s per-revision schema selection on
-    /// both Aevatar lineages: v4/v5 → `KeyCreateParamsSchema`; v6/v7/v8 →
-    /// `LeastScopeKeyCreateParamsSchema`. Other pinned verbs have a single
-    /// compiled constant.
-    fn aevatar_pinned_params_schema(revision: &str, action: &str) -> Value {
-        match action {
-            "key.create" => match revision {
-                "nyxid-assistant-actions.v6"
-                | "nyxid-assistant-actions.v7"
-                | "nyxid-assistant-actions.v8" => key_create_params_schema(),
-                _ => aevatar_key_create_params_schema_pre_least_scope(),
-            },
-            other => current_params_schema(other),
-        }
-    }
-
-    fn aevatar_pinned_risk(action: &str) -> &'static str {
-        match action {
-            "service.connect" | "service.reauthorize" | "key.create" | "key.rotate" => "grant",
-            other => panic!("no Aevatar pinned risk for {other}"),
-        }
-    }
-
-    fn aevatar_pinned_remember_eligible(action: &str) -> bool {
-        match action {
-            "service.connect" => true,
-            "service.reauthorize" | "key.create" | "key.rotate" => false,
-            other => panic!("no Aevatar pinned remember_eligible for {other}"),
-        }
-    }
-
-    #[derive(Debug, Deserialize, PartialEq, Eq)]
-    struct AevatarRevisionMirror {
-        lineages: StdHashMap<String, AevatarLineageMirror>,
-    }
-
-    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-    struct AevatarLineageMirror {
-        supported_revision: String,
-        revisions: StdHashMap<String, AevatarRevisionSets>,
-    }
-
-    #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-    struct AevatarRevisionSets {
-        pinned: Vec<String>,
-        executable: Vec<String>,
-    }
-
-    fn load_aevatar_revision_mirror() -> AevatarRevisionMirror {
+    fn consumer_contract_fixture() -> Value {
         serde_json::from_str(include_str!(
             "../../../tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json"
         ))
-        .expect("manually synced Aevatar revision-set mirror must parse")
+        .expect("AC-1 consumer contract fixture must parse")
     }
 
-    fn integrate_lineage_sets(revision: &str) -> AevatarRevisionSets {
-        load_aevatar_revision_mirror()
-            .lineages
-            .get("origin/feature/integrate")
-            .expect("mirror must include origin/feature/integrate")
-            .revisions
-            .get(revision)
-            .cloned()
-            .unwrap_or_else(|| panic!("integrate lineage missing {revision}"))
+    fn chat_contract_pin() -> Value {
+        serde_json::from_str(include_str!(
+            "../../../tests/fixtures/assistant/aevatar-chat-contract-pin.json"
+        ))
+        .expect("AC-0 pin must parse")
     }
 
-    /// Reproduces Aevatar `Load` + `ValidatePinnedContract` for one served
-    /// composition: skip unknown/non-pinned names, DeepEquals the
-    /// revision-selected schema (via `serde_json::Value`, the Rust analogue
-    /// of `JsonNode.DeepEquals` on canonicalized JSON), check pinned
-    /// risk/remember, require every pinned name, and require every
-    /// executable name.
-    fn assert_matches_aevatar_pinned_contract(body: &str, revision: &str) {
-        let sets = integrate_lineage_sets(revision);
-        let manifest: Value = serde_json::from_str(body).expect("served body must be JSON");
-        let actions = manifest["actions"]
+    fn fixture_action_names<'a>(fixture: &'a Value, field: &str) -> Vec<&'a str> {
+        fixture[field]
             .as_array()
-            .expect("actions must be an array");
+            .unwrap_or_else(|| panic!("{field}"))
+            .iter()
+            .map(|value| value.as_str().expect("action name"))
+            .collect()
+    }
 
-        let pinned: HashSet<&str> = sets.pinned.iter().map(String::as_str).collect();
-        let mut seen = HashSet::new();
-        for entry in actions {
-            let action = entry["action"].as_str().expect("action must be a string");
-            if !pinned.contains(action) {
+    enum ConsumerLoad {
+        SchemaUnsupported,
+        Loaded {
+            accepted: Vec<String>,
+            skipped: Vec<String>,
+        },
+    }
+
+    fn consume_like_aevatar(manifest: &Value) -> ConsumerLoad {
+        let schema = manifest["schema_version"].as_u64();
+        if schema != Some(u64::from(ASSISTANT_ACTIONS_SCHEMA_VERSION)) {
+            return ConsumerLoad::SchemaUnsupported;
+        }
+        let fixture = consumer_contract_fixture();
+        let supported = fixture_action_names(&fixture, "consumer_supported_actions");
+        let pinned = fixture_action_names(&fixture, "pinned_descriptor_actions");
+        let mut accepted = Vec::new();
+        let mut skipped = Vec::new();
+        for entry in manifest["actions"].as_array().expect("actions") {
+            let action = entry["action"].as_str().expect("action");
+            if !supported.contains(&action) {
                 continue;
             }
-            assert!(
-                seen.insert(action),
-                "duplicate pinned action {action} at {revision}"
-            );
-            assert_eq!(
-                entry["params_schema"],
-                aevatar_pinned_params_schema(revision, action),
-                "Aevatar JsonNode.DeepEquals pin failed for {action} at {revision}"
-            );
-            assert_eq!(
-                entry["risk"].as_str(),
-                Some(aevatar_pinned_risk(action)),
-                "pinned risk mismatch for {action} at {revision}"
-            );
-            assert_eq!(
-                entry["remember_eligible"].as_bool(),
-                Some(aevatar_pinned_remember_eligible(action)),
-                "pinned remember_eligible mismatch for {action} at {revision}"
-            );
+            let matches_pinned_contract = !pinned.contains(&action)
+                || (entry["params_schema"] == current_params_schema(action)
+                    && entry["risk"].as_str() == Some("grant")
+                    && entry["remember_eligible"].as_bool()
+                        == Some(current_remember_eligible(action)));
+            if matches_pinned_contract {
+                accepted.push(action.to_string());
+            } else {
+                skipped.push(action.to_string());
+            }
         }
-
-        let seen_owned: HashSet<String> = seen.iter().map(|name| (*name).to_string()).collect();
-        let pinned_owned: HashSet<String> = sets.pinned.iter().cloned().collect();
-        assert_eq!(
-            seen_owned, pinned_owned,
-            "served {revision} is missing a pinned action"
-        );
-        for executable in &sets.executable {
-            assert!(
-                seen_owned.contains(executable),
-                "executable action {executable} missing from served {revision}"
-            );
-        }
-        if revision == "nyxid-assistant-actions.v4" {
-            assert!(
-                !seen.contains("key.create"),
-                "v4 pins only service.connect; key.create must not be served"
-            );
-        }
+        ConsumerLoad::Loaded { accepted, skipped }
     }
 
     fn action_names(manifest: &Value) -> Vec<&str> {
@@ -2729,19 +2632,13 @@ mod tests {
         assert_manifest_conforms(manifest_body());
     }
 
-    /// Guards the dormant-merge protocol: the revision stays v8, the four
-    /// pinned descriptors keep their positions (deployed compositions
-    /// deep-equal their schemas), and every Wave-2 descriptor is present,
-    /// never remember-eligible, and correctly marked destructive where the
-    /// wave says so. A revision bump or a shipped-schema edit fails here
-    /// before it can fail an Aevatar startup.
     #[test]
-    fn dormant_descriptors_are_appended_and_never_remembered() {
+    fn additive_descriptors_are_appended_and_never_remembered() {
         let manifest: Value = serde_json::from_str(manifest_body()).unwrap();
         assert_eq!(manifest["revision"], "nyxid-assistant-actions.v8");
 
         let actions = manifest["actions"].as_array().unwrap();
-        for (index, pinned) in V8_PINNED_ACTIONS.iter().enumerate() {
+        for (index, pinned) in V8_PREFIX_ACTIONS.iter().enumerate() {
             assert_eq!(
                 actions[index]["action"], *pinned,
                 "pinned descriptor moved: {pinned}"
@@ -2769,10 +2666,10 @@ mod tests {
             "service_account.revoke_tokens",
             "developer_app.delete",
         ];
-        let wave2: Vec<&str> = SUPPORTED_ACTIONS
+        let additive: Vec<&str> = SUPPORTED_ACTIONS
             .iter()
             .copied()
-            .filter(|name| !V8_PINNED_ACTIONS.contains(name))
+            .filter(|name| !V8_PREFIX_ACTIONS.contains(name))
             .filter(|name| {
                 actions
                     .iter()
@@ -2780,11 +2677,11 @@ mod tests {
             })
             .collect();
         assert_eq!(
-            wave2.len(),
+            additive.len(),
             53,
             "expected 15 Wave-2 + 8 Wave-3 + 30 Wave-4 dormant descriptors"
         );
-        for name in wave2 {
+        for name in additive {
             let entry = actions
                 .iter()
                 .find(|entry| entry["action"].as_str() == Some(name))
@@ -2954,7 +2851,7 @@ mod tests {
         let (default_status, default_body) = response_bytes(default_response).await;
         assert_eq!(default_status, StatusCode::OK);
 
-        for (revision, expected_names) in PINNED_ACTIONS_BY_REVISION {
+        for (revision, expected_names) in PUBLISHED_ACTIONS_BY_REVISION {
             let response = request_assistant_actions(&format!(
                 "/api/v1/assistant/actions?revision={revision}"
             ))
@@ -2982,27 +2879,24 @@ mod tests {
 
     #[test]
     fn assistant_actions_every_published_revision_passes_parser_contract() {
-        for (revision, action_names) in PINNED_ACTIONS_BY_REVISION {
+        for (revision, action_names) in PUBLISHED_ACTIONS_BY_REVISION {
             let body = resolve_assistant_actions_body(Some(revision))
                 .unwrap_or_else(|error| panic!("missing composed body for {revision}: {error}"));
             assert_manifest_conforms_revision(body, revision, Some(action_names));
-            assert_matches_aevatar_pinned_contract(body, revision);
         }
         assert_manifest_conforms(manifest_body());
     }
 
     #[test]
     fn assistant_actions_revision_sets_are_monotone_append_only() {
-        // Going forward, each published set is a subset of the next. Aevatar's
-        // frozen pin map has one historical reduction: v5 (WaveOneDraft)
-        // listed reauthorize+rotate, then v6 (LeastScope) dropped them. That
-        // pair is the only permitted non-subset consecutive step.
-        let latest = PINNED_ACTIONS_BY_REVISION
+        // Each published set is a subset of the next except for the frozen
+        // v5-to-v6 reduction in NyxID's legacy revision responses.
+        let latest = PUBLISHED_ACTIONS_BY_REVISION
             .last()
             .expect("at least one published revision");
         let latest_set: HashSet<&str> = latest.1.iter().copied().collect();
 
-        for window in PINNED_ACTIONS_BY_REVISION.windows(2) {
+        for window in PUBLISHED_ACTIONS_BY_REVISION.windows(2) {
             let (left_revision, left_actions) = window[0];
             let (right_revision, right_actions) = window[1];
             let left: HashSet<&str> = left_actions.iter().copied().collect();
@@ -3022,90 +2916,14 @@ mod tests {
             );
         }
 
-        for (revision, actions) in PINNED_ACTIONS_BY_REVISION {
+        for (revision, actions) in PUBLISHED_ACTIONS_BY_REVISION {
             let set: HashSet<&str> = actions.iter().copied().collect();
             assert!(
                 set.is_subset(&latest_set),
-                "{revision} must be a subset of the latest pin {}",
+                "{revision} must be a subset of the latest published revision {}",
                 latest.0
             );
         }
-    }
-
-    #[test]
-    fn assistant_actions_revision_sets_match_manually_synced_aevatar_mirror() {
-        let mirror = load_aevatar_revision_mirror();
-        let dev = mirror
-            .lineages
-            .get("origin/dev")
-            .expect("mirror must include origin/dev");
-        let integrate = mirror
-            .lineages
-            .get("origin/feature/integrate")
-            .expect("mirror must include origin/feature/integrate");
-
-        assert_eq!(dev.supported_revision, "nyxid-assistant-actions.v7");
-        assert_eq!(integrate.supported_revision, "nyxid-assistant-actions.v8");
-        assert!(
-            !dev.revisions.contains_key("nyxid-assistant-actions.v8"),
-            "origin/dev does not publish v8"
-        );
-
-        assert_eq!(
-            integrate.revisions.len(),
-            PINNED_ACTIONS_BY_REVISION.len(),
-            "NyxID publishes the integrate superset of revisions"
-        );
-        for (revision, action_names) in PINNED_ACTIONS_BY_REVISION {
-            let sets = integrate
-                .revisions
-                .get(*revision)
-                .unwrap_or_else(|| panic!("integrate mirror missing {revision}"));
-            let expected: Vec<String> = action_names
-                .iter()
-                .map(|name| (*name).to_string())
-                .collect();
-            assert_eq!(
-                sets.pinned, expected,
-                "manually synced pinned set mismatch for {revision}"
-            );
-            for executable in &sets.executable {
-                assert!(
-                    sets.pinned.iter().any(|name| name == executable),
-                    "{executable} is executable on {revision} but not pinned"
-                );
-            }
-        }
-
-        for (revision, sets) in &dev.revisions {
-            assert_eq!(
-                integrate.revisions.get(revision),
-                Some(sets),
-                "{revision} pinned/executable sets must match across Aevatar lineages"
-            );
-        }
-
-        let v5 = integrate
-            .revisions
-            .get("nyxid-assistant-actions.v5")
-            .expect("v5");
-        assert_eq!(
-            v5.executable,
-            vec!["service.connect".to_string()],
-            "both lineages make only service.connect executable in v5"
-        );
-        let v8 = integrate
-            .revisions
-            .get("nyxid-assistant-actions.v8")
-            .expect("v8");
-        assert!(
-            v8.pinned.iter().any(|name| name == "service.reauthorize")
-                && !v8
-                    .executable
-                    .iter()
-                    .any(|name| name == "service.reauthorize"),
-            "v8 pins service.reauthorize dormant (not executable)"
-        );
     }
 
     #[tokio::test]
@@ -3177,32 +2995,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn assistant_actions_dormant_descriptor_is_served_but_absent_from_all_pinned_sets() {
+    async fn assistant_actions_additive_descriptors_are_absent_from_legacy_revision_responses() {
         let default_manifest: Value = serde_json::from_str(manifest_body()).unwrap();
         let default_names = action_names(&default_manifest);
-        let latest_pin: HashSet<&str> = PINNED_ACTIONS_BY_REVISION
+        let latest_revision: HashSet<&str> = PUBLISHED_ACTIONS_BY_REVISION
             .last()
-            .expect("latest pin")
+            .expect("latest published revision")
             .1
             .iter()
             .copied()
             .collect();
-        let dormant: Vec<&str> = default_names
+        let additive: Vec<&str> = default_names
             .iter()
             .copied()
-            .filter(|name| !latest_pin.contains(name))
+            .filter(|name| !latest_revision.contains(name))
             .collect();
         assert_eq!(
-            dormant.len(),
+            additive.len(),
             53,
             "expected 15 Wave-2 + 8 Wave-3 + 30 Wave-4 dormant descriptors"
         );
 
-        for (revision, action_names) in PINNED_ACTIONS_BY_REVISION {
-            for name in &dormant {
+        for (revision, action_names) in PUBLISHED_ACTIONS_BY_REVISION {
+            for name in &additive {
                 assert!(
                     !action_names.contains(name),
-                    "{name} must stay absent from pinned set {revision}"
+                    "{name} must stay absent from legacy revision {revision}"
                 );
             }
         }
@@ -3211,20 +3029,122 @@ mod tests {
         let (status, body) = response_bytes(response).await;
         assert_eq!(status, StatusCode::OK);
         let served: Value = serde_json::from_slice(&body).unwrap();
-        for name in dormant {
+        for name in additive {
             assert!(
                 action_names(&served).contains(&name),
-                "default body must still serve dormant descriptor {name}"
+                "default body must still serve additive descriptor {name}"
             );
         }
     }
 
     #[test]
+    fn default_manifest_action_names_match_consumer_fixture_golden() {
+        let fixture = consumer_contract_fixture();
+        let pin = chat_contract_pin();
+        let default_manifest: Value = serde_json::from_str(manifest_body()).unwrap();
+        let names = action_names(&default_manifest);
+        let golden: Vec<&str> = fixture["default_action_names"]
+            .as_array()
+            .expect("default_action_names")
+            .iter()
+            .map(|value| value.as_str().expect("action name"))
+            .collect();
+        assert_eq!(
+            default_manifest["schema_version"].as_u64(),
+            pin["action_registry"]["schema_version"].as_u64()
+        );
+        assert_eq!(names, golden);
+    }
+
+    #[test]
+    fn known_descriptors_are_accepted_by_the_per_action_consumer() {
+        let default_manifest: Value = serde_json::from_str(manifest_body()).unwrap();
+        match consume_like_aevatar(&default_manifest) {
+            ConsumerLoad::Loaded { accepted, skipped } => {
+                let fixture = consumer_contract_fixture();
+                assert_eq!(
+                    accepted,
+                    fixture_action_names(&fixture, "consumer_supported_actions")
+                        .into_iter()
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                );
+                assert!(skipped.is_empty());
+            }
+            ConsumerLoad::SchemaUnsupported => panic!("schema 4 must load"),
+        }
+    }
+
+    #[test]
+    fn unknown_descriptors_are_skipped_without_disabling_known_actions() {
+        let mut manifest: Value = serde_json::from_str(manifest_body()).unwrap();
+        let unknown = consumer_contract_fixture()["unknown_action"]
+            .as_str()
+            .expect("unknown_action")
+            .to_string();
+        manifest["actions"]
+            .as_array_mut()
+            .expect("actions")
+            .push(json!({
+                "action": unknown,
+                "description": "Unknown additive descriptor.",
+                "params_schema": { "type": "object", "additionalProperties": false },
+                "risk": "grant",
+                "tier": "v1",
+                "remember_eligible": false
+            }));
+        match consume_like_aevatar(&manifest) {
+            ConsumerLoad::Loaded { accepted, skipped } => {
+                assert!(!accepted.iter().any(|name| name == &unknown));
+                assert!(!skipped.iter().any(|name| name == &unknown));
+                assert_eq!(accepted.len(), 14);
+            }
+            ConsumerLoad::SchemaUnsupported => panic!("schema 4 must load"),
+        }
+    }
+
+    #[test]
+    fn divergent_descriptors_degrade_per_action() {
+        let mut manifest: Value = serde_json::from_str(manifest_body()).unwrap();
+        let actions = manifest["actions"].as_array_mut().expect("actions");
+        actions[0]["params_schema"] = json!({
+            "type": "object",
+            "additionalProperties": true
+        });
+        match consume_like_aevatar(&manifest) {
+            ConsumerLoad::Loaded { accepted, skipped } => {
+                assert_eq!(skipped, vec!["service.connect".to_string()]);
+                assert_eq!(accepted.len(), 13);
+                assert!(accepted.iter().any(|name| name == "key.create"));
+            }
+            ConsumerLoad::SchemaUnsupported => panic!("schema 4 must load"),
+        }
+    }
+
+    #[test]
+    fn schema_version_gates_the_registry() {
+        let mut manifest: Value = serde_json::from_str(manifest_body()).unwrap();
+        manifest["schema_version"] = json!(3);
+        assert!(matches!(
+            consume_like_aevatar(&manifest),
+            ConsumerLoad::SchemaUnsupported
+        ));
+        manifest["schema_version"] = json!(4);
+        manifest["revision"] = json!("nyxid-assistant-actions.future");
+        match consume_like_aevatar(&manifest) {
+            ConsumerLoad::Loaded { accepted, skipped } => {
+                assert_eq!(accepted.len(), 14);
+                assert!(skipped.is_empty());
+            }
+            ConsumerLoad::SchemaUnsupported => {
+                panic!("revision is an observability label, not a load gate")
+            }
+        }
+    }
+
+    #[test]
     fn default_manifest_matches_aevatar_chat_contract_pin() {
-        let pin: Value = serde_json::from_str(include_str!(
-            "../../../tests/fixtures/assistant/aevatar-chat-contract-pin.json"
-        ))
-        .expect("AC-0 pin must parse");
+        let pin = chat_contract_pin();
         let registry = pin
             .get("action_registry")
             .expect("pin must include action_registry");

--- a/backend/src/handlers/assistant_actions.rs
+++ b/backend/src/handlers/assistant_actions.rs
@@ -3218,4 +3218,45 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn default_manifest_matches_aevatar_chat_contract_pin() {
+        let pin: Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/assistant/aevatar-chat-contract-pin.json"
+        ))
+        .expect("AC-0 pin must parse");
+        let registry = pin
+            .get("action_registry")
+            .expect("pin must include action_registry");
+        assert_eq!(
+            registry.get("schema_version").and_then(Value::as_u64),
+            Some(u64::from(ASSISTANT_ACTIONS_SCHEMA_VERSION))
+        );
+        assert_eq!(
+            registry
+                .get("revision_is_observability_label")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            registry
+                .get("unknown_or_divergent_descriptors")
+                .and_then(Value::as_str),
+            Some("degrade_per_action")
+        );
+
+        let default_manifest: Value = serde_json::from_str(manifest_body()).unwrap();
+        let names = action_names(&default_manifest);
+        for action in [
+            "service.connect",
+            "service.reauthorize",
+            "key.create",
+            "key.rotate",
+        ] {
+            assert!(
+                names.contains(&action),
+                "{action} must remain in the additive default manifest"
+            );
+        }
+    }
 }

--- a/backend/src/handlers/proxy.rs
+++ b/backend/src/handlers/proxy.rs
@@ -10073,31 +10073,31 @@ mod proxy_resolution_integration_tests {
 
         let mut debug_echoes = Vec::new();
         let calls_before_unknown_type = captured.lock().unwrap().len();
-        let unknown_type_error = crate::handlers::assistant::typed_chat(
-            axum::extract::State(state.clone()),
-            auth.clone(),
-            request(
-                Method::POST,
-                "/api/v1/assistant/chat",
-                Some(r#"{"type":"workflow.studio","prompt":"do not fall through"}"#),
-            ),
-        )
-        .await
-        .expect_err("an unknown typed command must fail locally");
-        assert_eq!(
-            unknown_type_error.into_response().status(),
-            StatusCode::BAD_REQUEST
-        );
+        for rejected_body in [
+            r#"{"type":"workflow.studio","prompt":"do not fall through"}"#,
+            r#"{"type":"plan.resolve","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","taskId":"task-1","planId":"plan-1","requestId":"plan-gate-1","clientRequestId":"00000000-0000-4000-8000-000000000011","planRevision":3,"confirmed":true,"expectedStateVersion":23}"#,
+        ] {
+            let rejected_error = crate::handlers::assistant::typed_chat(
+                axum::extract::State(state.clone()),
+                auth.clone(),
+                request(Method::POST, "/api/v1/assistant/chat", Some(rejected_body)),
+            )
+            .await
+            .expect_err("an unsupported typed command must fail locally");
+            assert_eq!(
+                rejected_error.into_response().status(),
+                StatusCode::BAD_REQUEST
+            );
+        }
         assert_eq!(
             captured.lock().unwrap().len(),
             calls_before_unknown_type,
-            "an unknown typed command must not reach either upstream chat path"
+            "an unsupported typed command must not reach either upstream chat path"
         );
 
         for body in [
             r#"{"type":"text","prompt":"connect api-github","clientRequestId":"00000000-0000-4000-8000-000000000001"}"#,
             r#"{"type":"text","prompt":"continue","clientRequestId":"00000000-0000-4000-8000-000000000002","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae"}"#,
-            r#"{"type":"plan.resolve","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","taskId":"task-1","planId":"plan-1","requestId":"plan-gate-1","clientRequestId":"00000000-0000-4000-8000-000000000011","planRevision":3,"confirmed":true,"expectedStateVersion":23}"#,
             r#"{"type":"input.resolve","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000010","requestId":"input-1","answer":{"selectedOptionIds":["option-a","option-b"]},"expectedStateVersion":19}"#,
             r#"{"type":"action.continue","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000003","originTurnId":"turn-action-1","actions":[{"actionRequestId":"act-1","originTurnId":"turn-action-1","disposition":"completed","resource":{"userService":{"userServiceId":"00000000-0000-4000-8000-000000000123"}}}]}"#,
             r#"{"type":"action.continue","conversationId":"nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae","clientRequestId":"00000000-0000-4000-8000-000000000009","originTurnId":"turn-action-2","actions":[{"actionRequestId":"act-2","originTurnId":"turn-action-2","disposition":"failed"}]}"#,
@@ -10164,7 +10164,7 @@ mod proxy_resolution_integration_tests {
                 .count_documents(doc! { "user_id": &user_id })
                 .await
                 .expect("count stored assistant wire logs"),
-            11
+            10
         );
         assert_eq!(
             wire_logs
@@ -10184,7 +10184,7 @@ mod proxy_resolution_integration_tests {
                 })
                 .await
                 .expect("count conversation-scoped assistant wire logs"),
-            10
+            9
         );
 
         let malformed_typed_id = "nyxid-chat-not-a-guid";
@@ -10362,6 +10362,7 @@ mod proxy_resolution_integration_tests {
                 Method::GET,
                 "/api/v1/assistant/conversations/create-recovery/4380055d-e9c3-468e-bc93-64719a9f4658",
             ),
+            (Method::POST, "/api/v1/assistant/completions"),
         ] {
             let response = private
                 .clone()
@@ -10397,7 +10398,6 @@ mod proxy_resolution_integration_tests {
                 "/api/chat".to_string(),
                 "/api/chat".to_string(),
                 "/api/chat".to_string(),
-                "/api/chat".to_string(),
                 "/api/chat/conversations".to_string(),
                 format!("/api/scopes/{user_id}/chat-history"),
                 "/api/chat/conversations/nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae".to_string(),
@@ -10422,17 +10422,6 @@ mod proxy_resolution_integration_tests {
                 "prompt": "continue",
                 "clientRequestId": "00000000-0000-4000-8000-000000000002",
                 "conversationId": "nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae",
-            }),
-            serde_json::json!({
-                "type": "plan.resolve",
-                "conversationId": "nyxid-chat-4a1e60ebd1fd44f192bf4bb90e1812ae",
-                "taskId": "task-1",
-                "planId": "plan-1",
-                "requestId": "plan-gate-1",
-                "clientRequestId": "00000000-0000-4000-8000-000000000011",
-                "planRevision": 3,
-                "confirmed": true,
-                "expectedStateVersion": 23,
             }),
             serde_json::json!({
                 "type": "input.resolve",
@@ -10524,7 +10513,6 @@ mod proxy_resolution_integration_tests {
             "text/event-stream",
             "text/event-stream",
             "application/json",
-            "application/json",
             "text/event-stream",
             "text/event-stream",
             "application/json",
@@ -10559,7 +10547,7 @@ mod proxy_resolution_integration_tests {
             );
         }
 
-        assert_eq!(debug_echoes.len(), 11);
+        assert_eq!(debug_echoes.len(), 10);
         for (call_index, envelope_array) in debug_echoes.iter().enumerate() {
             assert_eq!(envelope_array.len(), 1);
             let envelope = &envelope_array[0];
@@ -10617,7 +10605,7 @@ mod proxy_resolution_integration_tests {
         }
 
         for (_, _, _, headers) in [
-            &calls[0], &calls[10], &calls[11], &calls[12], &calls[13], &calls[14],
+            &calls[0], &calls[9], &calls[10], &calls[11], &calls[12], &calls[13],
         ] {
             assert!(headers.get(axum::http::header::AUTHORIZATION).is_none());
             assert!(headers.get("x-nyxid-identity-token").is_some());

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1676,7 +1676,6 @@ fn build_router_internal(
                 "/conversations/{conversation_id}/state",
                 get(handlers::assistant::get_state),
             )
-            .route("/completions", post(handlers::assistant::completions))
             .route("/chat", post(handlers::assistant::typed_chat))
     )
     .route_layer(axum::Extension(

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -248,12 +248,6 @@ pub fn canonical_state_path(conversation_id: &str) -> AppResult<String> {
     ))
 }
 
-/// `v1/chat/completions` -- OpenAI-compatible surface. Scope-free: the
-/// endpoint is stateless and carries its history in the request body.
-pub fn completions_path() -> String {
-    "v1/chat/completions".to_string()
-}
-
 /// `api/chat` -- typed NyxIdChat create-and-first-turn stream.
 ///
 /// Aevatar selects the typed NyxIdChat producer from the discriminated body
@@ -309,12 +303,22 @@ pub enum AssistantChatCommand {
     InputResolve(InputResolveCommand),
     ActionContinue(ActionContinueCommand),
     ApprovalResolve(ApprovalResolveCommand),
-    PlanResolve(PlanResolveCommand),
     TaskStop(TaskStopCommand),
     TaskSteer(TaskSteerCommand),
     StepRetry(StepRetryCommand),
     StepSkip(StepSkipCommand),
 }
+
+const ASSISTANT_CHAT_COMMAND_TYPES: [&str; 8] = [
+    "text",
+    "input.resolve",
+    "action.continue",
+    "approval.resolve",
+    "task.stop",
+    "task.steer",
+    "step.retry",
+    "step.skip",
+];
 
 impl AssistantChatCommand {
     pub fn conversation_id(&self) -> Option<&str> {
@@ -323,7 +327,6 @@ impl AssistantChatCommand {
             Self::InputResolve(command) => Some(&command.conversation_id),
             Self::ActionContinue(command) => Some(&command.conversation_id),
             Self::ApprovalResolve(command) => Some(&command.conversation_id),
-            Self::PlanResolve(command) => Some(&command.conversation_id),
             Self::TaskStop(command) => Some(&command.conversation_id),
             Self::TaskSteer(command) => Some(&command.conversation_id),
             Self::StepRetry(command) => Some(&command.conversation_id),
@@ -384,18 +387,6 @@ pub struct ApprovalResolveCommand {
     pub request_id: String,
     pub approved: bool,
     pub reason: Option<String>,
-    pub expected_state_version: i64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PlanResolveCommand {
-    pub conversation_id: String,
-    pub task_id: String,
-    pub plan_id: String,
-    pub request_id: String,
-    pub client_request_id: String,
-    pub plan_revision: i64,
-    pub confirmed: bool,
     pub expected_state_version: i64,
 }
 
@@ -628,21 +619,6 @@ struct RawApprovalResolveCommand {
     approved: bool,
     #[serde(default)]
     reason: Option<String>,
-    expected_state_version: i64,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct RawPlanResolveCommand {
-    #[serde(rename = "type")]
-    _command_type: String,
-    conversation_id: String,
-    task_id: String,
-    plan_id: String,
-    request_id: String,
-    client_request_id: String,
-    plan_revision: i64,
-    confirmed: bool,
     expected_state_version: i64,
 }
 
@@ -904,6 +880,11 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
             AppError::BadRequest("Assistant chat commands require a type.".to_string())
         })?;
     reject_secret_shaped_command(&value)?;
+    if !ASSISTANT_CHAT_COMMAND_TYPES.contains(&command_type) {
+        return Err(AppError::BadRequest(
+            "Unsupported assistant chat command.".to_string(),
+        ));
+    }
 
     match command_type {
         "text" => {
@@ -918,28 +899,6 @@ pub fn parse_assistant_chat_command(bytes: &[u8]) -> AppResult<AssistantChatComm
                 prompt: raw.prompt,
                 client_request_id: raw.client_request_id,
                 conversation_id: raw.conversation_id,
-            }))
-        }
-        "plan.resolve" => {
-            let raw: RawPlanResolveCommand = serde_json::from_value(value).map_err(|e| {
-                AppError::BadRequest(format!("Invalid plan resolution request: {e}"))
-            })?;
-            validate_typed_conversation_id(&raw.conversation_id)?;
-            validate_control_identity(&raw.task_id, "taskId")?;
-            validate_control_identity(&raw.plan_id, "planId")?;
-            validate_control_identity(&raw.request_id, "requestId")?;
-            validate_control_identity(&raw.client_request_id, "clientRequestId")?;
-            validate_positive(raw.plan_revision, "planRevision")?;
-            validate_positive(raw.expected_state_version, "expectedStateVersion")?;
-            Ok(AssistantChatCommand::PlanResolve(PlanResolveCommand {
-                conversation_id: raw.conversation_id,
-                task_id: raw.task_id,
-                plan_id: raw.plan_id,
-                request_id: raw.request_id,
-                client_request_id: raw.client_request_id,
-                plan_revision: raw.plan_revision,
-                confirmed: raw.confirmed,
-                expected_state_version: raw.expected_state_version,
             }))
         }
         "input.resolve" => {
@@ -1284,21 +1243,6 @@ pub fn prepare_assistant_chat_command(
                 response_kind: AssistantChatResponseKind::Json,
             })
         }
-        AssistantChatCommand::PlanResolve(command) => Ok(PreparedAssistantChatCommand {
-            body: serde_json::json!({
-                "type": "plan.resolve",
-                "conversationId": command.conversation_id,
-                "taskId": command.task_id,
-                "planId": command.plan_id,
-                "requestId": command.request_id,
-                "clientRequestId": command.client_request_id,
-                "planRevision": command.plan_revision,
-                "confirmed": command.confirmed,
-                "expectedStateVersion": command.expected_state_version,
-            }),
-            client_request_id: command.client_request_id.clone(),
-            response_kind: AssistantChatResponseKind::Json,
-        }),
         AssistantChatCommand::TaskStop(command) => Ok(PreparedAssistantChatCommand {
             body: serde_json::json!({
                 "type": "task.stop",
@@ -1371,6 +1315,22 @@ mod tests {
         parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).unwrap()
     }
 
+    fn command_type_is_recognized(command_type: &str) -> bool {
+        let body = json!({ "type": command_type });
+        !matches!(
+            parse_assistant_chat_command(&serde_json::to_vec(&body).unwrap()),
+            Err(AppError::BadRequest(message))
+                if message == "Unsupported assistant chat command."
+        )
+    }
+
+    fn contract_pin() -> serde_json::Value {
+        serde_json::from_str(include_str!(
+            "../../../tests/fixtures/assistant/aevatar-chat-contract-pin.json"
+        ))
+        .expect("AC-0 pin must parse")
+    }
+
     macro_rules! command_contract_test {
         ($name:ident, $variant:ident, $body:expr, $response_kind:expr) => {
             #[test]
@@ -1437,23 +1397,6 @@ mod tests {
             "clientRequestId": "client-text-1"
         }),
         AssistantChatResponseKind::Stream
-    );
-
-    command_contract_test!(
-        plan_resolve_command_matches_the_typed_contract,
-        PlanResolve,
-        json!({
-            "type": "plan.resolve",
-            "conversationId": CONV,
-            "taskId": "task-alpha",
-            "planId": "plan-alpha",
-            "requestId": "plan-gate-alpha",
-            "clientRequestId": "client-plan-alpha",
-            "planRevision": 3,
-            "confirmed": true,
-            "expectedStateVersion": 23
-        }),
-        AssistantChatResponseKind::Json
     );
 
     command_contract_test!(
@@ -1713,7 +1656,6 @@ mod tests {
             ConversationResourceFamily::Legacy
         );
         assert_eq!(typed_chat_path(), "api/chat");
-        assert_eq!(completions_path(), "v1/chat/completions");
     }
 
     #[test]
@@ -1757,29 +1699,6 @@ mod tests {
     }
 
     #[test]
-    fn plan_resolve_requires_an_explicit_confirmed_decision() {
-        let error = parse_assistant_chat_command(
-            &serde_json::to_vec(&json!({
-                "type": "plan.resolve",
-                "conversationId": CONV,
-                "taskId": "task-alpha",
-                "planId": "plan-alpha",
-                "requestId": "plan-gate-alpha",
-                "clientRequestId": "client-plan-alpha",
-                "planRevision": 3,
-                "expectedStateVersion": 23
-            }))
-            .unwrap(),
-        )
-        .unwrap_err();
-
-        assert_eq!(
-            axum::response::IntoResponse::into_response(error).status(),
-            axum::http::StatusCode::BAD_REQUEST
-        );
-    }
-
-    #[test]
     fn legacy_conversation_ids_are_rejected_by_every_typed_verb() {
         let mut commands = vec![
             json!({
@@ -1787,17 +1706,6 @@ mod tests {
                 "prompt": "continue",
                 "clientRequestId": "client-text-1",
                 "conversationId": WORKFLOW_CONV
-            }),
-            json!({
-                "type": "plan.resolve",
-                "conversationId": WORKFLOW_CONV,
-                "taskId": "task-1",
-                "planId": "plan-1",
-                "requestId": "gate-1",
-                "clientRequestId": "client-plan-1",
-                "planRevision": 1,
-                "confirmed": true,
-                "expectedStateVersion": 1
             }),
             json!({
                 "type": "input.resolve",
@@ -1886,6 +1794,48 @@ mod tests {
             .unwrap(),
         )
         .unwrap_err();
+
+        assert_eq!(
+            axum::response::IntoResponse::into_response(error).status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn accepted_command_types_match_aevatar_chat_contract_pin() {
+        let pin = contract_pin();
+        let expected: Vec<&str> = pin["public_commands"]
+            .as_array()
+            .expect("pin public_commands")
+            .iter()
+            .map(|value| value.as_str().expect("command name"))
+            .collect();
+        assert_eq!(ASSISTANT_CHAT_COMMAND_TYPES.as_slice(), expected);
+        assert!(
+            ASSISTANT_CHAT_COMMAND_TYPES
+                .iter()
+                .all(|command_type| command_type_is_recognized(command_type))
+        );
+        assert!(!command_type_is_recognized("plan.resolve"));
+    }
+
+    #[test]
+    fn plan_resolve_is_rejected_at_the_typed_boundary() {
+        let error = parse_assistant_chat_command(
+            &serde_json::to_vec(&json!({
+                "type": "plan.resolve",
+                "conversationId": CONV,
+                "taskId": "task-alpha",
+                "planId": "plan-alpha",
+                "requestId": "plan-gate-alpha",
+                "clientRequestId": "client-plan-alpha",
+                "planRevision": 3,
+                "confirmed": true,
+                "expectedStateVersion": 23
+            }))
+            .unwrap(),
+        )
+        .expect_err("plan.resolve must fail at NyxID's typed boundary");
 
         assert_eq!(
             axum::response::IntoResponse::into_response(error).status(),
@@ -2435,92 +2385,6 @@ mod tests {
                 "approved": true,
                 "expectedStateVersion": 21,
                 "stateVersion": 21
-            }),
-        ] {
-            assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());
-        }
-    }
-
-    #[test]
-    fn parses_and_rebuilds_exact_plan_resolution() {
-        let prepared = prepare_assistant_chat_command(&parse_command(json!({
-            "type": "plan.resolve",
-            "conversationId": CONV,
-            "taskId": "task-alpha",
-            "planId": "plan-alpha",
-            "requestId": "plan-gate-alpha",
-            "clientRequestId": "client-plan-alpha",
-            "planRevision": 3,
-            "confirmed": true,
-            "expectedStateVersion": 23
-        })))
-        .unwrap();
-
-        assert_eq!(prepared.response_kind, AssistantChatResponseKind::Json);
-        assert_eq!(prepared.client_request_id, "client-plan-alpha");
-        assert_eq!(
-            prepared.body,
-            json!({
-                "type": "plan.resolve",
-                "conversationId": CONV,
-                "taskId": "task-alpha",
-                "planId": "plan-alpha",
-                "requestId": "plan-gate-alpha",
-                "clientRequestId": "client-plan-alpha",
-                "planRevision": 3,
-                "confirmed": true,
-                "expectedStateVersion": 23
-            })
-        );
-    }
-
-    #[test]
-    fn plan_resolution_requires_exact_positive_identities_and_versions() {
-        for value in [
-            json!({
-                "type": "plan.resolve",
-                "conversationId": CONV,
-                "taskId": "task-alpha",
-                "planId": "plan-alpha",
-                "requestId": "plan-gate-alpha",
-                "clientRequestId": "client-plan-alpha",
-                "planRevision": 0,
-                "confirmed": true,
-                "expectedStateVersion": 23
-            }),
-            json!({
-                "type": "plan.resolve",
-                "conversationId": CONV,
-                "taskId": "task-alpha",
-                "planId": "bad/plan",
-                "requestId": "plan-gate-alpha",
-                "clientRequestId": "client-plan-alpha",
-                "planRevision": 3,
-                "confirmed": false,
-                "expectedStateVersion": 23
-            }),
-            json!({
-                "type": "plan.resolve",
-                "conversationId": CONV,
-                "taskId": "task-alpha",
-                "planId": "plan-alpha",
-                "requestId": "plan-gate-alpha",
-                "clientRequestId": "client-plan-alpha",
-                "planRevision": 3,
-                "confirmed": true,
-                "expectedStateVersion": 0
-            }),
-            json!({
-                "type": "plan.resolve",
-                "conversationId": CONV,
-                "taskId": "task-alpha",
-                "planId": "plan-alpha",
-                "requestId": "plan-gate-alpha",
-                "clientRequestId": "client-plan-alpha",
-                "planRevision": 3,
-                "confirmed": true,
-                "expectedStateVersion": 23,
-                "stateVersion": 23
             }),
         ] {
             assert!(parse_assistant_chat_command(&serde_json::to_vec(&value).unwrap()).is_err());

--- a/docs/chat/02-wire-contract.md
+++ b/docs/chat/02-wire-contract.md
@@ -114,12 +114,13 @@ tools, action cards, approvals, task controls, or attachments.
 
 `POST /chat` accepts a discriminated command allowlist. NyxID parses each command with unknown-field denial, rejects secret-shaped keys and values, validates control identities, and rebuilds the exact upstream object. It never spreads an arbitrary caller object into the Aevatar body.
 
-Every typed command includes `clientRequestId`. NyxID copies that value into the outbound `Idempotency-Key` header. Text and action continuation request `Accept: text/event-stream`. Input, approval, and plan resolution plus stop, steer, retry, and skip request `Accept: application/json`.
+Every typed command includes `clientRequestId`. NyxID copies that value into the outbound `Idempotency-Key` header. Text and action continuation request `Accept: text/event-stream`. Input, approval, stop, steer, retry, and skip request `Accept: application/json`.
 
-The only accepted discriminators are `text`, `plan.resolve`, `input.resolve`,
+The only accepted discriminators are `text`, `input.resolve`,
 `action.continue`, `approval.resolve`, `task.stop`, `task.steer`, `step.retry`,
-and `step.skip`. An explicit unknown discriminator is a local `400`; it never
-falls back to a body without `type`.
+and `step.skip`. An explicit unknown discriminator, including the retired
+`plan.resolve` command, is a local `400`; it never falls back to a body without
+`type`.
 
 ### `text`
 
@@ -156,30 +157,6 @@ console-only `surface` and `attachment` fields and maps an attachment to
 `inputParts`; NyxID deliberately does not adopt that behaviour. Adding
 `inputParts` requires a separate feature with its own schema, secret review,
 and body-shape tests.
-
-### `plan.resolve`
-
-```json
-{
-  "type": "plan.resolve",
-  "conversationId": "nyxid-chat-f8369965a444433f92ec50e67ad8ee52",
-  "taskId": "task-identity",
-  "planId": "plan-identity",
-  "requestId": "plan-gate-identity",
-  "planRevision": 1,
-  "clientRequestId": "request-identity",
-  "expectedStateVersion": 22,
-  "confirmed": true
-}
-```
-
-The browser may send this only from the exact pending actor-owned gate. It
-copies every identity, revision, and fence from the current projection; the
-human supplies the `confirmed` decision. It does not derive actor facts from a
-transcript, URL, or previously rendered card. The
-deployment currently reports an automatic satisfied gate, so the normal path
-does not render a decision, but a conforming decoder and UI must retain the
-explicit-gate shape for deployments that return one.
 
 ### `input.resolve`
 
@@ -241,23 +218,9 @@ An empty `actions` array is a typed actor wake and may omit `originTurnId`.
 
 An empty reason is omitted. A nonempty reason is trimmed and limited to 2,048 characters. `expectedStateVersion` is required and must be positive. The browser reads it from the authoritative typed current-state envelope and verifies the exact pending approval identity. This command returns JSON transport acceptance; the matching `nyxid.approval.changed` or current-state `latestApprovalResolution` proves commit.
 
-### `plan.resolve`
-
-```json
-{
-  "type": "plan.resolve",
-  "conversationId": "nyxid-chat-f8369965a444433f92ec50e67ad8ee52",
-  "taskId": "task-identity",
-  "planId": "plan-identity",
-  "requestId": "plan-gate-identity",
-  "clientRequestId": "request-identity",
-  "planRevision": 3,
-  "confirmed": true,
-  "expectedStateVersion": 23
-}
-```
-
-All four plan and gate identities are required and `planRevision` plus `expectedStateVersion` must be positive. At click time the browser re-reads authoritative current state, requires an exact `confirm` + `pending` gate match, and submits the state version from that same read. A pending Stop fence is observed before this preflight. JSON 202 is dispatch acceptance only; the browser refreshes current state once and changes the card only when the actor-owned TaskPlan gate changes.
+Historical TaskPlan snapshots may still carry `gate.mode = "confirm"`. The
+decoder keeps that as display-only status. It does not preserve request
+identities and the browser has no Confirm or Reject plan control.
 
 ### `task.stop`
 

--- a/docs/chat/03-stream-protocol.md
+++ b/docs/chat/03-stream-protocol.md
@@ -1,6 +1,6 @@
 # Assistant Stream Protocol
 
-Last verified against Aevatar console and SDK commit `e7ba2e6eb` (2026-08-25).
+The Aevatar chat contract is pinned in `tests/fixtures/assistant/aevatar-chat-contract-pin.json`. See the pin section of [README.md](README.md).
 
 The Assistant consumes Aevatar AG-UI Server-Sent Events only from the typed
 `NyxIdChat` route. The stream is an ordered actor-observation protocol, not an

--- a/docs/chat/05-frontend-ui.md
+++ b/docs/chat/05-frontend-ui.md
@@ -1,6 +1,6 @@
 # Assistant Chat Frontend Contract
 
-Last verified against Aevatar console commit `e7ba2e6eb` (2026-08-25).
+The Aevatar chat contract is pinned in `tests/fixtures/assistant/aevatar-chat-contract-pin.json`. See the pin section of [README.md](README.md).
 
 The assistant page presents one continuous transcript, an anchored composer, and a conversation sidebar. Network and stream states change the same surface in place; loading, thinking, streaming, terminal, and recovery states do not replace the application shell.
 

--- a/docs/chat/06-actions-registry.md
+++ b/docs/chat/06-actions-registry.md
@@ -1,6 +1,7 @@
 # Assistant Actions Registry
 
-Last verified against the `service.reauthorize` implementation (2026-08-17).
+Last verified against Aevatar `feature/integrate` at
+`e5bba2e9719ad5132004b882744caa3875db1123` (2026-09-03).
 
 `GET /api/v1/assistant/actions` publishes the immutable action vocabulary that Aevatar may compose into typed NyxIdChat turns. It is a public, static JSON endpoint with an exact-path exemption from the global rate limiter. It does not depend on a session, database row, user scope, or model state.
 
@@ -8,7 +9,10 @@ The NyxID source is `backend/src/handlers/assistant_actions.rs`. The route is mo
 
 ## Response
 
-The response content type is `application/json`. The current body is equivalent to:
+The response content type is `application/json`. The default body begins with
+the four descriptors whose contracts Aevatar pins. It also includes the
+additive descriptors listed in
+`tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json`.
 
 ```json
 {
@@ -130,46 +134,69 @@ The response content type is `application/json`. The current body is equivalent 
 
 The default (no-query) serialized body is created once through `LazyLock<String>` and reused. Per-revision compositions are pre-serialized the same way. The handler has no service/model layer because the manifest is compile-time product metadata.
 
-### Revision negotiation
+### Consumer load contract
+
+Aevatar loads the default `GET /api/v1/assistant/actions` body. `schema_version`
+is the only registry-wide compatibility gate. The `revision` string is an
+observability label. A future or unlabeled revision still loads. Unknown action
+names are skipped silently. A known action whose descriptor is malformed or
+divergent from its pinned contract is skipped on its own and recorded. The rest
+of the registry stays enabled.
+
+Startup fetch retries three times. If every attempt fails, Aevatar pins a
+disabled fallback registry and keeps retrying in the background. Recovery may
+replace exactly that fallback with a served registry once. A served registry is
+never replaced afterwards.
+
+NyxID still accepts `?revision=` as its own historical composition selector.
+That query is not Aevatar's load gate.
 
 `GET /api/v1/assistant/actions?revision=<r>`:
 
 | Request | Response |
 | --- | --- |
-| No `revision` query param | Latest body, byte-identical to the default composition (`schema_version` 4, `revision` `nyxid-assistant-actions.v8`, including dormant Wave-2 descriptors). Current consumers are unchanged. |
-| Known `<r>` | A composition whose `revision` field is exactly `<r>` and whose `actions` are **that revision's action-name set**, serialized with **the `params_schema` Aevatar's `ValidatePinnedContract` selects for that revision**. Aevatar does per-revision schema selection, then `JsonNode.DeepEquals` against the chosen compiled constant — a local "current bytes only" rule cannot override the deployed validator. Descriptions use the current live text (Aevatar does not pin descriptions). Schema overrides live in the revision map (`PARAMS_SCHEMA_OVERRIDES_BY_REVISION`); a future split is a data row, not a compose-path branch. For `key.create` the split is identical on `origin/dev` and `origin/feature/integrate`: **v4, v5** → `KeyCreateParamsSchema` (no `minItems` / `maxItems` / `uniqueItems` on `allowedServiceIds`); **v6, v7, v8** → `LeastScopeKeyCreateParamsSchema` (the current live descriptor). v4 pins only `service.connect`, so `key.create` is not served there at all. The live consumer ask is `?revision={SupportedRegistryRevision}` (v7 on `origin/dev`, v8 on `origin/feature/integrate`); both of those select the least-scope schema. |
+| No `revision` query param | Latest body, byte-identical to the default composition (`schema_version` 4, `revision` `nyxid-assistant-actions.v8`, including all additive descriptors). This is the body Aevatar fetches. |
+| Known `<r>` | A composition whose `revision` field is exactly `<r>` and whose `actions` are that revision's action-name set. Schema overrides live in `PARAMS_SCHEMA_OVERRIDES_BY_REVISION`. |
 | Unknown `<r>` | `404` with the stable `not_found` / `1003` error body. No manifest fields. |
 | Malformed `<r>` (more than 128 characters, or any control character) | `400` with the stable `validation_error` / `1008` error body. |
 
-Known revisions are the static `revision → action-name set` map mirroring Aevatar `PinnedActionsByRevision` (`origin/dev` accepts `{v4, v5, v6, v7}`; `origin/feature/integrate` accepts those plus `v8`). v7's set is `{service.connect, key.create, key.rotate}` — not a prefix of the current default array (`service.reauthorize` sits at index 1). `aevatar-nyxid-actions.v1` is Aevatar's own composition namespace, not a NyxID-published revision; NyxID returns 404 for it. The checked-in file `tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json` is a **manually synced mirror** of both `PinnedActionsByRevision` and `ExecutableActionsByRevision` per lineage; CI does not read the Aevatar clone, so a green test is not evidence that upstream has not moved.
+`aevatar-nyxid-actions.v1` is Aevatar's own composition namespace, not a
+NyxID-published revision; NyxID returns 404 for it. The checked-in file
+`tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json` records three
+consumer-contract inputs for NyxID tests. They are the supported action names
+at the pinned source head, the additive default name golden, and the unknown
+action used to test skipping. The file is not a drift detector for upstream
+revision maps.
 
 The rate-limit exemption is exact-path (`/api/v1/assistant/actions`). Query strings do not change the path.
 
 #### Published-revision contract
 
-- **Immutable.** Once a revision is published, its action-name set and the `params_schema` served for each pinned action are never edited. A live-descriptor schema change is a new revision plus a historical override row, not a silent rewrite of an old composition.
-- **Monotone (each ⊆ the next), waves only append.** A new wave adds names under the current string as dormant descriptors, then a later revision-bump PR adds a new map entry whose set is the previous pin plus those names. Historical exception, frozen in Aevatar's pin map and not to be repeated: v5 (`WaveOneDraft`) listed `service.reauthorize` and `key.rotate`, then v6 (`LeastScope`) dropped them. From v6 onward the served sets are append-only.
-- **Dormant descriptors** (today: the 12 Wave-2 verbs) appear only in the default latest body. They are absent from every pinned revision set until a future revision pins them. No wave PR bumps `ASSISTANT_ACTIONS_REVISION`.
+- **Immutable.** Once a NyxID revision composition is published, its action-name set and the `params_schema` served for each named action are never edited. A live-descriptor schema change is a new revision plus a historical override row, not a silent rewrite of an old composition.
+- **Monotone (each ⊆ the next), waves only append.** A new wave adds names under the current string as additive descriptors, then a later revision-bump PR adds a new map entry whose set is the previous pin plus those names. One frozen historical exception must not be repeated. v5 listed `service.reauthorize` and `key.rotate`, then v6 dropped them. From v6 onward the served sets are append-only.
+- **Additive descriptors** appear in the default latest body. Aevatar skips names it does not know. No wave PR bumps `ASSISTANT_ACTIONS_REVISION` only to publish an additive descriptor.
 
-### Upstream consumer ask (Aevatar)
+### Upstream consumer fetch (Aevatar)
 
-Startup fetch should request:
+Startup fetch requests the bare path:
 
 ```text
-{Aevatar:NyxId:ApiBaseUrl}/api/v1/assistant/actions?revision={SupportedRegistryRevision}
+{Aevatar:NyxId:ApiBaseUrl}/api/v1/assistant/actions
 ```
 
-On `404` (older NyxID without negotiation), fall back to the bare path and existing set-membership validation. One URL-builder change plus fallback; NyxID and Aevatar can then deploy independently.
+The consumer does not require `?revision=`. NyxID may still serve historical
+compositions for its own clients.
 
 ## Top-level contract
 
 | Field | Value | Meaning |
 | --- | --- | --- |
-| `schema_version` | `4` | action request/report envelope generation |
-| `revision` | `nyxid-assistant-actions.v8` | exact composition snapshot expected by the pinned Aevatar client |
-| `actions` | descriptor array | actions that are both shipped by NyxID and executable by this Aevatar composition |
+| `schema_version` | `4` | action request/report envelope generation. A mismatch fails the whole registry |
+| `revision` | `nyxid-assistant-actions.v8` | observability label on the served composition |
+| `actions` | descriptor array | additive descriptors. Unknown or divergent entries degrade per action |
 
-Schema version and revision are independent checks. Aevatar rejects a version mismatch and rejects a revision mismatch. The registry is startup-pinned; a running host does not periodically refresh or replace it.
+The registry is startup-pinned. A running host retries only while the disabled
+fallback is installed.
 
 ## Shipped actions
 
@@ -193,12 +220,13 @@ The manifest schema defines structure. Aevatar and the browser apply additional 
 
 ### Where the browser is stricter than the published schema
 
-The manifest is the contract, and it is pinned byte-for-byte: Aevatar compares
-each published `params_schema` with `JsonNode.DeepEquals`, so a refinement
-added to the manifest to describe a browser-side rule would fail the pin and
-disable the whole registry. The rules below therefore live only in the browser
-and are invisible from the manifest. They are recorded here because a request
-that satisfies the published schema can still be refused.
+The manifest is the contract. Aevatar compares each known published
+`params_schema` with `JsonNode.DeepEquals` and skips that action when the
+descriptor diverges. A refinement added to the manifest to describe a
+browser-side rule would disable that one action, not the whole registry. The
+rules below therefore live only in the browser and are invisible from the
+manifest. They are recorded here because a request that satisfies the published
+schema can still be refused.
 
 | Parameter | Published schema | Browser rule (`frontend/src/schemas/assistant-actions.ts`) |
 | --- | --- | --- |
@@ -281,22 +309,34 @@ When `Aevatar:NyxId:AssistantActions:Enabled` is `true`, Aevatar registers a sta
 {Aevatar:NyxId:ApiBaseUrl}/api/v1/assistant/actions
 ```
 
-Once the consumer-ask above lands, that fetch appends `?revision={SupportedRegistryRevision}` and falls back to this bare path on 404.
-
 The source accepts an absolute HTTP or HTTPS NyxID base URL. It builds the registry URL from the configured origin and base path, performs one GET with response-header streaming, and enforces a 1 MiB limit from both `Content-Length` and bytes read.
 
-Startup then parses the JSON and validates at least:
+The loader rejects the whole response only when the top-level JSON is invalid,
+`schema_version` is not `4`, or `actions` is not an array. A missing, invalid,
+or future `revision` becomes an empty or preserved observability label. It does
+not reject the registry.
 
-- valid JSON object shape;
-- `schema_version == 4`;
-- `revision == "nyxid-assistant-actions.v8"`;
-- `actions` is an array;
-- action names, tier, risk, remember policy, description, and parameter-schema shape;
-- no duplicate action descriptor;
-- supported schema constructs; and
-- presence of every action this Aevatar version marks executable: `service.connect`, `service.reauthorize`, `key.create`, and `key.rotate` for the v8 composition.
+The loader evaluates each descriptor independently:
 
-Enabled startup fails if fetch, size, JSON, schema, revision, or required-action validation fails. The host therefore does not accept typed chat work with a partially loaded or ambiguous registry.
+- unknown action names are ignored.
+- a known action with an invalid tier, risk, remember policy, description,
+  parameter schema, or pinned descriptor contract is recorded and skipped.
+- a duplicate known action leaves the first valid entry loaded and records the
+  duplicate as a skipped descriptor.
+- missing or skipped known actions stay unavailable while valid actions remain
+  loaded.
+
+The executable set is the intersection of valid loaded descriptors and
+Aevatar's closed executable-action set. At the pinned source head that set is
+`service.connect`, `key.create`, and `key.rotate`. The loader knows the
+`service.reauthorize` descriptor contract, but Aevatar does not emit that
+action.
+
+Startup fetches at most three times with a one-second delay. If all three
+attempts fail, Aevatar installs an immutable disabled fallback and starts
+background recovery. Recovery starts at 30 seconds, doubles its delay to a
+five-minute ceiling, and may replace only that fallback with the first valid
+served registry. A served registry is never replaced.
 
 When the feature is disabled, Aevatar injects an immutable empty registry instead of running the fetch service. No action is executable, and attempts to resolve action requests fail closed as unsupported.
 
@@ -311,7 +351,7 @@ The upstream implementation anchors are:
 
 Risk and remember eligibility come from the pinned registry definition. An action request cannot override them. Aevatar rejects caller-supplied risk or remember-policy values during request validation.
 
-Unknown manifest actions that are not compiled into Aevatar do not become executable merely because NyxID publishes them. Conversely, Aevatar refuses startup if an action it requires for the current executable set is missing. Shipping a new action therefore requires coordinated support in:
+Unknown manifest actions that are not compiled into Aevatar do not become executable merely because NyxID publishes them. A missing or divergent known descriptor disables only that action. Shipping a new executable action therefore requires coordinated support in:
 
 - NyxID's static manifest;
 - Aevatar's compiled action contract and typed producer;

--- a/docs/chat/07-testing-and-gaps.md
+++ b/docs/chat/07-testing-and-gaps.md
@@ -1,6 +1,6 @@
 # Assistant Chat Testing and Gaps
 
-Last verified against Aevatar console and SDK commit `e7ba2e6eb` (2026-08-25).
+The Aevatar chat contract is pinned in `tests/fixtures/assistant/aevatar-chat-contract-pin.json`. See the pin section of [README.md](README.md).
 
 The assistant is covered at the HTTP fixture, protocol/reducer, React hook and
 component, Playwright, backend contract, and live producer-contract levels.

--- a/docs/chat/README.md
+++ b/docs/chat/README.md
@@ -1,6 +1,26 @@
 # Assistant Chat
 
-Last verified against Aevatar console and SDK commit `e7ba2e6eb` (2026-08-25).
+The Aevatar chat contract is pinned in
+`tests/fixtures/assistant/aevatar-chat-contract-pin.json`.
+Compare watched paths from the effective chat SHA to the live
+`feature/integrate` head with:
+
+```bash
+python3 scripts/check-aevatar-chat-drift.py \
+  --pin tests/fixtures/assistant/aevatar-chat-contract-pin.json \
+  --remote https://github.com/aevatarAI/aevatar.git \
+  --branch feature/integrate
+```
+
+Pin field sources at effective chat SHA `706ea7cab9d1f882e0fb0f034bb338102b6d5d2b`:
+
+- `remote`, `branch`, `remote_head`, `effective_chat_sha`, `watched_paths`: this pin
+- `public_commands`: `agents/Aevatar.GAgents.NyxidChat/NyxIdChatPublicEndpoints.cs`
+- `internal_actions`: `agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs` (`ResolveServiceAccessReview`)
+- `context_attachments`: `agents/Aevatar.GAgents.NyxidChat/ConversationContextAttachmentAdmission.cs`, `NyxIdChatEndpoints.Streaming.cs` (`NyxIdChatContextAttachmentDto`, `ToAttachmentAdmissionWireName`), `NyxIdChatLifecycleFacade.cs` (create-only admission)
+- `delete`: `agents/Aevatar.GAgents.NyxidChat/NyxIdChatPublicEndpoints.cs` (`HandlePublicDeleteConversationAsync`)
+- `keepalive_seconds`: `agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs` (`StreamKeepAliveInterval`)
+- `action_registry`: `agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs` (`SupportedSchemaVersion`, per-action skip on unknown or divergent descriptors)
 
 This directory is the canonical specification for the browser assistant chat surface. It describes the contract implemented by NyxID's `/api/v1/assistant/**` routes, the React assistant client, and the upstream chat endpoints those routes call. The default surface uses Aevatar's durable typed actor. A default-off feature flag can instead select the implemented stateless Direct Chrono-LLM engine for internal testing.
 
@@ -68,7 +88,8 @@ The normative implementation anchors are:
 - `frontend/src/components/assistant/**`: visible behavior and accessibility semantics.
 - `frontend/e2e/**` and assistant unit tests: executable browser and transport contracts.
 
-Upstream claims in this set are verified against Aevatar commit `e7ba2e6eb`.
+Upstream claims in this set are verified against
+`tests/fixtures/assistant/aevatar-chat-contract-pin.json`.
 The primary anchors are the console's chat page/API, SSE normalizer, runtime
 event accumulator, actor-state reducer, history decoders, and the typed actor's
 `NyxIdChatSseWriter`, `NyxIdChatProjectionSession`, and

--- a/docs/chat/README.md
+++ b/docs/chat/README.md
@@ -12,6 +12,10 @@ python3 scripts/check-aevatar-chat-drift.py \
   --branch feature/integrate
 ```
 
+The JSON receipt includes `pinned_remote_head`, `observed_head`,
+`effective_chat_sha`, `fetch_timestamp`, and `changed_watched_paths`.
+A moved remote head with no watched-path change stays clean.
+
 Pin field sources at effective chat SHA `706ea7cab9d1f882e0fb0f034bb338102b6d5d2b`:
 
 - `remote`, `branch`, `remote_head`, `effective_chat_sha`, `watched_paths`: this pin

--- a/docs/chat/assistant-waves-plan.md
+++ b/docs/chat/assistant-waves-plan.md
@@ -4,13 +4,25 @@
 - **Contract of record:** gist `ctkm-aelf/b4dd5182…`, revision `f45febb0` (verified current head, untouched since 2026-08-06)
 - **Issues:** #1400 (Wave 1 / NyxID deliverables), #1403 (Wave 2), #1401 (Wave 3), #1402 (Wave 4)
 
-**Bottom line.** NyxID's Wave-1 side is code-complete; the deploy lock is smaller than believed (Aevatar already validates an accepted-revision *set*, and the v8 pin is already merged to `feature/integrate`); the loader provably skips unknown manifest actions, so wave descriptors can merge to main continuously without touching the revision string. The four teams should ship **the revision-negotiation endpoint plus a trimmed Wave 2 (12 of 15 verbs)** — not Waves 2+3+4. Measured cost of the last two single-verb PRs is ~4.1–4.4k added LOC each; three full waves ≈ 53 verbs is not a four-team increment.
+**Bottom line.** NyxID's Wave-1 side is code-complete. Aevatar's current loader
+treats `schema_version` as the only registry-wide gate, treats `revision` as an
+observability label, and degrades unknown or divergent descriptors per action.
+Startup retries three times, then pins a disabled fallback and recovers in the
+background. Wave descriptors can merge to the default manifest without a
+revision bump. `plan.resolve` and `POST /api/v1/assistant/completions` are
+retired NyxID surfaces, not current contract. The four teams should ship a
+trimmed Wave 2 (12 of 15 verbs), not Waves 2+3+4. Measured cost of the last two
+single-verb PRs is about 4.1k to 4.4k added LOC each. Three full waves total
+about 53 verbs, which is not a four-team increment.
 
 ---
 
 ## 1. Verified state table
 
-Every claim re-verified against origin/main `c9776b49` (and Aevatar `origin/feature/integrate` / `origin/dev`, fetched 2026-08-20). Corrections are called out in bold.
+The original state table records sources fetched on 2026-08-20. AC-1 registry
+corrections were re-verified against Aevatar `feature/integrate` at
+`e5bba2e9719ad5132004b882744caa3875db1123` on 2026-09-03. Corrections are
+called out in bold.
 
 | # | Claim | Verdict | Evidence |
 |---|---|---|---|
@@ -24,8 +36,8 @@ Every claim re-verified against origin/main `c9776b49` (and Aevatar `origin/feat
 | 8 | Issues drop Wave 0; G1 undecided, G2 absent, G7 not started | **Confirmed, with G1 nuance** | No issue mentions Wave 0/G1/G2/G7. `nyx__list_api_keys` / `nyx__readiness`: zero hits in the tree. G7's trigger persists: `nyx__connect_service` still takes a raw `credential` string (`backend/src/services/mcp_service.rs:1869-1891`). G1 is **de facto decided as fork (b)** — see #9. |
 | 9 | Fork (b) chosen by construction, never written down | **Confirmed** | Wave 1 postconditions shipped as hardened REST projections + delegated `account:read` GET admission, consumed by Aevatar's REST reader; the MCP `nyx__*` G2 built-ins were never built. `docs/chat/06-actions-registry.md:188-216` documents the REST evidence reads as the operative contract. Recording this is a docs deliverable (§3). |
 | 10 | #1464 finding: detail responses unsafe as evidence | **Confirmed from code** | Reader runs a recursive secret-shape scan (`Bearer\s+\S+`, `nyxid_` prefix) over the whole document: doc comments at `handlers/keys.rs:567-587` and `handlers/api_keys.rs:351-368`, incl. the `name` irreducible remainder. Whether *every* family needs a projection is now answered per family in §6: **yes for every Wave 2/3/4 family except (marginally) notifications.** |
-| 11 | Deploy lock: Aevatar pins one string by exact equality; #3496 (v8 pin) open and blocking | **Materially corrected** | (a) Aevatar validates **set membership**, not a single string: `PinnedActionsByRevision.TryGetValue(revision, …)` with per-revision pinned + executable sets (`NyxIdAssistantActionRegistry.cs`, `feature/integrate`). `origin/dev` accepts {v4…v7}; `origin/feature/integrate` accepts {v4…v8}. (b) The v8 pin is **already merged to `feature/integrate`** as commit `418cab838` "Pin NyxID assistant registry v8 and keep service.reauthorize closed"; open PR #3496's head is *not* an ancestor of `feature/integrate` (overlapping/likely superseded content — needs an upstream disposition ask). #3497 (draft, stacked on #3496) is the step that makes reauthorize *executable*; until it lands, v8 pins reauthorize dormant. (c) "Main cannot be deployed today" is true only relative to the deployed dev-lineage composition (accepts ≤v7); the unblock is the routine `feature/integrate`→`dev` merge (last one, #3467 on 08-15, predates `418cab838`) + deploy — not #3496 per se. |
-| 12 | Manifest content additive/tolerant; string is the tripwire | **Confirmed at code level — and stronger than stated** | Loader: unknown wire action, or action not in the served revision's pinned set → `continue` (skipped, not fatal); `tier`/`risk`/schema validation and `DeepEquals` run **only for pinned actions**. Consequence (load-bearing for §5/§7): **NyxID can append fully-formed new descriptors to the live manifest under the unchanged v8 string; every current Aevatar composition skips them.** Only NyxID's own test rail (`SUPPORTED_ACTIONS`, `assistant_actions.rs:181-196`) must be extended first. |
+| 11 | Deploy lock: Aevatar pins one string by exact equality; #3496 (v8 pin) open and blocking | **Superseded by AC-0 and AC-1** | Current Aevatar `Load` does not fail the registry on revision mismatch. `schema_version` is the only registry-wide gate. `revision` is an observability label. Startup retries, then installs a disabled fallback and recovers later. |
+| 12 | Manifest content additive/tolerant; string is the tripwire | **Confirmed, and stronger** | Unknown wire actions are skipped. Known actions whose descriptors diverge are skipped per action and recorded. NyxID can append fully-formed new descriptors to the live manifest under the unchanged v8 string. |
 | 13 | Never modify a shipped verb's `params_schema`; browser may be stricter than manifest | **Confirmed** | `JsonNode.DeepEquals` pin + browser-only rules at `docs/chat/06-actions-registry.md:163-186`. History note: `key.create`'s schema did change v5→v6 (least-scope `minItems`), coordinated while the verb was not yet executable in a deployed composition — the rule binds for shipped-and-deployed verbs. |
 | 14 | (New) Allowlist arithmetic for the waves | **New finding** | Wave 2: only 1 of 15 verbs (`provider.set_app_credentials`) is in the 14-name parser allowlist; the other 14 need both the NyxID rail and Aevatar's `SupportedActions` extended. Wave 3: 4 of 8 allowlisted (`node.register_token`, `node.rotate_token`, `node.inject_credential`, `device.onboard`); `node.delete`, `node.transfer`, `pending_credential.push/.cancel` are not — the gist's "Waves 1 and 3 draw only from it" contradicts its own Wave-3 list. Allowlist extensions are upstream-parser work and must ride the consumer wave issues. |
 
@@ -39,9 +51,9 @@ The intake bot declined #1401/#1403 specifically on production canaries + deploy
 
 > ## Acceptance
 >
-> NyxID-side closure requires, per verb: grammar-safe descriptor merged **dormant** under the current registry revision (no revision bump in wave PRs); browser card + human-session journey; exactly one typed safe resource reference; an authoritative postcondition read on the family's hardened evidence projection (never the full detail response); and local integration tests proving typed read-back, exact-retry receipt replay, and the negative set (secret-shaped params, stale identity, conflicting-content replay, unauthorized scope) against a local replica-set backend. Utterance→route and honesty fixtures per contract §10 land in the matching Aevatar wave issue.
+> Each verb needs a grammar-safe descriptor published additively under the current registry revision, a browser card and human-session journey, and one typed safe resource reference. Each verb also needs an authoritative postcondition read on the family's hardened evidence projection, never the full detail response. Local replica-set integration tests must prove typed read-back, exact-retry receipt replay, and the negative cases. Those cases cover secret-shaped params, stale identity, conflicting-content replay, and unauthorized scope. Utterance-to-route and honesty fixtures per contract §10 land in the matching Aevatar wave issue.
 >
-> The registry revision bump for this wave is a separate, single-line PR gated on the cross-repo handshake (Aevatar ships acceptance of the new revision first, or the revision-negotiation endpoint is live and Aevatar fetches its pinned revision explicitly). Production rollout and verification are tracked in the handshake issue, not here; a descriptor or card mock alone is still not shipped.
+> Aevatar skips unknown descriptors and degrades divergent known descriptors per action. No registry revision bump or cross-repository revision handshake gates an additive descriptor. Production rollout and verification remain separate work. A descriptor or card mock alone is still not shipped.
 
 ### #1401 (Wave 3) — same Acceptance replacement as #1403, plus strike from **Required artifacts**:
 
@@ -56,7 +68,7 @@ The intake bot declined #1401/#1403 specifically on production canaries + deploy
 
 ### #1400 — no acceptance edits; add one clarifying comment:
 
-> NyxID side verified code-complete on main `c9776b49` (items 1–3 incl. the 2026-08-07 revision; #1405/#1406 closed). Remaining: the deploy handshake. Note the v8 pin is already on aevatar `feature/integrate` (`418cab838`); please confirm whether aevatar#3496 is superseded by it, and land the `feature/integrate`→`dev` merge + deploy before NyxID main deploys. aevatar#3497 is still required before `service.reauthorize` becomes executable (v8 pins it dormant).
+> NyxID side verified code-complete on main `c9776b49` for items 1 through 3, including the 2026-08-07 revision. #1405 and #1406 are closed. The current Aevatar loader does not gate on the revision label. Track deployment proof separately. `service.reauthorize` remains non-executable until its typed producer and postcondition path land upstream.
 
 Additionally, all three wave issues should gain one scope line: "Wave 0 is superseded for this wave: postconditions ride the fork-(b) REST evidence-projection pattern established by Wave 1 (see docs/chat/assistant-waves-plan.md §3); no MCP-client, `nyx__*` built-in, or planner-allowlist work is a prerequisite."
 
@@ -77,43 +89,41 @@ Additionally, all three wave issues should gain one scope line: "Wave 0 is super
 
 ---
 
-## 4. Revision-negotiation design
+## 4. Registry compatibility contract
 
-**What already exists (correcting the premise).** Aevatar (`feature/integrate`) validates the fetched revision by set membership over `PinnedActionsByRevision` {v4…v8}, validates schemas only for pinned actions, skips unknown actions, and keeps a per-revision executable subset (so v8 carries `service.reauthorize` dormant). Aevatar has even minted its own composition namespace (`aevatar-nyxid-actions.v1`). **The Aevatar half of negotiation is built.** What is missing:
+Aevatar fetches the bare `GET /api/v1/assistant/actions` path.
+`schema_version` is the only registry-wide compatibility gate. `revision` is
+an observability label, so a future or missing value does not reject the
+registry. The loader ignores unknown action names. It records and skips a known
+descriptor when its shape, policy, or pinned schema diverges. Every other valid
+descriptor remains loaded.
 
-- **NyxID side:** the endpoint serves only the latest composition. A deployed Aevatar that does not yet know revision N+1 hard-fails startup the moment NyxID deploys N+1. This forces "Aevatar always deploys first" as fragile choreography (exactly what broke: NyxID main hit v8 on 08-19 while the deployed lineage accepts ≤v7).
-- **Aevatar side (small consumer ask):** the startup fetch requests the bare path; it cannot ask for the revision it actually supports.
+The startup service tries the fetch three times. If all attempts fail, it pins
+a disabled fallback registry and retries in the background with capped
+exponential delay. The first valid response may replace only that fallback. A
+served registry remains pinned for the process lifetime.
 
-### Design: historical compositions on the same route
+NyxID still supports `GET /api/v1/assistant/actions?revision=<r>` for its own
+historical compositions. Aevatar does not use that query as a negotiation or
+load gate. New descriptors may ship additively under the current revision.
+They become executable only after Aevatar has the matching contract, producer,
+wire mapper, and postcondition reader.
 
-`GET /api/v1/assistant/actions?revision=<r>`:
+### Test cases
 
-- No param → latest body, byte-identical to today (zero risk to current consumers).
-- Known `<r>` → a composition with `revision: <r>` and **that revision's action-name set, serialized with the *current* schemas/descriptions**. Not historical bytes: schemas changed v5→v6, and Aevatar's `DeepEquals` compares against its single compiled constant per action — current bytes are the only ones that can pass. Note v7's set is {connect, key.create, key.rotate}: **not a prefix** of the current array (reauthorize sits at index 1), so the implementation is a static `revision → action-name set` map mirroring Aevatar's `PinnedActionsByRevision`, with per-revision bodies pre-serialized in the existing `LazyLock` pattern.
-- Unknown `<r>` → 404 with a stable error body; malformed/oversized (>128 chars, control chars) → 400.
-- Rate-limit exemption is exact-path (`mw/rate_limit.rs`); query strings don't change the path — verify with a test, no change expected.
-- Contract addition to `docs/chat/06-actions-registry.md`: published revisions are immutable (action set never edited), sets are monotone (each ⊆ the next), waves only append.
+| Name | Asserts |
+|---|---|
+| `default_manifest_action_names_match_consumer_fixture_golden` | The additive default manifest keeps every descriptor name. |
+| `default_manifest_matches_aevatar_chat_contract_pin` | The manifest uses the pinned schema version, revision semantics, and per-action degrade behavior. |
+| `known_descriptors_are_accepted_by_the_per_action_consumer` | Every descriptor name supported at the pinned Aevatar head loads from the default manifest. |
+| `unknown_descriptors_are_skipped_without_disabling_known_actions` | An additive unknown name does not change the accepted known set. |
+| `divergent_descriptors_degrade_per_action` | A divergent known descriptor is skipped while sibling actions remain loaded. |
+| `schema_version_gates_the_registry` | A schema mismatch rejects the registry, while a future revision label does not. |
 
-**Upstream consumer ask (file on aevatarAI/aevatar):** startup source appends `?revision={SupportedRegistryRevision}`; on 404 (older NyxID without the feature), fall back to the bare fetch + existing set-membership validation. One URL-builder change + fallback.
-
-**Resulting protocol — two independent deploys, permanently:** NyxID may deploy any time (history keeps serving every pinned composition); Aevatar may deploy any time (it fetches the composition it supports). Wave cadence becomes: descriptors merge dormant continuously under the current string (safe per §1 row 12); one single-line revision-bump PR per wave, mergeable the moment either the upstream fetch change is deployed or upstream ships acceptance of the new revision.
-
-**Immediate v8 unblock (process, not code, and not gated on this feature):** confirm the deployed Aevatar composition includes `418cab838` (needs a `feature/integrate`→`dev` merge later than #3467 + deploy), then NyxID main is deployable. `service.reauthorize` stays dormant until aevatar#3497.
-
-### Test cases (NyxID, concrete)
-
-| # | Name | Kind | Asserts |
-|---|---|---|---|
-| 1 | `assistant_actions_default_body_is_byte_identical_to_golden` | regression | bare GET == existing golden manifest, byte-for-byte |
-| 2 | `assistant_actions_revision_v7_serves_exact_action_set_with_current_schemas` | unit | `?revision=…v7` → revision field `v7`, actions == {connect, key.create, key.rotate}, each `params_schema` deep-equal to the current constants |
-| 3 | `assistant_actions_revision_v4_serves_service_connect_only` | unit | singleton set, current schema |
-| 4 | `assistant_actions_unknown_revision_returns_404_stable_error` | negative | `?revision=…v3` → 404, error body, no manifest content |
-| 5 | `assistant_actions_malformed_revision_param_returns_400` | negative | 129-char value; value with control chars |
-| 6 | `assistant_actions_every_published_revision_passes_parser_contract` | fixture | run `assert_manifest_conforms` over every historical body |
-| 7 | `assistant_actions_revision_sets_are_monotone_append_only` | invariant | for consecutive revisions rᵢ ⊆ rᵢ₊₁ |
-| 8 | `assistant_actions_revision_sets_match_aevatar_pinned_fixture` | drift | checked-in fixture mirroring `PinnedActionsByRevision`; diff fails the build |
-| 9 | `assistant_actions_route_with_query_remains_rate_limit_exempt` | integration | exemption unaffected by query string |
-| 10 | `assistant_actions_dormant_descriptor_is_served_but_absent_from_all_pinned_sets` | invariant | any action not in the latest revision's set is by definition dormant; guards the wave-merge protocol |
+Earlier revisions of this plan proposed a synchronized revision map and a
+consumer `?revision=` request. AC-1 removed those assumptions because a checked-in
+copy could not detect upstream drift and the pinned consumer no longer uses
+revision equality.
 
 ---
 
@@ -121,11 +131,21 @@ Additionally, all three wave issues should gain one scope line: "Wave 0 is super
 
 ### Scope decision (the numbers)
 
-Measured: ~4.1–4.4k added LOC per hardened verb (#1423; #1462+#1464). Assume 40–60% marginal savings from established receipt/evidence/journey patterns → **1.8–2.6k LOC/verb realistic**. Wave 2 (15) ≈ 27–39k; Wave 3 (8) ≈ 14–21k; Wave 4 (~30, incl. org ACLs and destructive `account.delete`) ≈ 55k+. Four teams cannot honestly ship 53 verbs in one increment. **Recommendation: this increment = negotiation + Wave 2 trimmed to 12 verbs.** Deferred from Wave 2 with reasons: `connection.revoke` and `provider.disconnect` (they mutate the *legacy* collections — `connections.rs`, `providers.rs`; re-scope after the unified-migration decision rather than build cards over surfaces slated for deletion, FI-007), and `provider.set_app_credentials` (the one already-allowlisted verb, but a secret-bearing journey of a different shape — batch it with Wave 4's `external_key.add_gcp_service_account`). Waves 3/4 are re-planned after re-measuring Wave-2 marginal cost.
+The last two hardened verbs added about 4.1k to 4.4k lines each in #1423,
+#1462, and #1464. A 40% to 60% marginal saving from the established receipt,
+evidence, and journey patterns puts each later verb at about 1.8k to 2.6k
+lines. Wave 2 has 15 verbs, Wave 3 has 8, and Wave 4 has about 30. Four teams
+cannot ship all 53 verbs in one increment. This increment should contain the
+registry contract correction and 12 Wave-2 verbs. Defer `connection.revoke`
+and `provider.disconnect` because they mutate the legacy collections in
+`connections.rs` and `providers.rs`. Revisit them after the unified migration
+decision. Defer the secret-bearing `provider.set_app_credentials` journey with
+Wave 4's `external_key.add_gcp_service_account`. Re-plan Waves 3 and 4 after
+measuring the Wave-2 cost.
 
 ### PM pre-landed shared contracts (WS-0 — merged before any team dispatches)
 
-1. **Registry descriptor block:** all 12 Wave-2 descriptors appended dormant to `assistant_actions.rs` under unchanged v8; `SUPPORTED_ACTIONS` rail extended with the 12 names; golden-manifest test updated. (Safe per §1 row 12; single hottest shared file leaves team ownership entirely.)
+1. **Registry descriptor block:** all 12 Wave-2 descriptors appended additively to `assistant_actions.rs` under unchanged v8; `SUPPORTED_ACTIONS` rail extended with the 12 names; golden-manifest test updated. Current Aevatar builds skip unsupported names per action. The single shared file stays under one team.
 2. **Zod envelope:** `frontend/src/schemas/assistant-actions.ts` extended with all 12 param/report shapes (schema only, no journeys).
 3. **Route nests:** `routes.rs` gains three one-line nests → `handlers/assistant_action_effects_keys.rs`, `_services.rs`, `_endpoints.rs`, each exporting a `router()` the owning team fills (routes.rs never touched again this increment). Confirm billing route-inventory coverage for nested routers at land time.
 4. **Receipt helper:** extract/bless the durable secret-free receipt pattern from the existing key-create/rotate effects (`handlers/assistant_action_effects.rs`) into a shared service if not already one.
@@ -133,12 +153,12 @@ Measured: ~4.1–4.4k added LOC per hardened verb (#1423; #1462+#1464). Assume 4
 
 Ground rules for every team: never `git add -A`; stage only owned files, commit atomically; no team edits `assistant_actions.rs`, `routes.rs`, or `schemas/assistant-actions.ts` (Team 1 excepted for the first); no PR bumps `ASSISTANT_ACTIONS_REVISION`; frontend gate is `npm run build` (not `tsc --noEmit`); backend tests need replica-set Mongo + `NYXID_TEST_DATABASE_URL` (~5000 failures in ~13s = connection failure); no frontend dep/lockfile changes (wizard freshness) — none of the owned files are in the wizard graph (`wizard-entry.tsx` does not import `components/assistant/`).
 
-### Team 1 — Revision negotiation (backend-only; no e2e)
+### Team 1. Registry contract correction
 
-- **Scope:** §4 in full: revision map, `?revision=` serving, tests 1–10, `docs/chat/06-actions-registry.md` negotiation + fork-(b) ADR section, drafted upstream consumer-ask issue text (PM files it).
-- **Files owned:** `backend/src/handlers/assistant_actions.rs`, `docs/chat/06-actions-registry.md`, new fixture file for the Aevatar pinned-set mirror.
-- **Interface contracts:** revision-set map is append-only and mirrors Aevatar; Teams 2–4 never depend on it (their verbs are dormant regardless).
-- **Acceptance:** tests 1–10 green; default body byte-identical; docs updated; consumer-ask text delivered.
+- **Scope.** Preserve NyxID's historical composition query, delete synchronized revision-map assertions, add a default-manifest golden, and test known, unknown, and divergent descriptors independently.
+- **Files owned.** `backend/src/handlers/assistant_actions.rs`, `docs/chat/06-actions-registry.md`, and `tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json`.
+- **Interface contracts.** `schema_version` gates the registry. `revision` is an observability label. Unknown or divergent descriptors degrade per action.
+- **Acceptance.** The default manifest keeps every additive descriptor, per-action tests pass, and the docs match the pinned Aevatar source.
 
 ### Team 2 — Wave 2 keys family (4 verbs: `key.update`, `key.delete`, `key.extend_scope`, `key.bind_credential`)
 
@@ -191,25 +211,17 @@ Criterion: the postcondition reader secret-scans the entire document (`Bearer\s+
 ## 7. Sequencing
 
 ```
-[now]      #1400 handshake (ops, no NyxID code):
-           confirm deployed Aevatar ≥ 418cab838 (feature/integrate→dev merge later
-           than #3467, + deploy)  ──►  NyxID main deployable (v8)
-           upstream disposition ask: is #3496 superseded? #3497 still required
-           before service.reauthorize is executable.
+[now]      AC-0 pins the Aevatar source head, public commands, and registry
+           semantics used by every later phase.
 
-[gate 0]   WS-0 (PM): dormant descriptors + rails + zod envelope + route nests +
+[gate 0]   AC-1 removes obsolete commands and revision-map assumptions. The
+           default-manifest golden and per-action tests preserve additive load.
+
+[gate 1]   WS-0 (PM): additive descriptors + rails + zod envelope + route nests +
            receipt helper. Merges FIRST. Teams dispatch only after.
 
-[parallel] Team 1 (negotiation)  ─ merge anytime after WS-0; MUST precede any
-                                   future revision bump; file upstream fetch ask.
-           Teams 2/3/4           ─ per-verb PRs merge continuously (dormant verbs,
-                                   revision untouched — safe per §1 row 12).
-
-[gate 1]   Wave-2 revision bump (v9): one single-line PR + revision-map entry.
-           Merge ONLY after (a) upstream merges v9 acceptance for the 12 verbs
-           (incl. SupportedActions parser extension — 11 of 12 names are outside
-           the current 14), OR (b) upstream ?revision= fetch change is deployed.
-           Until then v9 must not exist on main.
+[parallel] Teams 2/3/4           per-verb PRs merge continuously. Aevatar skips
+                                  unknown names until its typed support lands.
 
 [always]   Do-not-merge-before rules:
            - no wave PR touches ASSISTANT_ACTIONS_REVISION, assistant_actions.rs,
@@ -262,10 +274,10 @@ upstream changes. Requires an upstream ask.
 
 ### Per-stream
 
-- **T1 revision negotiation — FIXED (`eb3ff7a2`).** Served v5 composition used the
-  *current* `key.create` schema, but Aevatar does per-revision schema selection
-  (`ValidatePinnedContract`): v4/v5 pin the old schema, v6/v7/v8 the least-scope one.
-  A 200 that then fails `DeepEquals` disables the whole registry at startup.
+- **T1 revision negotiation.** The earlier exact-revision design was superseded
+  by AC-1. Aevatar now uses `DeepEquals` only to decide whether one known
+  descriptor loads. A mismatch skips that action and leaves sibling actions
+  enabled.
 - **T2 keys** — state-version fence non-atomic (lost update); `expected_state_version`
   absent from fingerprint; binding evidence unmounted and unaddressable from the
   report; `bind_credential` accepted revoked credentials then confirmed the binding.

--- a/docs/plans/aevatar-chat-feature-integrate-convergence.md
+++ b/docs/plans/aevatar-chat-feature-integrate-convergence.md
@@ -1,0 +1,691 @@
+# Aevatar chat feature integrate convergence plan
+
+This program closes the NyxID browser-chat gaps against Aevatar `feature/integrate` for NyxID users and the engineers who maintain the integration.
+Done means the pinned contract, typed commands, access review, context attachments, lifecycle recovery, and a credentialed producer canary all pass at named NyxID and Aevatar SHAs.
+The program excludes Direct Chrono-LLM, Studio workflow chat, voice, channels, dormant Wave-2 actions, `inputParts`, and explicit `agentProfile` selection.
+Execute `AC-0` through `AC-7` in order. Stop every phase at merge-ready.
+
+## How to read this
+
+One box is one unit of work. Every box names the evidence that proves it. A nested box is a sub-step of the box above it. Check a box only when its evidence exists as a file, log, screenshot, recording, test run, link, or SHA. The body is a how-to. The appendices explain decisions and preserve evidence.
+
+The program runs `references/playbook-autopilot-stack.md` from the active `heca-mode` skill. Repository policy comes from `CONTRIBUTING.md` and `WORKFLOW.md`. The operator retains merge authority. Every phase stops at merge-ready with `auto_merge` disabled.
+
+Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+## Program checklist
+
+### Arm the program
+
+- [ ] Present this plan and `docs/plans/aevatar-chat-feature-integrate-convergence.md` to the operator, then stop until explicit authorization. Evidence is the operator's go message.
+- [ ] Record `AC-0 -> AC-1 -> AC-2 -> AC-3 -> AC-4 -> AC-5 -> AC-6 -> AC-7`, the done predicate, exclusions, merge authority, and repository policy sources. Evidence is the program entry in the decision trail.
+- [ ] Read `references/playbook-autopilot-stack.md` at program start and after every resume. Evidence is the skill path and version in the latest status report.
+- [ ] Use a standing Heca task for the dependent stack and no team or loop unless execution shows that the coordinator needs one. Evidence is the Heca task id or the recorded reason for changing this choice.
+
+### Assign owners and verifiers
+
+- [ ] Resolve delegated owners and verifiers from `~/.heca/pstack-models.json` against one live provider catalog snapshot. Evidence is an assignment table with provider, model, effort, and spawn mode.
+- [ ] Spawn each delegated role with `heca_agent_spawn` and `notify_on_finish` set to `true`. Evidence is the agent id beside its phase id.
+- [ ] Give every writer one branch or worktree and hold the dependency graph at the root. Evidence is the branch, worktree, base SHA, and allowed file boundary in the assignment table.
+- [ ] Keep each verifier independent from the owner and read-only on the owner's branch. Evidence is the verifier assignment and its exact head SHA.
+
+### Hold repository policy
+
+- [ ] Re-read `CONTRIBUTING.md` and `WORKFLOW.md` before execution. Evidence is a policy note that records the `main` target default, one required approval, explicit security review for security-sensitive work, required `CI Pipeline`, and disabled auto-merge.
+- [ ] Keep each phase independently reviewable and buildable. Evidence is a green exact phase head with no planned internal breakage.
+- [ ] Preserve the ordered base and head chain after any topology change. Evidence is the refreshed phase table with exact SHAs.
+- [ ] Never merge, close, or arm auto-merge without explicit authority and a clean repository-policy verdict. Evidence is the authorization record or the merge-ready handoff.
+
+### Verify exact heads
+
+- [ ] Run repository, live, and warranted risk checks at each exact phase head. Evidence is the command output and real-surface artifact linked from that phase.
+- [ ] Send every finding back to the owner and reverify after any head change. Evidence is the new head SHA and replacement verdict.
+- [ ] React to Heca finish notifications and report material state changes without polling agents. Evidence is the notification-linked status entry.
+- [ ] Hold a throughput checkpoint after `AC-1` and `AC-4`; advance only when the completed phase is green and the next phase still uses its verified contract. Evidence is the checkpoint verdict with the parent and child SHAs.
+- [ ] End each phase with a handoff that names what changed, predicate state, open risks, and exact next input. Evidence is the phase handoff in the decision trail.
+
+## Pin the upstream contract and automate drift detection (AC-0)
+
+**Depends on.** None.
+
+**Owner.** A delegated contract-tooling owner on the stack root branch.
+
+**Verifier.** An independent read-only integration-contract verifier at the exact `AC-0` head.
+
+**Files.**
+
+- [ ] Add `tests/fixtures/assistant/aevatar-chat-contract-pin.json` with the audited branch, remote head, effective chat SHA, watched paths, public command set, internal action set, and context-attachment rules. Evidence is the parsed fixture at the phase head.
+  - [ ] Watch exactly these upstream paths, namely `agents/Aevatar.GAgents.NyxidChat/`, `apps/aevatar-console-web/src/pages/chat/`, `apps/aevatar-console-web/src/shared/auth/client.ts`, `src/Aevatar.Mainnet.Host.Api/Chat/MainnetChatEndpoints.cs`, `src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionAuthentication.cs`, `src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequireServiceTool.cs`, `src/Aevatar.AI.ToolProviders.NyxId/NyxIdActionEvidenceReadPort.cs`, `src/Aevatar.AI.ToolProviders.NyxId/NyxIdMcpOperationCatalogReader.cs`, `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs`, `src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs`, and `src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs`. Evidence is the fixture's `watched_paths` array.
+- [ ] Add `scripts/check-aevatar-chat-drift.py` and `scripts/tests/test_check_aevatar_chat_drift.py`. Evidence is the scoped diff with the checker and its deterministic tests.
+- [ ] Add `.github/workflows/aevatar-chat-drift.yml` with weekly and manual triggers. Evidence is the workflow diff and one manual run URL.
+- [ ] Update `docs/chat/README.md` to point to the machine-readable pin and its check command. Evidence is the rendered document at the phase head.
+
+**Build.**
+
+- [ ] Make the pin record Aevatar remote head `e5bba2e9719ad5132004b882744caa3875db1123` and effective chat SHA `706ea7cab9d1f882e0fb0f034bb338102b6d5d2b`. Evidence is the exact JSON values in the fixture.
+- [ ] Make the checker fetch `feature/integrate`, compare watched chat paths from the effective SHA to remote HEAD, and fail with changed path names when contract-owned files move. Evidence is a passing clean case and a failing synthetic-drift case.
+- [ ] Keep NyxID's additive action manifest. Treat `schema_version` as the registry-wide compatibility gate and `revision` as an observability label. Evidence is a fixture assertion that unknown or divergent descriptors do not require an exact revision-wide match.
+
+**You see.**
+
+- [ ] Run the checker against the audited Aevatar clone and observe zero watched-path changes between the effective chat SHA `706ea7cab` and remote HEAD `e5bba2e9`. Evidence is a JSON or text receipt naming both SHAs and an empty changed-path list.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run `python3 -m unittest scripts.tests.test_check_aevatar_chat_drift` and the documentation and workflow checks used by `CI Pipeline` at the exact head. Evidence is a log headed by `git rev-parse HEAD` and the required check URL.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run `python3 scripts/check-aevatar-chat-drift.py --remote https://github.com/aevatarAI/aevatar.git --branch feature/integrate --pin tests/fixtures/assistant/aevatar-chat-contract-pin.json`. Pass when it resolves the live remote, records the observed head, and reports no unreviewed watched-path drift. Evidence is the command receipt with the fetch timestamp and SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Point the checker at a temporary repository with one watched-path commit after the effective pin. Pass when the command exits nonzero and prints only the changed watched paths without modifying the NyxID worktree. Evidence is the negative-test transcript and clean `git status --short` output.
+
+**Review gate.** None. This phase changes contract metadata, checks, and documentation only.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready root PR with `main` as its base, `auto_merge` disabled, one independent verdict, and a green `CI Pipeline`. Evidence is the PR URL and exact head SHA.
+
+## Remove obsolete commands and stale registry assumptions (AC-1)
+
+**Depends on.** `AC-0` is green and its pin is the accepted contract source.
+
+**Owner.** A delegated assistant-boundary owner on a branch based on the exact `AC-0` head.
+
+**Verifier.** An independent read-only API and frontend verifier at the exact `AC-1` head.
+
+**Files.**
+
+- [ ] Edit `backend/src/services/assistant_service.rs` at `AssistantChatCommand`, `PlanResolveCommand`, `RawPlanResolveCommand`, `parse_assistant_chat_command`, and `prepare_assistant_chat_command`. Evidence is a diff with every `plan.resolve` parser and reconstruction path removed.
+- [ ] Edit `backend/src/handlers/assistant.rs` at `completions`, `backend/src/routes.rs` at `/assistant/completions`, and their tests. Evidence is a diff that removes the route unless production telemetry proves a current caller and records its closed typed contract.
+- [ ] Edit `frontend/src/lib/assistant/chat-api.ts`, `frontend/src/hooks/use-assistant-chat-controls.ts`, `frontend/src/hooks/use-assistant-chat.ts`, `frontend/src/components/assistant/chat-actor-controls.tsx`, `frontend/src/components/assistant/assistant-chat-page.tsx`, `frontend/src/components/assistant/blocks/task-plan-card.tsx`, and their tests. Evidence is a diff with no callable plan-confirmation control.
+- [ ] Edit `frontend/src/lib/assistant/chat-task-plan.ts` so historical unknown gate fields are ignored without preserving a callable `ChatPlanGate` state. Evidence is a decoder test for an old snapshot and no outbound command.
+- [ ] Edit `backend/src/handlers/assistant_actions.rs`, `tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json`, `docs/chat/02-wire-contract.md`, `docs/chat/06-actions-registry.md`, and `docs/chat/assistant-waves-plan.md`. Evidence is a diff that describes per-action degrade, retries, disabled fallback recovery, and revision observability accurately.
+
+**Build.**
+
+- [ ] Define the canonical public command set as `text`, `input.resolve`, `action.continue`, `approval.resolve`, `task.stop`, `task.steer`, `step.retry`, and `step.skip`. Evidence is a backend contract test and a frontend type test generated from the `AC-0` pin.
+- [ ] Reject `plan.resolve` at NyxID's typed boundary and delete its callers and tests in the same phase. Evidence is a 400 contract test and a whole-tree `rg` result with only historical audit or plan references.
+- [ ] Remove `/api/v1/assistant/completions` after checking production access evidence. If a live caller exists, stop this phase and replace the route only after its exact request contract is added to the pin. Evidence is the telemetry decision record and either route deletion or a strict typed reconstruction test.
+- [ ] Preserve all additive default action descriptors while deleting revision-map assertions that claim a manually synchronized fixture detects upstream drift. Evidence is a manifest golden test plus per-action known, unknown, and divergent descriptor tests.
+
+**You see.**
+
+- [ ] Open a stored task snapshot that contains the retired confirm gate and observe a readable task plan with no Confirm or Reject plan commands. Evidence is a desktop screenshot and the browser network log with no `plan.resolve` request.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, the green `CI Pipeline` URL, and matching `git rev-parse HEAD` output.
+- [ ] Run `rg -n 'plan\.resolve|resolvePlan|onResolvePlan' backend/src frontend/src tests/fixtures docs/chat`. Evidence is output limited to the convergence plan or explicit historical notes.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Send a real `plan.resolve` body through `/api/v1/assistant/chat` and request `/api/v1/assistant/completions` on a staging NyxID instance. Pass when both fail at NyxID with the documented 400 or 404 response and Aevatar receives neither body. Evidence is the HTTP transcript and metadata-only upstream wire log.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Review production route access evidence for `/api/v1/assistant/completions` across the agreed retention window. Pass when zero callers justify deletion, or when a named caller and approved replacement contract stop the phase before deletion. Evidence is the redacted query or dashboard link and the recorded decision.
+- [ ] Load old task-plan fixtures with confirm gates. Pass when they remain readable, expose no dead controls, and do not crash the actor reducer. Evidence is the focused Vitest log and screenshot.
+
+**Review gate.** Operator and API-owner review are required because this phase removes visible controls and a published route.
+
+- [ ] Have the operator inspect before-and-after task-plan screenshots and the no-request browser recording. Evidence is the approval note linked to the exact head.
+- [ ] Have the API owner inspect the completions usage evidence and route decision. Evidence is the approval note or a recorded blocker linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-1` PR based on the exact `AC-0` head with `auto_merge` disabled. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks.
+
+## Prove access-review reachability and choose its authority model (AC-2)
+
+**Depends on.** `AC-1` is green and the obsolete command paths are gone.
+
+**Owner.** A delegated security and integration owner on a branch based on the exact `AC-1` head.
+
+**Verifier.** An independent read-only security verifier who did not author the probe or decision.
+
+**Files.**
+
+- [ ] Add `scripts/probe-aevatar-chat-authority.mjs` with redacted identity, bearer-capability, delegation-header, consent, and replay probes. Evidence is the script diff and its documented environment contract.
+- [ ] Add `docs/chat/aevatar-access-review-authority.md` as the decision record for the deployed authorization-session design. Evidence is the accepted decision record with source and runtime receipts.
+- [ ] Update `docs/chat/01-architecture.md` and `docs/API.md` to remove the stale claim that Aevatar authenticates only the Bearer header. Update `docs/ENV.md` only if the accepted design adds configuration. Evidence is the corrected transport-auth sequence and configuration contract tied to the pinned upstream files.
+
+**Build.**
+
+- [ ] Reproduce the current cookie-session bridge with one connected service omitted from the Aevatar session authority. Evidence is a redacted claim summary that records `allow_all_services`, `allowed_service_ids`, and `resources` without a token.
+- [ ] Compare three authority designs in the decision record. The candidates are consent-derived delegated restrictions, a complete OAuth browser round trip with a NyxID return channel, and preserved unrestricted forwarding with an upstream reachability explanation. The consent-derived candidate requires three NyxID changes and the record must cost each of them, namely a delegated read allowance for `GET /api/v1/mcp/config` anchored by a live `CatalogDelegationGrant`, a platform-row exemption on the callback paths, and the Aevatar client link. Evidence is a table with threat model, revocation, retry, deployment, and rollback results.
+- [ ] Prove whether the bridge bearer can read `GET /api/v1/mcp/config`, the endpoint Aevatar uses for both the access probe and the access-review postcondition. Evidence is the route-policy citation at `backend/src/mw/auth.rs` `delegated_read_denied_path` and `delegated_request_allowed`, the middleware test that pins it, and a local-runtime HTTP receipt with a delegated token.
+- [ ] Prove whether a service-restricted delegated token can still complete the Aevatar LLM callback through `/api/v1/llm/gateway/v1` and `/api/v1/proxy/s/chrono-llm-public`. Evidence is a local-runtime receipt for each path with `allow_all_services=false`.
+- [ ] Resolve the Aevatar OAuth client identity without guessing. Production shows a registered client named `aevatar` with id `a6ff2946-f02f-4c35-8203-1ec46132b660`, which Aevatar pins as `BackendConsole.OidcClientId`. Decide between an admin-managed link on the `aevatar` catalog row and a configuration value. Evidence is the decision record entry and the field or setting it names.
+- [ ] Prefer consent-derived restrictions only if the probe proves chat bootstrap still works, the exact Aevatar OAuth client identity can be resolved without guessing, and an approved service changes the next minted capability. Evidence is the decision predicate and live result for each condition.
+- [ ] Keep `forward_access_token` enabled until the selected design proves that Aevatar receives both caller identity and a capability source for tool execution. Evidence is the deployment precondition in the decision record.
+
+**You see.**
+
+- [ ] Produce a seven-row probe receipt for identity only, identity plus capability Bearer, identity plus delegation header, replayed identity `jti`, bridge bearer reading `/api/v1/mcp/config`, restricted token on the LLM gateway path, and restricted token on the proxy slug path. Evidence is a redacted table with HTTP status, upstream code, surface used, and exact deployment version or local SHA.
+- [ ] Force or attempt `USER_SERVICE_ACCESS_REQUIRED` for a connected but unauthorized service. Evidence is the emitted `service.access_review` action or a falsified reachability result that names the authority preventing it.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the script's offline parser and redaction tests plus the documentation checks at the exact head. Evidence is the local log, clean `git status --short`, and green `CI Pipeline` URL.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the probe against the same deployed NyxID and Aevatar pair intended for `AC-3`. Pass when identity-only behavior, capability delivery, replay rejection, and access-review reachability are all observed and recorded, or when the phase stops with a falsified candidate and no implementation child starts. Evidence is the redacted probe receipt with both deployment SHAs or image digests.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Decode every probe token only inside the probe process and emit allowlisted claim summaries. Pass when logs contain no JWT, cookie, authorization code, refresh token, API key, or credential value. Evidence is a secret-pattern scan and independent log review.
+- [ ] Exercise expiry, `jti` replay, service removal, consent revocation, and cross-user resource substitution. Pass when each case fails closed without changing another user's consent or service authority. Evidence is the negative-case matrix and audit event ids.
+
+**Review gate.** Explicit security review is required because this decision changes which service authority Aevatar receives.
+
+- [ ] Have the security reviewer approve the chosen authority model, revocation behavior, token delivery headers, and rollback order. Evidence is a signed review verdict linked to the exact head and probe receipt.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-2` decision and probe PR based on the exact `AC-1` head. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks. No `AC-3` branch starts without the accepted decision.
+
+## Implement service access review end to end (AC-3)
+
+**Depends on.** `AC-2` is green, the live action is reachable, and security approved the authority model.
+
+**Owner.** A delegated full-stack access-review owner on a branch based on the exact `AC-2` head.
+
+**Verifier.** An independent read-only security and browser-flow verifier at the exact `AC-3` head.
+
+**Files.**
+
+- [ ] Edit `frontend/src/schemas/assistant-actions.ts` at `AssistantActionRequest`, `ActionCardParams`, and `ActionResource` to add the exact `service.access_review` variant. Evidence is a strict Zod contract test for `userServiceId`, `serviceSlug`, and `resourceUri`.
+- [ ] Edit `frontend/src/lib/assistant/action-registry.ts` and `frontend/src/lib/assistant/chat-action-validation.ts` to recognize, normalize, and recover the action. Evidence is the registry and recovery test diff.
+- [ ] Add `frontend/src/components/assistant/assistant-service-access-review-dialog.tsx` and wire it through `frontend/src/components/assistant/blocks/action-card.tsx` and `action-dialogs.tsx`. Evidence is the component and wiring tests at the phase head.
+- [ ] Edit `backend/src/handlers/assistant_action_effects_services.rs`, `backend/src/routes.rs`, and the service selected by the `AC-2` decision. Expected service candidates are `backend/src/services/consent_service.rs` and the assistant forward-authority code in `backend/src/handlers/assistant.rs`. Evidence is the accepted decision mapped to exact changed symbols.
+- [ ] Edit `frontend/src/hooks/use-assistant-chat-controls.ts` only as needed to report a completed resource shaped as `userService.userServiceId`. Evidence is the exact `action.continue` body test.
+- [ ] Update `docs/chat/04-action-cards.md`, `docs/chat/07-testing-and-gaps.md`, and `docs/API.md`. Evidence is documentation of the endpoint, journey, postcondition, and live proof.
+
+**Build.**
+
+- [ ] Parse only schema version 4 action envelopes whose action is `service.access_review` and whose params contain exactly one `serviceAccessReview` object. Evidence is strict valid, missing, extra-field, secret-shaped, and malformed-resource tests.
+- [ ] Resolve the target `UserService` under the authenticated owner and recompute its canonical RFC 8707 resource URI server-side. Evidence is a handler-to-service test that rejects caller substitution and slug or URI mismatch.
+- [ ] Apply the authority mutation chosen in `AC-2` only after an explicit human confirmation. Implement it in `backend/src/services/consent_service.rs` as a merge that preserves existing `scopes` and `allowed_service_ids` in one atomic update; `grant_consent_with_services` replaces the row and must not be called from this path. The effects handler stays HTTP and DTO. Evidence is before, first apply, retry, revoke, and cross-user database tests.
+- [ ] Report only `actionRequestId`, `originTurnId`, `disposition`, and `resource.userService.userServiceId`. Evidence is a serialized continuation body with no secrets or tokens.
+- [ ] Continue the same `nyxid-chat-*` actor and wait for Aevatar's postcondition result before presenting completion. Evidence is a reducer test and live wire sequence with stable actor id.
+
+**You see.**
+
+- [ ] Observe an access-review card that says the service is already connected, asks for exact service access, and never falls back to the unsupported-action card. Evidence is desktop and mobile screenshots.
+- [ ] Approve and decline separate requests. Evidence is a recording that shows the same conversation resume with completed and declined dispositions.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, the green `CI Pipeline` URL, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Use a staging human cookie session to trigger `USER_SERVICE_ACCESS_REQUIRED`, approve the card, observe a successful Aevatar postcondition, and use the same service on the next turn. Pass when the actor id stays stable and the second service call succeeds without another review. Evidence is the redacted browser recording, network trace, Aevatar event ids, and both exact deployment SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Try another user's `userServiceId`, a valid id with the wrong slug, an HTTP resource URI, userinfo, query, fragment, encoded path confusion, and an inactive service. Pass when every case fails before authority mutation and creates a metadata-only audit event. Evidence is the adversarial test matrix and database before-and-after snapshot.
+- [ ] Retry the same completion across a lost browser response. Pass when one authority change exists, the report remains replay-safe, and Aevatar reaches one terminal postcondition. Evidence is the idempotency transcript and stored consent or grant row.
+
+**Review gate.** Operator and security review are required for the consent interaction and authority change.
+
+- [ ] Have the operator review the desktop and mobile screenshots plus the approve, decline, cancel, error, and return states. Evidence is the operator verdict linked to the exact head.
+- [ ] Have the security reviewer verify the mutation, report allowlist, audit metadata, and cross-user denial. Evidence is the security verdict linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-3` PR based on the exact `AC-2` head with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdicts, and green required checks.
+
+## Add typed context-attachment transport and readback (AC-4)
+
+**Depends on.** `AC-1` is green and the `AC-0` pin still matches the current upstream attachment contract. `AC-4` is built on the exact `AC-1` head in parallel with `AC-2` and `AC-3` because its files are disjoint; the root rebases it onto the `AC-3` head before delivery and reverifies the gates.
+
+**Owner.** A delegated typed-contract owner on a branch based on the exact `AC-1` head.
+
+**Verifier.** An independent read-only boundary and compatibility verifier at the exact `AC-4` head.
+
+**Files.**
+
+- [ ] Edit `backend/src/services/assistant_service.rs` at `TextChatCommand`, `RawTextChatCommand`, `parse_assistant_chat_command`, and `prepare_assistant_chat_command` to add typed context attachments. Evidence is the parser and exact reconstruction diff.
+- [ ] Edit `frontend/src/lib/assistant/chat-api.ts` to model `ContextAttachmentReference` and allow it only on first-turn `text`. Evidence is a compile-time and runtime command-contract test.
+- [ ] Edit `frontend/src/lib/assistant/chat-types.ts` at `ConversationMeta` and `ChatConversationDetail`. Evidence is typed durable attachment references in list and detail state.
+- [ ] Edit `frontend/src/lib/assistant/chat-history-decoders.ts` at `decodeConversationMeta` and `decodeChatConversationDetail`, plus `frontend/src/lib/assistant/chat-actor-state.ts` at `applyCurrentStateResult`. Evidence is readback tests for list and current-state responses.
+- [ ] Edit `frontend/src/hooks/use-assistant-chat.ts` at the first-turn send boundary. Evidence is a test that attaches references only when `conversationId` is absent.
+- [ ] Update `frontend/src/lib/assistant/__fixtures__/aevatar-chat-history.json`, `frontend/src/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse`, and focused tests. Evidence is fixture coverage of create, reload, and admission errors.
+
+**Build.**
+
+- [ ] Model each attachment as `artifactId`, `revisionMode`, and `pinnedRevisionId`. Evidence is one discriminated type that makes `pinned_revision` require a nonempty revision id and makes `follow_current` omit it on the wire.
+- [ ] Enforce a maximum of four unique, nonempty artifact ids at NyxID's boundary. Evidence is focused tests for zero, one, four, five, duplicate, empty, pinned, and follow-current cases.
+- [ ] Reject attachments on follow-up text and preserve their create-only, sealed-to-conversation rule. Evidence is a boundary test that never forwards a replacement or removal attempt.
+- [ ] Preserve only references in `ConversationMeta`, transcript detail, and actor current state. Evidence is decoder output with no artifact body or backing-object data.
+- [ ] Preserve Aevatar's `ATTACHMENT_ADMISSION_DENIED` code and the reasons `not_found`, `access_denied`, `unsupported_kind`, `over_limit`, `pinned_revision_unavailable`, `invalid_request`, `inactive`, and `read_model_unavailable`. Evidence is the error-decoder matrix.
+
+**You see.**
+
+- [ ] Send a first-turn request with one `follow_current` and one `pinned_revision` reference, then reload list and current state. Evidence is a wire transcript that shows the exact normalized request and the same durable references on readback.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, green `CI Pipeline` URL, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Call the real first-turn endpoint with valid artifact references, follow it with a second turn, and read the list and state endpoints. Pass when Aevatar admits the first turn, rejects any replacement attempt, and returns the sealed references on every documented read model. Evidence is the redacted HTTP and SSE transcript with NyxID and Aevatar SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Send duplicate ids, five ids, missing pinned revision ids, unsupported modes, extra fields, and follow-up attachments. Pass when NyxID or Aevatar returns the pinned typed error and no conversation is created or mutated. Evidence is the negative-case matrix and list or state proof.
+- [ ] Inspect all logs and wire-capture output. Pass when only ids, modes, reason codes, byte counts, and statuses appear, with no artifact content. Evidence is a secret and content-pattern scan signed by the verifier.
+
+**Review gate.** None. This phase adds transport and readback only; it does not expose attachment controls yet.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-4` PR based on the exact `AC-3` head after the root-owned rebase, with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks.
+
+## Add server-scoped artifact discovery and new-chat selection (AC-5)
+
+**Depends on.** `AC-4` is green and its attachment types are the only browser-to-backend representation.
+
+**Owner.** A delegated full-stack attachment-UX owner on a branch based on the exact `AC-4` head.
+
+**Verifier.** An independent read-only security, accessibility, and browser verifier at the exact `AC-5` head.
+
+**Files.**
+
+- [ ] Edit `backend/src/services/assistant_service.rs` to add a server-owned content-artifact path builder derived from `AuthUser.user_id`. Evidence is a path test that has no caller-supplied `scopeId` input.
+- [ ] Edit `backend/src/handlers/assistant.rs` to add a bounded artifact-list handler with dedicated safe response structs, and edit `backend/src/routes.rs` to mount `GET /api/v1/assistant/context-artifacts`. Evidence is the handler, DTO, and route test diff.
+- [ ] Add `frontend/src/schemas/assistant-context-attachments.ts` and `frontend/src/hooks/use-assistant-context-artifacts.ts`. Evidence is strict response parsing and TanStack Query tests.
+- [ ] Add `frontend/src/components/assistant/context-attachment-picker.tsx` and wire it through `frontend/src/components/assistant/chat-composer.tsx`, `assistant-chat-page.tsx`, and `use-assistant-chat.ts`. Evidence is the component, composer, and send tests.
+- [ ] Update `docs/chat/05-frontend-ui.md`, `docs/chat/07-testing-and-gaps.md`, and `docs/API.md`. Evidence is the new endpoint, new-chat-only interaction, and safe discovery contract in the rendered docs.
+
+**Build.**
+
+- [ ] Derive `/api/scopes/{AuthUser.user_id}/content-artifacts` on the server and never accept a browser scope segment. Evidence is a route test that substitutes another user id and still forwards only the authenticated id.
+- [ ] Return only artifact id, title, kind, lifecycle status, current revision id, and safe revision metadata needed for pin selection. Never return inline content, backing object keys, content hashes unless required for display, access lists, owner internals, or provenance. Evidence is an exact response serialization test.
+- [ ] Filter the picker to active `text`, `markdown`, and `structured_document` artifacts and cap pages and aggregate bytes. Evidence is pagination, cap, unsupported-kind, and malformed-upstream tests.
+- [ ] Show attachment selection only for a new draft. Limit selection to four unique artifacts and provide `follow_current` or `pinned_revision` controls. Evidence is component state-machine tests.
+- [ ] Freeze the selected references when the first turn starts and hide editing after actor adoption. Evidence is a send-and-adopt test with stable references and no follow-up control.
+
+**You see.**
+
+- [ ] Open a new chat and select, change, and remove allowed artifacts without shifting the composer or covering adjacent controls. Evidence is desktop and mobile screenshots for empty, loading, selected, maxed, error, and pinned-revision states.
+- [ ] Send the first turn and observe the attachment summary become read-only after actor adoption. Evidence is a browser recording and network body.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, green `CI Pipeline` URL, wizard-bundle freshness result when its source closure changes, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Use a staging human cookie session to list real artifacts, select both revision modes, start a real Aevatar chat, and reload it. Pass when only owned or readable artifacts appear, the first turn succeeds, and the sealed reference summary survives reload. Evidence is the browser recording, screenshots, redacted network trace, and deployment SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Attempt caller-supplied scope injection, another user's page token and artifact id, unsupported kind selection, stale current revision, and oversized upstream pages. Pass when every case fails closed or returns an empty safe result without content disclosure. Evidence is the adversarial matrix and metadata-only audit ids.
+- [ ] Run keyboard-only and screen-reader checks at mobile and desktop widths. Pass when focus order, labels, mode controls, removal, errors, and the four-item limit are understandable and no text overlaps. Evidence is an accessibility report, screenshots, and recording.
+
+**Review gate.** Operator review is required because this phase changes the composer and new-chat workflow.
+
+- [ ] Have the operator inspect the named desktop and mobile states and the full selection-to-send recording. Evidence is the operator verdict linked to the exact head.
+- [ ] Have the security reviewer inspect the scoped handler and safe DTO. Evidence is the security verdict linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-5` PR based on the exact `AC-4` head with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdicts, and green required checks.
+
+## Fix lifecycle liveness and recoverable state (AC-6)
+
+**Depends on.** `AC-5` is green and the readback types include context attachments.
+
+**Owner.** A delegated frontend lifecycle owner on a branch based on the exact `AC-5` head.
+
+**Verifier.** An independent read-only concurrency and browser-state verifier at the exact `AC-6` head.
+
+**Files.**
+
+- [ ] Edit `frontend/src/lib/assistant/chat-history-api.ts` at `deleteConversation` and its tests to observe typed delete completion. Evidence is a bounded poll state machine for accepted, not-found, timeout, and abort cases.
+- [ ] Edit `frontend/src/hooks/use-assistant-chat.ts` and `frontend/src/components/assistant/assistant-sidebar.tsx` to retain an accepted deletion as deleting until state returns `not_found`. Evidence is hook and sidebar tests for no row resurrection.
+- [ ] Edit `frontend/src/lib/assistant/chat-stream-orchestrator.ts` and its tests so valid Aevatar keepalive frames reset the progress watchdog without becoming visible content. Evidence is a virtual-time test beyond 120 seconds.
+- [ ] Edit `frontend/src/lib/assistant/chat-session-state.ts`, `chat-history-decoders.ts`, `chat-actor-state.ts`, `runtime-event-semantics.ts`, and their tests for terminal refresh and recoverable action or authorization state. Evidence is reload and settlement test coverage.
+- [ ] Edit `docs/chat/03-stream-protocol.md`, `docs/chat/05-frontend-ui.md`, and `docs/chat/07-testing-and-gaps.md` to record the exact recovery boundary. Evidence is documentation that distinguishes durable state, live-only events, and upstream-owned omissions.
+
+**Build.**
+
+- [ ] Treat typed DELETE 202 as accepted work, follow the returned or canonical state URL with bounded jittered backoff, and finish only at `not_found`. Evidence is an explicit deleting state and timeout error in the domain type.
+- [ ] Treat `aevatar.nyxid_chat.keepalive` as stream progress for liveness only. Evidence is a watchdog test that neither times out nor appends a message for keepalive-only intervals.
+- [ ] Refresh current state and conversation metadata after terminal stream settlement and action postcondition settlement. Evidence is a test that terminal task, attention, attachment, and action state update without a page reload.
+- [ ] Restore pending `service.connect` and `service.access_review` cards from actor current state after reload; the access-review half depends on `AC-3`. Evidence is a reload test with an actionable card and the original action identity.
+- [ ] Probe whether public transcript `operations` or current state can reconstruct `MEDIA_CONTENT` and generic `nyxid.authorization.required`. If neither can, record the upstream ownership, file or link a pinned upstream issue, and do not add NyxID shadow persistence. Evidence is the response capture and documented ownership decision.
+
+**You see.**
+
+- [ ] Delete a real conversation and observe a stable deleting state followed by permanent removal. Evidence is a recording with the 202 response, state polling, terminal 404 or `not_found`, and refreshed list.
+- [ ] Reload while an access-review card is pending and after a terminal action result. Evidence is a recording that shows the actionable card and final status restored without duplicate controls.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Frontend gate set in Appendix D and focused fake-timer lifecycle tests at the exact head. Evidence is the local logs, green `CI Pipeline` URL, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run a real Aevatar turn that emits keepalives for more than 120 seconds, delete a real typed conversation, reload a pending access-review card, and settle one action. Pass when no client stop is sent during keepalives, deletion ends only at absence, and available durable state restores exactly once. Evidence is the browser recording, redacted network trace, event ids, and deployment SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Race delete against list refresh, route selection, component unmount, network loss, and an active stream. Pass when active-stream deletion remains refused, accepted deletion cannot resurrect a row, abort stops polling, and timeout leaves a retryable state. Evidence is the deterministic race-test log and browser recording.
+- [ ] Feed malformed and high-frequency keepalives. Pass when only a valid normalized keepalive resets liveness, no attacker-controlled event suppresses timeout, and timer count stays bounded. Evidence is the fake-timer and malformed-frame test log.
+
+**Review gate.** Operator review is required because this phase adds a deleting state and changes reload behavior.
+
+- [ ] Have the operator inspect delete success, timeout, retry, pending-card reload, and long-turn recordings at desktop and mobile sizes. Evidence is the operator verdict linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-6` PR based on the exact `AC-5` head with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks.
+
+## Add credentialed producer proof and close the contract (AC-7)
+
+**Depends on.** `AC-6` is green and all product paths required by the done predicate exist.
+
+**Owner.** A delegated release-verification owner on a branch based on the exact `AC-6` head.
+
+**Verifier.** An independent read-only release verifier who checks the exact stack tip and live receipts.
+
+**Files.**
+
+- [ ] Extend `frontend/scripts/verify-aevatar-action-wake.mjs` into a redacted producer-contract runner or split it into focused modules under `frontend/scripts/aevatar-chat-canary/`. Evidence is a script diff that covers the final matrix and preserves the existing empty-action wake.
+- [ ] Add `frontend/e2e/live-aevatar.spec.ts` and a non-mock Playwright project in `frontend/playwright.config.ts`. Evidence is a test that never appends `mock=1` and requires an explicit credentialed staging configuration.
+- [ ] Add `.github/workflows/aevatar-chat-canary.yml` with secret-backed scheduled and manual runs against a controlled staging pair. Evidence is the workflow diff and one successful run URL.
+- [ ] Update `docs/chat/README.md`, `docs/chat/07-testing-and-gaps.md`, and the `AC-0` contract pin only after re-auditing the remote. Evidence is final documentation and pin values tied to the canary run.
+
+**Build.**
+
+- [ ] Cover first and follow-up text, input, approval, stop, steer, retry, skip, empty `actions`, `service.connect`, `service.access_review`, `key.create`, `key.rotate`, context attachments, state reload, and delete observation. Evidence is a machine-readable canary result with one row per capability.
+- [ ] Record NyxID head SHA, Aevatar source or image SHA, effective chat pin, timestamps, actor ids, turn ids, action ids, status codes, and safe reason codes. Evidence is the allowlisted JSONL schema and one validated receipt.
+- [ ] Fail instead of skip when the credentialed workflow is armed but a secret, seed, producer condition, or deployment version is missing. Evidence is negative workflow tests for every prerequisite.
+- [ ] Keep the mock Playwright suite as deterministic regression coverage and label it as mock evidence only. Evidence is the existing suite result next to the separate live result.
+- [ ] Re-run the capability matrix in Appendix E and mark a row complete only when its repository and live evidence exists at the exact stack tip. Evidence is the final matrix with links and no unsupported completeness claim.
+
+**You see.**
+
+- [ ] Open the canary run summary and see one green row per done-predicate capability plus exact source pins. Evidence is the workflow artifact and run URL.
+- [ ] Open the non-mock Playwright recording and see the real staging host, real network calls, access review, attachment selection, reload, and delete completion. Evidence is the trace, screenshots, and recording.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Frontend gate set, the `AC-0` drift checker, the canary parser tests, and the plan checker in Appendix D at the exact head. Evidence is the local logs, green `CI Pipeline` URL, and matching stack-tip SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the credentialed producer workflow against the controlled staging NyxID and Aevatar pair. Pass when every required row is green, no row is skipped, the browser uses no mock transport, and the receipt names both exact deployments. Evidence is the workflow URL, JSONL receipt, Playwright trace, screenshots, and recording.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Scan workflow logs and artifacts for JWTs, cookies, authorization codes, refresh tokens, API keys, credential payloads, and artifact bodies. Pass when the scan is empty and artifacts expose only allowlisted metadata. Evidence is the scanner log and independent verifier signature.
+- [ ] Change one pinned command, action, or watched upstream path in a temporary fixture. Pass when drift or canary validation turns red and identifies the exact changed capability. Evidence is the deliberate-failure run and restored clean run.
+
+**Review gate.** None. This phase adds test and documentation infrastructure and does not change the product interaction.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-7` stack tip with the root-to-tip PR order and no merge or auto-merge action. Evidence is every PR URL, exact base and head SHA, independent verdict, green `CI Pipeline`, live canary URL, and final capability matrix.
+
+## Close the program
+
+- [ ] Check every box above only after its named evidence exists. Evidence is the completed plan and its linked artifacts.
+- [ ] Return the Autopilot Stack final report to the operator. Evidence is the root-to-tip PR order, exact bases and heads, one verdict per link, live canary receipt, and every parked item with its reason.
+
+## Appendix A. Prototype evidence
+
+The audit settled what source inspection could settle. It did not have credentials for a live NyxID-to-Aevatar producer run. `AC-2` therefore owns the remaining deployed-auth experiment.
+
+| Question | Artifact | Result | Remaining proof |
+|---|---|---|---|
+| Does NyxID derive Aevatar scope from the authenticated user | `backend/src/handlers/assistant.rs` at `forward` and `backend/src/services/assistant_service.rs` path builders | Yes. The browser cannot submit `scopeId` for chat, history, state, or delete | Repeat for the new artifact-list route in `AC-5` |
+| Can a normal cookie session naturally trigger service access review | `backend/src/mw/auth.rs` session `AuthUser`, `build_forward_authorization`, and `TokenRestrictionClaims::from_auth_user` | Probably not. Session auth currently has `allow_all_services` true, an empty id list, and no resource list, which the bridge copies into its delegated token | Run the controlled deployed probe in `AC-2` |
+| Does identity assertion remove the need for a capability | Aevatar `NyxIdIdentityAssertionAuthentication.cs` and `NyxIdChatEndpoints.Streaming.cs` | No. The identity header becomes authoritative for caller identity, while streaming still extracts a Bearer or delegation token for NyxID capability | Verify the four-row header matrix in `AC-2` |
+| Are context attachments part of the public typed browser contract | Aevatar `NyxIdChatPublicEndpoints.cs`, `NyxIdChatEndpoints.Streaming.cs`, and `ConversationContextAttachmentAdmission.cs` | Yes. They are create-only, maximum four, and durable by reference | Exercise valid and rejected requests against the deployed pair in `AC-4` |
+| Does Aevatar require exact action-registry revisions | Aevatar `NyxIdAssistantActionRegistry.cs` after `0b8ec500087331c3d12819b532e7dfa29e740fb4` | No. `schema_version` gates the registry. Revision labels are observational. Descriptor failures degrade per action | Automate watched-path drift detection in `AC-0` |
+| Is current browser proof live | `frontend/e2e/helpers.ts` and `frontend/scripts/verify-aevatar-action-wake.mjs` | No. Playwright always adds `mock=1`; the producer script only proves an empty action wake when manually credentialed | Add the secret-backed canary and non-mock browser run in `AC-7` |
+| Can the bridge bearer read the endpoint Aevatar probes for access | `backend/src/mw/auth.rs` at `delegated_read_denied_path` and `delegated_request_allowed`; Aevatar `NyxIdRequireServiceTool.cs` at `InspectCurrentBearerServiceAccessAsync` and `NyxIdApiClient.cs` at `GetMcpConfigAsync` | No. `/api/v1/mcp` is a denied class for every delegated GET, so the probe returns access denied and Aevatar reports `SourceStale`, never `USER_SERVICE_ACCESS_REQUIRED` | Local-runtime receipt in `AC-2` |
+| Does a restricted token break chat bootstrap | `backend/src/handlers/proxy.rs` at the legacy `DownstreamService` scoped denial and `execute_admin_proxy`; Aevatar `appsettings.json` `GatewayEndpoint` | Probably on the proxy slug path; the LLM gateway path checks only scope | Receipts for both callback paths in `AC-2` |
+| Is the Aevatar OAuth client resolvable | Production `/users/me/consents` shows client `aevatar` id `a6ff2946-f02f-4c35-8203-1ec46132b660`; Aevatar `appsettings.json` `BackendConsole.OidcClientId` | Yes as a registered client; NyxID has no link from the catalog row to it | Decide the link in `AC-2` |
+
+Focused baseline evidence at NyxID `52402f6a5510478b3601636a25572055f895c973` is 75 passing frontend tests across eight files and 35 passing Rust `assistant_service` tests. The Rust run filtered out 5,674 tests. These are regression baselines, not integration proof.
+
+`npm ci` installed 608 packages and reported 21 audit findings. The report contained 1 low, 11 moderate, 8 high, and 1 critical finding. No audit fix ran. Dependency remediation is outside this program unless a finding affects a changed assistant path.
+
+## Appendix B. Alternatives rejected
+
+| Alternative | Decision | Reason |
+|---|---|---|
+| Declare parity from focused unit and mock Playwright tests | Rejected | They do not exercise a credentialed Aevatar producer or deployed auth headers |
+| Copy Aevatar Console's OAuth card before probing reachability | Rejected | NyxID's cookie session and proxy-minted capability differ from Aevatar Console's resource-scoped OAuth browser session |
+| Keep the unrestricted cookie bridge and add only a visual access-review card | Rejected | The action may remain unreachable and approval may not change the next capability token |
+| Shrink the default NyxID action manifest to current Aevatar executables | Rejected | Current Aevatar tolerates unknown and divergent descriptors per action; additive descriptors do not widen its executable set |
+| Keep a manual per-revision fixture as the upstream drift guard | Rejected | It stays green when upstream changes until a human edits it |
+| Keep `plan.resolve` as a compatibility adapter | Rejected | Current Aevatar classifies it as unsupported, and no current actor source emits a confirmation gate |
+| Leave `/assistant/completions` as arbitrary pass-through | Rejected | It bypasses typed reconstruction and has no proven current in-repository caller |
+| Accept browser-supplied artifact `scopeId` | Rejected | Scope belongs to the authenticated server boundary, not the client request |
+| Persist media or authorization payloads in a new NyxID shadow store | Rejected | It duplicates Aevatar actor ownership and risks storing content that the current public read model intentionally omits |
+| Add `inputParts` and explicit `agentProfile` selection now | Rejected | Aevatar Console omits both in its browser chat, and NyxID's current product boundary is prompt plus durable context references |
+| Deliver one rollup PR | Rejected | Auth, contract, UI, and liveness failures would be harder to isolate and independently verify |
+
+## Appendix C. Risks
+
+| Risk | Owner phase | Check | Failure signal |
+|---|---|---|---|
+| Upstream changes after the audit | `AC-0`, `AC-7` | Fetch and compare watched paths from the effective pin | Nonzero drift check with changed path names |
+| Identity works but Aevatar has no usable NyxID capability | `AC-2` | Four-row header matrix and real tool callback | Stream 401 or tool authorization failure |
+| Access review is unreachable from a cookie session | `AC-2` | Connected but unauthorized live probe | No `USER_SERVICE_ACCESS_REQUIRED` or unrestricted token claims |
+| Access review widens another user or service | `AC-3` | Recompute owner and resource server-side; adversarial substitutions | Consent or grant diff outside the exact owner and service |
+| Consent succeeds but the next token remains stale | `AC-3` | Mint after approval and verify Aevatar postcondition | Repeated access-review action or unverified postcondition |
+| Attachments disclose cross-tenant content | `AC-4`, `AC-5` | Reference-only DTO and cross-user probes | Body, backing key, access list, or foreign artifact in response |
+| Follow-up text mutates sealed attachments | `AC-4` | Create-only parser and live replacement probe | Changed attachment list on current state |
+| Delete 202 is mistaken for completion | `AC-6` | Poll state until `not_found` | Sidebar row reappears after accepted delete |
+| Keepalive-blind watchdog stops a valid long turn | `AC-6` | More than 120 seconds of keepalive-only liveness | Client sends `task.stop` or aborts the stream |
+| History cannot restore live media or a generic auth blocker | `AC-6` | Inspect transcript operations and actor current state | Required state exists only in an expired SSE event |
+| Canary leaks credentials | `AC-7` | Allowlisted JSONL and secret scanner | Token, cookie, code, key, credential, or artifact body match |
+| A mock run is reported as live | `AC-7` | Separate non-mock Playwright project and strict prerequisites | `mock=1`, installed mock handler, or skipped credentialed row |
+| Removing completions breaks an external caller | `AC-1` | Production access evidence before deletion | Named current caller within the agreed retention window |
+
+## Appendix D. Links and reading list
+
+Repository policy and required gates live in `CONTRIBUTING.md`, `WORKFLOW.md`, and `.github/workflows/ci.yml`. Pull requests target `main` by default. A dependent phase PR targets its verified parent branch until the parent lands, then the root coordinator retargets it. At least one approval is required. Security-sensitive phases also require explicit security review. `CI Pipeline` is the required status. Auto-merge stays disabled.
+
+The Backend gate set is the following command group.
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run -p nyxid --profile ci
+cargo build -p nyxid --features aws-kms
+cargo build -p nyxid --features gcp-kms
+cargo build -p nyxid --features aws-kms,gcp-kms
+```
+
+The Frontend gate set is the following command group.
+
+```bash
+npm --prefix frontend run lint
+npm --prefix frontend run test
+npm --prefix frontend run build
+cargo test -p nyxid-cli --test wizard_bundle_freshness
+```
+
+Run the plan checker with the following command.
+
+```bash
+node /Users/chronoai/.codex/skills/heca-mode/references/check-plan.mjs docs/plans/aevatar-chat-feature-integrate-convergence.md
+```
+
+Core NyxID reading is `docs/chat/README.md`, `docs/chat/01-architecture.md`, `docs/chat/02-wire-contract.md`, `docs/chat/03-stream-protocol.md`, `docs/chat/04-action-cards.md`, `docs/chat/05-frontend-ui.md`, `docs/chat/06-actions-registry.md`, and `docs/chat/07-testing-and-gaps.md`.
+
+Core Aevatar reading at the audited clone is listed below.
+
+| Concern | Source |
+|---|---|
+| Public commands and attachments | `agents/Aevatar.GAgents.NyxidChat/NyxIdChatPublicEndpoints.cs` and `NyxIdChatEndpoints.Streaming.cs` |
+| Attachment admission | `agents/Aevatar.GAgents.NyxidChat/ConversationContextAttachmentAdmission.cs` and `NyxIdChatLifecycleFacade.cs` |
+| Artifact discovery contract | `src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs` and `src/Aevatar.Studio.Application.Abstractions/Studio/Contracts/ContentArtifactContracts.cs` |
+| Access-review production | `agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs` and `NyxIdChatConversationAguiFrameBuilder.cs` |
+| Action registry | `agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs` |
+| Browser reference | `apps/aevatar-console-web/src/pages/chat/chatActorState.ts`, `ChatActorControls.tsx`, `index.tsx`, and `apps/aevatar-console-web/src/shared/auth/client.ts` |
+| Identity assertion | `src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionAuthentication.cs` |
+
+Owners must read the active `heca-mode` skill, `references/playbook-autopilot-stack.md`, `pstack-architect`, `pstack-tdd`, `pstack-unslop`, `pstack-no-comments`, and `pstack-technical-writing` before editing. Security verifiers must also use `pstack-interrogate`. UI owners must exercise the real browser surface and attach screenshots or recordings.
+
+The external source is [Aevatar feature/integrate](https://github.com/aevatarAI/aevatar/tree/feature/integrate). Relevant upstream commits are [service access review](https://github.com/aevatarAI/aevatar/commit/0c5d4fbdb8e50037f78c5faa5e631d94e8dd30d7), [typed context attachments](https://github.com/aevatarAI/aevatar/commit/a850250d9c7822420bf4b07594b15397d80e71cd), [attachment readback and reasons](https://github.com/aevatarAI/aevatar/commit/676d577fd381e1b3dae227579b435662d6d49a44), [plan confirmation removal](https://github.com/aevatarAI/aevatar/commit/bf0536bf1d0f118e5fc50e4faf1fa19703796add), and [per-action registry degrade](https://github.com/aevatarAI/aevatar/commit/0b8ec500087331c3d12819b532e7dfa29e740fb4).
+
+## Appendix E. Capability matrix
+
+Verdicts use five values. `complete` means the current Aevatar contract has a NyxID implementation and focused tests. `partial` means a real path exists with a known gap. `missing` means the claimed browser experience requires the capability and NyxID lacks it. `obsolete` means NyxID still exposes behavior Aevatar removed. `not in scope` means the capability belongs outside this browser-chat program.
+
+| Capability | Current verdict | Evidence and gap | Target phase |
+|---|---|---|---|
+| Human cookie authorization boundary | complete | Human-only middleware rejects API key, service-account, delegated, and relay auth | Preserve in every phase |
+| Transport identity assertion and capability bearer | partial | Identity assertion is implemented, but the unrestricted cookie bridge may make access review unreachable and Aevatar still needs a capability | `AC-2`, `AC-3` |
+| Typed command reconstruction | partial | Strict reconstruction exists, but includes obsolete `plan.resolve` and omits context attachments | `AC-1`, `AC-4` |
+| SSE and AG-UI normalization | complete | The normalizer handles the current named actor facts and AG-UI frames | Preserve in `AC-6` |
+| Actor and session identity | complete | First-run adoption and follow-up identity checks reject actor changes | Preserve in `AC-7` |
+| First and follow-up turns | complete | First text omits conversation id; later text binds the adopted actor | Live proof in `AC-7` |
+| Conversation list, history, state, and delete | partial | List, transcript, and state exist; delete treats 202 as completion and transcript operations are ignored | `AC-6` |
+| Input, approval, stop, steer, retry, and skip | complete | Typed paths exist with state-version fences | Live proof in `AC-7` |
+| `service.connect` | complete | Implemented card, continuation report, and postcondition path; no credentialed producer receipt | Live proof in `AC-7` |
+| `key.create` and `key.rotate` | complete | Implemented dialogs and safe reports; no credentialed producer receipt | Live proof in `AC-7` |
+| Action reports and postconditions | complete | Existing action paths wait on typed Aevatar continuation and postcondition state | Refresh and live proof in `AC-6`, `AC-7` |
+| `service.reauthorize` | partial | NyxID advertises and renders it, while current Aevatar knows but does not execute it | Document in `AC-1`; no parity claim |
+| `service.access_review` | missing | Unknown-action recovery is decline-only | `AC-2`, `AC-3` |
+| Context-attachment transport | missing | Strict `RawTextChatCommand` rejects the field | `AC-4` |
+| Context-attachment discovery and UX | missing | No safe artifact route or new-chat picker exists | `AC-5` |
+| `plan.resolve` | obsolete | Backend and frontend still parse and send a command Aevatar rejects | `AC-1` |
+| Registry deployment semantics and docs | partial | Tests and docs still encode obsolete exact-revision behavior | `AC-0`, `AC-1` |
+| Keepalive liveness | partial | Valid keepalives do not reset the 120-second watchdog | `AC-6` |
+| Media restoration | partial | `MEDIA_CONTENT` renders live but is not restored from current NyxID history decoding | Classify and close available recovery in `AC-6` |
+| Authorization-card restoration | partial | Some actor cards restore from state; live-only generic authorization events do not | `AC-3`, `AC-6` |
+| Credentialed producer proof | missing | Playwright uses `mock=1`; the manual script covers only empty action wake | `AC-7` |
+| Direct engine durability | not in scope | Direct Chrono-LLM is a separate memory-only engine | Excluded |
+| `inputParts` | not in scope | Aevatar Studio uses it, but current Aevatar Console browser chat and NyxID's product boundary do not | Excluded |
+| Explicit `agentProfile` selection | not in scope | Optional upstream field with no current NyxID browser requirement | Excluded |
+| Assistant feature-flag route enforcement | partial | The flag hides navigation but does not block the page or API | Product-policy decision outside Aevatar contract parity |
+
+## Appendix F. Audit pins and independent review
+
+| Item | Value |
+|---|---|
+| NyxID worktree | `/Users/chronoai/Library/Application Support/heca/worktrees/ea204fe1/swift-mesa` |
+| NyxID branch | `add-test` |
+| Audited NyxID HEAD | `52402f6a5510478b3601636a25572055f895c973` |
+| `origin/main` observed during audit | `bba9682c9ab1bf166f7676982b61b7cf1995f50e` |
+| Merge base | `52402f6a5510478b3601636a25572055f895c973` |
+| Aevatar clone | `/tmp/aevatar-integrate.R1n4oF/repo` |
+| Aevatar branch HEAD | `d53d150817c17f06e9e58b069d2da9ec41196900` |
+| Effective last changed chat SHA | `b0b3738ed9477513edbfc6b9a6a75f14a592dbf4` |
+| Prior NyxID documentation pin | `e7ba2e6eb` |
+| Heca invocation | `01a060f1-08a4-7a00-9ef0-98b960983381` |
+| Independent Grok agent | `01a060f1-08aa-7390-86c8-7c8bb67c1a04` |
+| Independent provider | `grok` |
+| Independent model | `grok-4.6` |
+| Independent effort | `x_high`, requested as `xhigh` |
+| Independent mode | `bypassPermissions` |
+| Independent final state | `idle` |
+| Independent final activity | sequence `5628`, output event id `707723` |
+| Watched chat paths after effective SHA | No changes through Aevatar branch HEAD |
+| NyxID stack base (`origin/main` at program start) | `4bc00e1a103b94ad7847aa776b50bfa87572c68d` |
+| Aevatar branch HEAD at program start | `e5bba2e9719ad5132004b882744caa3875db1123` |
+| Effective chat SHA at program start | `706ea7cab9d1f882e0fb0f034bb338102b6d5d2b` (tool-catalog materialization only; browser contract files unchanged since `b0b3738e`) |
+| Operator go | 2026-09-02, this session, Fable restricted to planning |
+
+The independent review answered no to the completeness question. Its additional validated findings were accepted for delete 202 observation, keepalive liveness, untyped completions forwarding, lack of credentialed producer proof, and the identity-versus-capability distinction. Its feature-flag finding is a product-policy issue, not an Aevatar contract defect. Its recommendation to shrink the default action manifest was rejected because current upstream code degrades unknown or divergent descriptors per action.
+
+No product code changed during the audit. `frontend/node_modules` was installed with `npm ci` and remains ignored. No live NyxID-to-Aevatar producer test ran because the required deployment credentials and controlled producer state were unavailable.
+
+## Appendix G. Pinned wire facts
+
+The canonical public command set is shown below.
+
+```text
+text
+input.resolve
+action.continue
+approval.resolve
+task.stop
+task.steer
+step.retry
+step.skip
+```
+
+The internal Aevatar access-review action uses the following parameters.
+
+```text
+action = service.access_review
+userServiceId
+serviceSlug
+resourceUri
+```
+
+The context-attachment request shape is shown below.
+
+```text
+contextAttachments[]
+  artifactId
+  revisionMode = follow_current | pinned_revision
+  pinnedRevisionId
+```
+
+The attachment set is create-only and sealed to the conversation. It contains at most four unique nonempty artifact ids. `pinned_revision` requires `pinnedRevisionId`. `follow_current` clears it. Allowed kinds are `text`, `markdown`, and `structured_document`. Public list and current-state reads expose references, not bodies. Admission uses `ATTACHMENT_ADMISSION_DENIED` and the reason set pinned in `AC-4`.
+
+Aevatar delete returns HTTP 202 with `status` set to `accepted` and a `stateUrl`. The client must observe state until `not_found`. Aevatar sends keepalive events every 15 seconds. NyxID's 120-second progress watchdog must count a valid keepalive as liveness without rendering it.
+
+## Appendix H. Principles that changed this plan
+
+| Principle | Concrete choice |
+|---|---|
+| Prove It Works | The done predicate requires live browser and producer receipts, exact-head evidence, a real remote drift check, and deployment SHAs. Mock Playwright does not close a capability row |
+| Sequence Work into Verifiable Units | The stack removes drift and obsolete paths before auth, actions, attachments, UX, liveness, and release proof. A dependent phase starts only after its parent has a green exact-head verdict |
+| Guard the Context Window | The audit read targeted symbols and commit deltas, preserved summarized evidence here, and avoided copying complete source files into the plan |
+| Never Block on the Human | Reversible scope and phase decisions are fixed now. Operator attention is reserved for explicit UI review, security authority, and merge gates |
+| Foundational Thinking | `AC-0` establishes contract types and drift detection. `AC-4` establishes the attachment data shape before the picker uses it |
+| Boundary Discipline | NyxID reconstructs typed Aevatar bodies, derives scope and resource identity server-side, and returns a dedicated reference-only artifact DTO |
+| Build the Lever | `AC-0` replaces manual fixture synchronization with a rerunnable drift checker. `AC-7` adds a rerunnable credentialed contract canary |
+| Subtract Before You Add | `AC-1` removes `plan.resolve`, the unsafe unused completions route, and stale revision assumptions before new state is added |
+| Migrate Callers Then Delete Legacy APIs | Every `plan.resolve` caller, parser, control, fixture, test, and current-contract document moves or disappears in one phase |
+| Model the Domain | Access review, attachment revision mode, deleting state, typed errors, and canary results use explicit variants and state transitions instead of generic objects or booleans |
+
+## Appendix I. Open decisions and stop conditions
+
+`AC-2` must choose the deployed authorization-session model. The current recommendation is consent-derived delegated restrictions, but only if the live probe proves bootstrap, client identity, mutation, revocation, and next-token behavior. A failed predicate changes the decision before product code starts.
+
+`AC-1` must inspect production access evidence before removing `/api/v1/assistant/completions`. A current external caller pauses deletion until its owner and strict typed contract are known. Repository search alone cannot disprove external use.
+
+`AC-6` must classify media and generic authorization recovery from the public Aevatar read models. If upstream exposes no durable source, the owner files or links an upstream issue and documents the boundary. NyxID does not create a shadow content store to manufacture parity.
+
+The `experimental:ai-assistant` flag currently hides navigation only. Whether it must also block the route and backend API is a NyxID product-policy choice. It does not block this Aevatar contract program and needs a separate operator decision.
+
+Any Aevatar watched-path drift, failed security review, missing credentialed staging prerequisite, changed phase head after verification, or red `CI Pipeline` voids the current verdict. The affected phase remains unready and no dependent phase advances.
+
+## Appendix J. Decisions taken at program start and live-environment constraints
+
+The operator delegated these decisions by authorizing execution on the reviewer's recommendation.
+
+| Decision | Choice | Reversible by |
+|---|---|---|
+| Authority model candidate | Consent-derived delegated restrictions with the three enabling NyxID changes, falsifiable by the `AC-2` probe rows | `AC-2` decision record |
+| Aevatar client identity | Admin-managed link from the `aevatar` catalog row to the registered OAuth client, chosen in `AC-2` | `AC-2` decision record |
+| Consent mutation semantics | Merge, never replace, in `consent_service`; the OAuth consent page's replace behavior is filed as a separate issue | `AC-3` review |
+| `/api/v1/assistant/completions` | Delete. The route sits on the human-only router, which rejects API keys, service accounts, delegated, and relay tokens, and no CLI, SDK, mobile, or frontend caller exists. Route-level telemetry does not exist, so router policy is the access evidence | `AC-1` review |
+| `experimental:ai-assistant` enforcement | Out of scope; filed as a separate issue | Operator |
+| Delegated routing | `~/.heca/pstack-models.json` with every `claude-fable` selection replaced by the next entry in its chain, because the operator restricted Fable to planning | Operator |
+
+These live-environment constraints were observed at program start.
+
+- No staging NyxID or Aevatar pair exists. The production pair is NyxID `https://nyx-api.chrono-ai.fun` and Aevatar `https://aevatar-console-backend-api.aevatar.ai`.
+- Aevatar validates NyxID tokens against production JWKS, so a changed local NyxID cannot be exercised against real Aevatar before deployment. Deployment is operator authority.
+- `dotnet` is not installed, so Aevatar cannot run locally. Docker is not running; a local single-node replica-set mongod on `127.0.0.1:27017` serves backend tests.
+- Each phase names its live surface honestly. The surfaces are production read-only probes where no NyxID change is required, the local NyxID runtime with real HTTP for changed NyxID behavior, and the credentialed canary in `AC-7` designed to run after deployment. A mock run is never reported as live.

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -18,6 +18,10 @@ export const SEEDED = {
   },
   github: { id: "conversation-github", title: "Rotate GitHub deploy key" },
   weekly: { id: "conversation-weekly", title: "Weekly usage report" },
+  taskPlan: {
+    id: "conversation-task-plan",
+    title: "Historical task plan",
+  },
 } as const;
 
 /** Final text every scripted mock turn streams (createScriptedTurn). */

--- a/frontend/e2e/new-chat.spec.ts
+++ b/frontend/e2e/new-chat.spec.ts
@@ -36,7 +36,7 @@ test("a first send stays continuous through the canonical id transition", async 
     ),
   ).toBeVisible();
   expect(new URL(page.url()).searchParams.has("c")).toBe(false);
-  await expect(sidebarRows).toHaveCount(3);
+  await expect(sidebarRows).toHaveCount(4);
   for (const conversation of Object.values(SEEDED)) {
     await expect(conversationRow(page, conversation.title)).toHaveCSS(
       "font-weight",
@@ -57,7 +57,7 @@ test("a first send stays continuous through the canonical id transition", async 
   ).toBeVisible({ timeout: 5_000 });
   await expect(composerInput(page)).toBeEnabled({ timeout: 10_000 });
   await expect(echoedMessage).toHaveCount(1);
-  await expect(sidebarRows).toHaveCount(4);
+  await expect(sidebarRows).toHaveCount(5);
 
   const newRow = conversationRow(page, message);
   await expect(newRow).toHaveCount(1);

--- a/frontend/e2e/task-plan.spec.ts
+++ b/frontend/e2e/task-plan.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { writeFileSync } from "node:fs";
+import { openAssistant, SEEDED } from "./helpers";
+
+test("a historical confirm-gate snapshot stays readable and sends no plan.resolve", async (
+  { page },
+  testInfo,
+) => {
+  const network: string[] = [];
+  page.on("request", (request) => {
+    const body = request.postData() ?? "";
+    network.push(`${request.method()} ${request.url()} ${body}`);
+  });
+
+  await openAssistant(page, { conversation: SEEDED.taskPlan.id });
+  const plan = page.getByRole("region", { name: "Task plan" });
+  await expect(plan).toBeVisible({ timeout: 20_000 });
+  await expect(plan.getByText("Publish a weekly update")).toBeVisible();
+  await expect(plan.getByText("confirm / pending")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Confirm plan" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Reject plan" }),
+  ).toHaveCount(0);
+
+  const screenshotPath = testInfo.outputPath("task-plan-after.png");
+  await plan.screenshot({ path: screenshotPath });
+  await testInfo.attach("task-plan-after", {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+  const networkPath = testInfo.outputPath("task-plan-network.log");
+  writeFileSync(networkPath, `${network.join("\n")}\n`);
+  await testInfo.attach("task-plan-network", {
+    path: networkPath,
+    contentType: "text/plain",
+  });
+
+  expect(
+    network.filter((entry) => entry.includes("plan.resolve")),
+  ).toEqual([]);
+});

--- a/frontend/src/components/assistant/assistant-chat-page.tsx
+++ b/frontend/src/components/assistant/assistant-chat-page.tsx
@@ -196,7 +196,6 @@ export function AssistantChatPage() {
       actionOverrides={chat.actionOverrides}
       onResolveInput={chat.resolveInput}
       onResolveApproval={chat.resolveApproval}
-      onResolvePlan={chat.resolvePlan}
       onStop={chat.stop}
       onControlStep={chat.controlStep}
       onActionProgress={(requestId, active) =>

--- a/frontend/src/components/assistant/assistant-wire-log-panel.test.tsx
+++ b/frontend/src/components/assistant/assistant-wire-log-panel.test.tsx
@@ -225,7 +225,7 @@ describe("AssistantWireLogPanel", () => {
       "header",
       200,
       null,
-      "POST /assistant/completions",
+      "GET /assistant/actions",
     );
 
     renderWithTooltips(
@@ -238,7 +238,7 @@ describe("AssistantWireLogPanel", () => {
       screen.queryByText("GET /assistant/conversations/other"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("POST /assistant/completions"),
+      screen.queryByText("GET /assistant/actions"),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("switch", { name: "Show all conversations" }),
@@ -251,7 +251,7 @@ describe("AssistantWireLogPanel", () => {
     expect(
       screen.getByText("GET /assistant/conversations/other"),
     ).toBeInTheDocument();
-    expect(screen.getByText("POST /assistant/completions")).toBeInTheDocument();
+    expect(screen.getByText("GET /assistant/actions")).toBeInTheDocument();
   });
 
   it("fetches an id-backed payload only after its metadata row expands", async () => {

--- a/frontend/src/components/assistant/blocks/task-plan-card.test.tsx
+++ b/frontend/src/components/assistant/blocks/task-plan-card.test.tsx
@@ -66,14 +66,12 @@ describe("TaskPlanCard", () => {
     const onStop = vi.fn().mockResolvedValue(undefined);
     const onRetry = vi.fn().mockResolvedValue(undefined);
     const onSkip = vi.fn().mockResolvedValue(undefined);
-    const onResolve = vi.fn().mockResolvedValue(undefined);
     render(
       <TaskPlanCard
         block={block()}
         onStop={onStop}
         onRetry={onRetry}
         onSkip={onSkip}
-        onResolve={onResolve}
       />,
     );
 
@@ -113,7 +111,6 @@ describe("TaskPlanCard", () => {
         onStop={vi.fn()}
         onRetry={vi.fn()}
         onSkip={vi.fn()}
-        onResolve={vi.fn()}
       />,
     );
 
@@ -128,8 +125,7 @@ describe("TaskPlanCard", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("offers only the exact pending confirm gate and dispatches both decisions", async () => {
-    const onResolve = vi.fn().mockResolvedValue(undefined);
+  it("renders a historical confirm gate as a readable plan with no confirm controls", () => {
     render(
       <TaskPlanCard
         block={block(
@@ -146,18 +142,17 @@ describe("TaskPlanCard", () => {
         onStop={vi.fn()}
         onRetry={vi.fn()}
         onSkip={vi.fn()}
-        onResolve={onResolve}
       />,
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Confirm plan" }));
-    });
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Reject plan" }));
-    });
-    expect(onResolve).toHaveBeenNthCalledWith(1, true);
-    expect(onResolve).toHaveBeenNthCalledWith(2, false);
+    expect(screen.getByText("Publish a weekly update")).toBeInTheDocument();
+    expect(screen.getByText("confirm / pending")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Confirm plan" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reject plan" }),
+    ).not.toBeInTheDocument();
   });
 
   it("disables plan, step, and stop controls behind the state-version fence", () => {
@@ -178,7 +173,6 @@ describe("TaskPlanCard", () => {
         onStop={vi.fn()}
         onRetry={vi.fn()}
         onSkip={vi.fn()}
-        onResolve={vi.fn()}
       />,
     );
 

--- a/frontend/src/components/assistant/blocks/task-plan-card.tsx
+++ b/frontend/src/components/assistant/blocks/task-plan-card.tsx
@@ -29,12 +29,7 @@ interface TaskPlanCardBlock {
   readonly plan: ChatTaskPlan;
 }
 
-type TaskControl =
-  | "stop"
-  | "plan:confirm"
-  | "plan:reject"
-  | `retry:${string}`
-  | `skip:${string}`;
+type TaskControl = "stop" | `retry:${string}` | `skip:${string}`;
 
 const STATUS_STYLE: Record<ChatTaskStepStatus, string> = {
   planned: "text-text-tertiary",
@@ -192,20 +187,16 @@ export function TaskPlanCard({
   onStop,
   onRetry,
   onSkip,
-  onResolve,
 }: {
   readonly block: TaskPlanCardBlock;
   readonly disabled?: boolean;
   readonly onStop: () => Promise<void>;
   readonly onRetry: (stepId: string) => Promise<void>;
   readonly onSkip: (stepId: string) => Promise<void>;
-  readonly onResolve: (confirmed: boolean) => Promise<void>;
 }) {
   const [pending, setPending] = useState<TaskControl | null>(null);
   const plan = block.plan;
   const canStop = plan.steps.some((step) => step.availableActions.stop);
-  const pendingGate =
-    plan.gate?.mode === "confirm" && plan.gate.status === "pending";
 
   async function run(control: TaskControl, action: () => Promise<void>) {
     if (disabled || pending) return;
@@ -247,40 +238,6 @@ export function TaskPlanCard({
         <p className="border-b border-border px-3 py-2 text-[10px] leading-relaxed text-muted-foreground">
           {plan.gate.reason}
         </p>
-      ) : null}
-      {pendingGate ? (
-        <div className="flex flex-wrap items-center justify-end gap-1.5 border-b border-border px-3 py-2">
-          <Button
-            type="button"
-            size="sm"
-            variant="primary"
-            disabled={disabled || pending !== null}
-            onClick={() =>
-              void run("plan:confirm", () => onResolve(true))
-            }
-          >
-            {pending === "plan:confirm" ? (
-              <Loader2 className="animate-spin" />
-            ) : (
-              <Check />
-            )}
-            Confirm plan
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="destructive"
-            disabled={disabled || pending !== null}
-            onClick={() => void run("plan:reject", () => onResolve(false))}
-          >
-            {pending === "plan:reject" ? (
-              <Loader2 className="animate-spin" />
-            ) : (
-              <X />
-            )}
-            Reject plan
-          </Button>
-        </div>
       ) : null}
       <ol className="divide-y divide-border">
         {plan.steps.map((step) => (

--- a/frontend/src/components/assistant/chat-actor-controls.tsx
+++ b/frontend/src/components/assistant/chat-actor-controls.tsx
@@ -11,7 +11,6 @@ import type {
   ChatPendingInput,
 } from "@/lib/assistant/chat-actor-state";
 import type { ChatInputAnswer } from "@/lib/assistant/chat-api";
-import type { ChatPlanGate } from "@/lib/assistant/chat-task-plan";
 import type { ActionReport } from "@/schemas/assistant-actions";
 import type { InputCardContentBlock } from "@/types/assistant";
 
@@ -39,7 +38,6 @@ export function ChatActorControls({
   actionOverrides,
   onResolveInput,
   onResolveApproval,
-  onResolvePlan,
   onStop,
   onControlStep,
   onActionProgress,
@@ -59,10 +57,6 @@ export function ChatActorControls({
   readonly onResolveApproval: (
     requestId: string,
     approved: boolean,
-  ) => Promise<void>;
-  readonly onResolvePlan: (
-    confirmed: boolean,
-    gate: ChatPlanGate,
   ) => Promise<void>;
   readonly onStop: () => Promise<void>;
   readonly onControlStep: (
@@ -113,10 +107,6 @@ export function ChatActorControls({
           onSkip={(stepId) => {
             const step = projection.steps.get(stepId);
             return step ? onControlStep("step.skip", step) : Promise.resolve();
-          }}
-          onResolve={(confirmed) => {
-            const gate = projection.task?.gate;
-            return gate ? onResolvePlan(confirmed, gate) : Promise.resolve();
           }}
         />
       ) : null}

--- a/frontend/src/components/assistant/chat-actor-controls.view.test.tsx
+++ b/frontend/src/components/assistant/chat-actor-controls.view.test.tsx
@@ -33,7 +33,6 @@ const callbacks = {
   actionOverrides: new Map(),
   onResolveInput: vi.fn(),
   onResolveApproval: vi.fn(),
-  onResolvePlan: vi.fn(),
   onStop: vi.fn(),
   onControlStep: vi.fn(),
   onActionProgress: vi.fn(),

--- a/frontend/src/hooks/use-assistant-chat-controls.ts
+++ b/frontend/src/hooks/use-assistant-chat-controls.ts
@@ -12,7 +12,6 @@ import type {
 import { createClientId, stringField } from "@/lib/assistant/chat-session-state";
 import { currentActorTurnId, ReaderStoppedError } from "@/lib/assistant/chat-session-runtime";
 import type { ChatSessionState } from "@/lib/assistant/chat-types";
-import type { ChatPlanGate } from "@/lib/assistant/chat-task-plan";
 import type { ActionReport } from "@/schemas/assistant-actions";
 
 type ControlCommand = Exclude<ChatCommand, { readonly type: "text" }>;
@@ -77,33 +76,6 @@ export function useAssistantChatControls({
         clientRequestId: createClientId(),
         approved,
         ...(reason?.trim() ? { reason: reason.trim() } : {}),
-        expectedStateVersion: context.state.stateVersion,
-      });
-    },
-    [controlContext, dispatchAcceptedCommand],
-  );
-
-  const resolvePlan = useCallback(
-    async (confirmed: boolean, gate: ChatPlanGate) => {
-      const context = controlContext();
-      if (
-        !context ||
-        gate.mode !== "confirm" ||
-        gate.status !== "pending" ||
-        !gate.requestId ||
-        !gate.taskId ||
-        !gate.planId ||
-        gate.planRevision === undefined
-      ) return;
-      await dispatchAcceptedCommand(context.key, {
-        type: "plan.resolve",
-        conversationId: context.conversationId,
-        taskId: gate.taskId,
-        planId: gate.planId,
-        requestId: gate.requestId,
-        clientRequestId: createClientId(),
-        planRevision: gate.planRevision,
-        confirmed,
         expectedStateVersion: context.state.stateVersion,
       });
     },
@@ -208,7 +180,6 @@ export function useAssistantChatControls({
     reportAction,
     resolveApproval,
     resolveInput,
-    resolvePlan,
     steer,
     stop,
   } as const;

--- a/frontend/src/hooks/use-assistant-chat.test.tsx
+++ b/frontend/src/hooks/use-assistant-chat.test.tsx
@@ -1022,7 +1022,6 @@ describe("useAssistantChat", () => {
     const projection = result.current.projection!;
     const input = projection.pendingInput!;
     const approval = projection.pendingApproval!;
-    const gate = projection.task!.gate!;
     const step = projection.steps.get("step-active")!;
 
     await act(async () =>
@@ -1035,7 +1034,6 @@ describe("useAssistantChat", () => {
         "Not now",
       ),
     );
-    await act(async () => result.current.resolvePlan(true, gate));
     await act(async () => result.current.steer("Keep the current scope"));
     await act(async () => result.current.controlStep("step.retry", step));
     await act(async () => result.current.controlStep("step.skip", step));
@@ -1051,20 +1049,19 @@ describe("useAssistantChat", () => {
     expect(commands.map((command) => command.type)).toEqual([
       "input.resolve",
       "approval.resolve",
-      "plan.resolve",
       "task.steer",
       "step.retry",
       "step.skip",
       "task.stop",
       "action.continue",
     ]);
-    for (const command of commands.slice(0, 7)) {
+    for (const command of commands.slice(0, 6)) {
       expect(command.expectedStateVersion).toBe(7);
     }
     expect(commands[1]).toMatchObject({ approved: false, reason: "Not now" });
+    expect(commands[3]).toMatchObject({ expectedOperationGeneration: 4 });
     expect(commands[4]).toMatchObject({ expectedOperationGeneration: 4 });
-    expect(commands[5]).toMatchObject({ expectedOperationGeneration: 4 });
-    expect(stateReads).toBeGreaterThanOrEqual(10);
+    expect(stateReads).toBeGreaterThanOrEqual(9);
     expect(
       result.current.session?.messages.some(
         (message) => message.content === "NyxID action update: declined.",
@@ -1158,9 +1155,6 @@ describe("useAssistantChat", () => {
         projection.pendingApproval!.approvalRequestId,
         true,
       ),
-    );
-    await act(async () =>
-      result.current.resolvePlan(true, projection.task!.gate!),
     );
     await act(async () => result.current.steer("Do not send"));
     await act(async () =>

--- a/frontend/src/hooks/use-assistant-chat.ts
+++ b/frontend/src/hooks/use-assistant-chat.ts
@@ -662,7 +662,6 @@ export function useAssistantChat({
     reportAction,
     resolveApproval,
     resolveInput,
-    resolvePlan,
     steer,
     stop,
   } = useAssistantChatControls({
@@ -760,7 +759,6 @@ export function useAssistantChat({
     reportAction,
     resolveApproval,
     resolveInput,
-    resolvePlan,
     send,
     session,
     setActionOverride,

--- a/frontend/src/lib/assistant/assistant-http-fixture-data.ts
+++ b/frontend/src/lib/assistant/assistant-http-fixture-data.ts
@@ -175,7 +175,56 @@ export function createSeededAssistantFixtureConversations(): AssistantFixtureCon
       ],
       14,
     ),
+    (() => {
+      const seeded = conversation(
+        "conversation-task-plan",
+        "Historical task plan",
+        [
+          storedMessage(
+            "message-task-plan-user",
+            "user",
+            "Publish a weekly update once the plan is confirmed.",
+            now - 4 * 86_400_000,
+          ),
+          storedMessage(
+            "message-task-plan-assistant",
+            "assistant",
+            "Here is the task plan.",
+            now - 4 * 86_400_000 + 60_000,
+          ),
+        ],
+        4,
+      );
+      seeded.activeTask = historicalConfirmGateTask(
+        "conversation-task-plan",
+        "turn-task-plan",
+      );
+      seeded.activeTurn = {
+        turnId: "turn-task-plan",
+        taskId: "task-turn-task-plan",
+        status: "active",
+      };
+      seeded.stateVersion = 7;
+      seeded.progressSequence = 7;
+      return seeded;
+    })(),
   ];
+}
+
+export function historicalConfirmGateTask(actorId: string, turnId: string) {
+  return {
+    ...activeTaskFixture(actorId, turnId),
+    title: "Publish a weekly update",
+    gate: {
+      mode: "confirm",
+      status: "pending",
+      requestId: "plan-gate-historical",
+      taskId: `task-${turnId}`,
+      planId: `plan-${turnId}`,
+      planRevision: 1,
+      reason: "Confirm the planned write steps.",
+    },
+  };
 }
 
 export function activeTaskFixture(actorId: string, turnId: string) {

--- a/frontend/src/lib/assistant/assistant-http-fixtures.ts
+++ b/frontend/src/lib/assistant/assistant-http-fixtures.ts
@@ -311,14 +311,6 @@ export class AssistantHttpFixtureWorld {
       conversation.pendingApproval = null;
     } else if (type === "input.resolve") {
       conversation.pendingInput = null;
-    } else if (type === "plan.resolve" && conversation.activeTask) {
-      conversation.activeTask = {
-        ...conversation.activeTask,
-        gate: {
-          ...asRecord(conversation.activeTask.gate),
-          status: body.confirmed === true ? "satisfied" : "rejected",
-        },
-      };
     } else if (type === "task.stop") {
       conversation.activeTurn = null;
       conversation.latestTurn = { turnId: body.turnId, status: "stopped" };

--- a/frontend/src/lib/assistant/chat-api.test.ts
+++ b/frontend/src/lib/assistant/chat-api.test.ts
@@ -1,7 +1,54 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { sendChatCommand, ChatApiError } from "@/lib/assistant/chat-api";
+import {
+  sendChatCommand,
+  ChatApiError,
+  type ChatCommand,
+} from "@/lib/assistant/chat-api";
+
+const PIN = JSON.parse(
+  readFileSync(
+    path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../../tests/fixtures/assistant/aevatar-chat-contract-pin.json",
+    ),
+    "utf8",
+  ),
+) as { public_commands: string[] };
+
+type ChatCommandType = ChatCommand["type"];
+const PUBLIC_COMMAND_TYPES = [
+  "text",
+  "input.resolve",
+  "action.continue",
+  "approval.resolve",
+  "task.stop",
+  "task.steer",
+  "step.retry",
+  "step.skip",
+] as const satisfies readonly ChatCommandType[];
+
+const _exhaustiveCommandTypes: Record<ChatCommandType, true> = {
+  text: true,
+  "input.resolve": true,
+  "action.continue": true,
+  "approval.resolve": true,
+  "task.stop": true,
+  "task.steer": true,
+  "step.retry": true,
+  "step.skip": true,
+};
+void _exhaustiveCommandTypes;
 
 describe("chat API", () => {
+  it("exposes exactly the pin public_commands as the ChatCommand union", () => {
+    expect([...PUBLIC_COMMAND_TYPES].sort()).toEqual(
+      [...PIN.public_commands].sort(),
+    );
+  });
+
   beforeEach(() => {
     vi.unstubAllGlobals();
     globalThis.__nyxidAssistantHttpMock = undefined;

--- a/frontend/src/lib/assistant/chat-api.ts
+++ b/frontend/src/lib/assistant/chat-api.ts
@@ -30,17 +30,6 @@ export type ChatCommand =
       readonly prompt: string;
     }
   | {
-      readonly type: "plan.resolve";
-      readonly conversationId: string;
-      readonly taskId: string;
-      readonly planId: string;
-      readonly requestId: string;
-      readonly clientRequestId: string;
-      readonly planRevision: number;
-      readonly confirmed: boolean;
-      readonly expectedStateVersion: number;
-    }
-  | {
       readonly type: "input.resolve";
       readonly conversationId: string;
       readonly requestId: string;

--- a/frontend/src/lib/assistant/chat-task-plan.test.ts
+++ b/frontend/src/lib/assistant/chat-task-plan.test.ts
@@ -165,6 +165,58 @@ describe("decodeChatTaskPlan", () => {
     });
   });
 
+  it("decodes a historical confirm gate as a readable plan with no outbound command identity", () => {
+    const decoded = decodeChatTaskPlan({
+      schemaVersion: 4,
+      actorId: "conversation-alpha",
+      taskId: "task-alpha",
+      turnId: "turn-alpha",
+      planId: "plan-alpha",
+      planRevision: 3,
+      planRevisions: [],
+      title: "Inspect repository",
+      status: "active",
+      gate: {
+        mode: "confirm",
+        status: "pending",
+        requestId: "plan-gate-alpha",
+        taskId: "task-alpha",
+        planId: "plan-alpha",
+        planRevision: 3,
+        reason: "Confirm the planned write steps.",
+      },
+      steps: [
+        {
+          stepId: "step-alpha",
+          order: 1,
+          kind: "tool",
+          status: "waiting",
+          required: true,
+          description: "Inspect repository",
+          source: { tool: { toolName: "repository_read" } },
+          mayChangeExternalState: false,
+          externalEffect: "not_started",
+          availableActions: {},
+          dependsOn: [],
+          substeps: [],
+        },
+      ],
+    });
+
+    expect(decoded.title).toBe("Inspect repository");
+    expect(decoded.steps).toHaveLength(1);
+    expect(decoded.gate).toEqual({
+      mode: "confirm",
+      status: "pending",
+      reason: "Confirm the planned write steps.",
+    });
+    expect(decoded.gate).not.toHaveProperty("requestId");
+    expect(decoded.gate).not.toHaveProperty("taskId");
+    expect(decoded.gate).not.toHaveProperty("planId");
+    expect(decoded.gate).not.toHaveProperty("planRevision");
+    expect(JSON.stringify(decoded)).not.toContain("plan.resolve");
+  });
+
   it.each([
     ["thresholdOrigin", "override"],
     ["comparison", "gt"],

--- a/frontend/src/lib/assistant/chat-task-plan.ts
+++ b/frontend/src/lib/assistant/chat-task-plan.ts
@@ -154,10 +154,6 @@ export type ChatActorStep = {
 export type ChatPlanGate = {
   readonly mode: "auto" | "confirm";
   readonly status?: "pending" | "satisfied" | "rejected";
-  readonly requestId?: string;
-  readonly taskId?: string;
-  readonly planId?: string;
-  readonly planRevision?: number;
   readonly reason?: string;
   readonly decidedAt?: string;
 };
@@ -297,7 +293,7 @@ export function decodeChatTaskPlan(input: unknown): ChatTaskPlan {
       : {}),
     ...(value.gate === undefined || value.gate === null
       ? {}
-      : { gate: decodeGate(value.gate, taskId, planId, planRevision) }),
+      : { gate: decodeGate(value.gate) }),
     steps: ordered,
   };
 }
@@ -440,14 +436,9 @@ function decodeApprovalObservation(input: unknown): ChatApprovalObservation {
   };
 }
 
-function decodeGate(
-  input: unknown,
-  taskId: string,
-  planId: string,
-  planRevision: number,
-): ChatPlanGate {
+function decodeGate(input: unknown): ChatPlanGate {
   const value = record(input, "plan gate");
-  const gate: ChatPlanGate = {
+  return {
     mode: closed(value.mode, ["auto", "confirm"] as const, "gate.mode"),
     ...(value.status !== undefined
       ? {
@@ -458,18 +449,6 @@ function decodeGate(
           ),
         }
       : {}),
-    ...(optionalIdentity(value.requestId)
-      ? { requestId: optionalIdentity(value.requestId) }
-      : {}),
-    ...(optionalIdentity(value.taskId)
-      ? { taskId: optionalIdentity(value.taskId) }
-      : {}),
-    ...(optionalIdentity(value.planId)
-      ? { planId: optionalIdentity(value.planId) }
-      : {}),
-    ...(optionalInteger(value.planRevision, 1) !== undefined
-      ? { planRevision: optionalInteger(value.planRevision, 1) }
-      : {}),
     ...(optionalString(value.reason)
       ? { reason: optionalString(value.reason) }
       : {}),
@@ -477,19 +456,6 @@ function decodeGate(
       ? { decidedAt: optionalString(value.decidedAt) }
       : {}),
   };
-  if (gate.mode === "confirm" && gate.status === "pending") {
-    if (
-      !gate.requestId ||
-      gate.taskId !== taskId ||
-      gate.planId !== planId ||
-      gate.planRevision !== planRevision
-    ) {
-      throw invalid(
-        "Pending plan gate does not bind the exact TaskPlan identity.",
-      );
-    }
-  }
-  return gate;
 }
 
 function decodeRevision(input: unknown): ChatPlanRevision {

--- a/scripts/check-aevatar-chat-drift.py
+++ b/scripts/check-aevatar-chat-drift.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Compare Aevatar watched chat paths from a pinned SHA to the live branch head."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+EXIT_CLEAN = 0
+EXIT_DRIFT = 1
+EXIT_TOOL = 2
+GIT_TIMEOUT_SECS = 180
+
+
+class ToolError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class ContractPin:
+    remote: str
+    branch: str
+    remote_head: str
+    effective_chat_sha: str
+    watched_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DriftReceipt:
+    effective_chat_sha: str
+    observed_head: str
+    fetch_timestamp: str
+    changed_watched_paths: tuple[str, ...]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "effective_chat_sha": self.effective_chat_sha,
+            "observed_head": self.observed_head,
+            "fetch_timestamp": self.fetch_timestamp,
+            "changed_watched_paths": list(self.changed_watched_paths),
+        }
+
+
+def load_pin(path: Path) -> ContractPin:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ToolError(f"cannot read pin {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ToolError(f"pin is not valid JSON: {error}") from error
+    if not isinstance(raw, dict):
+        raise ToolError("pin must be a JSON object")
+
+    remote = _require_str(raw, "remote")
+    branch = _require_str(raw, "branch")
+    remote_head = _require_str(raw, "remote_head")
+    effective_chat_sha = _require_str(raw, "effective_chat_sha")
+    watched = raw.get("watched_paths")
+    if not isinstance(watched, list) or not watched:
+        raise ToolError("pin.watched_paths must be a nonempty array")
+    paths: list[str] = []
+    for item in watched:
+        if not isinstance(item, str) or not item.strip():
+            raise ToolError("pin.watched_paths entries must be nonempty strings")
+        paths.append(item)
+    return ContractPin(
+        remote=remote,
+        branch=branch,
+        remote_head=remote_head,
+        effective_chat_sha=effective_chat_sha,
+        watched_paths=tuple(paths),
+    )
+
+
+def _require_str(raw: dict[str, object], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ToolError(f"pin.{key} must be a nonempty string")
+    return value
+
+
+def _git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
+
+
+def git(repo: str, *args: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", "-C", repo, *args],
+            capture_output=True,
+            text=True,
+            env=_git_env(),
+            timeout=GIT_TIMEOUT_SECS,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise ToolError("git is not installed") from error
+    except subprocess.TimeoutExpired as error:
+        raise ToolError(f"git timed out: {' '.join(args)}") from error
+
+
+def git_ok(repo: str, *args: str) -> str:
+    result = git(repo, *args)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise ToolError(detail or f"git {' '.join(args)} failed")
+    return result.stdout.strip()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def ensure_git_repo(path: str) -> None:
+    result = git(path, "rev-parse", "--git-dir")
+    if result.returncode != 0:
+        raise ToolError(f"{path} is not a git repository")
+
+
+def fetch_branch(repo: str, remote: str, branch: str, pin_sha: str) -> str:
+    fetched = git(repo, "fetch", "--", remote, f"refs/heads/{branch}")
+    if fetched.returncode != 0:
+        detail = (fetched.stderr or fetched.stdout or "").strip()
+        raise ToolError(detail or f"failed to fetch {remote} {branch}")
+    observed_head = git_ok(repo, "rev-parse", "--verify", "FETCH_HEAD")
+    present = git(repo, "cat-file", "-e", f"{pin_sha}^{{commit}}")
+    if present.returncode != 0:
+        pin_fetch = git(repo, "fetch", "--", remote, pin_sha)
+        if pin_fetch.returncode != 0:
+            detail = (pin_fetch.stderr or pin_fetch.stdout or "").strip()
+            raise ToolError(detail or f"failed to fetch pin SHA {pin_sha}")
+        still_missing = git(repo, "cat-file", "-e", f"{pin_sha}^{{commit}}")
+        if still_missing.returncode != 0:
+            raise ToolError(f"pin SHA {pin_sha} is not in {remote}")
+    return observed_head
+
+
+def changed_paths(repo: str, pin_sha: str, observed_head: str, watched: tuple[str, ...]) -> tuple[str, ...]:
+    output = git_ok(
+        repo,
+        "diff",
+        "--name-only",
+        "--no-renames",
+        pin_sha,
+        observed_head,
+        "--",
+        *watched,
+    )
+    paths = [line for line in output.splitlines() if line]
+    return tuple(paths)
+
+
+def run_check(pin: ContractPin, remote: str, branch: str, reuse_repo: str | None) -> DriftReceipt:
+    if reuse_repo is not None:
+        ensure_git_repo(reuse_repo)
+        observed_head = fetch_branch(reuse_repo, remote, branch, pin.effective_chat_sha)
+        fetch_timestamp = utc_now()
+        changed = changed_paths(
+            reuse_repo,
+            pin.effective_chat_sha,
+            observed_head,
+            pin.watched_paths,
+        )
+        return DriftReceipt(
+            effective_chat_sha=pin.effective_chat_sha,
+            observed_head=observed_head,
+            fetch_timestamp=fetch_timestamp,
+            changed_watched_paths=changed,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="aevatar-chat-drift-") as tmp:
+        init = subprocess.run(
+            ["git", "init", "--bare", tmp],
+            capture_output=True,
+            text=True,
+            env=_git_env(),
+            timeout=GIT_TIMEOUT_SECS,
+            check=False,
+        )
+        if init.returncode != 0:
+            detail = (init.stderr or init.stdout or "").strip()
+            raise ToolError(detail or "failed to create temporary clone")
+        observed_head = fetch_branch(tmp, remote, branch, pin.effective_chat_sha)
+        fetch_timestamp = utc_now()
+        changed = changed_paths(
+            tmp,
+            pin.effective_chat_sha,
+            observed_head,
+            pin.watched_paths,
+        )
+        return DriftReceipt(
+            effective_chat_sha=pin.effective_chat_sha,
+            observed_head=observed_head,
+            fetch_timestamp=fetch_timestamp,
+            changed_watched_paths=changed,
+        )
+
+
+def emit(receipt: DriftReceipt, as_json: bool) -> None:
+    if as_json:
+        json.dump(receipt.to_json(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+    sys.stdout.write(f"observed_head: {receipt.observed_head}\n")
+    sys.stdout.write(f"fetch_timestamp: {receipt.fetch_timestamp}\n")
+    sys.stdout.write("changed_watched_paths:\n")
+    if not receipt.changed_watched_paths:
+        sys.stdout.write("(none)\n")
+        return
+    for path in receipt.changed_watched_paths:
+        sys.stdout.write(f"{path}\n")
+
+
+def emit_error(message: str, as_json: bool) -> None:
+    if as_json:
+        json.dump({"error": message}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return
+    sys.stderr.write(f"{message}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail when Aevatar watched chat paths move after the pinned SHA.",
+    )
+    parser.add_argument("--pin", required=True, help="Path to aevatar-chat-contract-pin.json")
+    parser.add_argument("--remote", help="Git remote URL. Defaults to the pin remote.")
+    parser.add_argument("--branch", help="Branch name. Defaults to the pin branch.")
+    parser.add_argument(
+        "--repo",
+        help="Existing clone to reuse. Only git fetch runs against it.",
+    )
+    parser.add_argument("--json", action="store_true", help="Write a machine-readable receipt.")
+    args = parser.parse_args(argv)
+
+    try:
+        pin = load_pin(Path(args.pin))
+        remote = args.remote.strip() if args.remote else pin.remote
+        branch = args.branch.strip() if args.branch else pin.branch
+        if not remote or not branch:
+            raise ToolError("remote and branch are required")
+        reuse = args.repo
+        receipt = run_check(pin, remote, branch, reuse)
+    except ToolError as error:
+        emit_error(str(error), args.json)
+        return EXIT_TOOL
+    except OSError as error:
+        emit_error(str(error), args.json)
+        return EXIT_TOOL
+
+    emit(receipt, args.json)
+    if receipt.changed_watched_paths:
+        return EXIT_DRIFT
+    return EXIT_CLEAN
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-aevatar-chat-drift.py
+++ b/scripts/check-aevatar-chat-drift.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Compare Aevatar watched chat paths from a pinned SHA to the live branch head."""
+"""Compare Aevatar watched chat paths from a pinned SHA to the live branch head.
+
+Receipt fields are pinned_remote_head, observed_head, effective_chat_sha,
+fetch_timestamp, and changed_watched_paths. Exit 0 when the watched-path
+list is empty, 1 when it is not, and 2 on tool or ancestry failure. A moved
+remote head with no watched-path change is still clean.
+"""
 
 from __future__ import annotations
 
@@ -36,6 +42,7 @@ class ContractPin:
 @dataclass(frozen=True)
 class DriftReceipt:
     effective_chat_sha: str
+    pinned_remote_head: str
     observed_head: str
     fetch_timestamp: str
     changed_watched_paths: tuple[str, ...]
@@ -43,6 +50,7 @@ class DriftReceipt:
     def to_json(self) -> dict[str, object]:
         return {
             "effective_chat_sha": self.effective_chat_sha,
+            "pinned_remote_head": self.pinned_remote_head,
             "observed_head": self.observed_head,
             "fetch_timestamp": self.fetch_timestamp,
             "changed_watched_paths": list(self.changed_watched_paths),
@@ -142,6 +150,17 @@ def fetch_branch(repo: str, remote: str, branch: str, pin_sha: str) -> str:
         still_missing = git(repo, "cat-file", "-e", f"{pin_sha}^{{commit}}")
         if still_missing.returncode != 0:
             raise ToolError(f"pin SHA {pin_sha} is not in {remote}")
+    ancestry = git(repo, "merge-base", "--is-ancestor", pin_sha, observed_head)
+    if ancestry.returncode == 1:
+        raise ToolError(
+            f"effective_chat_sha {pin_sha} is not an ancestor of observed_head {observed_head}"
+        )
+    if ancestry.returncode != 0:
+        detail = (ancestry.stderr or ancestry.stdout or "").strip()
+        raise ToolError(
+            detail
+            or f"failed to verify ancestry of {pin_sha} against {observed_head}"
+        )
     return observed_head
 
 
@@ -173,6 +192,7 @@ def run_check(pin: ContractPin, remote: str, branch: str, reuse_repo: str | None
         )
         return DriftReceipt(
             effective_chat_sha=pin.effective_chat_sha,
+            pinned_remote_head=pin.remote_head,
             observed_head=observed_head,
             fetch_timestamp=fetch_timestamp,
             changed_watched_paths=changed,
@@ -200,6 +220,7 @@ def run_check(pin: ContractPin, remote: str, branch: str, reuse_repo: str | None
         )
         return DriftReceipt(
             effective_chat_sha=pin.effective_chat_sha,
+            pinned_remote_head=pin.remote_head,
             observed_head=observed_head,
             fetch_timestamp=fetch_timestamp,
             changed_watched_paths=changed,
@@ -211,6 +232,7 @@ def emit(receipt: DriftReceipt, as_json: bool) -> None:
         json.dump(receipt.to_json(), sys.stdout, indent=2)
         sys.stdout.write("\n")
         return
+    sys.stdout.write(f"pinned_remote_head: {receipt.pinned_remote_head}\n")
     sys.stdout.write(f"observed_head: {receipt.observed_head}\n")
     sys.stdout.write(f"fetch_timestamp: {receipt.fetch_timestamp}\n")
     sys.stdout.write("changed_watched_paths:\n")
@@ -259,6 +281,12 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_TOOL
 
     emit(receipt, args.json)
+    if receipt.pinned_remote_head != receipt.observed_head:
+        sys.stderr.write(
+            "notice: pinned_remote_head "
+            f"{receipt.pinned_remote_head} differs from observed_head "
+            f"{receipt.observed_head}\n"
+        )
     if receipt.changed_watched_paths:
         return EXIT_DRIFT
     return EXIT_CLEAN

--- a/scripts/tests/test_check_aevatar_chat_drift.py
+++ b/scripts/tests/test_check_aevatar_chat_drift.py
@@ -29,14 +29,20 @@ def git(repo: Path, *args: str) -> str:
     return subprocess.check_output(
         ["git", "-C", str(repo), *args],
         text=True,
+        stderr=subprocess.DEVNULL,
     ).strip()
 
 
-def write_pin(path: Path, remote: str, effective_chat_sha: str) -> None:
+def write_pin(
+    path: Path,
+    remote: str,
+    effective_chat_sha: str,
+    remote_head: str | None = None,
+) -> None:
     payload = {
         "remote": remote,
         "branch": BRANCH,
-        "remote_head": effective_chat_sha,
+        "remote_head": remote_head or effective_chat_sha,
         "effective_chat_sha": effective_chat_sha,
         "watched_paths": [WATCHED_PATH],
         "public_commands": [],
@@ -114,6 +120,7 @@ class CheckAevatarChatDriftTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             receipt = json.loads(result.stdout)
             self.assertEqual(receipt["observed_head"], pin_sha)
+            self.assertEqual(receipt["pinned_remote_head"], pin_sha)
             self.assertEqual(receipt["effective_chat_sha"], pin_sha)
             self.assertEqual(receipt["changed_watched_paths"], [])
             self.assertRegex(receipt["fetch_timestamp"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
@@ -138,9 +145,56 @@ class CheckAevatarChatDriftTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1, result.stderr)
             receipt = json.loads(result.stdout)
             self.assertEqual(receipt["observed_head"], head)
+            self.assertEqual(receipt["pinned_remote_head"], pin_sha)
             self.assertEqual(receipt["effective_chat_sha"], pin_sha)
             self.assertEqual(receipt["changed_watched_paths"], [WATCHED_PATH])
             self.assertNotIn(UNWATCHED_PATH, receipt["changed_watched_paths"])
+            self.assertIn("differs from observed_head", result.stderr)
+
+    def test_receipt_carries_pinned_and_observed_heads(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ac0-heads-") as raw:
+            root = Path(raw)
+            repo = root / "repo"
+            init_repo(repo)
+            pin_sha = commit_file(repo, WATCHED_PATH, "pinned\n", "pin")
+            commit_file(repo, UNWATCHED_PATH, "noise\n", "unwatched")
+            head = git(repo, "rev-parse", "HEAD")
+            pin_path = root / "pin.json"
+            write_pin(pin_path, str(repo), pin_sha, remote_head=pin_sha)
+
+            result = run_checker(pin=pin_path, repo=repo)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            receipt = json.loads(result.stdout)
+            self.assertEqual(receipt["pinned_remote_head"], pin_sha)
+            self.assertEqual(receipt["observed_head"], head)
+            self.assertNotEqual(receipt["pinned_remote_head"], receipt["observed_head"])
+            self.assertEqual(receipt["changed_watched_paths"], [])
+            self.assertIn("differs from observed_head", result.stderr)
+
+    def test_non_ancestor_pin_exits_two(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ac0-orphan-") as raw:
+            root = Path(raw)
+            repo = root / "repo"
+            init_repo(repo)
+            pin_sha = commit_file(repo, WATCHED_PATH, "pinned\n", "pin")
+            git(repo, "checkout", "--orphan", "unrelated")
+            git(repo, "commit", "--allow-empty", "-m", "unrelated root")
+            unrelated_head = git(repo, "rev-parse", "HEAD")
+            git(repo, "branch", "-f", BRANCH, unrelated_head)
+            git(repo, "checkout", BRANCH)
+            pin_path = root / "pin.json"
+            write_pin(pin_path, str(repo), pin_sha)
+
+            before = nyxid_status()
+            result = run_checker(pin=pin_path, repo=repo)
+            after = nyxid_status()
+
+            self.assertEqual(before, after)
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            combined = result.stdout + result.stderr
+            self.assertIn(pin_sha, combined)
+            self.assertIn(unrelated_head, combined)
+            self.assertIn("not an ancestor", combined)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_aevatar_chat_drift.py
+++ b/scripts/tests/test_check_aevatar_chat_drift.py
@@ -1,0 +1,147 @@
+"""Deterministic tests for scripts/check-aevatar-chat-drift.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+NYXID_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = NYXID_ROOT / "scripts" / "check-aevatar-chat-drift.py"
+WATCHED_PATH = "agents/Aevatar.GAgents.NyxidChat/contract.txt"
+UNWATCHED_PATH = "unwatched/notes.txt"
+BRANCH = "feature/integrate"
+
+
+def nyxid_status() -> str:
+    return subprocess.check_output(
+        ["git", "status", "--short"],
+        cwd=NYXID_ROOT,
+        text=True,
+    )
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(repo), *args],
+        text=True,
+    ).strip()
+
+
+def write_pin(path: Path, remote: str, effective_chat_sha: str) -> None:
+    payload = {
+        "remote": remote,
+        "branch": BRANCH,
+        "remote_head": effective_chat_sha,
+        "effective_chat_sha": effective_chat_sha,
+        "watched_paths": [WATCHED_PATH],
+        "public_commands": [],
+        "internal_actions": [],
+        "context_attachments": {},
+        "delete": {},
+        "keepalive_seconds": 15,
+        "action_registry": {
+            "schema_version": 4,
+            "revision_is_observability_label": True,
+            "unknown_or_divergent_descriptors": "degrade_per_action",
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True)
+    subprocess.check_call(
+        ["git", "init", "-b", BRANCH, str(repo)],
+        stdout=subprocess.DEVNULL,
+    )
+    git(repo, "config", "user.name", "ac0-test")
+    git(repo, "config", "user.email", "ac0-test@example.com")
+    git(repo, "config", "commit.gpgsign", "false")
+
+
+def commit_file(repo: Path, relative: str, contents: str, message: str) -> str:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(contents, encoding="utf-8")
+    git(repo, "add", relative)
+    git(repo, "commit", "-m", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+def run_checker(*, pin: Path, repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            str(CHECKER),
+            "--pin",
+            str(pin),
+            "--remote",
+            str(repo),
+            "--branch",
+            BRANCH,
+            "--repo",
+            str(repo),
+            "--json",
+        ],
+        cwd=NYXID_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class CheckAevatarChatDriftTests(unittest.TestCase):
+    def test_clean_case_exits_zero_with_empty_path_list(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ac0-clean-") as raw:
+            root = Path(raw)
+            repo = root / "repo"
+            init_repo(repo)
+            pin_sha = commit_file(repo, WATCHED_PATH, "pinned\n", "pin")
+            pin_path = root / "pin.json"
+            write_pin(pin_path, str(repo), pin_sha)
+
+            before = nyxid_status()
+            result = run_checker(pin=pin_path, repo=repo)
+            after = nyxid_status()
+
+            self.assertEqual(before, after)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            receipt = json.loads(result.stdout)
+            self.assertEqual(receipt["observed_head"], pin_sha)
+            self.assertEqual(receipt["effective_chat_sha"], pin_sha)
+            self.assertEqual(receipt["changed_watched_paths"], [])
+            self.assertRegex(receipt["fetch_timestamp"], r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_drift_case_exits_one_listing_only_the_watched_path(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="ac0-drift-") as raw:
+            root = Path(raw)
+            repo = root / "repo"
+            init_repo(repo)
+            pin_sha = commit_file(repo, WATCHED_PATH, "pinned\n", "pin")
+            commit_file(repo, WATCHED_PATH, "moved\n", "watched drift")
+            commit_file(repo, UNWATCHED_PATH, "noise\n", "unwatched")
+            head = git(repo, "rev-parse", "HEAD")
+            pin_path = root / "pin.json"
+            write_pin(pin_path, str(repo), pin_sha)
+
+            before = nyxid_status()
+            result = run_checker(pin=pin_path, repo=repo)
+            after = nyxid_status()
+
+            self.assertEqual(before, after)
+            self.assertEqual(result.returncode, 1, result.stderr)
+            receipt = json.loads(result.stdout)
+            self.assertEqual(receipt["observed_head"], head)
+            self.assertEqual(receipt["effective_chat_sha"], pin_sha)
+            self.assertEqual(receipt["changed_watched_paths"], [WATCHED_PATH])
+            self.assertNotIn(UNWATCHED_PATH, receipt["changed_watched_paths"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/assistant/aevatar-chat-contract-pin.json
+++ b/tests/fixtures/assistant/aevatar-chat-contract-pin.json
@@ -1,0 +1,76 @@
+{
+  "remote": "https://github.com/aevatarAI/aevatar.git",
+  "branch": "feature/integrate",
+  "remote_head": "e5bba2e9719ad5132004b882744caa3875db1123",
+  "effective_chat_sha": "706ea7cab9d1f882e0fb0f034bb338102b6d5d2b",
+  "watched_paths": [
+    "agents/Aevatar.GAgents.NyxidChat/",
+    "apps/aevatar-console-web/src/pages/chat/",
+    "apps/aevatar-console-web/src/shared/auth/client.ts",
+    "src/Aevatar.Mainnet.Host.Api/Chat/MainnetChatEndpoints.cs",
+    "src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionAuthentication.cs",
+    "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequireServiceTool.cs",
+    "src/Aevatar.AI.ToolProviders.NyxId/NyxIdActionEvidenceReadPort.cs",
+    "src/Aevatar.AI.ToolProviders.NyxId/NyxIdMcpOperationCatalogReader.cs",
+    "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs",
+    "src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs",
+    "src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs"
+  ],
+  "public_commands": [
+    "text",
+    "input.resolve",
+    "action.continue",
+    "approval.resolve",
+    "task.stop",
+    "task.steer",
+    "step.retry",
+    "step.skip"
+  ],
+  "internal_actions": [
+    {
+      "action": "service.access_review",
+      "params": [
+        "userServiceId",
+        "serviceSlug",
+        "resourceUri"
+      ]
+    }
+  ],
+  "context_attachments": {
+    "max_unique_nonempty_artifact_id": 4,
+    "revision_modes": [
+      "follow_current",
+      "pinned_revision"
+    ],
+    "pinned_revision_requires": "pinnedRevisionId",
+    "kinds": [
+      "text",
+      "markdown",
+      "structured_document"
+    ],
+    "create_only": true,
+    "admission_code": "ATTACHMENT_ADMISSION_DENIED",
+    "admission_reasons": [
+      "not_found",
+      "access_denied",
+      "unsupported_kind",
+      "over_limit",
+      "pinned_revision_unavailable",
+      "invalid_request",
+      "inactive",
+      "read_model_unavailable"
+    ]
+  },
+  "delete": {
+    "accepted_status": 202,
+    "state": "accepted",
+    "state_url_field": "stateUrl",
+    "observe_until": "not_found"
+  },
+  "keepalive_seconds": 15,
+  "action_registry": {
+    "schema_version": 4,
+    "revision_is_observability_label": true,
+    "unknown_or_divergent_descriptors": "degrade_per_action"
+  }
+}

--- a/tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json
+++ b/tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json
@@ -1,77 +1,84 @@
 {
-  "sync": {
-    "kind": "manually_synced_mirror",
-    "not_a_drift_detector": true,
-    "source_file": "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs",
-    "maps": ["PinnedActionsByRevision", "ExecutableActionsByRevision"],
-    "verified_at": "2026-08-20",
-    "verified_revs": {
-      "origin/dev": "f3e1e81500bcaef8d26acbe6ed28452089edc2e4",
-      "origin/feature/integrate": "7d16dbcc5be96ace03e48bf80fdeae20547cf22e"
-    },
-    "note": "Checked-in copy of Aevatar's per-revision pinned and executable sets. CI does not read the Aevatar clone; if upstream changes a set, this file stays green until a human re-syncs it."
-  },
-  "lineages": {
-    "origin/dev": {
-      "supported_revision": "nyxid-assistant-actions.v7",
-      "revisions": {
-        "nyxid-assistant-actions.v4": {
-          "pinned": ["service.connect"],
-          "executable": ["service.connect"]
-        },
-        "nyxid-assistant-actions.v5": {
-          "pinned": [
-            "service.connect",
-            "service.reauthorize",
-            "key.create",
-            "key.rotate"
-          ],
-          "executable": ["service.connect"]
-        },
-        "nyxid-assistant-actions.v6": {
-          "pinned": ["service.connect", "key.create"],
-          "executable": ["service.connect", "key.create"]
-        },
-        "nyxid-assistant-actions.v7": {
-          "pinned": ["service.connect", "key.create", "key.rotate"],
-          "executable": ["service.connect", "key.create", "key.rotate"]
-        }
-      }
-    },
-    "origin/feature/integrate": {
-      "supported_revision": "nyxid-assistant-actions.v8",
-      "revisions": {
-        "nyxid-assistant-actions.v4": {
-          "pinned": ["service.connect"],
-          "executable": ["service.connect"]
-        },
-        "nyxid-assistant-actions.v5": {
-          "pinned": [
-            "service.connect",
-            "service.reauthorize",
-            "key.create",
-            "key.rotate"
-          ],
-          "executable": ["service.connect"]
-        },
-        "nyxid-assistant-actions.v6": {
-          "pinned": ["service.connect", "key.create"],
-          "executable": ["service.connect", "key.create"]
-        },
-        "nyxid-assistant-actions.v7": {
-          "pinned": ["service.connect", "key.create", "key.rotate"],
-          "executable": ["service.connect", "key.create", "key.rotate"]
-        },
-        "nyxid-assistant-actions.v8": {
-          "pinned": [
-            "service.connect",
-            "service.reauthorize",
-            "key.create",
-            "key.rotate"
-          ],
-          "executable": ["service.connect", "key.create", "key.rotate"]
-        }
-      }
-    }
-  }
+  "consumer_supported_actions": [
+    "service.connect",
+    "service.reauthorize",
+    "key.create",
+    "key.rotate",
+    "provider.set_app_credentials",
+    "node.register_token",
+    "node.rotate_token",
+    "node.inject_credential",
+    "device.onboard",
+    "account.mfa_setup",
+    "service_account.create",
+    "service_account.rotate_secret",
+    "developer_app.create",
+    "developer_app.rotate_secret"
+  ],
+  "pinned_descriptor_actions": [
+    "service.connect",
+    "service.reauthorize",
+    "key.create",
+    "key.rotate"
+  ],
+  "unknown_action": "workflow.launch",
+  "default_action_names": [
+    "service.connect",
+    "service.reauthorize",
+    "key.create",
+    "key.rotate",
+    "key.update",
+    "key.delete",
+    "key.extend_scope",
+    "key.bind_credential",
+    "service.update",
+    "service.delete",
+    "service.route",
+    "service.rotate_credential",
+    "endpoint.update",
+    "endpoint.delete",
+    "external_key.rotate",
+    "external_key.delete",
+    "connection.revoke",
+    "provider.disconnect",
+    "provider.set_app_credentials",
+    "node.register_token",
+    "node.rotate_token",
+    "node.delete",
+    "node.transfer",
+    "node.inject_credential",
+    "pending_credential.push",
+    "pending_credential.cancel",
+    "device.onboard",
+    "org.create",
+    "org.update",
+    "org.delete",
+    "org.member_add",
+    "org.member_remove",
+    "org.member_update_role",
+    "org.invite",
+    "org.set_primary",
+    "account.profile_update",
+    "account.revoke_consent",
+    "account.delete",
+    "account.mfa_setup",
+    "approval.configure",
+    "approval.enable",
+    "approval.disable",
+    "approval.revoke_grant",
+    "notifications.update",
+    "notifications.telegram_link",
+    "notifications.telegram_disconnect",
+    "service_account.create",
+    "service_account.update",
+    "service_account.delete",
+    "service_account.rotate_secret",
+    "service_account.revoke_tokens",
+    "developer_app.create",
+    "developer_app.update",
+    "developer_app.delete",
+    "developer_app.rotate_secret",
+    "external_key.add_gcp_service_account",
+    "openclaw.connect"
+  ]
 }


### PR DESCRIPTION
## Summary

- Remove `plan.resolve` from NyxID's typed assistant parser, canonical reconstruction, frontend command union, hooks, and controls. Historical confirm gates now decode into display-only task-plan state.
- Delete the untyped `POST /api/v1/assistant/completions` pass-through. Boundary tests require `plan.resolve` to fail locally with 400, require the deleted route to return 404, and verify that neither request reaches the configured Aevatar upstream.
- Replace the manually synchronized revision-map assertions with a default-manifest golden and known, unknown, divergent, schema-version, and revision-label consumer cases based on the AC-0 contract pin.
- Update the chat wire, action-registry, and wave-plan documentation to describe the eight-command contract and per-action registry degradation.

## Stack position

This PR stacks on `chore/aevatar-chat-ac0-contract-pin`, PR #1520, and must land after it. The PR targets `main` because `CI Pipeline` only runs for main-based PRs. Until #1520 merges, this PR's diff also shows AC-0's commits.

## Verification

Completed locally on `99d87f6728bf37efed9446b22e9577e5f7be1430` before the disk hold:

- `cargo fmt --all -- --check`, exit 0: `.audit/evidence/ac1/round3/cargo-fmt.log`
- `cargo clippy --workspace --all-targets -- -D warnings`, exit 0: `.audit/evidence/ac1/round3/cargo-clippy.log`
- `npm --prefix frontend ci`, exit 0: `.audit/evidence/ac1/round3/frontend-npm-ci.log`
- `npm --prefix frontend run lint`, exit 0 with 27 existing warnings and no errors: `.audit/evidence/ac1/round3/frontend-lint.log`
- `npm --prefix frontend run test`, exit 0 with 291 files and 2,897 tests passed: `.audit/evidence/ac1/round3/frontend-test.log`
- `npm --prefix frontend run build`, exit 0: `.audit/evidence/ac1/round3/frontend-build.log`
- `cargo test -p nyxid-cli --test wizard_bundle_freshness`, exit 0: `.audit/evidence/ac1/round3/cli-wizard-bundle-freshness.log`
- Plan checker, exit 0 with 8 phases and 0 problems: `.audit/evidence/ac1/round3/plan-check.log`
- Retired-command search, exit 0: `.audit/evidence/ac1/round3/rg-plan-resolve.log`
- Completions access search, exit 0: `.audit/evidence/ac1/round3/rg-assistant-completions.log`
- Mongo replica-set check, exit 0 with `rs0 PRIMARY` on port 27021: `.audit/evidence/ac1/round3/mongo-rs0-start.log`

Pending under the coordinator's local disk hold:

- The focused backend Nextest selection was stopped by the coordinator during compilation and exited 143. It did not report `No space left on device`: `.audit/evidence/ac1/round3/backend-nextest-focused.log`
- Local-runtime proof of 400 for `plan.resolve`, 404 for the deleted completions route, and zero requests at a recording upstream stub.
- Final-head Playwright mock-transport check, screenshot, and network log for a historical task-plan confirm gate.

The full backend suite is intentionally left to `CI Pipeline` per the AC-1 root ruling. The previous local full-suite run passed 5,741 of 5,742 tests, with one unrelated cluster-coordination flake.

## Risks

- Removing a published route can affect an unknown human-session caller. NyxID has no route-level telemetry, so the decision relies on the route's human-only middleware and the repository-wide caller search below.
- Older Direct Chrono-LLM planning and review documents still describe the legacy route as retained. They are outside AC-1's file fence and are not runtime callers, but maintainers should treat the AC-1 convergence plan and current router as authoritative.
- The local focused backend test, runtime receipt, and final browser evidence remain pending until the coordinator releases the disk hold.

## Access evidence for `/assistant/completions`

Appendix J records the access decision. The deleted route was inside the human-only assistant router, which rejects API keys, service accounts, delegated callers, and relay tokens. NyxID has no route-level telemetry. The repository search finds no caller in `cli`, `sdk`, `mobile`, `frontend/src`, or backend production code. The backend match is the 404 route test. The remaining matches are the convergence record and older Direct Chrono-LLM planning or review documents.

Command run at `99d87f6728bf37efed9446b22e9577e5f7be1430`:

```text
rg -n "assistant/completions" cli sdk mobile frontend/src backend/src docs
docs/chat/direct-chronollm-impl-plan.md:71:`POST /api/v1/assistant/completions` stays: it is a documented retained
docs/chat/direct-chronollm-impl-plan.md:109:Resurrect `git show e3c2f36e^:frontend/src/lib/assistant/completions-transport.ts`
docs/plans/aevatar-chat-feature-integrate-convergence.md:102:- [ ] Edit `backend/src/handlers/assistant.rs` at `completions`, `backend/src/routes.rs` at `/assistant/completions`, and their tests. Evidence is a diff that removes the route unless production telemetry proves a current caller and records its closed typed contract.
docs/plans/aevatar-chat-feature-integrate-convergence.md:111:- [ ] Remove `/api/v1/assistant/completions` after checking production access evidence. If a live caller exists, stop this phase and replace the route only after its exact request contract is added to the pin. Evidence is the telemetry decision record and either route deletion or a strict typed reconstruction test.
docs/plans/aevatar-chat-feature-integrate-convergence.md:125:- [ ] Send a real `plan.resolve` body through `/api/v1/assistant/chat` and request `/api/v1/assistant/completions` on a staging NyxID instance. Pass when both fail at NyxID with the documented 400 or 404 response and Aevatar receives neither body. Evidence is the HTTP transcript and metadata-only upstream wire log.
docs/plans/aevatar-chat-feature-integrate-convergence.md:129:- [ ] Review production route access evidence for `/api/v1/assistant/completions` across the agreed retention window. Pass when zero callers justify deletion, or when a named caller and approved replacement contract stop the phase before deletion. Evidence is the redacted query or dashboard link and the recorded decision.
docs/plans/aevatar-chat-feature-integrate-convergence.md:474:| Leave `/assistant/completions` as arbitrary pass-through | Rejected | It bypasses typed reconstruction and has no proven current in-repository caller |
docs/plans/aevatar-chat-feature-integrate-convergence.md:665:`AC-1` must inspect production access evidence before removing `/api/v1/assistant/completions`. A current external caller pauses deletion until its owner and strict typed contract are known. Repository search alone cannot disprove external use.
docs/plans/aevatar-chat-feature-integrate-convergence.md:682:| `/api/v1/assistant/completions` | Delete. The route sits on the human-only router, which rejects API keys, service accounts, delegated, and relay tokens, and no CLI, SDK, mobile, or frontend caller exists. Route-level telemetry does not exist, so router policy is the access evidence | `AC-1` review |
docs/chat/direct-chronollm-impl.review.md:310:  `POST /api/v1/assistant/completions` is untouched (`routes.rs:1350`). The
docs/chat/direct-chronollm-final-opus-verdict.md:217:  `/assistant/completions`; only `DIRECT_COMPLETIONS_URL =
docs/chat/direct-chronollm-final-opus-verdict.md:219:  legacy `POST /api/v1/assistant/completions` backend route is a *retained,
docs/chat/direct-chronollm-final-opus-verdict.md:313:4. **`POST /api/v1/assistant/completions` deprecation (BE-4, deferred).** Still
docs/chat/assistant-waves-plan.md:12:revision bump. `plan.resolve` and `POST /api/v1/assistant/completions` are
docs/chat/direct-chronollm-plan.review.md:24:- **Evidence:** The historical implementation to be resurrected stores every transcript in an instance-wide `Map` and returns the entire map from `listConversations` (`e3c2f36e^:frontend/src/lib/assistant/completions-transport.ts:80-110`). The transport singleton survives logout (`frontend/src/lib/assistant/transport.ts:744-774`). Auth cleanup clears context, draft, and wire-log stores, but not any assistant transport (`frontend/src/stores/auth-store.ts:14-18`, `frontend/src/stores/auth-store.ts:84-98`, `frontend/src/stores/auth-store.ts:110-127`); explicit logout clears React Query only (`frontend/src/hooks/use-auth.ts:66-77`). `resetAssistantTransport` resets only `MockAssistantTransport` (`frontend/src/lib/assistant/transport.ts:776-779`). A logout followed by a different login in the same SPA lifetime can therefore render the previous user's local direct conversations.
docs/chat/direct-chronollm-plan.review.md:38:- **Evidence:** The historical reader returns as soon as `run.finished` becomes true (`e3c2f36e^:frontend/src/lib/assistant/completions-transport.ts:267-276`), while `finish_reason` immediately calls `finishTurn` (`e3c2f36e^:frontend/src/lib/assistant/completions-transport.ts:321-355`). It also treats bare EOF as successful completion (`e3c2f36e^:frontend/src/lib/assistant/completions-transport.ts:278-282`). In the saved stream, finish is at `frontend/src/lib/assistant/__fixtures__/chrono-llm-direct-stream.sse:21`, usage at line 23, and `[DONE]` at line 25. Dropping the browser response can cancel the backend response stream and upstream body (`backend/src/downstream_disconnect.rs:75-106`), potentially before a separately delivered usage frame is observed. The old class is also no longer structurally compatible with the expanded transport contract (`frontend/src/types/assistant.ts:282-339`).
docs/chat/direct-chronollm-plan.review.md:61:- **Claim attacked:** BE-4 calls `POST /api/v1/assistant/completions` dead and says FE/CLI/docs grep was clean (`docs/chat/direct-chronollm-impl-plan.md:58-62`; `docs/chat/direct-chronollm-spec.md:134-138`).
docs/chat/direct-chronollm-spec.md:139:`POST /api/v1/assistant/completions` route is a documented retained surface
docs/chat/direct-chronollm-spec.md:340:`e3c2f36e^:frontend/src/lib/assistant/completions-transport.ts`) as
backend/src/handlers/proxy.rs:10365:            (Method::POST, "/api/v1/assistant/completions"),
```

## Review gate

- API owner: inspect the router-policy access evidence and approve removal of the untyped route.
- Operator: inspect the final task-plan screenshot and no-`plan.resolve` network log after the local hold is released.
- Independent read-only audits found no runtime gap in the backend boundary, historical-gate decoding, or frontend sender removal. The comment audit proposed zero deletions; the retained registry comment records the external byte-compatibility constraint.
- Required remote check: `CI Pipeline` must be green on the exact PR head. Auto-merge remains disabled, and this PR must not merge before #1520.
