### PR TITLE
docs(assistant): decide the Aevatar access-review authority model and add the probe

### DIFF
--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -809,18 +809,19 @@ async fn forward(
     };
 
     // TD-3 bridge: cookie sessions carry no bearer for `forward_access_token`
-    // to forward, and prod Aevatar authenticates only `Authorization: Bearer
-    // <NyxID JWT>`. Mint a DELEGATED access token and OVERWRITE Authorization
-    // — `AuthMethod::Session` means bearer auth did not happen, so any header
-    // present is not an authenticated credential. A delegated token is the
-    // platform standard for "downstream calls NyxID on the user's behalf":
-    // Aevatar reuses this same bearer to reach NyxID's LLM/proxy routes
-    // (`/proxy/s/chrono-llm-public`, `/llm/*`), which the delegated router
-    // accepts, while `reject_delegated_tokens` keeps a leaked copy off every
-    // account-management, admin, and key surface. The delegated capability
-    // comes from the row's `delegation_token_scope` (same source of truth as
-    // the standard `inject_delegation_token` path). Bearer callers (CLI login
-    // JWTs) never enter this branch and keep their token byte-for-byte.
+    // to forward. Aevatar authenticates caller identity from
+    // `X-NyxID-Identity-Token`, then selects an execution capability separately.
+    // Authorization Bearer takes precedence. `X-NyxID-Delegation-Token` is the
+    // Bearer-absent fallback. Mint a DELEGATED access token and overwrite
+    // Authorization. `AuthMethod::Session` means bearer auth did not happen, so
+    // any existing header is not an authenticated credential. Aevatar reuses
+    // this capability to reach NyxID's LLM/proxy routes, including
+    // `/proxy/s/chrono-llm-public` and `/llm/*`. `reject_delegated_tokens` keeps
+    // a leaked copy off every account-management, admin, and key route. The
+    // delegated capability comes from the row's `delegation_token_scope`. The
+    // standard `inject_delegation_token` path reads the same field. Bearer
+    // callers, including CLI login JWTs, never enter this branch and keep their
+    // token byte-for-byte.
     if bridge_minted {
         let value = build_forward_authorization(state, auth_user, &service)?;
         request.headers_mut().insert(header::AUTHORIZATION, value);

--- a/backend/src/handlers/assistant.rs
+++ b/backend/src/handlers/assistant.rs
@@ -666,13 +666,11 @@ fn synthetic_request(
     Ok(request)
 }
 
-/// Whether this call needs the TD-3 forward-token bridge: cookie sessions
-/// carry no bearer for `forward_access_token` to forward, so Aevatar —
-/// which today authenticates only `Authorization: Bearer <NyxID JWT>` —
-/// answers 401 for exactly the browser. Minting is gated on the row still
-/// being in Bearer-forwarding mode: when the TD-3 rollout flips
-/// `forward_access_token` off (Aevatar validates the identity token
-/// instead), the bridge retires itself with no code change.
+/// Whether this call needs the forward-token bridge. Cookie sessions carry no
+/// bearer for `forward_access_token` to forward. Aevatar validates the
+/// identity assertion separately, but typed execution still requires an
+/// Authorization Bearer or a delegation-header capability. The live row keeps
+/// this bridge enabled until deployment evidence proves the replacement path.
 fn needs_forward_token_bridge(auth_method: &AuthMethod, forward_access_token: bool) -> bool {
     *auth_method == AuthMethod::Session && forward_access_token
 }

--- a/backend/src/services/assistant_service.rs
+++ b/backend/src/services/assistant_service.rs
@@ -63,22 +63,22 @@ pub async fn resolve_admin_service_by_slug(
     Ok(service)
 }
 
-/// Surface the one row misconfiguration that silently 401s the entire chat
-/// surface, instead of waiting for a user to report it.
+/// Report the row misconfiguration that causes every typed chat request to
+/// return 401.
 ///
-/// Deployed Aevatar authenticates only `Authorization: Bearer <NyxID JWT>`.
-/// The bridge that supplies it (`handlers/assistant.rs::needs_forward_token_bridge`)
-/// is gated on `Session && forward_access_token`, so clearing that flag both
-/// stops the bearer forward and disarms the mint: NyxID then sends no
-/// `Authorization` at all and every Aevatar surface answers 401. This exact
-/// flip took production chat down on 2026-08-12, and nothing in the system
-/// said so — the only signal was a user seeing a failed chat.
+/// Deployed Aevatar authenticates caller identity from `X-NyxID-Identity-Token`.
+/// Workflow execution separately selects `Authorization: Bearer <NyxID JWT>`
+/// first, then `X-NyxID-Delegation-Token` when Bearer is absent. The bridge that
+/// supplies the Bearer (`handlers/assistant.rs::needs_forward_token_bridge`) is
+/// gated on `Session && forward_access_token`, so clearing that flag stops the
+/// forward and disarms the mint. NyxID still sends identity, but typed streaming
+/// has no execution capability and answers 401. This exact flip took production
+/// chat down on 2026-08-12, and the only signal was a user seeing a failed chat.
 ///
-/// Deliberately a warning, not a hard failure: `false` becomes the CORRECT
-/// value once Aevatar validates `X-NyxID-Identity-Token` (the TD-3 cutover),
-/// and failing closed here would turn that rollout into an outage of its own.
-/// Fires once per process — the condition is process-lifetime config, so
-/// per-request logging would only add noise.
+/// This is a warning, not a hard failure. `false` becomes the correct value once
+/// a proven replacement supplies both identity and execution capability.
+/// Failing closed here would turn that rollout into an outage. The warning fires
+/// once per process because the condition is process-lifetime configuration.
 fn warn_if_bridge_disarmed(service: &DownstreamService) {
     if service.forward_access_token {
         return;

--- a/docs/API.md
+++ b/docs/API.md
@@ -3511,8 +3511,9 @@ Forward any HTTP request to a registered downstream service. NyxID resolves the 
 
 **Delegation Token Injection:** If the service has `inject_delegation_token: true`, NyxID generates a short-lived delegated access token (5-minute TTL) and injects it as the `X-NyxID-Delegation-Token` header. This allows the downstream service to call NyxID APIs on behalf of the user according to the admin-configured service scope. Proxy and LLM scopes retain their existing behavior; the service-only `account:read` scope adds GET-only management parity with explicit route-class and WebSocket exclusions. Other eligible scopes can be refreshed via `POST /api/v1/delegation/refresh` for long-running workflows, but refresh cannot re-add `account:read`; the service must receive a newly minted token from an eligible invocation. See [Token Exchange (Delegated Access)](#token-exchange-delegated-access) for details.
 
-**Assistant identity and capability transport (assistant mount only):** A browser
-session authenticates to NyxID with a cookie on the `/api/v1/assistant/*`
+##### Assistant identity and capability transport
+
+A browser session authenticates to NyxID with a cookie on the `/api/v1/assistant/*`
 pass-through. The session carries no Bearer for `forward_access_token` to
 forward. While the `aevatar` service row has `forward_access_token: true`, NyxID
 mints a delegated access token for the session user. The token has

--- a/docs/API.md
+++ b/docs/API.md
@@ -3511,7 +3511,35 @@ Forward any HTTP request to a registered downstream service. NyxID resolves the 
 
 **Delegation Token Injection:** If the service has `inject_delegation_token: true`, NyxID generates a short-lived delegated access token (5-minute TTL) and injects it as the `X-NyxID-Delegation-Token` header. This allows the downstream service to call NyxID APIs on behalf of the user according to the admin-configured service scope. Proxy and LLM scopes retain their existing behavior; the service-only `account:read` scope adds GET-only management parity with explicit route-class and WebSocket exclusions. Other eligible scopes can be refreshed via `POST /api/v1/delegation/refresh` for long-running workflows, but refresh cannot re-add `account:read`; the service must receive a newly minted token from an eligible invocation. See [Token Exchange (Delegated Access)](#token-exchange-delegated-access) for details.
 
-**Assistant Forward Token (transitional, assistant mount only):** Not a new identity mode. On the `/api/v1/assistant/*` pass-through, a browser session authenticates with a cookie and therefore carries no bearer for `forward_access_token` to forward. While the `aevatar` service row has `forward_access_token: true`, NyxID mints a **delegated access token** for the session user (the same `delegated: true` capability token described under Delegation Token Injection, scoped `proxy`, 5-minute TTL, `act.sub = "aevatar"`) and sends it as `Authorization: Bearer` alongside the standard identity headers above (which flow unchanged). Aevatar reuses that bearer to call NyxID's LLM/proxy routes on the user's behalf; because it is a delegated token, `reject_delegated_tokens` keeps a leaked copy off every account-management, admin, and key surface while the proxy/LLM routes accept it. It is delivered in `Authorization` rather than `X-NyxID-Delegation-Token` only because Aevatar's currently deployed validator reads `Authorization`. Unlike identity/delegation *injection* (which log and continue on generation failure), a mint failure fails the assistant request: the token is required authentication for the downstream today. Flipping the row to `forward_access_token: false` (the identity-token rollout, with `inject_delegation_token: true`) retires this Authorization mint and hands over to the standard `X-NyxID-Delegation-Token` header with no code change.
+**Assistant identity and capability transport (assistant mount only):** A browser
+session authenticates to NyxID with a cookie on the `/api/v1/assistant/*`
+pass-through. The session carries no Bearer for `forward_access_token` to
+forward. While the `aevatar` service row has `forward_access_token: true`, NyxID
+mints a delegated access token for the session user. The token has
+`delegated: true`, a REST-capable proxy scope, a 5-minute TTL, and
+`act.sub = "aevatar"`. NyxID sends the token as `Authorization: Bearer` with the
+standard identity assertion.
+
+At Aevatar, these credentials have different authorities.
+`X-NyxID-Identity-Token` selects a dedicated authentication scheme. Its signed
+subject is the caller identity and the Aevatar tenant identity.
+`Authorization: Bearer` remains available to workflow execution and takes
+precedence as the execution credential. Aevatar classifies a Bearer with the
+delegated claim as `ProxyDelegation`. If Bearer is absent,
+`X-NyxID-Delegation-Token` can supply the proxy-delegation capability. Identity
+alone is not sufficient for typed streaming. These rules are pinned by
+`NyxIdIdentityAssertionAuthentication.cs`,
+`NyxIdIdentityAssertionValidator.cs`, `NyxIdChatEndpoints.Streaming.cs`, and
+`NyxIdChatEndpoints.cs` at Aevatar
+`e5bba2e9719ad5132004b882744caa3875db1123`.
+
+Because the bridge token is delegated, `reject_delegated_tokens` keeps a leaked
+copy off account-management, admin, and key routes. Proxy and LLM routes accept
+the token. A mint failure fails the assistant request. Keep
+`forward_access_token: true` on the live `aevatar` row until a deployed probe
+proves that Aevatar receives both the identity assertion and a usable
+replacement capability. Source support for the delegation header alone is not
+a deployment receipt.
 
 **Response:** The downstream service's response status code, allowed headers, and body are returned directly. Only a safe allowlist of response headers is forwarded.
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -313,12 +313,13 @@ curl -X PUT http://localhost:3001/api/v1/services/<service_id> \
 | `jwt`     | `X-NyxID-Identity-Token` (RS256-signed, 60s TTL)              |
 | `both`    | All of the above                                               |
 
-> **Aevatar compatibility note:** the assistant pass-through additionally
+> **Aevatar compatibility.** The assistant pass-through also
 > mints a transitional `Authorization: Bearer` token for cookie-session
 > callers while the `aevatar` row has `forward_access_token: true`, because
-> Aevatar's current validator authenticates only NyxID JWT Bearers. It is
-> not an identity mode — see "Assistant Forward Token" in `API.md` — and it
-> retires automatically when the row flips to identity-token validation.
+> Aevatar uses `X-NyxID-Identity-Token` for caller identity and separately
+> requires an execution capability. `Authorization: Bearer` takes precedence;
+> `X-NyxID-Delegation-Token` is the Bearer-absent fallback. See
+> [Assistant identity and capability transport](API.md#assistant-identity-and-capability-transport-assistant-mount-only).
 
 ### Verifying Identity JWTs
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -319,7 +319,7 @@ curl -X PUT http://localhost:3001/api/v1/services/<service_id> \
 > Aevatar uses `X-NyxID-Identity-Token` for caller identity and separately
 > requires an execution capability. `Authorization: Bearer` takes precedence;
 > `X-NyxID-Delegation-Token` is the Bearer-absent fallback. See
-> [Assistant identity and capability transport](API.md#assistant-identity-and-capability-transport-assistant-mount-only).
+> [Assistant identity and capability transport](API.md#assistant-identity-and-capability-transport).
 
 ### Verifying Identity JWTs
 

--- a/docs/chat/01-architecture.md
+++ b/docs/chat/01-architecture.md
@@ -1,7 +1,7 @@
 # Assistant Chat Architecture
 
-Last verified against Aevatar `0a86713671fcf551dc19ad86b1b6aa8ae6cb980b` and the
-production typed-chat probe (2026-08-11).
+Last verified against Aevatar `e5bba2e9719ad5132004b882744caa3875db1123` and the
+AC-2 authority probe (2026-09-02).
 
 ## System boundary
 
@@ -105,13 +105,38 @@ forward_access_token:         true    <-- REQUIRED. Setting this false takes cha
 
 Identity and delegated-capability construction live in `backend/src/handlers/proxy.rs`; assistant-specific forwarding and fallback scope selection live in `backend/src/handlers/assistant.rs:resolve_forward_scope` and `build_forward_authorization`.
 
-### Authorization is not caller passthrough
+### Transport authentication and capability selection
 
-`forward_access_token` must be `true` on the live row. That flag does not mean "copy the browser's inbound Authorization value" — it never does that. It is the enable switch for the bridge in `backend/src/handlers/assistant.rs:needs_forward_token_bridge`, which for a cookie-authenticated session mints a NyxID delegated token server-side and *overwrites* the upstream `Authorization` header. A verified bearer caller keeps its own verified bearer; the assistant route policy excludes API keys, service accounts, delegated tokens, and relay tokens before the handler runs.
+`forward_access_token` must be `true` on the live row. That flag never copies the
+browser's inbound Authorization value. It enables the bridge in
+`backend/src/handlers/assistant.rs:needs_forward_token_bridge`. For a
+cookie-authenticated session, the bridge mints a NyxID delegated token and
+overwrites the upstream `Authorization` header. A verified Bearer caller keeps
+the verified Bearer. The assistant route policy excludes API keys, service
+accounts, delegated tokens, and relay tokens before the handler runs.
 
-Deployed Aevatar authenticates **only** `Authorization: Bearer <NyxID JWT>`. It does not yet validate the `X-NyxID-Identity-Token` or `X-NyxID-Delegation-Token` headers that NyxID also sends. Because the bridge is gated on `Session && forward_access_token`, setting the flag to `false` both stops the bearer forward *and* disarms the mint, so NyxID sends no `Authorization` at all and **every** Aevatar surface returns 401 `authentication_required` — the typed `/api/chat`, `/api/chat/conversations`, and legacy `v1/chat/completions` alike. This is not a theoretical failure mode: it took production chat down on 2026-08-12 and was resolved only by setting the flag back to `true`.
+Aevatar authenticates caller identity and selects tool capability separately. If
+`X-NyxID-Identity-Token` is present, its dedicated authentication scheme
+validates signature, issuer, audience, lifetime, subject, `iat`, and single-use
+`jti`. The signed subject is authoritative for the Aevatar scope. The
+`Authorization` header remains on the request for execution. A valid Bearer has
+precedence as the execution credential and a delegated Bearer is classified as
+`ProxyDelegation`. If Bearer is absent, `X-NyxID-Delegation-Token` can supply
+that proxy-delegation capability. Identity alone is insufficient: typed
+streaming returns 401 when neither execution credential is present.
 
-`forward_access_token: false` becomes correct **only after** Aevatar ships identity-assertion validation (the TD-3 cutover). Until that is verified live against the deployed Aevatar, do not set it. The bridge is designed to retire itself with no code change on that day; flipping the flag ahead of the upstream capability is what breaks it.
+The pinned sources are
+`src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionAuthentication.cs`,
+`NyxIdIdentityAssertionValidator.cs`,
+`agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs`, and
+`NyxIdChatEndpoints.cs` at Aevatar
+`e5bba2e9719ad5132004b882744caa3875db1123`.
+
+Keep `forward_access_token: true` until a deployed probe proves Aevatar receives
+both a valid identity assertion and a usable capability through the replacement
+path. Source support for the delegation header is necessary but is not a live
+deployment receipt. Turning the bridge off before that proof can leave Aevatar
+with caller identity but no authority to run tools.
 
 `JWT_ASSISTANT_FORWARD_TTL_SECS`, `crypto/jwt.rs:generate_assistant_forward_access_token`, and the `assistant_forward` claim are compatibility tombstones. They preserve rejection behavior for a prior token shape and do not control live assistant authentication. New code must not depend on them.
 

--- a/docs/chat/01-architecture.md
+++ b/docs/chat/01-architecture.md
@@ -13,6 +13,7 @@ React browser
   -> NyxID /api/v1/assistant/**
      -> default: admin-managed DownstreamService slug "aevatar"
         -> Aevatar /api/chat and conversation-history resources
+           -> default LLM callback: NyxID /api/v1/proxy/s/chrono-llm-public
      -> experimental: admin-managed DownstreamService slug "chrono-llm-public"
         -> Chrono LLM /v1/chat/completions (relative to the service base_url)
 ```
@@ -58,9 +59,11 @@ The route placement and rejection layers are authoritative: `backend/src/routes.
 
 Assistant handlers do not resolve a user-owned `UserService`. The default
 Aevatar handlers resolve the active admin-managed `DownstreamService` whose
-slug is `aevatar`; the Direct handler uses `chrono-llm-public`. Both require the
-row not to need a per-user credential and call the administrative proxy path.
-This has several consequences:
+slug is `aevatar`. The Direct handler uses `chrono-llm-public`. Both ingress
+handlers require their row not to need a per-user credential and call the
+administrative proxy path. Aevatar also uses the active `chrono-llm-public` row
+as its default LLM callback through the ordinary
+`/api/v1/proxy/s/chrono-llm-public` path. This has several consequences:
 
 - The caller cannot choose the upstream base URL.
 - A personal or organization service with the same slug does not override the platform target.

--- a/docs/chat/aevatar-access-review-authority.md
+++ b/docs/chat/aevatar-access-review-authority.md
@@ -62,8 +62,12 @@ rows were rerun through a real `cargo run` NyxID backend at the recorded SHA.
 The only stub was a loopback OpenAI-compatible downstream behind NyxID. It
 returned one fixed, successful chat-completion response so the gateway row
 could prove that NyxID forwarded the request; it did not replace NyxID or
-Aevatar. The gateway row is a control, not Aevatar's default route. Raw response
-logs are under `/tmp/ac2-evidence/runtime/`.
+Aevatar. The stub log contains four identical POST shapes from the repaired
+receipt run, the raw-response capture, the error-code-parser rerun, and the
+final rerun after correcting the local identity-token fixture to a 60-second
+lifetime. The final machine receipt comes from the fourth run; the raw gateway
+response comes from the second. The gateway row is a control, not Aevatar's
+default route. Raw response logs are under `/tmp/ac2-evidence/runtime/`.
 
 ## What the transport authenticates
 
@@ -209,6 +213,17 @@ IDs, so it cannot restore a platform row to a restricted catalog.
    (`src/Aevatar.Mainnet.Host.Api/appsettings.json:41-44`), but the current
    NyxID row has no field that resolves that identity.
 
+   The linked client's `delegation_scopes` must contain both `proxy:*` and
+   `mcp:catalog:read`. `validate_live_grant` checks every minted scope against
+   both the actor and receiving client, even when the link supplies both roles
+   (`backend/src/services/catalog_delegation_service.rs:120-132` and
+   `backend/src/services/token_exchange_service.rs:487-499`).
+   `OAUTH_CLIENT_DELEGATION_SCOPES` admits `proxy:*` and
+   `mcp:catalog:read`, but not bare `proxy`. This allowed list is why the mint
+   uses `proxy:* mcp:catalog:read`
+   (`backend/src/services/oauth_client_service.rs:41-49`). Validate the complete
+   scope at link time and again at mint time. A missing scope must fail closed.
+
 ## Decision predicate
 
 | Condition | Current system | Candidate design | Evidence and AC-3 proof |
@@ -241,6 +256,12 @@ capability from the linked client's current consent with scope
 no-grant denial and matching-live-grant success cases, and it remains subject to
 an independent security review before implementation begins.
 
+Before restricted minting is enabled, provision or verify both `proxy:*` and
+`mcp:catalog:read` in the linked Aevatar OAuth client's `delegation_scopes`.
+Verify the same complete scope for both actor and receiving client if AC-3 uses
+separate clients. Deployment must stop if either client is missing either
+scope.
+
 Until AC-3 lands and proves that Aevatar receives both caller identity and the
 restricted capability, keep `forward_access_token=true` and preserve the
 current unrestricted forwarding posture. Access review remains unreachable in
@@ -255,10 +276,11 @@ AC-3 remains subject to its own security review gate.
 | --- | --- |
 | Atomic consent merge | Add `consent_service::merge_consent_services_atomic` in `backend/src/services/consent_service.rs`. Use one atomic aggregation-pipeline `find_one_and_update` upsert keyed by `(user_id, client_id)`. Set-union the requested service ID and required scopes while preserving all existing scopes, IDs, `allow_all_services`, grant identity, and unrelated fields. On a concurrent first-approval E11000, retry as a non-upserting merge against the winning row. Never call `grant_consent_with_services`. `grant_consent_internal` replaces the full row at lines 71-100, and the OAuth consent page in `backend/src/handlers/oauth.rs:807-836` still calls that replacement path; treat it as a known concurrent-writer hazard. The unique `(user_id, client_id)` index is at `backend/src/db.rs:911-920`. |
 | HTTP effect | Add the confirmed `service.access_review` effect in `backend/src/handlers/assistant_action_effects_services.rs` and mount only its typed route in `backend/src/routes.rs`. Call `assistant_action_receipts::reserve_or_replay` before mutation. Resolve actor, client link, and user-owned service server-side; reject cross-user IDs before the merge. |
-| Authority mint | Replace the session projection in `backend/src/handlers/assistant.rs:build_forward_authorization`. Re-resolve the active `aevatar` row and `delegated_authority_client_id`, read current consent, derive `CatalogAuthority`, and call `generate_delegated_access_token_for_client` with exact scope `proxy:* mcp:catalog:read` so `client_id` is present. Use the linked client as both actor and receiver unless AC-3 introduces and validates a separate actor client. Persist the matching online grant with `catalog_delegation_service::persist_grant` before forwarding. Do not derive service restrictions from session `AuthUser`. |
+| Authority mint | Replace the session projection in `backend/src/handlers/assistant.rs:build_forward_authorization`. Re-resolve the active `aevatar` row and `delegated_authority_client_id`, read current consent, derive `CatalogAuthority`, and call `generate_delegated_access_token_for_client` with exact scope `proxy:* mcp:catalog:read` so `client_id` is present. Use the linked client as both actor and receiver unless AC-3 introduces and validates a separate actor client. Before minting, require every scope in that exact string to appear in both clients' `delegation_scopes`; fail closed on a missing scope. `OAUTH_CLIENT_DELEGATION_SCOPES` permits this pair and excludes bare `proxy` (`backend/src/services/oauth_client_service.rs:41-49`). Persist the matching online grant with `catalog_delegation_service::persist_grant` before forwarding. Do not derive service restrictions from session `AuthUser`. |
 | REST catalog guard | Change `mw/auth.rs:delegated_request_allowed`, `reject_delegated_tokens`, and their route tests; add verified live-grant enforcement before `handlers/mcp.rs:get_mcp_config` publishes `mcp_service::ServiceScope`. |
 | Platform callback | Narrow the legacy `DownstreamService` gate in `handlers/proxy.rs:execute_proxy_inner` for the exact active `chrono-llm-public` row. Require delegated assistant authority, actor and receiving client equal to the current Aevatar row link, and a valid live grant. Keep `handlers/llm_gateway.rs:gateway_request` as a control path; it is not Aevatar's default route. |
-| Client link | Extend `models/downstream_service.rs`, the admin service request and response DTOs in `handlers/services.rs`, and admin validation. At link create or change, require an active OAuth client and call `catalog_delegation_service::ensure_client_can_delegate_catalog`; append a metadata-only audit event. Re-resolve the link at mint time. No environment variable is added. |
+| Client link | Extend `models/downstream_service.rs`, the admin service request and response DTOs in `handlers/services.rs`, and admin validation. At link create or change, require an active OAuth client, call `catalog_delegation_service::ensure_client_can_delegate_catalog`, and validate complete delegation scope `proxy:* mcp:catalog:read`. Append a metadata-only audit event. Re-resolve the link and repeat both scope checks at mint time. No environment variable is added. |
+| OAuth client prerequisite | Before deployment, provision or verify `proxy:*` and `mcp:catalog:read` in the linked Aevatar client's `delegation_scopes`. Use `token_exchange_service::validate_delegation_scope` for the complete string and keep `catalog_delegation_service::validate_live_grant` authoritative at request time. Apply the same check to both actor and receiver if AC-3 uses separate clients. `OAUTH_CLIENT_DELEGATION_SCOPES` in `services/oauth_client_service.rs` permits this pair and excludes bare `proxy`. Fail closed if either scope is missing. |
 | Consent revocation | Extend `consent_service::revoke_consent` and `handlers/consent.rs::revoke_my_consent` to mark all outstanding catalog grants for the user and linked client revoked before consent deletion completes. Regranting consent within the old token's TTL must not reactivate that token. |
 | Audit | Append metadata-only events `assistant_delegated_authority_client_link_changed`, `assistant_service_access_review_requested`, `assistant_service_access_grant_merged`, `assistant_service_access_grant_replayed`, `assistant_service_access_grant_denied`, and `assistant_delegated_authority_minted`. Include actor ID, owner ID, service ID, client ID, action request ID, outcome, and online-grant ID where applicable; never include a token, credential, cookie, or authorization value. Preserve the existing `oauth_consent_revoked` event and make grant invalidation observable. |
 
@@ -270,7 +292,9 @@ denied, a missing/inactive/mismatched client link, exact-route denial without a
 grant, and audit metadata redaction. Catalog tests must prove that a restricted
 mint drops every platform row and that consent cannot restore one. Bootstrap
 tests must cover both the gateway control and the default proxy-slug callback,
-including denial for the wrong row, actor, receiver, or grant.
+including denial for the wrong row, actor, receiver, or grant. Client tests must
+remove `proxy:*` and `mcp:catalog:read` one at a time from both the actor and
+receiving client, and prove that link validation and minting fail closed.
 
 ## Negative cases
 

--- a/docs/chat/aevatar-access-review-authority.md
+++ b/docs/chat/aevatar-access-review-authority.md
@@ -1,0 +1,298 @@
+# Aevatar access-review authority decision
+
+**Status.** Use consent-derived delegated restrictions as the AC-3 authority
+model. Service access review is not reachable from the current assistant
+bridge, so preserve unrestricted forwarding until AC-3 passes its security and
+deployment gates.
+
+This record is the AC-2 probe and authority decision. It changes no product
+behavior. NyxID evidence was collected from local SHA
+`3fbae40a7b9526afdc97b3fdc005c1a543dabaaf`. Aevatar source evidence is pinned
+to `e5bba2e9719ad5132004b882744caa3875db1123`. Runtime Aevatar rows are marked
+source-proven because this environment has no .NET runtime and Aevatar accepts
+only production-JWKS tokens.
+
+## Receipt contract
+
+Every fixed probe row is reconstructed as this closed record:
+
+```text
+ProbeReceiptRow
+  row_id
+  surface
+  deployment_version
+  request_shape
+  http_status
+  upstream_code
+  claim_summary
+    delegated
+    actor_present
+    client_id_present
+    allow_all_services
+    allowed_service_ids_count
+    resource_count
+    scope_names
+    expiry_window_seconds
+  verdict
+  observation_kind
+```
+
+The probe never emits subjects, actor values, client values, service IDs,
+resource URIs, `jti` values, tokens, cookies, authorization values, refresh
+tokens, API keys, or response prose. The source rows deliberately use `null`
+where pinned source does not establish an HTTP observation.
+
+## Seven-row receipt
+
+| Row | Surface and version | HTTP | Safe code | Claim summary | Verdict |
+| --- | --- | ---: | --- | --- | --- |
+| Identity only | Pinned Aevatar source `e5bba2e` | n/a | n/a | non-delegated; no actor, client, service, or resource authority; 60-second lifetime | Execution capability is still required; source-proven, not runtime-observed |
+| Identity plus capability Bearer | Pinned Aevatar source `e5bba2e` | n/a | n/a | delegated; actor present; `allow_all_services=false`; 1 allowed service; 0 resources; `proxy`; 300 seconds | Authorization Bearer is selected as `ProxyDelegation`; source-proven, not runtime-observed |
+| Identity plus delegation header | Pinned Aevatar source `e5bba2e` | n/a | n/a | delegated; actor present; `allow_all_services=true`; 0 allowed services and 0 resources; `proxy:*`; 300 seconds | Delegation header supplies `ProxyDelegation` when Bearer is absent; source-proven, not runtime-observed |
+| Replayed identity `jti` | Pinned Aevatar source `e5bba2e` | 401 | `identity_assertion_replayed` | non-delegated identity assertion; 60 seconds | Replay rejected; source-proven, not runtime-observed |
+| Bridge Bearer reads REST MCP config | Local NyxID `3fbae40a` | 403 | none exposed | delegated; actor present; `allow_all_services=true`; 0 allowed services and 0 resources; `proxy:*`; 300 seconds | Route denied before catalog filtering |
+| Restricted Bearer uses LLM gateway | Local NyxID `3fbae40a` | 200 | none | delegated; actor present; `allow_all_services=false`; 1 allowed service; 0 resources; `proxy`; 300 seconds | Pinned gateway callback is reachable |
+| Restricted Bearer uses platform proxy slug | Local NyxID `3fbae40a` | 403 | none exposed | same restricted summary | Legacy platform-row scope gate denies the callback |
+
+The machine receipt is `/tmp/ac2-evidence/seven-row-receipt.json`. Local setup
+statuses are in `/tmp/ac2-evidence/local-runtime-setup.json`.
+
+## What the transport authenticates
+
+The identity assertion and execution capability have separate jobs. Aevatar
+selects `X-NyxID-Identity-Token` as the authentication scheme whenever it is
+present and treats its signed subject as the tenant identity, while leaving the
+Authorization header available to workflow execution
+(`NyxIdIdentityAssertionAuthentication.cs:31-46,68-98`). Its validator checks
+signature, issuer, audience, lifetime, `sub`, `jti`, and `iat`, then atomically
+consumes replay state (`NyxIdIdentityAssertionValidator.cs:120-183`).
+
+Identity alone is not an execution capability. Streaming extracts a NyxID
+credential and returns 401 when none is available
+(`NyxIdChatEndpoints.Streaming.cs:91-101`). Credential extraction gives a
+Bearer header precedence, classifies a delegated Bearer as `ProxyDelegation`,
+and falls back to `X-NyxID-Delegation-Token` only when Bearer is absent
+(`NyxIdChatEndpoints.cs:317-379`). The pinned header-matrix test independently
+fixes identity-only as credential-less and both delegation forms as proxy
+delegation (`NyxIdChatBrowserCredentialTests.cs:31-33` and
+`ChatEndpointsInternalTests.cs:1859-1899`).
+
+NyxID's session bridge currently supplies both sides. Session authentication
+constructs `AuthUser` with `allow_all_services=true`, an empty service list, and
+no resource list (`backend/src/mw/auth.rs:920-941`).
+`TokenRestrictionClaims::from_auth_user` copies those values
+(`backend/src/crypto/jwt.rs:341-353`), and
+`build_forward_authorization` signs that projection into the five-minute
+delegated Bearer (`backend/src/handlers/assistant.rs:722-741`). Standard
+`X-NyxID-Delegation-Token` injection uses the same projection
+(`backend/src/handlers/proxy.rs:2493-2507`).
+
+## Why access review is unreachable
+
+`USER_SERVICE_ACCESS_REQUIRED` requires a successful current-bearer catalog
+read followed by zero exact matches. Aevatar calls `GET /api/v1/mcp/config`
+with the execution Bearer (`NyxIdRequireServiceTool.cs:311-344` and
+`NyxIdApiClient.cs:1339-1340`). Access denial becomes source unavailable, which
+produces `SourceStale` or `INVENTORY_INVALID`, not service access denied
+(`NyxIdRequireServiceTool.cs:217-280`). The access-review postcondition follows
+the same path through `NyxIdMcpOperationCatalogReader.ReadAsync`
+(`NyxIdActionEvidenceReadPort.cs:75-145` and
+`NyxIdMcpOperationCatalogReader.cs:48-95`).
+
+Two independent NyxID authorities prevent the required zero-match result:
+
+1. **The read cannot run.** `delegated_read_denied_path` rejects the entire
+   `mcp` class (`backend/src/mw/auth.rs:394-420`).
+   `delegated_request_allowed` requires both exact `account:read` and a path
+   outside that class (`backend/src/mw/auth.rs:468-482`), and
+   `reject_delegated_tokens` enforces it (`backend/src/mw/auth.rs:1159-1181`).
+   `catalog_read_scope_alone_grants_no_proxy_or_management_route` pins
+   `/api/v1/mcp/config` as denied (`backend/src/mw/auth.rs:1508-1518`). The
+   local bridge receipt confirms HTTP 403.
+2. **The current bridge cannot omit one connected service.** If the route were
+   reachable, `get_mcp_config` would select `ServiceScope::Unrestricted` for
+   this token (`backend/src/handlers/mcp.rs:83-111`). The service filter admits
+   every row in that mode (`backend/src/services/mcp_service.rs:676-709`). The
+   bridge receipt records `allow_all_services=true`, and the consent-revocation
+   probe records the same unrestricted summary before and after revocation.
+
+The JSON-RPC `/mcp` transport is not a substitute for Aevatar's REST call. Its
+catalog authority is online and revocable: a signed `mcp:catalog:read` token
+must match an unexpired, unrevoked `CatalogDelegationGrant`, active clients,
+current consent, service ownership, and canonical resources
+(`backend/src/services/catalog_delegation_service.rs:38-42,81-172`). Aevatar
+does not call this transport for either access check.
+
+## Authority candidates
+
+| Candidate | Threat model | Revocation and retry | Deployment | Rollback |
+| --- | --- | --- | --- | --- |
+| Consent-derived delegated restrictions | Least authority can exclude unapproved user services. It is safe only with a live grant bound to `jti`, subject, actor client, receiving client, service IDs, resources, and expiry. A bare scope claim is insufficient. | Consent revocation must invalidate the online grant and the next minted capability. Confirmation retry must atomically merge the same service without replacing existing scopes or IDs. | Requires the live-grant-backed REST read and the validated Aevatar client link. The pinned gateway survives restriction. The platform proxy slug does not, but no receipt shows that Aevatar calls it. | Disable the access-review action and effect first. Then stop restricted minting, restore unrestricted bridge minting, verify both auth inputs, and remove the REST exception and client link. Keep old grants deny-by-default until expiry. |
+| Complete OAuth browser round trip with NyxID return channel | OAuth authorization code, PKCE, `state`, redirect ownership, tab and session binding, and return-channel replay become part of chat's security boundary. It duplicates an identity and capability transport that already exists. | Standard OAuth revocation is clear, but assistant retry must resume across redirects and distinguish user cancellation, callback replay, stale conversations, and completed-but-unobserved consent. | Requires new browser navigation, a callback and return protocol, Aevatar continuation state, and two-system rollout. No such return channel exists in the pinned contract. | Disable the new browser entry and return to the bridge. In-flight OAuth state must expire without resuming a chat action. |
+| Preserve unrestricted forwarding with an upstream reachability explanation | Aevatar retains broad service authority for the session, so it cannot represent per-service approval. The UI must not claim that it can. Existing route denials still protect management surfaces. | Five-minute capabilities expire normally. Consent and service review cannot revoke a subset because no subset is minted. Ordinary chat retry behavior is unchanged. | No product change. Keep the live row's `forward_access_token=true` as the deployed posture until AC-3 is proven. | This is the rollback posture. A restricted rollout must disable its access-review action before restoring this bridge, then verify identity plus capability delivery. |
+
+### Cost of the consent-derived candidate
+
+1. **Reachable, live-grant-backed REST catalog read.** Add an exact GET-only
+   exception for `/api/v1/mcp/config` in
+   `backend/src/mw/auth.rs:delegated_request_allowed` without opening the rest
+   of the `mcp` class. The verified request must also pass
+   `catalog_delegation_service::validate_live_grant`; accepting
+   `mcp:catalog:read` from the middleware's unverified payload peek is not
+   sufficient. `handlers/mcp.rs:get_mcp_config` must receive the verified grant
+   identity before it calls `mcp_service::load_operation_catalog`.
+   `catalog_read_scope_alone_grants_no_proxy_or_management_route` must change
+   from unconditional denial to two cases: no live grant remains denied, while
+   the exact route plus a matching live grant reaches the handler. Every other
+   proxy and management route remains denied.
+2. **Restricted platform callback.** The configured gateway already suffices.
+   `llm_gateway::gateway_request` starts with only
+   `ensure_llm_proxy_access` (`backend/src/handlers/llm_gateway.rs:557-575`),
+   and the local restricted receipt is 200. The ordinary platform proxy fails.
+   `execute_proxy_inner` returns `ApiKeyScopeForbidden` on any legacy
+   `DownstreamService` when `allow_all_services=false`
+   (`backend/src/handlers/proxy.rs:2011-2033`). If
+   `/proxy/s/chrono-llm-public` remains a supported callback, add an exemption
+   bound to the exact platform row, verified Aevatar actor and receiving
+   client, and live catalog grant. Do not broadly bypass the gate. The
+   server-chosen assistant ingress already uses `execute_admin_proxy`, which
+   intentionally skips this caller-addressed gate
+   (`backend/src/handlers/proxy.rs:1439-1481`). This exemption is not required
+   for AC-3 unless an Aevatar receipt shows a call to the proxy-slug path.
+3. **Durable Aevatar client link.** Add an admin-managed
+   `delegated_authority_client_id` field to the `aevatar`
+   `DownstreamService`, and validate that it references an active OAuth client
+   on create and update. Do not reuse `oauth_client_id`. That field means the OIDC
+   client used when `auth_method="oidc"`
+   (`backend/src/models/downstream_service.rs:220-222`). A row field is
+   preferable to environment configuration because the row already owns the
+   integration's base URL, identity audience, token forwarding, and delegation
+   policy. It can be inspected, validated, audited, and rolled back with the
+   integration. A process setting would permit row/config drift and make
+   multiple Aevatar rows ambiguous. The pinned upstream client is
+   `a6ff2946-f02f-4c35-8203-1ec46132b660`
+   (`src/Aevatar.Mainnet.Host.Api/appsettings.json:41-44`), but the current
+   NyxID row has no field that resolves that identity.
+
+## Decision predicate
+
+| Condition | Current system | Candidate design | Evidence and AC-3 proof |
+| --- | --- | --- | --- |
+| Restricted chat bootstrap still works | **Pass on the configured path.** The restricted local request to `/api/v1/llm/gateway/v1` returned 200. The proxy-slug request returned 403, but the pinned Aevatar configuration names the gateway path. | **Pass.** Keep `handlers/llm_gateway.rs:gateway_request` as the callback. Do not add a proxy-slug exemption unless an Aevatar receipt establishes that dependency. | Seven-row restricted callback rows; pinned `GatewayEndpoint` at `appsettings.json:16-20` |
+| Exact Aevatar OAuth client resolves without guessing | **Not linked.** Aevatar and the registered NyxID client agree on `a6ff2946-f02f-4c35-8203-1ec46132b660`, but `DownstreamService` cannot express that relationship today. | **Pass.** Add the validated admin-managed `delegated_authority_client_id` field to the `aevatar` row. The field must resolve the registered active client before minting. | Pinned `BackendConsole.OidcClientId`; production client observation; `DownstreamService` field audit; AC-3 validation tests |
+| Approving a service changes the next minted capability | **Not implemented.** Revoking consent changed the consent read but left the next current-bridge summary unrestricted. | **Pass.** Mint each assistant capability from current consent for the linked client. An atomic approval merge must therefore change the next minted service list, while revocation must remove that authority. | Negative-case consent receipt; AC-3 before, apply, retry, next-mint, and revoke tests |
+
+The current bridge fails the last two conditions by construction. Those results
+explain why access review is unreachable today. They do not falsify the
+candidate that adds the missing client link and derives every new capability
+from current consent.
+
+The consent-derived candidate satisfies the predicate and is accepted for
+AC-3. A complete OAuth round trip is rejected because it adds a browser return
+protocol without improving the chosen authority model. Unrestricted forwarding
+remains the deployed and rollback posture until AC-3 proves the replacement.
+
+### Accepted operational design
+
+AC-3 may implement consent-derived delegated restrictions under its own
+security review. It must add the exact GET-only `/api/v1/mcp/config` allowance
+backed by a verified live `CatalogDelegationGrant`, while every other route in
+the `mcp` class remains denied. It must also add the validated
+`delegated_authority_client_id` link and mint each assistant capability from the
+linked client's current consent. AC-3 must split the existing route-policy test
+into no-grant denial and matching-live-grant success cases.
+
+Do not add a `/proxy/s/chrono-llm-public` exemption unless a new receipt proves
+that Aevatar uses that callback. The pinned Aevatar deployment configures the
+gateway path, and that path passed the restricted-token probe.
+
+Until AC-3 lands and proves that Aevatar receives both caller identity and the
+restricted capability, keep `forward_access_token=true` and preserve the
+current unrestricted forwarding posture. Access review remains unreachable in
+that interim state for the independent route-denial and allow-all reasons above.
+
+## AC-3 change map
+
+This map defines the symbols for the authorized consent-derived implementation.
+AC-3 remains subject to its own security review gate.
+
+| Responsibility | Symbols |
+| --- | --- |
+| Atomic consent merge | Add `consent_service::merge_consent_services_atomic` in `backend/src/services/consent_service.rs`. Use one atomic aggregation-pipeline `find_one_and_update` keyed by `(user_id, client_id)`. Union the requested service ID and required scopes while preserving all existing scopes, IDs, `allow_all_services`, grant identity, and unrelated fields. Never call `grant_consent_with_services`. `grant_consent_internal` replaces the full row at lines 71-100. The unique `(user_id, client_id)` index is at `backend/src/db.rs:911-920`. |
+| HTTP effect | Add the confirmed `service.access_review` effect in `backend/src/handlers/assistant_action_effects_services.rs` and mount only its typed route in `backend/src/routes.rs`. Resolve actor, client link, and user-owned service server-side; reject cross-user IDs before the merge. |
+| Authority mint | Replace the session projection in `backend/src/handlers/assistant.rs:build_forward_authorization`. Resolve `delegated_authority_client_id`, read current consent, derive `CatalogAuthority`, call `generate_delegated_access_token_for_client` so `client_id` is present, then persist the matching online grant with `catalog_delegation_service::persist_grant`. Do not derive service restrictions from session `AuthUser`. |
+| REST catalog guard | Change `mw/auth.rs:delegated_request_allowed`, `reject_delegated_tokens`, and their route tests; add verified live-grant enforcement before `handlers/mcp.rs:get_mcp_config` publishes `mcp_service::ServiceScope`. |
+| Platform callback | Keep `handlers/llm_gateway.rs:gateway_request` as the proven path. No proxy-slug exemption is required. If a later Aevatar receipt shows that callback, narrow the legacy gate in `handlers/proxy.rs:execute_proxy_inner` to the exact live-grant-bound Aevatar platform callback. |
+| Client link | Extend `models/downstream_service.rs`, the admin service request and response DTOs in `handlers/services.rs`, and admin validation so `delegated_authority_client_id` always names an active OAuth client. No environment variable is added. |
+| Audit | Append metadata-only events `assistant_service_access_review_requested`, `assistant_service_access_grant_merged`, `assistant_service_access_grant_replayed`, `assistant_service_access_grant_denied`, and `assistant_delegated_authority_minted`. Include actor ID, owner ID, service ID, client ID, action request ID, outcome, and online-grant ID where applicable; never include a token, credential, cookie, or authorization value. Preserve the existing `oauth_consent_revoked` event and make grant invalidation observable. |
+
+Required tests include database cases for the state before the merge, the first
+apply, an idempotent retry, revocation, and a cross-user request. They also
+include concurrent merges of different service IDs, live-grant expiry and
+revocation, a missing/inactive/mismatched client link, exact-route denial
+without a grant, catalog filtering, gateway bootstrap, continued proxy-slug
+denial unless a dependency is observed, and audit metadata redaction.
+
+## Negative cases
+
+| Case | Evidence | Result | Audit |
+| --- | --- | --- | --- |
+| Expired delegated capability | The local gateway received an expired delegated capability | 401; failed closed | The receipt records no audit event ID |
+| Identity `jti` replay | Pinned validator consumes replay state only after signed-claim validation; its authentication test sends the same token twice (`NyxIdIdentityAssertionAuthenticationTests.cs:87-96`) | Second request is 401 with `identity_assertion_replayed`; source-proven because Aevatar cannot run locally | Replay guard is upstream; no local NyxID audit ID |
+| Service removal | A user service deletion returned 200. The next request for the removed service returned 404. | Failed closed | The receipt records audit event `a62fe61d-cd77-461f-b942-7fbbf50e935f` without an event name |
+| Consent revocation | The revoked user's consent read became 404. The other user's consent read stayed 200. The next bridge summary did not change. | Revocation is owner-scoped, but the consent-derived bridge candidate fails because bridge authority did not change. | The receipt records audit event `f37bd037-41a0-4359-851b-3e0d98232c69` without an event name |
+| Cross-user resource substitution | The substitution case returned 404. The other user's consent read stayed 200. | Failed closed | The receipt records no audit event ID |
+
+The machine matrix is `/tmp/ac2-evidence/negative-case-receipt.json`.
+
+## Deployment and rollback
+
+`forward_access_token` must remain `true` on the live `aevatar` row until a
+replacement is proven to deliver both the caller identity assertion and an
+execution capability to Aevatar. The identity assertion cannot replace the
+capability: Aevatar's stream rejects identity-only requests.
+
+For a future restricted rollout, use this rollback order:
+
+1. Disable the access-review action and effect so no new confirmation can
+   promise a per-service grant.
+2. Stop issuing restricted assistant grants and restore the current
+   unrestricted session bridge.
+3. Verify typed chat, identity assertion receipt, and capability receipt using
+   the pinned gateway.
+4. Remove the proxy-slug exemption, then the REST MCP exception.
+5. Remove or clear the authority-client link only after no minted grant depends
+   on it; leave online grants revoked or let them expire.
+
+This order restores execution before removing read paths and metadata. It does
+not create an interval where a UI claims per-service authority while Aevatar is
+running unrestricted.
+
+## Production attempt
+
+The permitted production read probe ran against
+`https://nyx-api.chrono-ai.fun`. The supplied `~/.nyxid/access_token` expired
+during the probe window. Authenticated reads returned 401; the public assistant
+action manifest returned 200 with 57 items. No production chat POST or DELETE
+was attempted. The redacted receipt is
+`/tmp/ac2-evidence/production-read.json`. This is an explicit missing deployed
+observation, not a runtime claim about Aevatar.
+
+## Method decisions
+
+- **Model the Domain.** The receipt is a discriminated, fixed seven-row record,
+  not generic request and response logging.
+- **Boundary Discipline.** Tokens stay inside the probe process. The probe
+  reconstructs output field by field and applies a final secret-shape barrier.
+- **Fix Root Causes.** The accepted design addresses the route denial and the
+  unrestricted bridge claims as separate authorities. It does not add a
+  proxy-slug exemption without evidence that Aevatar uses that path.
+- **Prove It Works.** The record labels source-only Aevatar rows separately from
+  runtime NyxID rows. It reports the missing .NET runtime and the expired
+  production token instead of inventing observations.
+- **Sequence Work into Verifiable Units.** The probe tests route reachability,
+  claim authority, callback bootstrap, consent revocation, and cross-user
+  isolation independently. AC-3 owns the missing authorities and must pass a
+  separate security review before rollout.
+- **Build the Lever.** The dependency-free probe is rerunnable and mode-gated.
+  It keeps production reads separate from the one-write chat transaction.

--- a/docs/chat/aevatar-access-review-authority.md
+++ b/docs/chat/aevatar-access-review-authority.md
@@ -1,13 +1,15 @@
 # Aevatar access-review authority decision
 
 **Status.** Use consent-derived delegated restrictions as the AC-3 authority
-model. Service access review is not reachable from the current assistant
-bridge, so preserve unrestricted forwarding until AC-3 passes its security and
-deployment gates.
+model, with the live-grant-backed REST read, the exact platform-callback
+exemption, and the validated Aevatar client link. Service access review remains
+unreachable today because the current bridge is both route-denied and
+unrestricted. Keep `forward_access_token=true` and unrestricted forwarding in
+production until AC-3 lands; AC-3 proceeds under its own security review gate.
 
 This record is the AC-2 probe and authority decision. It changes no product
 behavior. NyxID evidence was collected from local SHA
-`3fbae40a7b9526afdc97b3fdc005c1a543dabaaf`. Aevatar source evidence is pinned
+`28f26d85b00ca00e23dfeb50c38251e184e95d06`. Aevatar source evidence is pinned
 to `e5bba2e9719ad5132004b882744caa3875db1123`. Runtime Aevatar rows are marked
 source-proven because this environment has no .NET runtime and Aevatar accepts
 only production-JWKS tokens.
@@ -50,12 +52,18 @@ where pinned source does not establish an HTTP observation.
 | Identity plus capability Bearer | Pinned Aevatar source `e5bba2e` | n/a | n/a | delegated; actor present; `allow_all_services=false`; 1 allowed service; 0 resources; `proxy`; 300 seconds | Authorization Bearer is selected as `ProxyDelegation`; source-proven, not runtime-observed |
 | Identity plus delegation header | Pinned Aevatar source `e5bba2e` | n/a | n/a | delegated; actor present; `allow_all_services=true`; 0 allowed services and 0 resources; `proxy:*`; 300 seconds | Delegation header supplies `ProxyDelegation` when Bearer is absent; source-proven, not runtime-observed |
 | Replayed identity `jti` | Pinned Aevatar source `e5bba2e` | 401 | `identity_assertion_replayed` | non-delegated identity assertion; 60 seconds | Replay rejected; source-proven, not runtime-observed |
-| Bridge Bearer reads REST MCP config | Local NyxID `3fbae40a` | 403 | none exposed | delegated; actor present; `allow_all_services=true`; 0 allowed services and 0 resources; `proxy:*`; 300 seconds | Route denied before catalog filtering |
-| Restricted Bearer uses LLM gateway | Local NyxID `3fbae40a` | 200 | none | delegated; actor present; `allow_all_services=false`; 1 allowed service; 0 resources; `proxy`; 300 seconds | Pinned gateway callback is reachable |
-| Restricted Bearer uses platform proxy slug | Local NyxID `3fbae40a` | 403 | none exposed | same restricted summary | Legacy platform-row scope gate denies the callback |
+| Bridge Bearer reads REST MCP config | Local NyxID `28f26d85` | 403 | `1002` | delegated; actor present; `allow_all_services=true`; 0 allowed services and 0 resources; `proxy:*`; 300 seconds | Route denied before catalog filtering; runtime-observed |
+| Restricted Bearer uses LLM gateway | Local NyxID `28f26d85` | 200 | none | delegated; actor present; `allow_all_services=false`; 1 allowed service; 0 resources; `proxy`; 300 seconds | Gateway control reaches its upstream; runtime-observed |
+| Restricted Bearer uses platform proxy slug | Local NyxID `28f26d85` | 403 | `9000` | same restricted summary | Legacy platform-row scope gate denies Aevatar's default callback; runtime-observed |
 
 The machine receipt is `/tmp/ac2-evidence/seven-row-receipt.json`. Local setup
-statuses are in `/tmp/ac2-evidence/local-runtime-setup.json`.
+statuses are in `/tmp/ac2-evidence/local-runtime-setup.json`. The three local
+rows were rerun through a real `cargo run` NyxID backend at the recorded SHA.
+The only stub was a loopback OpenAI-compatible downstream behind NyxID. It
+returned one fixed, successful chat-completion response so the gateway row
+could prove that NyxID forwarded the request; it did not replace NyxID or
+Aevatar. The gateway row is a control, not Aevatar's default route. Raw response
+logs are under `/tmp/ac2-evidence/runtime/`.
 
 ## What the transport authenticates
 
@@ -121,13 +129,23 @@ catalog authority is online and revocable: a signed `mcp:catalog:read` token
 must match an unexpired, unrevoked `CatalogDelegationGrant`, active clients,
 current consent, service ownership, and canonical resources
 (`backend/src/services/catalog_delegation_service.rs:38-42,81-172`). Aevatar
-does not call this transport for either access check.
+does not call this transport for either access check. The current bridge Bearer
+can already read the same operation catalog through `POST /mcp` `tools/list`
+(`backend/src/handlers/mcp_transport.rs:455-470,709-739,1248-1266`). The REST
+allowance therefore exposes no new catalog data class to that bearer; its new
+security surface is the live-grant check on the additional route.
+
+Restricted catalog projection has a deliberate limitation. `ServiceScope::Allowed`
+keeps user-service rows only and drops every platform row
+(`backend/src/services/mcp_service.rs:676-709`); JSON-RPC applies the same rule
+(`backend/src/handlers/mcp_transport.rs:709-739`). Consent contains user-service
+IDs, so it cannot restore a platform row to a restricted catalog.
 
 ## Authority candidates
 
 | Candidate | Threat model | Revocation and retry | Deployment | Rollback |
 | --- | --- | --- | --- | --- |
-| Consent-derived delegated restrictions | Least authority can exclude unapproved user services. It is safe only with a live grant bound to `jti`, subject, actor client, receiving client, service IDs, resources, and expiry. A bare scope claim is insufficient. | Consent revocation must invalidate the online grant and the next minted capability. Confirmation retry must atomically merge the same service without replacing existing scopes or IDs. | Requires the live-grant-backed REST read and the validated Aevatar client link. The pinned gateway survives restriction. The platform proxy slug does not, but no receipt shows that Aevatar calls it. | Disable the access-review action and effect first. Then stop restricted minting, restore unrestricted bridge minting, verify both auth inputs, and remove the REST exception and client link. Keep old grants deny-by-default until expiry. |
+| Consent-derived delegated restrictions | Least authority can exclude unapproved user services. It is safe only with a live grant bound to `jti`, subject, actor client, receiving client, service IDs, resources, and expiry. A bare scope claim is insufficient. | Consent revocation must invalidate the online grant and the next minted capability. Confirmation retry must atomically merge the same service without replacing existing scopes or IDs. | Requires the live-grant-backed REST read, an exact platform-callback exemption, and the validated Aevatar client link. The gateway control survives restriction, but Aevatar's default slug callback does not without the exemption. | Disable the access-review action and effect first. Revoke grants, restore unrestricted bridge minting, verify both auth inputs and default chat, then remove the slug and REST exceptions before clearing the client link. |
 | Complete OAuth browser round trip with NyxID return channel | OAuth authorization code, PKCE, `state`, redirect ownership, tab and session binding, and return-channel replay become part of chat's security boundary. It duplicates an identity and capability transport that already exists. | Standard OAuth revocation is clear, but assistant retry must resume across redirects and distinguish user cancellation, callback replay, stale conversations, and completed-but-unobserved consent. | Requires new browser navigation, a callback and return protocol, Aevatar continuation state, and two-system rollout. No such return channel exists in the pinned contract. | Disable the new browser entry and return to the bridge. In-flight OAuth state must expire without resuming a chat action. |
 | Preserve unrestricted forwarding with an upstream reachability explanation | Aevatar retains broad service authority for the session, so it cannot represent per-service approval. The UI must not claim that it can. Existing route denials still protect management surfaces. | Five-minute capabilities expire normally. Consent and service review cannot revoke a subset because no subset is minted. Ordinary chat retry behavior is unchanged. | No product change. Keep the live row's `forward_access_token=true` as the deployed posture until AC-3 is proven. | This is the rollback posture. A restricted rollout must disable its access-review action before restoring this bridge, then verify identity plus capability delivery. |
 
@@ -144,32 +162,49 @@ does not call this transport for either access check.
    `catalog_read_scope_alone_grants_no_proxy_or_management_route` must change
    from unconditional denial to two cases: no live grant remains denied, while
    the exact route plus a matching live grant reaches the handler. Every other
-   proxy and management route remains denied.
-2. **Restricted platform callback.** The configured gateway already suffices.
-   `llm_gateway::gateway_request` starts with only
-   `ensure_llm_proxy_access` (`backend/src/handlers/llm_gateway.rs:557-575`),
-   and the local restricted receipt is 200. The ordinary platform proxy fails.
-   `execute_proxy_inner` returns `ApiKeyScopeForbidden` on any legacy
-   `DownstreamService` when `allow_all_services=false`
-   (`backend/src/handlers/proxy.rs:2011-2033`). If
-   `/proxy/s/chrono-llm-public` remains a supported callback, add an exemption
-   bound to the exact platform row, verified Aevatar actor and receiving
-   client, and live catalog grant. Do not broadly bypass the gate. The
-   server-chosen assistant ingress already uses `execute_admin_proxy`, which
-   intentionally skips this caller-addressed gate
-   (`backend/src/handlers/proxy.rs:1439-1481`). This exemption is not required
-   for AC-3 unless an Aevatar receipt shows a call to the proxy-slug path.
+   proxy and management route remains denied. The handler itself calls
+   `ensure_rest_proxy_access` (`backend/src/handlers/mcp.rs:88-92`), so the
+   assistant capability's exact scope string must be
+   `proxy:* mcp:catalog:read`. Do not add `mcp:catalog:read` to
+   `SERVICE_DELEGATION_SCOPES`: that list feeds ordinary
+   `inject_delegation_token` minting, which has no matching online-grant
+   persistence (`backend/src/mw/auth.rs:271-279` and
+   `backend/src/handlers/proxy.rs:2493-2507`).
+2. **Restricted platform callback.** Aevatar's default chat path is
+   `/api/v1/proxy/s/chrono-llm-public`. `LlmDefaults.NyxIdRoute` supplies the
+   slug when `Aevatar:NyxId:DefaultRoute` is unset, as it is in the pinned
+   mainnet settings; `NyxIdLLMProvider` then normalizes it to the proxy path
+   (`LlmDefaults.cs:21`, `ServiceCollectionExtensions.cs:1167-1170`,
+   `NyxIdLLMProvider.cs:365-379`, and `NyxIdChatEndpoints.cs:272`). NyxID's own
+   bridge documentation names the same route
+   (`backend/src/handlers/assistant.rs:691-699,811-820`). The gateway control
+   reaches the stub, but it is not the default callback.
+
+   The default path currently fails because `execute_proxy_inner` returns
+   `ApiKeyScopeForbidden` for every legacy `DownstreamService` when
+   `allow_all_services=false` (`backend/src/handlers/proxy.rs:2011-2033`). Add a
+   narrow exemption for the exact active `chrono-llm-public` platform row. It
+   must require verified delegated assistant authority, actor equal to the
+   Aevatar row's linked client, receiving client equal to that same link, and a
+   valid live catalog grant. Do not bypass the gate for any other platform row
+   or delegated caller. The server-chosen assistant ingress is different: it
+   uses `execute_admin_proxy`, which already skips this caller-addressed gate
+   (`backend/src/handlers/proxy.rs:1439-1481`).
 3. **Durable Aevatar client link.** Add an admin-managed
    `delegated_authority_client_id` field to the `aevatar`
-   `DownstreamService`, and validate that it references an active OAuth client
-   on create and update. Do not reuse `oauth_client_id`. That field means the OIDC
-   client used when `auth_method="oidc"`
+   `DownstreamService`. On create or change, resolve an active OAuth client and
+   call `catalog_delegation_service::ensure_client_can_delegate_catalog`; emit a
+   metadata-only audit event for the link change. Resolve and validate the row
+   and client again for every mint. Do not reuse `oauth_client_id`. That field
+   means the OIDC client used when `auth_method="oidc"`
    (`backend/src/models/downstream_service.rs:220-222`). A row field is
    preferable to environment configuration because the row already owns the
    integration's base URL, identity audience, token forwarding, and delegation
    policy. It can be inspected, validated, audited, and rolled back with the
-   integration. A process setting would permit row/config drift and make
-   multiple Aevatar rows ambiguous. The pinned upstream client is
+   integration. A process setting would permit row/config drift and split one
+   integration's policy across deployment state. NyxID already prevents active
+   row ambiguity with a partial unique index on `slug` for `is_active=true`
+   (`backend/src/db.rs:335-352`). The pinned upstream client is
    `a6ff2946-f02f-4c35-8203-1ec46132b660`
    (`src/Aevatar.Mainnet.Host.Api/appsettings.json:41-44`), but the current
    NyxID row has no field that resolves that identity.
@@ -178,14 +213,15 @@ does not call this transport for either access check.
 
 | Condition | Current system | Candidate design | Evidence and AC-3 proof |
 | --- | --- | --- | --- |
-| Restricted chat bootstrap still works | **Pass on the configured path.** The restricted local request to `/api/v1/llm/gateway/v1` returned 200. The proxy-slug request returned 403, but the pinned Aevatar configuration names the gateway path. | **Pass.** Keep `handlers/llm_gateway.rs:gateway_request` as the callback. Do not add a proxy-slug exemption unless an Aevatar receipt establishes that dependency. | Seven-row restricted callback rows; pinned `GatewayEndpoint` at `appsettings.json:16-20` |
-| Exact Aevatar OAuth client resolves without guessing | **Not linked.** Aevatar and the registered NyxID client agree on `a6ff2946-f02f-4c35-8203-1ec46132b660`, but `DownstreamService` cannot express that relationship today. | **Pass.** Add the validated admin-managed `delegated_authority_client_id` field to the `aevatar` row. The field must resolve the registered active client before minting. | Pinned `BackendConsole.OidcClientId`; production client observation; `DownstreamService` field audit; AC-3 validation tests |
+| Restricted chat bootstrap still works | **Fail.** The restricted gateway control reaches its upstream, but the default `/api/v1/proxy/s/chrono-llm-public` callback returns 403 at the legacy platform-row gate. | **Pass only with change 2.** The exact live-grant-bound `chrono-llm-public` exemption admits the default callback without admitting another platform row. | Seven-row restricted callback rows; pinned default-route selection in `LlmDefaults.cs:21`, `ServiceCollectionExtensions.cs:1167-1170`, `NyxIdLLMProvider.cs:365-379`, and `NyxIdChatEndpoints.cs:272` |
+| Exact Aevatar OAuth client resolves without guessing | **Not linked.** Aevatar and the registered NyxID client agree on `a6ff2946-f02f-4c35-8203-1ec46132b660`, but `DownstreamService` cannot express that relationship today. | **Pass.** Add the admin-managed `delegated_authority_client_id` field, validate catalog delegation at link time, and re-resolve it before every mint. | Pinned `BackendConsole.OidcClientId`; production client observation; `DownstreamService` field and audit tests |
 | Approving a service changes the next minted capability | **Not implemented.** Revoking consent changed the consent read but left the next current-bridge summary unrestricted. | **Pass.** Mint each assistant capability from current consent for the linked client. An atomic approval merge must therefore change the next minted service list, while revocation must remove that authority. | Negative-case consent receipt; AC-3 before, apply, retry, next-mint, and revoke tests |
 
-The current bridge fails the last two conditions by construction. Those results
-explain why access review is unreachable today. They do not falsify the
-candidate that adds the missing client link and derives every new capability
-from current consent.
+The current system fails all three conditions: restriction breaks the default
+callback, the bridge has no client link, and consent cannot change its minted
+authority. Those results explain why access review is unreachable today. They
+do not falsify the candidate, whose three enabling changes supply the missing
+authorities.
 
 The consent-derived candidate satisfies the predicate and is accepted for
 AC-3. A complete OAuth round trip is rejected because it adds a browser return
@@ -197,14 +233,13 @@ remains the deployed and rollback posture until AC-3 proves the replacement.
 AC-3 may implement consent-derived delegated restrictions under its own
 security review. It must add the exact GET-only `/api/v1/mcp/config` allowance
 backed by a verified live `CatalogDelegationGrant`, while every other route in
-the `mcp` class remains denied. It must also add the validated
-`delegated_authority_client_id` link and mint each assistant capability from the
-linked client's current consent. AC-3 must split the existing route-policy test
-into no-grant denial and matching-live-grant success cases.
-
-Do not add a `/proxy/s/chrono-llm-public` exemption unless a new receipt proves
-that Aevatar uses that callback. The pinned Aevatar deployment configures the
-gateway path, and that path passed the restricted-token probe.
+the `mcp` class remains denied. It must add the exact live-grant-bound
+`chrono-llm-public` exemption required by Aevatar's default chat route, plus the
+validated `delegated_authority_client_id` link, and mint each assistant
+capability from the linked client's current consent with scope
+`proxy:* mcp:catalog:read`. AC-3 must split the existing route-policy test into
+no-grant denial and matching-live-grant success cases, and it remains subject to
+an independent security review before implementation begins.
 
 Until AC-3 lands and proves that Aevatar receives both caller identity and the
 restricted capability, keep `forward_access_token=true` and preserve the
@@ -218,20 +253,24 @@ AC-3 remains subject to its own security review gate.
 
 | Responsibility | Symbols |
 | --- | --- |
-| Atomic consent merge | Add `consent_service::merge_consent_services_atomic` in `backend/src/services/consent_service.rs`. Use one atomic aggregation-pipeline `find_one_and_update` keyed by `(user_id, client_id)`. Union the requested service ID and required scopes while preserving all existing scopes, IDs, `allow_all_services`, grant identity, and unrelated fields. Never call `grant_consent_with_services`. `grant_consent_internal` replaces the full row at lines 71-100. The unique `(user_id, client_id)` index is at `backend/src/db.rs:911-920`. |
-| HTTP effect | Add the confirmed `service.access_review` effect in `backend/src/handlers/assistant_action_effects_services.rs` and mount only its typed route in `backend/src/routes.rs`. Resolve actor, client link, and user-owned service server-side; reject cross-user IDs before the merge. |
-| Authority mint | Replace the session projection in `backend/src/handlers/assistant.rs:build_forward_authorization`. Resolve `delegated_authority_client_id`, read current consent, derive `CatalogAuthority`, call `generate_delegated_access_token_for_client` so `client_id` is present, then persist the matching online grant with `catalog_delegation_service::persist_grant`. Do not derive service restrictions from session `AuthUser`. |
+| Atomic consent merge | Add `consent_service::merge_consent_services_atomic` in `backend/src/services/consent_service.rs`. Use one atomic aggregation-pipeline `find_one_and_update` upsert keyed by `(user_id, client_id)`. Set-union the requested service ID and required scopes while preserving all existing scopes, IDs, `allow_all_services`, grant identity, and unrelated fields. On a concurrent first-approval E11000, retry as a non-upserting merge against the winning row. Never call `grant_consent_with_services`. `grant_consent_internal` replaces the full row at lines 71-100, and the OAuth consent page in `backend/src/handlers/oauth.rs:807-836` still calls that replacement path; treat it as a known concurrent-writer hazard. The unique `(user_id, client_id)` index is at `backend/src/db.rs:911-920`. |
+| HTTP effect | Add the confirmed `service.access_review` effect in `backend/src/handlers/assistant_action_effects_services.rs` and mount only its typed route in `backend/src/routes.rs`. Call `assistant_action_receipts::reserve_or_replay` before mutation. Resolve actor, client link, and user-owned service server-side; reject cross-user IDs before the merge. |
+| Authority mint | Replace the session projection in `backend/src/handlers/assistant.rs:build_forward_authorization`. Re-resolve the active `aevatar` row and `delegated_authority_client_id`, read current consent, derive `CatalogAuthority`, and call `generate_delegated_access_token_for_client` with exact scope `proxy:* mcp:catalog:read` so `client_id` is present. Use the linked client as both actor and receiver unless AC-3 introduces and validates a separate actor client. Persist the matching online grant with `catalog_delegation_service::persist_grant` before forwarding. Do not derive service restrictions from session `AuthUser`. |
 | REST catalog guard | Change `mw/auth.rs:delegated_request_allowed`, `reject_delegated_tokens`, and their route tests; add verified live-grant enforcement before `handlers/mcp.rs:get_mcp_config` publishes `mcp_service::ServiceScope`. |
-| Platform callback | Keep `handlers/llm_gateway.rs:gateway_request` as the proven path. No proxy-slug exemption is required. If a later Aevatar receipt shows that callback, narrow the legacy gate in `handlers/proxy.rs:execute_proxy_inner` to the exact live-grant-bound Aevatar platform callback. |
-| Client link | Extend `models/downstream_service.rs`, the admin service request and response DTOs in `handlers/services.rs`, and admin validation so `delegated_authority_client_id` always names an active OAuth client. No environment variable is added. |
-| Audit | Append metadata-only events `assistant_service_access_review_requested`, `assistant_service_access_grant_merged`, `assistant_service_access_grant_replayed`, `assistant_service_access_grant_denied`, and `assistant_delegated_authority_minted`. Include actor ID, owner ID, service ID, client ID, action request ID, outcome, and online-grant ID where applicable; never include a token, credential, cookie, or authorization value. Preserve the existing `oauth_consent_revoked` event and make grant invalidation observable. |
+| Platform callback | Narrow the legacy `DownstreamService` gate in `handlers/proxy.rs:execute_proxy_inner` for the exact active `chrono-llm-public` row. Require delegated assistant authority, actor and receiving client equal to the current Aevatar row link, and a valid live grant. Keep `handlers/llm_gateway.rs:gateway_request` as a control path; it is not Aevatar's default route. |
+| Client link | Extend `models/downstream_service.rs`, the admin service request and response DTOs in `handlers/services.rs`, and admin validation. At link create or change, require an active OAuth client and call `catalog_delegation_service::ensure_client_can_delegate_catalog`; append a metadata-only audit event. Re-resolve the link at mint time. No environment variable is added. |
+| Consent revocation | Extend `consent_service::revoke_consent` and `handlers/consent.rs::revoke_my_consent` to mark all outstanding catalog grants for the user and linked client revoked before consent deletion completes. Regranting consent within the old token's TTL must not reactivate that token. |
+| Audit | Append metadata-only events `assistant_delegated_authority_client_link_changed`, `assistant_service_access_review_requested`, `assistant_service_access_grant_merged`, `assistant_service_access_grant_replayed`, `assistant_service_access_grant_denied`, and `assistant_delegated_authority_minted`. Include actor ID, owner ID, service ID, client ID, action request ID, outcome, and online-grant ID where applicable; never include a token, credential, cookie, or authorization value. Preserve the existing `oauth_consent_revoked` event and make grant invalidation observable. |
 
 Required tests include database cases for the state before the merge, the first
 apply, an idempotent retry, revocation, and a cross-user request. They also
 include concurrent merges of different service IDs, live-grant expiry and
-revocation, a missing/inactive/mismatched client link, exact-route denial
-without a grant, catalog filtering, gateway bootstrap, continued proxy-slug
-denial unless a dependency is observed, and audit metadata redaction.
+revocation, revoke then regrant within one token TTL with the old token still
+denied, a missing/inactive/mismatched client link, exact-route denial without a
+grant, and audit metadata redaction. Catalog tests must prove that a restricted
+mint drops every platform row and that consent cannot restore one. Bootstrap
+tests must cover both the gateway control and the default proxy-slug callback,
+including denial for the wrong row, actor, receiver, or grant.
 
 ## Negative cases
 
@@ -256,10 +295,11 @@ For a future restricted rollout, use this rollback order:
 
 1. Disable the access-review action and effect so no new confirmation can
    promise a per-service grant.
-2. Stop issuing restricted assistant grants and restore the current
-   unrestricted session bridge.
+2. Stop issuing restricted assistant grants, mark their outstanding
+   `CatalogDelegationGrant` rows revoked, and restore the current unrestricted
+   session bridge.
 3. Verify typed chat, identity assertion receipt, and capability receipt using
-   the pinned gateway.
+   Aevatar's default proxy-slug route; keep the gateway as a control.
 4. Remove the proxy-slug exemption, then the REST MCP exception.
 5. Remove or clear the authority-client link only after no minted grant depends
    on it; leave online grants revoked or let them expire.
@@ -282,11 +322,16 @@ observation, not a runtime claim about Aevatar.
 
 - **Model the Domain.** The receipt is a discriminated, fixed seven-row record,
   not generic request and response logging.
+- **Laziness Protocol.** The authority link lives on the existing Aevatar row;
+  AC-3 adds no process configuration or second integration registry.
 - **Boundary Discipline.** Tokens stay inside the probe process. The probe
   reconstructs output field by field and applies a final secret-shape barrier.
+- **Make Operations Idempotent.** The access-review effect reserves or replays
+  its request before one atomic set-union merge, including an E11000 retry for
+  simultaneous first approvals.
 - **Fix Root Causes.** The accepted design addresses the route denial and the
-  unrestricted bridge claims as separate authorities. It does not add a
-  proxy-slug exemption without evidence that Aevatar uses that path.
+  unrestricted bridge claims as separate authorities, and binds the required
+  proxy-slug exception to the same live grant instead of opening platform rows.
 - **Prove It Works.** The record labels source-only Aevatar rows separately from
   runtime NyxID rows. It reports the missing .NET runtime and the expired
   production token instead of inventing observations.

--- a/docs/plans/aevatar-chat-feature-integrate-convergence.md
+++ b/docs/plans/aevatar-chat-feature-integrate-convergence.md
@@ -1,0 +1,691 @@
+# Aevatar chat feature integrate convergence plan
+
+This program closes the NyxID browser-chat gaps against Aevatar `feature/integrate` for NyxID users and the engineers who maintain the integration.
+Done means the pinned contract, typed commands, access review, context attachments, lifecycle recovery, and a credentialed producer canary all pass at named NyxID and Aevatar SHAs.
+The program excludes Direct Chrono-LLM, Studio workflow chat, voice, channels, dormant Wave-2 actions, `inputParts`, and explicit `agentProfile` selection.
+Execute `AC-0` through `AC-7` in order. Stop every phase at merge-ready.
+
+## How to read this
+
+One box is one unit of work. Every box names the evidence that proves it. A nested box is a sub-step of the box above it. Check a box only when its evidence exists as a file, log, screenshot, recording, test run, link, or SHA. The body is a how-to. The appendices explain decisions and preserve evidence.
+
+The program runs `references/playbook-autopilot-stack.md` from the active `heca-mode` skill. Repository policy comes from `CONTRIBUTING.md` and `WORKFLOW.md`. The operator retains merge authority. Every phase stops at merge-ready with `auto_merge` disabled.
+
+Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+## Program checklist
+
+### Arm the program
+
+- [ ] Present this plan and `docs/plans/aevatar-chat-feature-integrate-convergence.md` to the operator, then stop until explicit authorization. Evidence is the operator's go message.
+- [ ] Record `AC-0 -> AC-1 -> AC-2 -> AC-3 -> AC-4 -> AC-5 -> AC-6 -> AC-7`, the done predicate, exclusions, merge authority, and repository policy sources. Evidence is the program entry in the decision trail.
+- [ ] Read `references/playbook-autopilot-stack.md` at program start and after every resume. Evidence is the skill path and version in the latest status report.
+- [ ] Use a standing Heca task for the dependent stack and no team or loop unless execution shows that the coordinator needs one. Evidence is the Heca task id or the recorded reason for changing this choice.
+
+### Assign owners and verifiers
+
+- [ ] Resolve delegated owners and verifiers from `~/.heca/pstack-models.json` against one live provider catalog snapshot. Evidence is an assignment table with provider, model, effort, and spawn mode.
+- [ ] Spawn each delegated role with `heca_agent_spawn` and `notify_on_finish` set to `true`. Evidence is the agent id beside its phase id.
+- [ ] Give every writer one branch or worktree and hold the dependency graph at the root. Evidence is the branch, worktree, base SHA, and allowed file boundary in the assignment table.
+- [ ] Keep each verifier independent from the owner and read-only on the owner's branch. Evidence is the verifier assignment and its exact head SHA.
+
+### Hold repository policy
+
+- [ ] Re-read `CONTRIBUTING.md` and `WORKFLOW.md` before execution. Evidence is a policy note that records the `main` target default, one required approval, explicit security review for security-sensitive work, required `CI Pipeline`, and disabled auto-merge.
+- [ ] Keep each phase independently reviewable and buildable. Evidence is a green exact phase head with no planned internal breakage.
+- [ ] Preserve the ordered base and head chain after any topology change. Evidence is the refreshed phase table with exact SHAs.
+- [ ] Never merge, close, or arm auto-merge without explicit authority and a clean repository-policy verdict. Evidence is the authorization record or the merge-ready handoff.
+
+### Verify exact heads
+
+- [ ] Run repository, live, and warranted risk checks at each exact phase head. Evidence is the command output and real-surface artifact linked from that phase.
+- [ ] Send every finding back to the owner and reverify after any head change. Evidence is the new head SHA and replacement verdict.
+- [ ] React to Heca finish notifications and report material state changes without polling agents. Evidence is the notification-linked status entry.
+- [ ] Hold a throughput checkpoint after `AC-1` and `AC-4`; advance only when the completed phase is green and the next phase still uses its verified contract. Evidence is the checkpoint verdict with the parent and child SHAs.
+- [ ] End each phase with a handoff that names what changed, predicate state, open risks, and exact next input. Evidence is the phase handoff in the decision trail.
+
+## Pin the upstream contract and automate drift detection (AC-0)
+
+**Depends on.** None.
+
+**Owner.** A delegated contract-tooling owner on the stack root branch.
+
+**Verifier.** An independent read-only integration-contract verifier at the exact `AC-0` head.
+
+**Files.**
+
+- [ ] Add `tests/fixtures/assistant/aevatar-chat-contract-pin.json` with the audited branch, remote head, effective chat SHA, watched paths, public command set, internal action set, and context-attachment rules. Evidence is the parsed fixture at the phase head.
+  - [ ] Watch exactly these upstream paths, namely `agents/Aevatar.GAgents.NyxidChat/`, `apps/aevatar-console-web/src/pages/chat/`, `apps/aevatar-console-web/src/shared/auth/client.ts`, `src/Aevatar.Mainnet.Host.Api/Chat/MainnetChatEndpoints.cs`, `src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionAuthentication.cs`, `src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequireServiceTool.cs`, `src/Aevatar.AI.ToolProviders.NyxId/NyxIdActionEvidenceReadPort.cs`, `src/Aevatar.AI.ToolProviders.NyxId/NyxIdMcpOperationCatalogReader.cs`, `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs`, `src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs`, and `src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs`. Evidence is the fixture's `watched_paths` array.
+- [ ] Add `scripts/check-aevatar-chat-drift.py` and `scripts/tests/test_check_aevatar_chat_drift.py`. Evidence is the scoped diff with the checker and its deterministic tests.
+- [ ] Add `.github/workflows/aevatar-chat-drift.yml` with weekly and manual triggers. Evidence is the workflow diff and one manual run URL.
+- [ ] Update `docs/chat/README.md` to point to the machine-readable pin and its check command. Evidence is the rendered document at the phase head.
+
+**Build.**
+
+- [ ] Make the pin record Aevatar remote head `e5bba2e9719ad5132004b882744caa3875db1123` and effective chat SHA `706ea7cab9d1f882e0fb0f034bb338102b6d5d2b`. Evidence is the exact JSON values in the fixture.
+- [ ] Make the checker fetch `feature/integrate`, compare watched chat paths from the effective SHA to remote HEAD, and fail with changed path names when contract-owned files move. Evidence is a passing clean case and a failing synthetic-drift case.
+- [ ] Keep NyxID's additive action manifest. Treat `schema_version` as the registry-wide compatibility gate and `revision` as an observability label. Evidence is a fixture assertion that unknown or divergent descriptors do not require an exact revision-wide match.
+
+**You see.**
+
+- [ ] Run the checker against the audited Aevatar clone and observe zero watched-path changes between the effective chat SHA `706ea7cab` and remote HEAD `e5bba2e9`. Evidence is a JSON or text receipt naming both SHAs and an empty changed-path list.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run `python3 -m unittest scripts.tests.test_check_aevatar_chat_drift` and the documentation and workflow checks used by `CI Pipeline` at the exact head. Evidence is a log headed by `git rev-parse HEAD` and the required check URL.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run `python3 scripts/check-aevatar-chat-drift.py --remote https://github.com/aevatarAI/aevatar.git --branch feature/integrate --pin tests/fixtures/assistant/aevatar-chat-contract-pin.json`. Pass when it resolves the live remote, records the observed head, and reports no unreviewed watched-path drift. Evidence is the command receipt with the fetch timestamp and SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Point the checker at a temporary repository with one watched-path commit after the effective pin. Pass when the command exits nonzero and prints only the changed watched paths without modifying the NyxID worktree. Evidence is the negative-test transcript and clean `git status --short` output.
+
+**Review gate.** None. This phase changes contract metadata, checks, and documentation only.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready root PR with `main` as its base, `auto_merge` disabled, one independent verdict, and a green `CI Pipeline`. Evidence is the PR URL and exact head SHA.
+
+## Remove obsolete commands and stale registry assumptions (AC-1)
+
+**Depends on.** `AC-0` is green and its pin is the accepted contract source.
+
+**Owner.** A delegated assistant-boundary owner on a branch based on the exact `AC-0` head.
+
+**Verifier.** An independent read-only API and frontend verifier at the exact `AC-1` head.
+
+**Files.**
+
+- [ ] Edit `backend/src/services/assistant_service.rs` at `AssistantChatCommand`, `PlanResolveCommand`, `RawPlanResolveCommand`, `parse_assistant_chat_command`, and `prepare_assistant_chat_command`. Evidence is a diff with every `plan.resolve` parser and reconstruction path removed.
+- [ ] Edit `backend/src/handlers/assistant.rs` at `completions`, `backend/src/routes.rs` at `/assistant/completions`, and their tests. Evidence is a diff that removes the route unless production telemetry proves a current caller and records its closed typed contract.
+- [ ] Edit `frontend/src/lib/assistant/chat-api.ts`, `frontend/src/hooks/use-assistant-chat-controls.ts`, `frontend/src/hooks/use-assistant-chat.ts`, `frontend/src/components/assistant/chat-actor-controls.tsx`, `frontend/src/components/assistant/assistant-chat-page.tsx`, `frontend/src/components/assistant/blocks/task-plan-card.tsx`, and their tests. Evidence is a diff with no callable plan-confirmation control.
+- [ ] Edit `frontend/src/lib/assistant/chat-task-plan.ts` so historical unknown gate fields are ignored without preserving a callable `ChatPlanGate` state. Evidence is a decoder test for an old snapshot and no outbound command.
+- [ ] Edit `backend/src/handlers/assistant_actions.rs`, `tests/fixtures/assistant/aevatar-pinned-actions-by-revision.json`, `docs/chat/02-wire-contract.md`, `docs/chat/06-actions-registry.md`, and `docs/chat/assistant-waves-plan.md`. Evidence is a diff that describes per-action degrade, retries, disabled fallback recovery, and revision observability accurately.
+
+**Build.**
+
+- [ ] Define the canonical public command set as `text`, `input.resolve`, `action.continue`, `approval.resolve`, `task.stop`, `task.steer`, `step.retry`, and `step.skip`. Evidence is a backend contract test and a frontend type test generated from the `AC-0` pin.
+- [ ] Reject `plan.resolve` at NyxID's typed boundary and delete its callers and tests in the same phase. Evidence is a 400 contract test and a whole-tree `rg` result with only historical audit or plan references.
+- [ ] Remove `/api/v1/assistant/completions` after checking production access evidence. If a live caller exists, stop this phase and replace the route only after its exact request contract is added to the pin. Evidence is the telemetry decision record and either route deletion or a strict typed reconstruction test.
+- [ ] Preserve all additive default action descriptors while deleting revision-map assertions that claim a manually synchronized fixture detects upstream drift. Evidence is a manifest golden test plus per-action known, unknown, and divergent descriptor tests.
+
+**You see.**
+
+- [ ] Open a stored task snapshot that contains the retired confirm gate and observe a readable task plan with no Confirm or Reject plan commands. Evidence is a desktop screenshot and the browser network log with no `plan.resolve` request.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, the green `CI Pipeline` URL, and matching `git rev-parse HEAD` output.
+- [ ] Run `rg -n 'plan\.resolve|resolvePlan|onResolvePlan' backend/src frontend/src tests/fixtures docs/chat`. Evidence is output limited to the convergence plan or explicit historical notes.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Send a real `plan.resolve` body through `/api/v1/assistant/chat` and request `/api/v1/assistant/completions` on a staging NyxID instance. Pass when both fail at NyxID with the documented 400 or 404 response and Aevatar receives neither body. Evidence is the HTTP transcript and metadata-only upstream wire log.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Review production route access evidence for `/api/v1/assistant/completions` across the agreed retention window. Pass when zero callers justify deletion, or when a named caller and approved replacement contract stop the phase before deletion. Evidence is the redacted query or dashboard link and the recorded decision.
+- [ ] Load old task-plan fixtures with confirm gates. Pass when they remain readable, expose no dead controls, and do not crash the actor reducer. Evidence is the focused Vitest log and screenshot.
+
+**Review gate.** Operator and API-owner review are required because this phase removes visible controls and a published route.
+
+- [ ] Have the operator inspect before-and-after task-plan screenshots and the no-request browser recording. Evidence is the approval note linked to the exact head.
+- [ ] Have the API owner inspect the completions usage evidence and route decision. Evidence is the approval note or a recorded blocker linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-1` PR based on the exact `AC-0` head with `auto_merge` disabled. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks.
+
+## Prove access-review reachability and choose its authority model (AC-2)
+
+**Depends on.** `AC-1` is green and the obsolete command paths are gone.
+
+**Owner.** A delegated security and integration owner on a branch based on the exact `AC-1` head.
+
+**Verifier.** An independent read-only security verifier who did not author the probe or decision.
+
+**Files.**
+
+- [ ] Add `scripts/probe-aevatar-chat-authority.mjs` with redacted identity, bearer-capability, delegation-header, consent, and replay probes. Evidence is the script diff and its documented environment contract.
+- [ ] Add `docs/chat/aevatar-access-review-authority.md` as the decision record for the deployed authorization-session design. Evidence is the accepted decision record with source and runtime receipts.
+- [ ] Update `docs/chat/01-architecture.md` and `docs/API.md` to remove the stale claim that Aevatar authenticates only the Bearer header. Update `docs/ENV.md` only if the accepted design adds configuration. Evidence is the corrected transport-auth sequence and configuration contract tied to the pinned upstream files.
+
+**Build.**
+
+- [ ] Reproduce the current cookie-session bridge with one connected service omitted from the Aevatar session authority. Evidence is a redacted claim summary that records `allow_all_services`, `allowed_service_ids`, and `resources` without a token.
+- [ ] Compare three authority designs in the decision record. The candidates are consent-derived delegated restrictions, a complete OAuth browser round trip with a NyxID return channel, and preserved unrestricted forwarding with an upstream reachability explanation. The consent-derived candidate requires three NyxID changes and the record must cost each of them, namely a delegated read allowance for `GET /api/v1/mcp/config` anchored by a live `CatalogDelegationGrant`, a platform-row exemption on the callback paths, and the Aevatar client link. Evidence is a table with threat model, revocation, retry, deployment, and rollback results.
+- [ ] Prove whether the bridge bearer can read `GET /api/v1/mcp/config`, the endpoint Aevatar uses for both the access probe and the access-review postcondition. Evidence is the route-policy citation at `backend/src/mw/auth.rs` `delegated_read_denied_path` and `delegated_request_allowed`, the middleware test that pins it, and a local-runtime HTTP receipt with a delegated token.
+- [ ] Prove whether a service-restricted delegated token can still complete the Aevatar LLM callback through `/api/v1/llm/gateway/v1` and `/api/v1/proxy/s/chrono-llm-public`. Evidence is a local-runtime receipt for each path with `allow_all_services=false`.
+- [ ] Resolve the Aevatar OAuth client identity without guessing. Production shows a registered client named `aevatar` with id `a6ff2946-f02f-4c35-8203-1ec46132b660`, which Aevatar pins as `BackendConsole.OidcClientId`. Decide between an admin-managed link on the `aevatar` catalog row and a configuration value. Evidence is the decision record entry and the field or setting it names.
+- [ ] Prefer consent-derived restrictions only if the probe proves chat bootstrap still works, the exact Aevatar OAuth client identity can be resolved without guessing, and an approved service changes the next minted capability. Evidence is the decision predicate and live result for each condition.
+- [ ] Keep `forward_access_token` enabled until the selected design proves that Aevatar receives both caller identity and a capability source for tool execution. Evidence is the deployment precondition in the decision record.
+
+**You see.**
+
+- [ ] Produce a seven-row probe receipt for identity only, identity plus capability Bearer, identity plus delegation header, replayed identity `jti`, bridge bearer reading `/api/v1/mcp/config`, restricted token on the LLM gateway path, and restricted token on the proxy slug path. Evidence is a redacted table with HTTP status, upstream code, surface used, and exact deployment version or local SHA.
+- [ ] Force or attempt `USER_SERVICE_ACCESS_REQUIRED` for a connected but unauthorized service. Evidence is the emitted `service.access_review` action or a falsified reachability result that names the authority preventing it.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the script's offline parser and redaction tests plus the documentation checks at the exact head. Evidence is the local log, clean `git status --short`, and green `CI Pipeline` URL.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the probe against the same deployed NyxID and Aevatar pair intended for `AC-3`. Pass when identity-only behavior, capability delivery, replay rejection, and access-review reachability are all observed and recorded, or when the phase stops with a falsified candidate and no implementation child starts. Evidence is the redacted probe receipt with both deployment SHAs or image digests.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Decode every probe token only inside the probe process and emit allowlisted claim summaries. Pass when logs contain no JWT, cookie, authorization code, refresh token, API key, or credential value. Evidence is a secret-pattern scan and independent log review.
+- [ ] Exercise expiry, `jti` replay, service removal, consent revocation, and cross-user resource substitution. Pass when each case fails closed without changing another user's consent or service authority. Evidence is the negative-case matrix and audit event ids.
+
+**Review gate.** Explicit security review is required because this decision changes which service authority Aevatar receives.
+
+- [ ] Have the security reviewer approve the chosen authority model, revocation behavior, token delivery headers, and rollback order. Evidence is a signed review verdict linked to the exact head and probe receipt.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-2` decision and probe PR based on the exact `AC-1` head. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks. No `AC-3` branch starts without the accepted decision.
+
+## Implement service access review end to end (AC-3)
+
+**Depends on.** `AC-2` is green, the live action is reachable, and security approved the authority model.
+
+**Owner.** A delegated full-stack access-review owner on a branch based on the exact `AC-2` head.
+
+**Verifier.** An independent read-only security and browser-flow verifier at the exact `AC-3` head.
+
+**Files.**
+
+- [ ] Edit `frontend/src/schemas/assistant-actions.ts` at `AssistantActionRequest`, `ActionCardParams`, and `ActionResource` to add the exact `service.access_review` variant. Evidence is a strict Zod contract test for `userServiceId`, `serviceSlug`, and `resourceUri`.
+- [ ] Edit `frontend/src/lib/assistant/action-registry.ts` and `frontend/src/lib/assistant/chat-action-validation.ts` to recognize, normalize, and recover the action. Evidence is the registry and recovery test diff.
+- [ ] Add `frontend/src/components/assistant/assistant-service-access-review-dialog.tsx` and wire it through `frontend/src/components/assistant/blocks/action-card.tsx` and `action-dialogs.tsx`. Evidence is the component and wiring tests at the phase head.
+- [ ] Edit `backend/src/handlers/assistant_action_effects_services.rs`, `backend/src/routes.rs`, and the service selected by the `AC-2` decision. Expected service candidates are `backend/src/services/consent_service.rs` and the assistant forward-authority code in `backend/src/handlers/assistant.rs`. Evidence is the accepted decision mapped to exact changed symbols.
+- [ ] Edit `frontend/src/hooks/use-assistant-chat-controls.ts` only as needed to report a completed resource shaped as `userService.userServiceId`. Evidence is the exact `action.continue` body test.
+- [ ] Update `docs/chat/04-action-cards.md`, `docs/chat/07-testing-and-gaps.md`, and `docs/API.md`. Evidence is documentation of the endpoint, journey, postcondition, and live proof.
+
+**Build.**
+
+- [ ] Parse only schema version 4 action envelopes whose action is `service.access_review` and whose params contain exactly one `serviceAccessReview` object. Evidence is strict valid, missing, extra-field, secret-shaped, and malformed-resource tests.
+- [ ] Resolve the target `UserService` under the authenticated owner and recompute its canonical RFC 8707 resource URI server-side. Evidence is a handler-to-service test that rejects caller substitution and slug or URI mismatch.
+- [ ] Apply the authority mutation chosen in `AC-2` only after an explicit human confirmation. Implement it in `backend/src/services/consent_service.rs` as a merge that preserves existing `scopes` and `allowed_service_ids` in one atomic update; `grant_consent_with_services` replaces the row and must not be called from this path. The effects handler stays HTTP and DTO. Evidence is before, first apply, retry, revoke, and cross-user database tests.
+- [ ] Report only `actionRequestId`, `originTurnId`, `disposition`, and `resource.userService.userServiceId`. Evidence is a serialized continuation body with no secrets or tokens.
+- [ ] Continue the same `nyxid-chat-*` actor and wait for Aevatar's postcondition result before presenting completion. Evidence is a reducer test and live wire sequence with stable actor id.
+
+**You see.**
+
+- [ ] Observe an access-review card that says the service is already connected, asks for exact service access, and never falls back to the unsupported-action card. Evidence is desktop and mobile screenshots.
+- [ ] Approve and decline separate requests. Evidence is a recording that shows the same conversation resume with completed and declined dispositions.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, the green `CI Pipeline` URL, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Use a staging human cookie session to trigger `USER_SERVICE_ACCESS_REQUIRED`, approve the card, observe a successful Aevatar postcondition, and use the same service on the next turn. Pass when the actor id stays stable and the second service call succeeds without another review. Evidence is the redacted browser recording, network trace, Aevatar event ids, and both exact deployment SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Try another user's `userServiceId`, a valid id with the wrong slug, an HTTP resource URI, userinfo, query, fragment, encoded path confusion, and an inactive service. Pass when every case fails before authority mutation and creates a metadata-only audit event. Evidence is the adversarial test matrix and database before-and-after snapshot.
+- [ ] Retry the same completion across a lost browser response. Pass when one authority change exists, the report remains replay-safe, and Aevatar reaches one terminal postcondition. Evidence is the idempotency transcript and stored consent or grant row.
+
+**Review gate.** Operator and security review are required for the consent interaction and authority change.
+
+- [ ] Have the operator review the desktop and mobile screenshots plus the approve, decline, cancel, error, and return states. Evidence is the operator verdict linked to the exact head.
+- [ ] Have the security reviewer verify the mutation, report allowlist, audit metadata, and cross-user denial. Evidence is the security verdict linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-3` PR based on the exact `AC-2` head with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdicts, and green required checks.
+
+## Add typed context-attachment transport and readback (AC-4)
+
+**Depends on.** `AC-1` is green and the `AC-0` pin still matches the current upstream attachment contract. `AC-4` is built on the exact `AC-1` head in parallel with `AC-2` and `AC-3` because its files are disjoint; the root rebases it onto the `AC-3` head before delivery and reverifies the gates.
+
+**Owner.** A delegated typed-contract owner on a branch based on the exact `AC-1` head.
+
+**Verifier.** An independent read-only boundary and compatibility verifier at the exact `AC-4` head.
+
+**Files.**
+
+- [ ] Edit `backend/src/services/assistant_service.rs` at `TextChatCommand`, `RawTextChatCommand`, `parse_assistant_chat_command`, and `prepare_assistant_chat_command` to add typed context attachments. Evidence is the parser and exact reconstruction diff.
+- [ ] Edit `frontend/src/lib/assistant/chat-api.ts` to model `ContextAttachmentReference` and allow it only on first-turn `text`. Evidence is a compile-time and runtime command-contract test.
+- [ ] Edit `frontend/src/lib/assistant/chat-types.ts` at `ConversationMeta` and `ChatConversationDetail`. Evidence is typed durable attachment references in list and detail state.
+- [ ] Edit `frontend/src/lib/assistant/chat-history-decoders.ts` at `decodeConversationMeta` and `decodeChatConversationDetail`, plus `frontend/src/lib/assistant/chat-actor-state.ts` at `applyCurrentStateResult`. Evidence is readback tests for list and current-state responses.
+- [ ] Edit `frontend/src/hooks/use-assistant-chat.ts` at the first-turn send boundary. Evidence is a test that attaches references only when `conversationId` is absent.
+- [ ] Update `frontend/src/lib/assistant/__fixtures__/aevatar-chat-history.json`, `frontend/src/lib/assistant/__fixtures__/aevatar-nyxid-chat-stream.sse`, and focused tests. Evidence is fixture coverage of create, reload, and admission errors.
+
+**Build.**
+
+- [ ] Model each attachment as `artifactId`, `revisionMode`, and `pinnedRevisionId`. Evidence is one discriminated type that makes `pinned_revision` require a nonempty revision id and makes `follow_current` omit it on the wire.
+- [ ] Enforce a maximum of four unique, nonempty artifact ids at NyxID's boundary. Evidence is focused tests for zero, one, four, five, duplicate, empty, pinned, and follow-current cases.
+- [ ] Reject attachments on follow-up text and preserve their create-only, sealed-to-conversation rule. Evidence is a boundary test that never forwards a replacement or removal attempt.
+- [ ] Preserve only references in `ConversationMeta`, transcript detail, and actor current state. Evidence is decoder output with no artifact body or backing-object data.
+- [ ] Preserve Aevatar's `ATTACHMENT_ADMISSION_DENIED` code and the reasons `not_found`, `access_denied`, `unsupported_kind`, `over_limit`, `pinned_revision_unavailable`, `invalid_request`, `inactive`, and `read_model_unavailable`. Evidence is the error-decoder matrix.
+
+**You see.**
+
+- [ ] Send a first-turn request with one `follow_current` and one `pinned_revision` reference, then reload list and current state. Evidence is a wire transcript that shows the exact normalized request and the same durable references on readback.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, green `CI Pipeline` URL, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Call the real first-turn endpoint with valid artifact references, follow it with a second turn, and read the list and state endpoints. Pass when Aevatar admits the first turn, rejects any replacement attempt, and returns the sealed references on every documented read model. Evidence is the redacted HTTP and SSE transcript with NyxID and Aevatar SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Send duplicate ids, five ids, missing pinned revision ids, unsupported modes, extra fields, and follow-up attachments. Pass when NyxID or Aevatar returns the pinned typed error and no conversation is created or mutated. Evidence is the negative-case matrix and list or state proof.
+- [ ] Inspect all logs and wire-capture output. Pass when only ids, modes, reason codes, byte counts, and statuses appear, with no artifact content. Evidence is a secret and content-pattern scan signed by the verifier.
+
+**Review gate.** None. This phase adds transport and readback only; it does not expose attachment controls yet.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-4` PR based on the exact `AC-3` head after the root-owned rebase, with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks.
+
+## Add server-scoped artifact discovery and new-chat selection (AC-5)
+
+**Depends on.** `AC-4` is green and its attachment types are the only browser-to-backend representation.
+
+**Owner.** A delegated full-stack attachment-UX owner on a branch based on the exact `AC-4` head.
+
+**Verifier.** An independent read-only security, accessibility, and browser verifier at the exact `AC-5` head.
+
+**Files.**
+
+- [ ] Edit `backend/src/services/assistant_service.rs` to add a server-owned content-artifact path builder derived from `AuthUser.user_id`. Evidence is a path test that has no caller-supplied `scopeId` input.
+- [ ] Edit `backend/src/handlers/assistant.rs` to add a bounded artifact-list handler with dedicated safe response structs, and edit `backend/src/routes.rs` to mount `GET /api/v1/assistant/context-artifacts`. Evidence is the handler, DTO, and route test diff.
+- [ ] Add `frontend/src/schemas/assistant-context-attachments.ts` and `frontend/src/hooks/use-assistant-context-artifacts.ts`. Evidence is strict response parsing and TanStack Query tests.
+- [ ] Add `frontend/src/components/assistant/context-attachment-picker.tsx` and wire it through `frontend/src/components/assistant/chat-composer.tsx`, `assistant-chat-page.tsx`, and `use-assistant-chat.ts`. Evidence is the component, composer, and send tests.
+- [ ] Update `docs/chat/05-frontend-ui.md`, `docs/chat/07-testing-and-gaps.md`, and `docs/API.md`. Evidence is the new endpoint, new-chat-only interaction, and safe discovery contract in the rendered docs.
+
+**Build.**
+
+- [ ] Derive `/api/scopes/{AuthUser.user_id}/content-artifacts` on the server and never accept a browser scope segment. Evidence is a route test that substitutes another user id and still forwards only the authenticated id.
+- [ ] Return only artifact id, title, kind, lifecycle status, current revision id, and safe revision metadata needed for pin selection. Never return inline content, backing object keys, content hashes unless required for display, access lists, owner internals, or provenance. Evidence is an exact response serialization test.
+- [ ] Filter the picker to active `text`, `markdown`, and `structured_document` artifacts and cap pages and aggregate bytes. Evidence is pagination, cap, unsupported-kind, and malformed-upstream tests.
+- [ ] Show attachment selection only for a new draft. Limit selection to four unique artifacts and provide `follow_current` or `pinned_revision` controls. Evidence is component state-machine tests.
+- [ ] Freeze the selected references when the first turn starts and hide editing after actor adoption. Evidence is a send-and-adopt test with stable references and no follow-up control.
+
+**You see.**
+
+- [ ] Open a new chat and select, change, and remove allowed artifacts without shifting the composer or covering adjacent controls. Evidence is desktop and mobile screenshots for empty, loading, selected, maxed, error, and pinned-revision states.
+- [ ] Send the first turn and observe the attachment summary become read-only after actor adoption. Evidence is a browser recording and network body.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Backend gate set and Frontend gate set in Appendix D at the exact head. Evidence is the local logs, green `CI Pipeline` URL, wizard-bundle freshness result when its source closure changes, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Use a staging human cookie session to list real artifacts, select both revision modes, start a real Aevatar chat, and reload it. Pass when only owned or readable artifacts appear, the first turn succeeds, and the sealed reference summary survives reload. Evidence is the browser recording, screenshots, redacted network trace, and deployment SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Attempt caller-supplied scope injection, another user's page token and artifact id, unsupported kind selection, stale current revision, and oversized upstream pages. Pass when every case fails closed or returns an empty safe result without content disclosure. Evidence is the adversarial matrix and metadata-only audit ids.
+- [ ] Run keyboard-only and screen-reader checks at mobile and desktop widths. Pass when focus order, labels, mode controls, removal, errors, and the four-item limit are understandable and no text overlaps. Evidence is an accessibility report, screenshots, and recording.
+
+**Review gate.** Operator review is required because this phase changes the composer and new-chat workflow.
+
+- [ ] Have the operator inspect the named desktop and mobile states and the full selection-to-send recording. Evidence is the operator verdict linked to the exact head.
+- [ ] Have the security reviewer inspect the scoped handler and safe DTO. Evidence is the security verdict linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-5` PR based on the exact `AC-4` head with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdicts, and green required checks.
+
+## Fix lifecycle liveness and recoverable state (AC-6)
+
+**Depends on.** `AC-5` is green and the readback types include context attachments.
+
+**Owner.** A delegated frontend lifecycle owner on a branch based on the exact `AC-5` head.
+
+**Verifier.** An independent read-only concurrency and browser-state verifier at the exact `AC-6` head.
+
+**Files.**
+
+- [ ] Edit `frontend/src/lib/assistant/chat-history-api.ts` at `deleteConversation` and its tests to observe typed delete completion. Evidence is a bounded poll state machine for accepted, not-found, timeout, and abort cases.
+- [ ] Edit `frontend/src/hooks/use-assistant-chat.ts` and `frontend/src/components/assistant/assistant-sidebar.tsx` to retain an accepted deletion as deleting until state returns `not_found`. Evidence is hook and sidebar tests for no row resurrection.
+- [ ] Edit `frontend/src/lib/assistant/chat-stream-orchestrator.ts` and its tests so valid Aevatar keepalive frames reset the progress watchdog without becoming visible content. Evidence is a virtual-time test beyond 120 seconds.
+- [ ] Edit `frontend/src/lib/assistant/chat-session-state.ts`, `chat-history-decoders.ts`, `chat-actor-state.ts`, `runtime-event-semantics.ts`, and their tests for terminal refresh and recoverable action or authorization state. Evidence is reload and settlement test coverage.
+- [ ] Edit `docs/chat/03-stream-protocol.md`, `docs/chat/05-frontend-ui.md`, and `docs/chat/07-testing-and-gaps.md` to record the exact recovery boundary. Evidence is documentation that distinguishes durable state, live-only events, and upstream-owned omissions.
+
+**Build.**
+
+- [ ] Treat typed DELETE 202 as accepted work, follow the returned or canonical state URL with bounded jittered backoff, and finish only at `not_found`. Evidence is an explicit deleting state and timeout error in the domain type.
+- [ ] Treat `aevatar.nyxid_chat.keepalive` as stream progress for liveness only. Evidence is a watchdog test that neither times out nor appends a message for keepalive-only intervals.
+- [ ] Refresh current state and conversation metadata after terminal stream settlement and action postcondition settlement. Evidence is a test that terminal task, attention, attachment, and action state update without a page reload.
+- [ ] Restore pending `service.connect` and `service.access_review` cards from actor current state after reload; the access-review half depends on `AC-3`. Evidence is a reload test with an actionable card and the original action identity.
+- [ ] Probe whether public transcript `operations` or current state can reconstruct `MEDIA_CONTENT` and generic `nyxid.authorization.required`. If neither can, record the upstream ownership, file or link a pinned upstream issue, and do not add NyxID shadow persistence. Evidence is the response capture and documented ownership decision.
+
+**You see.**
+
+- [ ] Delete a real conversation and observe a stable deleting state followed by permanent removal. Evidence is a recording with the 202 response, state polling, terminal 404 or `not_found`, and refreshed list.
+- [ ] Reload while an access-review card is pending and after a terminal action result. Evidence is a recording that shows the actionable card and final status restored without duplicate controls.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Frontend gate set in Appendix D and focused fake-timer lifecycle tests at the exact head. Evidence is the local logs, green `CI Pipeline` URL, and matching head SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run a real Aevatar turn that emits keepalives for more than 120 seconds, delete a real typed conversation, reload a pending access-review card, and settle one action. Pass when no client stop is sent during keepalives, deletion ends only at absence, and available durable state restores exactly once. Evidence is the browser recording, redacted network trace, event ids, and deployment SHAs.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Race delete against list refresh, route selection, component unmount, network loss, and an active stream. Pass when active-stream deletion remains refused, accepted deletion cannot resurrect a row, abort stops polling, and timeout leaves a retryable state. Evidence is the deterministic race-test log and browser recording.
+- [ ] Feed malformed and high-frequency keepalives. Pass when only a valid normalized keepalive resets liveness, no attacker-controlled event suppresses timeout, and timer count stays bounded. Evidence is the fake-timer and malformed-frame test log.
+
+**Review gate.** Operator review is required because this phase adds a deleting state and changes reload behavior.
+
+- [ ] Have the operator inspect delete success, timeout, retry, pending-card reload, and long-turn recordings at desktop and mobile sizes. Evidence is the operator verdict linked to the exact head.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-6` PR based on the exact `AC-5` head with no merge or auto-merge action. Evidence is the PR URL, base SHA, head SHA, independent verdict, and green required checks.
+
+## Add credentialed producer proof and close the contract (AC-7)
+
+**Depends on.** `AC-6` is green and all product paths required by the done predicate exist.
+
+**Owner.** A delegated release-verification owner on a branch based on the exact `AC-6` head.
+
+**Verifier.** An independent read-only release verifier who checks the exact stack tip and live receipts.
+
+**Files.**
+
+- [ ] Extend `frontend/scripts/verify-aevatar-action-wake.mjs` into a redacted producer-contract runner or split it into focused modules under `frontend/scripts/aevatar-chat-canary/`. Evidence is a script diff that covers the final matrix and preserves the existing empty-action wake.
+- [ ] Add `frontend/e2e/live-aevatar.spec.ts` and a non-mock Playwright project in `frontend/playwright.config.ts`. Evidence is a test that never appends `mock=1` and requires an explicit credentialed staging configuration.
+- [ ] Add `.github/workflows/aevatar-chat-canary.yml` with secret-backed scheduled and manual runs against a controlled staging pair. Evidence is the workflow diff and one successful run URL.
+- [ ] Update `docs/chat/README.md`, `docs/chat/07-testing-and-gaps.md`, and the `AC-0` contract pin only after re-auditing the remote. Evidence is final documentation and pin values tied to the canary run.
+
+**Build.**
+
+- [ ] Cover first and follow-up text, input, approval, stop, steer, retry, skip, empty `actions`, `service.connect`, `service.access_review`, `key.create`, `key.rotate`, context attachments, state reload, and delete observation. Evidence is a machine-readable canary result with one row per capability.
+- [ ] Record NyxID head SHA, Aevatar source or image SHA, effective chat pin, timestamps, actor ids, turn ids, action ids, status codes, and safe reason codes. Evidence is the allowlisted JSONL schema and one validated receipt.
+- [ ] Fail instead of skip when the credentialed workflow is armed but a secret, seed, producer condition, or deployment version is missing. Evidence is negative workflow tests for every prerequisite.
+- [ ] Keep the mock Playwright suite as deterministic regression coverage and label it as mock evidence only. Evidence is the existing suite result next to the separate live result.
+- [ ] Re-run the capability matrix in Appendix E and mark a row complete only when its repository and live evidence exists at the exact stack tip. Evidence is the final matrix with links and no unsupported completeness claim.
+
+**You see.**
+
+- [ ] Open the canary run summary and see one green row per done-predicate capability plus exact source pins. Evidence is the workflow artifact and run URL.
+- [ ] Open the non-mock Playwright recording and see the real staging host, real network calls, access review, attachment selection, reload, and delete completion. Evidence is the trace, screenshots, and recording.
+
+**Verify, repository.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the Frontend gate set, the `AC-0` drift checker, the canary parser tests, and the plan checker in Appendix D at the exact head. Evidence is the local logs, green `CI Pipeline` URL, and matching stack-tip SHA.
+
+**Verify, live.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Run the credentialed producer workflow against the controlled staging NyxID and Aevatar pair. Pass when every required row is green, no row is skipped, the browser uses no mock transport, and the receipt names both exact deployments. Evidence is the workflow URL, JSONL receipt, Playwright trace, screenshots, and recording.
+
+**Verify, risk.** Tests alone are not sufficient verification. A phase is verified only when its repository and live checks have evidence and every warranted risk-specific check has evidence.
+
+- [ ] Scan workflow logs and artifacts for JWTs, cookies, authorization codes, refresh tokens, API keys, credential payloads, and artifact bodies. Pass when the scan is empty and artifacts expose only allowlisted metadata. Evidence is the scanner log and independent verifier signature.
+- [ ] Change one pinned command, action, or watched upstream path in a temporary fixture. Pass when drift or canary validation turns red and identifies the exact changed capability. Evidence is the deliberate-failure run and restored clean run.
+
+**Review gate.** None. This phase adds test and documentation infrastructure and does not change the product interaction.
+
+**Deliver.**
+
+- [ ] Hand off the merge-ready `AC-7` stack tip with the root-to-tip PR order and no merge or auto-merge action. Evidence is every PR URL, exact base and head SHA, independent verdict, green `CI Pipeline`, live canary URL, and final capability matrix.
+
+## Close the program
+
+- [ ] Check every box above only after its named evidence exists. Evidence is the completed plan and its linked artifacts.
+- [ ] Return the Autopilot Stack final report to the operator. Evidence is the root-to-tip PR order, exact bases and heads, one verdict per link, live canary receipt, and every parked item with its reason.
+
+## Appendix A. Prototype evidence
+
+The audit settled what source inspection could settle. It did not have credentials for a live NyxID-to-Aevatar producer run. `AC-2` therefore owns the remaining deployed-auth experiment.
+
+| Question | Artifact | Result | Remaining proof |
+|---|---|---|---|
+| Does NyxID derive Aevatar scope from the authenticated user | `backend/src/handlers/assistant.rs` at `forward` and `backend/src/services/assistant_service.rs` path builders | Yes. The browser cannot submit `scopeId` for chat, history, state, or delete | Repeat for the new artifact-list route in `AC-5` |
+| Can a normal cookie session naturally trigger service access review | `backend/src/mw/auth.rs` session `AuthUser`, `build_forward_authorization`, and `TokenRestrictionClaims::from_auth_user` | Probably not. Session auth currently has `allow_all_services` true, an empty id list, and no resource list, which the bridge copies into its delegated token | Run the controlled deployed probe in `AC-2` |
+| Does identity assertion remove the need for a capability | Aevatar `NyxIdIdentityAssertionAuthentication.cs` and `NyxIdChatEndpoints.Streaming.cs` | No. The identity header becomes authoritative for caller identity, while streaming still extracts a Bearer or delegation token for NyxID capability | Verify the four-row header matrix in `AC-2` |
+| Are context attachments part of the public typed browser contract | Aevatar `NyxIdChatPublicEndpoints.cs`, `NyxIdChatEndpoints.Streaming.cs`, and `ConversationContextAttachmentAdmission.cs` | Yes. They are create-only, maximum four, and durable by reference | Exercise valid and rejected requests against the deployed pair in `AC-4` |
+| Does Aevatar require exact action-registry revisions | Aevatar `NyxIdAssistantActionRegistry.cs` after `0b8ec500087331c3d12819b532e7dfa29e740fb4` | No. `schema_version` gates the registry. Revision labels are observational. Descriptor failures degrade per action | Automate watched-path drift detection in `AC-0` |
+| Is current browser proof live | `frontend/e2e/helpers.ts` and `frontend/scripts/verify-aevatar-action-wake.mjs` | No. Playwright always adds `mock=1`; the producer script only proves an empty action wake when manually credentialed | Add the secret-backed canary and non-mock browser run in `AC-7` |
+| Can the bridge bearer read the endpoint Aevatar probes for access | `backend/src/mw/auth.rs` at `delegated_read_denied_path` and `delegated_request_allowed`; Aevatar `NyxIdRequireServiceTool.cs` at `InspectCurrentBearerServiceAccessAsync` and `NyxIdApiClient.cs` at `GetMcpConfigAsync` | No. `/api/v1/mcp` is a denied class for every delegated GET, so the probe returns access denied and Aevatar reports `SourceStale`, never `USER_SERVICE_ACCESS_REQUIRED` | Local-runtime receipt in `AC-2` |
+| Does a restricted token break chat bootstrap | `backend/src/handlers/proxy.rs` at the legacy `DownstreamService` scoped denial and `execute_admin_proxy`; Aevatar `appsettings.json` `GatewayEndpoint` | Probably on the proxy slug path; the LLM gateway path checks only scope | Receipts for both callback paths in `AC-2` |
+| Is the Aevatar OAuth client resolvable | Production `/users/me/consents` shows client `aevatar` id `a6ff2946-f02f-4c35-8203-1ec46132b660`; Aevatar `appsettings.json` `BackendConsole.OidcClientId` | Yes as a registered client; NyxID has no link from the catalog row to it | Decide the link in `AC-2` |
+
+Focused baseline evidence at NyxID `52402f6a5510478b3601636a25572055f895c973` is 75 passing frontend tests across eight files and 35 passing Rust `assistant_service` tests. The Rust run filtered out 5,674 tests. These are regression baselines, not integration proof.
+
+`npm ci` installed 608 packages and reported 21 audit findings. The report contained 1 low, 11 moderate, 8 high, and 1 critical finding. No audit fix ran. Dependency remediation is outside this program unless a finding affects a changed assistant path.
+
+## Appendix B. Alternatives rejected
+
+| Alternative | Decision | Reason |
+|---|---|---|
+| Declare parity from focused unit and mock Playwright tests | Rejected | They do not exercise a credentialed Aevatar producer or deployed auth headers |
+| Copy Aevatar Console's OAuth card before probing reachability | Rejected | NyxID's cookie session and proxy-minted capability differ from Aevatar Console's resource-scoped OAuth browser session |
+| Keep the unrestricted cookie bridge and add only a visual access-review card | Rejected | The action may remain unreachable and approval may not change the next capability token |
+| Shrink the default NyxID action manifest to current Aevatar executables | Rejected | Current Aevatar tolerates unknown and divergent descriptors per action; additive descriptors do not widen its executable set |
+| Keep a manual per-revision fixture as the upstream drift guard | Rejected | It stays green when upstream changes until a human edits it |
+| Keep `plan.resolve` as a compatibility adapter | Rejected | Current Aevatar classifies it as unsupported, and no current actor source emits a confirmation gate |
+| Leave `/assistant/completions` as arbitrary pass-through | Rejected | It bypasses typed reconstruction and has no proven current in-repository caller |
+| Accept browser-supplied artifact `scopeId` | Rejected | Scope belongs to the authenticated server boundary, not the client request |
+| Persist media or authorization payloads in a new NyxID shadow store | Rejected | It duplicates Aevatar actor ownership and risks storing content that the current public read model intentionally omits |
+| Add `inputParts` and explicit `agentProfile` selection now | Rejected | Aevatar Console omits both in its browser chat, and NyxID's current product boundary is prompt plus durable context references |
+| Deliver one rollup PR | Rejected | Auth, contract, UI, and liveness failures would be harder to isolate and independently verify |
+
+## Appendix C. Risks
+
+| Risk | Owner phase | Check | Failure signal |
+|---|---|---|---|
+| Upstream changes after the audit | `AC-0`, `AC-7` | Fetch and compare watched paths from the effective pin | Nonzero drift check with changed path names |
+| Identity works but Aevatar has no usable NyxID capability | `AC-2` | Four-row header matrix and real tool callback | Stream 401 or tool authorization failure |
+| Access review is unreachable from a cookie session | `AC-2` | Connected but unauthorized live probe | No `USER_SERVICE_ACCESS_REQUIRED` or unrestricted token claims |
+| Access review widens another user or service | `AC-3` | Recompute owner and resource server-side; adversarial substitutions | Consent or grant diff outside the exact owner and service |
+| Consent succeeds but the next token remains stale | `AC-3` | Mint after approval and verify Aevatar postcondition | Repeated access-review action or unverified postcondition |
+| Attachments disclose cross-tenant content | `AC-4`, `AC-5` | Reference-only DTO and cross-user probes | Body, backing key, access list, or foreign artifact in response |
+| Follow-up text mutates sealed attachments | `AC-4` | Create-only parser and live replacement probe | Changed attachment list on current state |
+| Delete 202 is mistaken for completion | `AC-6` | Poll state until `not_found` | Sidebar row reappears after accepted delete |
+| Keepalive-blind watchdog stops a valid long turn | `AC-6` | More than 120 seconds of keepalive-only liveness | Client sends `task.stop` or aborts the stream |
+| History cannot restore live media or a generic auth blocker | `AC-6` | Inspect transcript operations and actor current state | Required state exists only in an expired SSE event |
+| Canary leaks credentials | `AC-7` | Allowlisted JSONL and secret scanner | Token, cookie, code, key, credential, or artifact body match |
+| A mock run is reported as live | `AC-7` | Separate non-mock Playwright project and strict prerequisites | `mock=1`, installed mock handler, or skipped credentialed row |
+| Removing completions breaks an external caller | `AC-1` | Production access evidence before deletion | Named current caller within the agreed retention window |
+
+## Appendix D. Links and reading list
+
+Repository policy and required gates live in `CONTRIBUTING.md`, `WORKFLOW.md`, and `.github/workflows/ci.yml`. Pull requests target `main` by default. A dependent phase PR targets its verified parent branch until the parent lands, then the root coordinator retargets it. At least one approval is required. Security-sensitive phases also require explicit security review. `CI Pipeline` is the required status. Auto-merge stays disabled.
+
+The Backend gate set is the following command group.
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run -p nyxid --profile ci
+cargo build -p nyxid --features aws-kms
+cargo build -p nyxid --features gcp-kms
+cargo build -p nyxid --features aws-kms,gcp-kms
+```
+
+The Frontend gate set is the following command group.
+
+```bash
+npm --prefix frontend run lint
+npm --prefix frontend run test
+npm --prefix frontend run build
+cargo test -p nyxid-cli --test wizard_bundle_freshness
+```
+
+Run the plan checker with the following command.
+
+```bash
+node /Users/chronoai/.codex/skills/heca-mode/references/check-plan.mjs docs/plans/aevatar-chat-feature-integrate-convergence.md
+```
+
+Core NyxID reading is `docs/chat/README.md`, `docs/chat/01-architecture.md`, `docs/chat/02-wire-contract.md`, `docs/chat/03-stream-protocol.md`, `docs/chat/04-action-cards.md`, `docs/chat/05-frontend-ui.md`, `docs/chat/06-actions-registry.md`, and `docs/chat/07-testing-and-gaps.md`.
+
+Core Aevatar reading at the audited clone is listed below.
+
+| Concern | Source |
+|---|---|
+| Public commands and attachments | `agents/Aevatar.GAgents.NyxidChat/NyxIdChatPublicEndpoints.cs` and `NyxIdChatEndpoints.Streaming.cs` |
+| Attachment admission | `agents/Aevatar.GAgents.NyxidChat/ConversationContextAttachmentAdmission.cs` and `NyxIdChatLifecycleFacade.cs` |
+| Artifact discovery contract | `src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs` and `src/Aevatar.Studio.Application.Abstractions/Studio/Contracts/ContentArtifactContracts.cs` |
+| Access-review production | `agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs` and `NyxIdChatConversationAguiFrameBuilder.cs` |
+| Action registry | `agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs` |
+| Browser reference | `apps/aevatar-console-web/src/pages/chat/chatActorState.ts`, `ChatActorControls.tsx`, `index.tsx`, and `apps/aevatar-console-web/src/shared/auth/client.ts` |
+| Identity assertion | `src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionAuthentication.cs` |
+
+Owners must read the active `heca-mode` skill, `references/playbook-autopilot-stack.md`, `pstack-architect`, `pstack-tdd`, `pstack-unslop`, `pstack-no-comments`, and `pstack-technical-writing` before editing. Security verifiers must also use `pstack-interrogate`. UI owners must exercise the real browser surface and attach screenshots or recordings.
+
+The external source is [Aevatar feature/integrate](https://github.com/aevatarAI/aevatar/tree/feature/integrate). Relevant upstream commits are [service access review](https://github.com/aevatarAI/aevatar/commit/0c5d4fbdb8e50037f78c5faa5e631d94e8dd30d7), [typed context attachments](https://github.com/aevatarAI/aevatar/commit/a850250d9c7822420bf4b07594b15397d80e71cd), [attachment readback and reasons](https://github.com/aevatarAI/aevatar/commit/676d577fd381e1b3dae227579b435662d6d49a44), [plan confirmation removal](https://github.com/aevatarAI/aevatar/commit/bf0536bf1d0f118e5fc50e4faf1fa19703796add), and [per-action registry degrade](https://github.com/aevatarAI/aevatar/commit/0b8ec500087331c3d12819b532e7dfa29e740fb4).
+
+## Appendix E. Capability matrix
+
+Verdicts use five values. `complete` means the current Aevatar contract has a NyxID implementation and focused tests. `partial` means a real path exists with a known gap. `missing` means the claimed browser experience requires the capability and NyxID lacks it. `obsolete` means NyxID still exposes behavior Aevatar removed. `not in scope` means the capability belongs outside this browser-chat program.
+
+| Capability | Current verdict | Evidence and gap | Target phase |
+|---|---|---|---|
+| Human cookie authorization boundary | complete | Human-only middleware rejects API key, service-account, delegated, and relay auth | Preserve in every phase |
+| Transport identity assertion and capability bearer | partial | Identity assertion is implemented, but the unrestricted cookie bridge may make access review unreachable and Aevatar still needs a capability | `AC-2`, `AC-3` |
+| Typed command reconstruction | partial | Strict reconstruction exists, but includes obsolete `plan.resolve` and omits context attachments | `AC-1`, `AC-4` |
+| SSE and AG-UI normalization | complete | The normalizer handles the current named actor facts and AG-UI frames | Preserve in `AC-6` |
+| Actor and session identity | complete | First-run adoption and follow-up identity checks reject actor changes | Preserve in `AC-7` |
+| First and follow-up turns | complete | First text omits conversation id; later text binds the adopted actor | Live proof in `AC-7` |
+| Conversation list, history, state, and delete | partial | List, transcript, and state exist; delete treats 202 as completion and transcript operations are ignored | `AC-6` |
+| Input, approval, stop, steer, retry, and skip | complete | Typed paths exist with state-version fences | Live proof in `AC-7` |
+| `service.connect` | complete | Implemented card, continuation report, and postcondition path; no credentialed producer receipt | Live proof in `AC-7` |
+| `key.create` and `key.rotate` | complete | Implemented dialogs and safe reports; no credentialed producer receipt | Live proof in `AC-7` |
+| Action reports and postconditions | complete | Existing action paths wait on typed Aevatar continuation and postcondition state | Refresh and live proof in `AC-6`, `AC-7` |
+| `service.reauthorize` | partial | NyxID advertises and renders it, while current Aevatar knows but does not execute it | Document in `AC-1`; no parity claim |
+| `service.access_review` | missing | Unknown-action recovery is decline-only | `AC-2`, `AC-3` |
+| Context-attachment transport | missing | Strict `RawTextChatCommand` rejects the field | `AC-4` |
+| Context-attachment discovery and UX | missing | No safe artifact route or new-chat picker exists | `AC-5` |
+| `plan.resolve` | obsolete | Backend and frontend still parse and send a command Aevatar rejects | `AC-1` |
+| Registry deployment semantics and docs | partial | Tests and docs still encode obsolete exact-revision behavior | `AC-0`, `AC-1` |
+| Keepalive liveness | partial | Valid keepalives do not reset the 120-second watchdog | `AC-6` |
+| Media restoration | partial | `MEDIA_CONTENT` renders live but is not restored from current NyxID history decoding | Classify and close available recovery in `AC-6` |
+| Authorization-card restoration | partial | Some actor cards restore from state; live-only generic authorization events do not | `AC-3`, `AC-6` |
+| Credentialed producer proof | missing | Playwright uses `mock=1`; the manual script covers only empty action wake | `AC-7` |
+| Direct engine durability | not in scope | Direct Chrono-LLM is a separate memory-only engine | Excluded |
+| `inputParts` | not in scope | Aevatar Studio uses it, but current Aevatar Console browser chat and NyxID's product boundary do not | Excluded |
+| Explicit `agentProfile` selection | not in scope | Optional upstream field with no current NyxID browser requirement | Excluded |
+| Assistant feature-flag route enforcement | partial | The flag hides navigation but does not block the page or API | Product-policy decision outside Aevatar contract parity |
+
+## Appendix F. Audit pins and independent review
+
+| Item | Value |
+|---|---|
+| NyxID worktree | `/Users/chronoai/Library/Application Support/heca/worktrees/ea204fe1/swift-mesa` |
+| NyxID branch | `add-test` |
+| Audited NyxID HEAD | `52402f6a5510478b3601636a25572055f895c973` |
+| `origin/main` observed during audit | `bba9682c9ab1bf166f7676982b61b7cf1995f50e` |
+| Merge base | `52402f6a5510478b3601636a25572055f895c973` |
+| Aevatar clone | `/tmp/aevatar-integrate.R1n4oF/repo` |
+| Aevatar branch HEAD | `d53d150817c17f06e9e58b069d2da9ec41196900` |
+| Effective last changed chat SHA | `b0b3738ed9477513edbfc6b9a6a75f14a592dbf4` |
+| Prior NyxID documentation pin | `e7ba2e6eb` |
+| Heca invocation | `01a060f1-08a4-7a00-9ef0-98b960983381` |
+| Independent Grok agent | `01a060f1-08aa-7390-86c8-7c8bb67c1a04` |
+| Independent provider | `grok` |
+| Independent model | `grok-4.6` |
+| Independent effort | `x_high`, requested as `xhigh` |
+| Independent mode | `bypassPermissions` |
+| Independent final state | `idle` |
+| Independent final activity | sequence `5628`, output event id `707723` |
+| Watched chat paths after effective SHA | No changes through Aevatar branch HEAD |
+| NyxID stack base (`origin/main` at program start) | `4bc00e1a103b94ad7847aa776b50bfa87572c68d` |
+| Aevatar branch HEAD at program start | `e5bba2e9719ad5132004b882744caa3875db1123` |
+| Effective chat SHA at program start | `706ea7cab9d1f882e0fb0f034bb338102b6d5d2b` (tool-catalog materialization only; browser contract files unchanged since `b0b3738e`) |
+| Operator go | 2026-09-02, this session, Fable restricted to planning |
+
+The independent review answered no to the completeness question. Its additional validated findings were accepted for delete 202 observation, keepalive liveness, untyped completions forwarding, lack of credentialed producer proof, and the identity-versus-capability distinction. Its feature-flag finding is a product-policy issue, not an Aevatar contract defect. Its recommendation to shrink the default action manifest was rejected because current upstream code degrades unknown or divergent descriptors per action.
+
+No product code changed during the audit. `frontend/node_modules` was installed with `npm ci` and remains ignored. No live NyxID-to-Aevatar producer test ran because the required deployment credentials and controlled producer state were unavailable.
+
+## Appendix G. Pinned wire facts
+
+The canonical public command set is shown below.
+
+```text
+text
+input.resolve
+action.continue
+approval.resolve
+task.stop
+task.steer
+step.retry
+step.skip
+```
+
+The internal Aevatar access-review action uses the following parameters.
+
+```text
+action = service.access_review
+userServiceId
+serviceSlug
+resourceUri
+```
+
+The context-attachment request shape is shown below.
+
+```text
+contextAttachments[]
+  artifactId
+  revisionMode = follow_current | pinned_revision
+  pinnedRevisionId
+```
+
+The attachment set is create-only and sealed to the conversation. It contains at most four unique nonempty artifact ids. `pinned_revision` requires `pinnedRevisionId`. `follow_current` clears it. Allowed kinds are `text`, `markdown`, and `structured_document`. Public list and current-state reads expose references, not bodies. Admission uses `ATTACHMENT_ADMISSION_DENIED` and the reason set pinned in `AC-4`.
+
+Aevatar delete returns HTTP 202 with `status` set to `accepted` and a `stateUrl`. The client must observe state until `not_found`. Aevatar sends keepalive events every 15 seconds. NyxID's 120-second progress watchdog must count a valid keepalive as liveness without rendering it.
+
+## Appendix H. Principles that changed this plan
+
+| Principle | Concrete choice |
+|---|---|
+| Prove It Works | The done predicate requires live browser and producer receipts, exact-head evidence, a real remote drift check, and deployment SHAs. Mock Playwright does not close a capability row |
+| Sequence Work into Verifiable Units | The stack removes drift and obsolete paths before auth, actions, attachments, UX, liveness, and release proof. A dependent phase starts only after its parent has a green exact-head verdict |
+| Guard the Context Window | The audit read targeted symbols and commit deltas, preserved summarized evidence here, and avoided copying complete source files into the plan |
+| Never Block on the Human | Reversible scope and phase decisions are fixed now. Operator attention is reserved for explicit UI review, security authority, and merge gates |
+| Foundational Thinking | `AC-0` establishes contract types and drift detection. `AC-4` establishes the attachment data shape before the picker uses it |
+| Boundary Discipline | NyxID reconstructs typed Aevatar bodies, derives scope and resource identity server-side, and returns a dedicated reference-only artifact DTO |
+| Build the Lever | `AC-0` replaces manual fixture synchronization with a rerunnable drift checker. `AC-7` adds a rerunnable credentialed contract canary |
+| Subtract Before You Add | `AC-1` removes `plan.resolve`, the unsafe unused completions route, and stale revision assumptions before new state is added |
+| Migrate Callers Then Delete Legacy APIs | Every `plan.resolve` caller, parser, control, fixture, test, and current-contract document moves or disappears in one phase |
+| Model the Domain | Access review, attachment revision mode, deleting state, typed errors, and canary results use explicit variants and state transitions instead of generic objects or booleans |
+
+## Appendix I. Open decisions and stop conditions
+
+`AC-2` must choose the deployed authorization-session model. The current recommendation is consent-derived delegated restrictions, but only if the live probe proves bootstrap, client identity, mutation, revocation, and next-token behavior. A failed predicate changes the decision before product code starts.
+
+`AC-1` must inspect production access evidence before removing `/api/v1/assistant/completions`. A current external caller pauses deletion until its owner and strict typed contract are known. Repository search alone cannot disprove external use.
+
+`AC-6` must classify media and generic authorization recovery from the public Aevatar read models. If upstream exposes no durable source, the owner files or links an upstream issue and documents the boundary. NyxID does not create a shadow content store to manufacture parity.
+
+The `experimental:ai-assistant` flag currently hides navigation only. Whether it must also block the route and backend API is a NyxID product-policy choice. It does not block this Aevatar contract program and needs a separate operator decision.
+
+Any Aevatar watched-path drift, failed security review, missing credentialed staging prerequisite, changed phase head after verification, or red `CI Pipeline` voids the current verdict. The affected phase remains unready and no dependent phase advances.
+
+## Appendix J. Decisions taken at program start and live-environment constraints
+
+The operator delegated these decisions by authorizing execution on the reviewer's recommendation.
+
+| Decision | Choice | Reversible by |
+|---|---|---|
+| Authority model candidate | Consent-derived delegated restrictions with the three enabling NyxID changes, falsifiable by the `AC-2` probe rows | `AC-2` decision record |
+| Aevatar client identity | Admin-managed link from the `aevatar` catalog row to the registered OAuth client, chosen in `AC-2` | `AC-2` decision record |
+| Consent mutation semantics | Merge, never replace, in `consent_service`; the OAuth consent page's replace behavior is filed as a separate issue | `AC-3` review |
+| `/api/v1/assistant/completions` | Delete. The route sits on the human-only router, which rejects API keys, service accounts, delegated, and relay tokens, and no CLI, SDK, mobile, or frontend caller exists. Route-level telemetry does not exist, so router policy is the access evidence | `AC-1` review |
+| `experimental:ai-assistant` enforcement | Out of scope; filed as a separate issue | Operator |
+| Delegated routing | `~/.heca/pstack-models.json` with every `claude-fable` selection replaced by the next entry in its chain, because the operator restricted Fable to planning | Operator |
+
+These live-environment constraints were observed at program start.
+
+- No staging NyxID or Aevatar pair exists. The production pair is NyxID `https://nyx-api.chrono-ai.fun` and Aevatar `https://aevatar-console-backend-api.aevatar.ai`.
+- Aevatar validates NyxID tokens against production JWKS, so a changed local NyxID cannot be exercised against real Aevatar before deployment. Deployment is operator authority.
+- `dotnet` is not installed, so Aevatar cannot run locally. Docker is not running; a local single-node replica-set mongod on `127.0.0.1:27017` serves backend tests.
+- Each phase names its live surface honestly. The surfaces are production read-only probes where no NyxID change is required, the local NyxID runtime with real HTTP for changed NyxID behavior, and the credentialed canary in `AC-7` designed to run after deployment. A mock run is never reported as live.

--- a/scripts/probe-aevatar-chat-authority.mjs
+++ b/scripts/probe-aevatar-chat-authority.mjs
@@ -8,9 +8,15 @@
  *   AC2_RESTRICTED_DELEGATED_BEARER are secrets.
  * - AC2_GATEWAY_MODEL must be a public label.
  * - AC2_ACK_LOCAL_POSTS must equal "ac2-local-only".
+ * - AC2_PRODUCTION_USER_ID is the required expected operator UUID for both
+ *   production commands. It has no committed default.
+ * - AC2_PRODUCTION_BASE_URL defaults to https://nyx-api.chrono-ai.fun and may
+ *   override that target with another HTTPS origin.
+ * - AC2_AEVATAR_CLIENT_ID defaults to the registered production Aevatar client
+ *   UUID and may override the client used for the consent read.
  * - Stdout contains allowlisted receipt JSON only. Redirect it to the evidence file.
  * - `production-read <token-file>` performs the fixed allowlisted GETs against
- *   the production pair and checks the fixed operator user.
+ *   the configured production origin and checks the configured operator user.
  * - `production-chat <token-file>` additionally requires
  *   AC2_ACK_PRODUCTION_CHAT="post-one-chat-and-delete". The command posts one
  *   typed turn, deletes only its new conversation, and confirms deletion.
@@ -25,11 +31,11 @@ const MAX_RESPONSE_BYTES = 64 * 1024;
 const REQUEST_TIMEOUT_MS = 15_000;
 const LOCAL_ACKNOWLEDGEMENT = "ac2-local-only";
 const PRODUCTION_CHAT_ACKNOWLEDGEMENT = "post-one-chat-and-delete";
-const PRODUCTION_BASE_URL = "https://nyx-api.chrono-ai.fun";
-const PRODUCTION_USER_ID = "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b";
-const AEVATAR_CLIENT_ID = "a6ff2946-f02f-4c35-8203-1ec46132b660";
+const DEFAULT_PRODUCTION_BASE_URL = "https://nyx-api.chrono-ai.fun";
+const DEFAULT_AEVATAR_CLIENT_ID = "a6ff2946-f02f-4c35-8203-1ec46132b660";
 const SAFE_PUBLIC_LABEL = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const SAFE_CODE = /^[A-Za-z][A-Za-z0-9_-]{0,127}$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SECRET_PATTERNS = [
   /eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}/i,
   /nyx_[A-Za-z0-9_-]+/i,
@@ -148,15 +154,21 @@ export async function runSevenRowProbe({
   return [...sourceRows, ...localRows];
 }
 
-export async function runProductionReadProbe({ token, fetchImpl = globalThis.fetch } = {}) {
+export async function runProductionReadProbe({
+  token,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const config = loadProductionProbeConfig(env);
   requireSecret(token);
   const tokenSummary = decodeJwtClaimSummary(token);
+  const context = { config, token, fetchImpl };
   const specs = [
     ["me", "/api/v1/users/me"],
     ["consents", "/api/v1/users/me/consents"],
     [
       "aevatar_consent_authorization",
-      `/api/v1/users/me/consents/${AEVATAR_CLIENT_ID}/authorization`,
+      `/api/v1/users/me/consents/${config.aevatarClientId}/authorization`,
     ],
     ["keys", "/api/v1/keys"],
     ["assistant_actions", "/api/v1/assistant/actions"],
@@ -167,7 +179,7 @@ export async function runProductionReadProbe({ token, fetchImpl = globalThis.fet
   const observations = {};
   const bodies = {};
   for (const [name, path] of specs) {
-    const { response, body } = await productionJsonRequest(path, token, fetchImpl);
+    const { response, body } = await productionJsonRequest(context, path);
     observations[name] = {
       status: response.status,
       upstream_code: extractSafeUpstreamCode(body),
@@ -180,9 +192,9 @@ export async function runProductionReadProbe({ token, fetchImpl = globalThis.fet
   const authorization = bodies.aevatar_consent_authorization;
   return {
     surface: "production-read-only",
-    nyxid_base: "production-pair",
+    nyxid_base: config.baseUrl.origin,
     aevatar_source_version: AEVATAR_PINNED_VERSION,
-    expected_user_matched: meId === PRODUCTION_USER_ID,
+    expected_user_matched: meId === config.expectedUserId,
     token_claim_summary: tokenSummary,
     aevatar_authorized_service_count: countNamedArray(authorization, [
       "allowed_service_ids",
@@ -201,50 +213,43 @@ export async function runProductionChatProbe({
   if (env.AC2_ACK_PRODUCTION_CHAT !== PRODUCTION_CHAT_ACKNOWLEDGEMENT) {
     throw new Error("production_chat_not_acknowledged");
   }
+  const config = loadProductionProbeConfig(env);
   requireSecret(token);
+  const context = { config, token, fetchImpl };
 
-  const meRead = await productionJsonRequest("/api/v1/users/me", token, fetchImpl);
+  const meRead = await productionJsonRequest(context, "/api/v1/users/me");
   if (
     meRead.response.status !== 200 ||
     !isPlainObject(meRead.body) ||
-    meRead.body.id !== PRODUCTION_USER_ID
+    meRead.body.id !== config.expectedUserId
   ) {
     throw new Error("production_user_mismatch");
   }
 
-  const keysRead = await productionJsonRequest("/api/v1/keys", token, fetchImpl);
+  const keysRead = await productionJsonRequest(context, "/api/v1/keys");
   if (keysRead.response.status !== 200) {
     throw new Error("production_keys_unavailable");
   }
   const selectedService = selectConnectedService(keysRead.body);
-  const beforeRead = await productionJsonRequest(
-    "/api/v1/assistant/conversations",
-    token,
-    fetchImpl,
-  );
+  const beforeRead = await productionJsonRequest(context, "/api/v1/assistant/conversations");
   if (beforeRead.response.status !== 200) {
     throw new Error("production_conversations_unavailable");
   }
   const beforeIds = collectConversationIds(beforeRead.body);
 
-  const chatResponse = await productionFetch(
-    "/api/v1/assistant/chat",
-    token,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        accept: "text/event-stream",
-        "x-nyxid-debug-upstream": "1",
-      },
-      body: JSON.stringify({
-        type: "text",
-        prompt: `Use the already connected service ${selectedService.slug} and report whether it is available.`,
-        clientRequestId: `ac2-production-${Date.now()}`,
-      }),
+  const chatResponse = await productionFetch(context, "/api/v1/assistant/chat", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      "x-nyxid-debug-upstream": "1",
     },
-    fetchImpl,
-  );
+    body: JSON.stringify({
+      type: "text",
+      prompt: `Use the already connected service ${selectedService.slug} and report whether it is available.`,
+      clientRequestId: `ac2-production-${Date.now()}`,
+    }),
+  });
   let chatBytes = Buffer.alloc(0);
   let chatReadError = null;
   try {
@@ -254,11 +259,7 @@ export async function runProductionChatProbe({
   }
   const chatText = chatBytes.toString("utf8");
 
-  const afterRead = await productionJsonRequest(
-    "/api/v1/assistant/conversations",
-    token,
-    fetchImpl,
-  );
+  const afterRead = await productionJsonRequest(context, "/api/v1/assistant/conversations");
   if (afterRead.response.status !== 200) {
     throw new Error("production_conversations_unavailable");
   }
@@ -282,10 +283,9 @@ export async function runProductionChatProbe({
   let stateConfirmation;
   try {
     deleteResponse = await productionFetch(
+      context,
       `/api/v1/assistant/conversations/${conversationId}`,
-      token,
       { method: "DELETE" },
-      fetchImpl,
     );
     try {
       await readBoundedBytes(deleteResponse, 256 * 1024);
@@ -293,14 +293,12 @@ export async function runProductionChatProbe({
       // The typed reads below are the authoritative deletion confirmation.
     }
     historyConfirmation = await productionJsonRequest(
+      context,
       `/api/v1/assistant/conversations/${conversationId}`,
-      token,
-      fetchImpl,
     );
     stateConfirmation = await productionJsonRequest(
+      context,
       `/api/v1/assistant/conversations/${conversationId}/state`,
-      token,
-      fetchImpl,
     );
   } catch {
     throw new Error("production_conversation_cleanup_failed");
@@ -393,6 +391,46 @@ function assertLoopbackTarget(rawUrl) {
   }
   url.pathname = url.pathname.replace(/\/$/, "");
   return url;
+}
+
+function loadProductionProbeConfig(env) {
+  const expectedUserId = requireUuid(
+    env.AC2_PRODUCTION_USER_ID,
+    "production_user_id_missing",
+    "production_user_id_invalid",
+  );
+  const aevatarClientId = requireUuid(
+    env.AC2_AEVATAR_CLIENT_ID ?? DEFAULT_AEVATAR_CLIENT_ID,
+    "aevatar_client_id_missing",
+    "aevatar_client_id_invalid",
+  );
+  let baseUrl;
+  try {
+    baseUrl = new URL(env.AC2_PRODUCTION_BASE_URL ?? DEFAULT_PRODUCTION_BASE_URL);
+  } catch {
+    throw new Error("production_base_url_invalid");
+  }
+  if (
+    baseUrl.protocol !== "https:" ||
+    baseUrl.username !== "" ||
+    baseUrl.password !== "" ||
+    baseUrl.pathname !== "/" ||
+    baseUrl.search !== "" ||
+    baseUrl.hash !== ""
+  ) {
+    throw new Error("production_base_url_invalid");
+  }
+  return Object.freeze({ baseUrl, expectedUserId, aevatarClientId });
+}
+
+function requireUuid(value, missingCode, invalidCode) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(missingCode);
+  }
+  if (!UUID.test(value)) {
+    throw new Error(invalidCode);
+  }
+  return value;
 }
 
 function buildSourceRows(inputs) {
@@ -557,8 +595,8 @@ async function readBoundedJson(response) {
   }
 }
 
-async function productionJsonRequest(path, token, fetchImpl) {
-  const response = await productionFetch(path, token, { method: "GET" }, fetchImpl);
+async function productionJsonRequest(context, path) {
+  const response = await productionFetch(context, path, { method: "GET" });
   const bytes = await readBoundedBytes(response, 4 * 1024 * 1024);
   let body = null;
   if (bytes.length > 0) {
@@ -571,14 +609,14 @@ async function productionJsonRequest(path, token, fetchImpl) {
   return { response, body };
 }
 
-async function productionFetch(path, token, init, fetchImpl) {
+async function productionFetch(context, path, init) {
   let response;
   try {
-    response = await fetchImpl(new URL(path, PRODUCTION_BASE_URL), {
+    response = await context.fetchImpl(new URL(path, context.config.baseUrl), {
       ...init,
       headers: {
         ...init.headers,
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${context.token}`,
       },
       redirect: "manual",
     });
@@ -848,6 +886,9 @@ if (isMainModule()) {
         "local_posts_not_acknowledged",
         "missing_probe_secret",
         "network_failure",
+        "aevatar_client_id_invalid",
+        "aevatar_client_id_missing",
+        "production_base_url_invalid",
         "production_chat_not_acknowledged",
         "production_connected_service_missing",
         "production_conversation_cleanup_failed",
@@ -857,6 +898,8 @@ if (isMainModule()) {
         "production_token_file_missing",
         "production_token_file_unreadable",
         "production_user_mismatch",
+        "production_user_id_invalid",
+        "production_user_id_missing",
         "response_read_failed",
         "response_too_large",
         "secret_barrier_triggered",

--- a/scripts/probe-aevatar-chat-authority.mjs
+++ b/scripts/probe-aevatar-chat-authority.mjs
@@ -133,6 +133,10 @@ export function extractSafeUpstreamCode(value) {
   if (direct !== null) {
     return direct;
   }
+  const errorCode = nullableSafeCodeOrNull(value.error_code);
+  if (errorCode !== null) {
+    return errorCode;
+  }
   if (isPlainObject(value.error)) {
     return nullableSafeCodeOrNull(value.error.code);
   }

--- a/scripts/probe-aevatar-chat-authority.mjs
+++ b/scripts/probe-aevatar-chat-authority.mjs
@@ -1,0 +1,871 @@
+#!/usr/bin/env node
+
+/**
+ * Environment and command contract for the fixed AC-2 probe:
+ * - AC2_NYXID_BASE_URL must be loopback HTTP without credentials, query, or fragment.
+ * - AC2_LOCAL_VERSION is a public Git SHA or conservative deployment label.
+ * - AC2_IDENTITY_ASSERTION, AC2_BRIDGE_BEARER, and
+ *   AC2_RESTRICTED_DELEGATED_BEARER are secrets.
+ * - AC2_GATEWAY_MODEL must be a public label.
+ * - AC2_ACK_LOCAL_POSTS must equal "ac2-local-only".
+ * - Stdout contains allowlisted receipt JSON only. Redirect it to the evidence file.
+ * - `production-read <token-file>` performs the fixed allowlisted GETs against
+ *   the production pair and checks the fixed operator user.
+ * - `production-chat <token-file>` additionally requires
+ *   AC2_ACK_PRODUCTION_CHAT="post-one-chat-and-delete". The command posts one
+ *   typed turn, deletes only its new conversation, and confirms deletion.
+ * - The default command is `seven-row`; it never selects a production command.
+ */
+
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const AEVATAR_PINNED_VERSION = "e5bba2e9719ad5132004b882744caa3875db1123";
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const REQUEST_TIMEOUT_MS = 15_000;
+const LOCAL_ACKNOWLEDGEMENT = "ac2-local-only";
+const PRODUCTION_CHAT_ACKNOWLEDGEMENT = "post-one-chat-and-delete";
+const PRODUCTION_BASE_URL = "https://nyx-api.chrono-ai.fun";
+const PRODUCTION_USER_ID = "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b";
+const AEVATAR_CLIENT_ID = "a6ff2946-f02f-4c35-8203-1ec46132b660";
+const SAFE_PUBLIC_LABEL = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SAFE_CODE = /^[A-Za-z][A-Za-z0-9_-]{0,127}$/;
+const SECRET_PATTERNS = [
+  /eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}/i,
+  /nyx_[A-Za-z0-9_-]+/i,
+  new RegExp(`${["nyxid", "ag"].join("_")}_+[A-Za-z0-9_-]+`, "i"),
+  /authorization\s*:\s*(?:bearer\s+)?\S+/i,
+  /(?:set-)?cookie\s*:\s*\S+/i,
+];
+const ROW_IDS = [
+  "identity_only",
+  "identity_plus_capability_bearer",
+  "identity_plus_delegation_header",
+  "replayed_identity_jti",
+  "bridge_bearer_mcp_config",
+  "restricted_bearer_llm_gateway",
+  "restricted_bearer_proxy_slug",
+];
+
+export function decodeJwtClaimSummary(token) {
+  if (typeof token !== "string" || token.split(".").length !== 3) {
+    throw new Error("invalid_jwt_shape");
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString("utf8"));
+  } catch {
+    throw new Error("invalid_jwt_payload");
+  }
+  if (!isPlainObject(payload)) {
+    throw new Error("invalid_jwt_payload");
+  }
+
+  const scopeNames = normalizeScopes(payload.scope ?? payload.scopes);
+  const expiryWindowSeconds =
+    Number.isSafeInteger(payload.iat) &&
+    Number.isSafeInteger(payload.exp) &&
+    payload.exp >= payload.iat
+      ? payload.exp - payload.iat
+      : null;
+
+  return {
+    delegated: payload.delegated === true,
+    actor_present:
+      isPlainObject(payload.act) &&
+      typeof payload.act.sub === "string" &&
+      payload.act.sub.length > 0,
+    client_id_present:
+      typeof payload.client_id === "string" && payload.client_id.length > 0,
+    allow_all_services:
+      typeof payload.allow_all_services === "boolean" ? payload.allow_all_services : null,
+    allowed_service_ids_count: Array.isArray(payload.allowed_service_ids)
+      ? payload.allowed_service_ids.length
+      : 0,
+    resource_count: Array.isArray(payload.resources) ? payload.resources.length : 0,
+    scope_names: scopeNames,
+    expiry_window_seconds: expiryWindowSeconds,
+  };
+}
+
+export function sanitizeReceipt(candidate) {
+  if (!isPlainObject(candidate) || !isPlainObject(candidate.claim_summary)) {
+    throw new Error("invalid_receipt");
+  }
+
+  return {
+    row_id: requireSafeString(candidate.row_id),
+    surface: requireSafeString(candidate.surface),
+    deployment_version: requireSafeString(candidate.deployment_version),
+    request_shape: requireSafeString(candidate.request_shape),
+    http_status: nullableStatus(candidate.http_status),
+    upstream_code: nullableSafeCode(candidate.upstream_code),
+    claim_summary: sanitizeClaimSummary(candidate.claim_summary),
+    verdict: requireSafeString(candidate.verdict),
+    observation_kind: requireSafeString(candidate.observation_kind),
+  };
+}
+
+export function serializeReceipts(rows) {
+  if (!Array.isArray(rows)) {
+    throw new Error("invalid_receipts");
+  }
+  const sanitized = rows.map(sanitizeReceipt);
+  const serialized = `${JSON.stringify(sanitized, null, 2)}\n`;
+  if (SECRET_PATTERNS.some((pattern) => pattern.test(serialized))) {
+    throw new Error("secret_barrier_triggered");
+  }
+  return serialized;
+}
+
+export function extractSafeUpstreamCode(value) {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+  const direct = nullableSafeCodeOrNull(value.code);
+  if (direct !== null) {
+    return direct;
+  }
+  if (isPlainObject(value.error)) {
+    return nullableSafeCodeOrNull(value.error.code);
+  }
+  return null;
+}
+
+export async function runSevenRowProbe({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const inputs = loadSevenRowInputs(env);
+  const sourceRows = buildSourceRows(inputs);
+  const localRows = [];
+
+  for (const spec of localRequestSpecs(inputs)) {
+    localRows.push(await observeLocalRow(spec, inputs, fetchImpl));
+  }
+
+  return [...sourceRows, ...localRows];
+}
+
+export async function runProductionReadProbe({ token, fetchImpl = globalThis.fetch } = {}) {
+  requireSecret(token);
+  const tokenSummary = decodeJwtClaimSummary(token);
+  const specs = [
+    ["me", "/api/v1/users/me"],
+    ["consents", "/api/v1/users/me/consents"],
+    [
+      "aevatar_consent_authorization",
+      `/api/v1/users/me/consents/${AEVATAR_CLIENT_ID}/authorization`,
+    ],
+    ["keys", "/api/v1/keys"],
+    ["assistant_actions", "/api/v1/assistant/actions"],
+    ["assistant_readiness", "/api/v1/assistant/readiness"],
+    ["mcp_config", "/api/v1/mcp/config"],
+    ["assistant_conversations", "/api/v1/assistant/conversations"],
+  ];
+  const observations = {};
+  const bodies = {};
+  for (const [name, path] of specs) {
+    const { response, body } = await productionJsonRequest(path, token, fetchImpl);
+    observations[name] = {
+      status: response.status,
+      upstream_code: extractSafeUpstreamCode(body),
+      item_count: countKnownItems(body),
+    };
+    bodies[name] = body;
+  }
+
+  const meId = isPlainObject(bodies.me) ? bodies.me.id ?? bodies.me.user_id : null;
+  const authorization = bodies.aevatar_consent_authorization;
+  return {
+    surface: "production-read-only",
+    nyxid_base: "production-pair",
+    aevatar_source_version: AEVATAR_PINNED_VERSION,
+    expected_user_matched: meId === PRODUCTION_USER_ID,
+    token_claim_summary: tokenSummary,
+    aevatar_authorized_service_count: countNamedArray(authorization, [
+      "allowed_service_ids",
+      "service_ids",
+      "services",
+    ]),
+    observations,
+  };
+}
+
+export async function runProductionChatProbe({
+  token,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (env.AC2_ACK_PRODUCTION_CHAT !== PRODUCTION_CHAT_ACKNOWLEDGEMENT) {
+    throw new Error("production_chat_not_acknowledged");
+  }
+  requireSecret(token);
+
+  const meRead = await productionJsonRequest("/api/v1/users/me", token, fetchImpl);
+  if (
+    meRead.response.status !== 200 ||
+    !isPlainObject(meRead.body) ||
+    meRead.body.id !== PRODUCTION_USER_ID
+  ) {
+    throw new Error("production_user_mismatch");
+  }
+
+  const keysRead = await productionJsonRequest("/api/v1/keys", token, fetchImpl);
+  if (keysRead.response.status !== 200) {
+    throw new Error("production_keys_unavailable");
+  }
+  const selectedService = selectConnectedService(keysRead.body);
+  const beforeRead = await productionJsonRequest(
+    "/api/v1/assistant/conversations",
+    token,
+    fetchImpl,
+  );
+  if (beforeRead.response.status !== 200) {
+    throw new Error("production_conversations_unavailable");
+  }
+  const beforeIds = collectConversationIds(beforeRead.body);
+
+  const chatResponse = await productionFetch(
+    "/api/v1/assistant/chat",
+    token,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        "x-nyxid-debug-upstream": "1",
+      },
+      body: JSON.stringify({
+        type: "text",
+        prompt: `Use the already connected service ${selectedService.slug} and report whether it is available.`,
+        clientRequestId: `ac2-production-${Date.now()}`,
+      }),
+    },
+    fetchImpl,
+  );
+  let chatBytes = Buffer.alloc(0);
+  let chatReadError = null;
+  try {
+    chatBytes = await readBoundedBytes(chatResponse, 8 * 1024 * 1024);
+  } catch (error) {
+    chatReadError = error;
+  }
+  const chatText = chatBytes.toString("utf8");
+
+  const afterRead = await productionJsonRequest(
+    "/api/v1/assistant/conversations",
+    token,
+    fetchImpl,
+  );
+  if (afterRead.response.status !== 200) {
+    throw new Error("production_conversations_unavailable");
+  }
+  const afterIds = collectConversationIds(afterRead.body);
+  const newIds = [...afterIds].filter((id) => !beforeIds.has(id));
+  if (newIds.length !== 1) {
+    throw new Error("production_conversation_identity_ambiguous");
+  }
+  const conversationId = newIds[0];
+  const streamedIds = collectConversationIds(chatText);
+  let resultError = chatReadError;
+  if (
+    resultError === null &&
+    (streamedIds.size > 1 || (streamedIds.size === 1 && !streamedIds.has(conversationId)))
+  ) {
+    resultError = new Error("production_conversation_identity_ambiguous");
+  }
+
+  let deleteResponse;
+  let historyConfirmation;
+  let stateConfirmation;
+  try {
+    deleteResponse = await productionFetch(
+      `/api/v1/assistant/conversations/${conversationId}`,
+      token,
+      { method: "DELETE" },
+      fetchImpl,
+    );
+    try {
+      await readBoundedBytes(deleteResponse, 256 * 1024);
+    } catch {
+      // The typed reads below are the authoritative deletion confirmation.
+    }
+    historyConfirmation = await productionJsonRequest(
+      `/api/v1/assistant/conversations/${conversationId}`,
+      token,
+      fetchImpl,
+    );
+    stateConfirmation = await productionJsonRequest(
+      `/api/v1/assistant/conversations/${conversationId}/state`,
+      token,
+      fetchImpl,
+    );
+  } catch {
+    throw new Error("production_conversation_cleanup_failed");
+  }
+  const deletionConfirmed =
+    historyConfirmation.response.status === 404 && stateConfirmation.response.status === 404;
+  if (!deletionConfirmed) {
+    throw new Error("production_conversation_cleanup_failed");
+  }
+  if (resultError !== null) {
+    throw resultError;
+  }
+
+  const recognizedClassifications = [
+    "USER_SERVICE_ACCESS_REQUIRED",
+    "SourceStale",
+    "INVENTORY_INVALID",
+    "unsupported-action",
+  ].filter((classification) => chatText.includes(classification));
+
+  return {
+    surface: "production-single-chat",
+    aevatar_source_version: AEVATAR_PINNED_VERSION,
+    selected_service_id: selectedService.id,
+    chat_status: chatResponse.status,
+    chat_response_bytes: chatBytes.length,
+    recognized_classifications: recognizedClassifications,
+    created_conversation_id: conversationId,
+    delete_status: deleteResponse.status,
+    history_confirmation_status: historyConfirmation.response.status,
+    history_confirmation_code: extractSafeUpstreamCode(historyConfirmation.body),
+    state_confirmation_status: stateConfirmation.response.status,
+    state_confirmation_code: extractSafeUpstreamCode(stateConfirmation.body),
+    deletion_confirmed: deletionConfirmed,
+  };
+}
+
+export function serializeSafeEvidence(value) {
+  const serialized = `${JSON.stringify(value, null, 2)}\n`;
+  if (SECRET_PATTERNS.some((pattern) => pattern.test(serialized))) {
+    throw new Error("secret_barrier_triggered");
+  }
+  return serialized;
+}
+
+function loadSevenRowInputs(env) {
+  if (env.AC2_ACK_LOCAL_POSTS !== LOCAL_ACKNOWLEDGEMENT) {
+    throw new Error("local_posts_not_acknowledged");
+  }
+  const baseUrl = assertLoopbackTarget(env.AC2_NYXID_BASE_URL);
+  const deploymentVersion = requirePublicLabel(
+    env.AC2_LOCAL_VERSION,
+    "invalid_local_version",
+  );
+  const gatewayModel = requirePublicLabel(env.AC2_GATEWAY_MODEL, "invalid_gateway_model");
+  const identityAssertion = requireSecret(env.AC2_IDENTITY_ASSERTION);
+  const bridgeBearer = requireSecret(env.AC2_BRIDGE_BEARER);
+  const restrictedBearer = requireSecret(env.AC2_RESTRICTED_DELEGATED_BEARER);
+
+  return {
+    baseUrl,
+    deploymentVersion,
+    gatewayModel,
+    identityAssertion,
+    bridgeBearer,
+    restrictedBearer,
+    identitySummary: decodeJwtClaimSummary(identityAssertion),
+    bridgeSummary: decodeJwtClaimSummary(bridgeBearer),
+    restrictedSummary: decodeJwtClaimSummary(restrictedBearer),
+  };
+}
+
+function assertLoopbackTarget(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error("local_base_url_invalid");
+  }
+  const loopbackHosts = new Set(["127.0.0.1", "[::1]", "localhost"]);
+  if (
+    url.protocol !== "http:" ||
+    !loopbackHosts.has(url.hostname) ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== ""
+  ) {
+    throw new Error("local_base_url_not_loopback");
+  }
+  url.pathname = url.pathname.replace(/\/$/, "");
+  return url;
+}
+
+function buildSourceRows(inputs) {
+  const source = "pinned-aevatar-source";
+  const observation = "source-proven-not-runtime-observed";
+  const common = {
+    surface: source,
+    deployment_version: AEVATAR_PINNED_VERSION,
+    http_status: null,
+    upstream_code: null,
+    observation_kind: observation,
+  };
+
+  return [
+    sanitizeReceipt({
+      ...common,
+      row_id: ROW_IDS[0],
+      request_shape: "identity assertion only",
+      claim_summary: inputs.identitySummary,
+      verdict: "execution_capability_required",
+    }),
+    sanitizeReceipt({
+      ...common,
+      row_id: ROW_IDS[1],
+      request_shape: "identity assertion plus capability bearer",
+      claim_summary: inputs.restrictedSummary,
+      verdict: "capability_selected_from_bearer",
+    }),
+    sanitizeReceipt({
+      ...common,
+      row_id: ROW_IDS[2],
+      request_shape: "identity assertion plus delegation header",
+      claim_summary: inputs.bridgeSummary,
+      verdict: "capability_selected_from_delegation_header",
+    }),
+    sanitizeReceipt({
+      ...common,
+      row_id: ROW_IDS[3],
+      request_shape: "replayed identity assertion identifier",
+      http_status: 401,
+      upstream_code: "identity_assertion_replayed",
+      claim_summary: inputs.identitySummary,
+      verdict: "replay_rejected",
+    }),
+  ];
+}
+
+function localRequestSpecs(inputs) {
+  const completionBody = JSON.stringify({
+    model: inputs.gatewayModel,
+    messages: [{ role: "user", content: "AC-2 local authority reachability probe" }],
+    stream: false,
+  });
+  return [
+    {
+      rowId: ROW_IDS[4],
+      requestShape: "bridge bearer reads REST MCP config",
+      path: "/api/v1/mcp/config",
+      init: { method: "GET", headers: bearerHeaders(inputs.bridgeBearer) },
+      claimSummary: inputs.bridgeSummary,
+      verdictForStatus: (status) => (status === 403 ? "route_denied" : "unexpected_result"),
+    },
+    {
+      rowId: ROW_IDS[5],
+      requestShape: "restricted delegated bearer posts LLM gateway completion",
+      path: "/api/v1/llm/gateway/v1/chat/completions",
+      init: {
+        method: "POST",
+        headers: jsonBearerHeaders(inputs.restrictedBearer),
+        body: completionBody,
+      },
+      claimSummary: inputs.restrictedSummary,
+      verdictForStatus: (status) =>
+        status >= 200 && status < 300 ? "callback_reachable" : "unexpected_result",
+    },
+    {
+      rowId: ROW_IDS[6],
+      requestShape: "restricted delegated bearer posts platform proxy slug",
+      path: "/api/v1/proxy/s/chrono-llm-public",
+      init: {
+        method: "POST",
+        headers: jsonBearerHeaders(inputs.restrictedBearer),
+        body: completionBody,
+      },
+      claimSummary: inputs.restrictedSummary,
+      verdictForStatus: (status) =>
+        status === 403 ? "restricted_platform_row_denied" : "unexpected_result",
+    },
+  ];
+}
+
+async function observeLocalRow(spec, inputs, fetchImpl) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetchImpl(new URL(spec.path, inputs.baseUrl), {
+      ...spec.init,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+  } catch {
+    throw new Error("network_failure");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const body = await readBoundedJson(response);
+  return sanitizeReceipt({
+    row_id: spec.rowId,
+    surface: "local-nyxid-runtime",
+    deployment_version: inputs.deploymentVersion,
+    request_shape: spec.requestShape,
+    http_status: response.status,
+    upstream_code: extractSafeUpstreamCode(body),
+    claim_summary: spec.claimSummary,
+    verdict: spec.verdictForStatus(response.status),
+    observation_kind: "runtime-observed",
+  });
+}
+
+async function readBoundedJson(response) {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
+    throw new Error("response_too_large");
+  }
+  if (response.body === null) {
+    return null;
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error("response_too_large");
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === "response_too_large") {
+      throw error;
+    }
+    throw new Error("response_read_failed");
+  }
+
+  if (totalBytes === 0) {
+    return null;
+  }
+  try {
+    const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function productionJsonRequest(path, token, fetchImpl) {
+  const response = await productionFetch(path, token, { method: "GET" }, fetchImpl);
+  const bytes = await readBoundedBytes(response, 4 * 1024 * 1024);
+  let body = null;
+  if (bytes.length > 0) {
+    try {
+      body = JSON.parse(bytes.toString("utf8"));
+    } catch {
+      body = null;
+    }
+  }
+  return { response, body };
+}
+
+async function productionFetch(path, token, init, fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(new URL(path, PRODUCTION_BASE_URL), {
+      ...init,
+      headers: {
+        ...init.headers,
+        authorization: `Bearer ${token}`,
+      },
+      redirect: "manual",
+    });
+  } catch {
+    throw new Error("network_failure");
+  }
+  return response;
+}
+
+async function readBoundedBytes(response, limit) {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > limit) {
+    throw new Error("response_too_large");
+  }
+  if (response.body === null) {
+    return Buffer.alloc(0);
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > limit) {
+        await reader.cancel();
+        throw new Error("response_too_large");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === "response_too_large") {
+      throw error;
+    }
+    throw new Error("response_read_failed");
+  }
+  return Buffer.concat(chunks);
+}
+
+function selectConnectedService(body) {
+  const keys = isPlainObject(body) && Array.isArray(body.keys) ? body.keys : [];
+  const selected = keys.find(
+    (key) =>
+      isPlainObject(key) &&
+      key.is_active !== false &&
+      typeof key.id === "string" &&
+      /^[A-Za-z0-9_-]{1,128}$/.test(key.id) &&
+      typeof key.slug === "string" &&
+      /^[a-z0-9][a-z0-9-]{0,99}$/.test(key.slug),
+  );
+  if (!selected) {
+    throw new Error("production_connected_service_missing");
+  }
+  return { id: selected.id, slug: selected.slug };
+}
+
+function collectConversationIds(value) {
+  const ids = new Set();
+  if (typeof value === "string") {
+    for (const match of value.matchAll(/(?:nyxid-chat-[A-Za-z0-9_-]+|chatc-[A-Za-z0-9_-]+)/g)) {
+      ids.add(match[0]);
+    }
+    return ids;
+  }
+  visitJson(value, (key, candidate) => {
+    if (
+      ["id", "conversationId", "conversation_id"].includes(key) &&
+      typeof candidate === "string" &&
+      /^(?:nyxid-chat-|chatc-)[A-Za-z0-9_-]+$/.test(candidate)
+    ) {
+      ids.add(candidate);
+    }
+  });
+  return ids;
+}
+
+function visitJson(value, visitor) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitJson(item, visitor);
+    }
+    return;
+  }
+  if (!isPlainObject(value)) {
+    return;
+  }
+  for (const [key, candidate] of Object.entries(value)) {
+    visitor(key, candidate);
+    visitJson(candidate, visitor);
+  }
+}
+
+function countKnownItems(value) {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  return countNamedArray(value, [
+    "actions",
+    "consents",
+    "conversations",
+    "items",
+    "keys",
+    "services",
+  ]);
+}
+
+function countNamedArray(value, names) {
+  if (!isPlainObject(value)) {
+    return 0;
+  }
+  for (const name of names) {
+    if (Array.isArray(value[name])) {
+      return value[name].length;
+    }
+  }
+  return 0;
+}
+
+function sanitizeClaimSummary(summary) {
+  return {
+    delegated: summary.delegated === true,
+    actor_present: summary.actor_present === true,
+    client_id_present: summary.client_id_present === true,
+    allow_all_services:
+      typeof summary.allow_all_services === "boolean" ? summary.allow_all_services : null,
+    allowed_service_ids_count: nonnegativeSafeInteger(summary.allowed_service_ids_count),
+    resource_count: nonnegativeSafeInteger(summary.resource_count),
+    scope_names: Array.isArray(summary.scope_names)
+      ? [...new Set(summary.scope_names.filter(isSafeScope))].sort()
+      : [],
+    expiry_window_seconds:
+      summary.expiry_window_seconds === null
+        ? null
+        : nonnegativeSafeInteger(summary.expiry_window_seconds),
+  };
+}
+
+function normalizeScopes(value) {
+  const candidates = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(/\s+/)
+      : [];
+  return [...new Set(candidates.filter(isSafeScope).map((scope) => scope.trim()))].sort();
+}
+
+function isSafeScope(value) {
+  return typeof value === "string" && /^[A-Za-z0-9:*._/-]{1,128}$/.test(value.trim());
+}
+
+function bearerHeaders(secret) {
+  return { authorization: `Bearer ${secret}` };
+}
+
+function jsonBearerHeaders(secret) {
+  return {
+    ...bearerHeaders(secret),
+    "content-type": "application/json",
+  };
+}
+
+function nullableStatus(value) {
+  if (value === null) {
+    return null;
+  }
+  if (Number.isInteger(value) && value >= 100 && value <= 599) {
+    return value;
+  }
+  throw new Error("invalid_receipt_status");
+}
+
+function nullableSafeCode(value) {
+  if (value === null) {
+    return null;
+  }
+  const safe = nullableSafeCodeOrNull(value);
+  if (safe === null) {
+    throw new Error("invalid_receipt_code");
+  }
+  return safe;
+}
+
+function nullableSafeCodeOrNull(value) {
+  if (Number.isSafeInteger(value) && value >= 0 && value <= 999_999) {
+    return value;
+  }
+  if (typeof value === "string" && SAFE_CODE.test(value)) {
+    return value;
+  }
+  return null;
+}
+
+function nonnegativeSafeInteger(value) {
+  if (Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  throw new Error("invalid_receipt_count");
+}
+
+function requireSafeString(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 256) {
+    throw new Error("invalid_receipt_string");
+  }
+  return value;
+}
+
+function requirePublicLabel(value, errorCode) {
+  if (typeof value !== "string" || !SAFE_PUBLIC_LABEL.test(value)) {
+    throw new Error(errorCode);
+  }
+  return value;
+}
+
+function requireSecret(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("missing_probe_secret");
+  }
+  return value;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isMainModule() {
+  return process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+async function runCli() {
+  const command = process.argv[2] ?? "seven-row";
+  if (command === "seven-row") {
+    return serializeReceipts(await runSevenRowProbe());
+  }
+  if (command === "production-read" || command === "production-chat") {
+    const tokenFile = process.argv[3];
+    if (typeof tokenFile !== "string" || tokenFile.length === 0) {
+      throw new Error("production_token_file_missing");
+    }
+    let token;
+    try {
+      token = (await readFile(tokenFile, "utf8")).trim();
+    } catch {
+      throw new Error("production_token_file_unreadable");
+    }
+    const result = command === "production-read"
+      ? await runProductionReadProbe({ token })
+      : await runProductionChatProbe({ token });
+    return serializeSafeEvidence(result);
+  }
+  throw new Error("unknown_probe_command");
+}
+
+if (isMainModule()) {
+  runCli()
+    .then((output) => process.stdout.write(output))
+    .catch((error) => {
+      const safeCodes = new Set([
+        "invalid_gateway_model",
+        "invalid_jwt_payload",
+        "invalid_jwt_shape",
+        "invalid_local_version",
+        "local_base_url_invalid",
+        "local_base_url_not_loopback",
+        "local_posts_not_acknowledged",
+        "missing_probe_secret",
+        "network_failure",
+        "production_chat_not_acknowledged",
+        "production_connected_service_missing",
+        "production_conversation_cleanup_failed",
+        "production_conversation_identity_ambiguous",
+        "production_conversations_unavailable",
+        "production_keys_unavailable",
+        "production_token_file_missing",
+        "production_token_file_unreadable",
+        "production_user_mismatch",
+        "response_read_failed",
+        "response_too_large",
+        "secret_barrier_triggered",
+        "unknown_probe_command",
+      ]);
+      const code = error instanceof Error && safeCodes.has(error.message)
+        ? error.message
+        : "probe_failed";
+      process.stderr.write(`${code}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/tests/probe-aevatar-chat-authority.test.mjs
+++ b/scripts/tests/probe-aevatar-chat-authority.test.mjs
@@ -5,6 +5,7 @@ import {
   decodeJwtClaimSummary,
   extractSafeUpstreamCode,
   runProductionChatProbe,
+  runProductionReadProbe,
   runSevenRowProbe,
   sanitizeReceipt,
   serializeReceipts,
@@ -19,6 +20,8 @@ const ROW_IDS = [
   "restricted_bearer_llm_gateway",
   "restricted_bearer_proxy_slug",
 ];
+const TEST_PRODUCTION_USER_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_AEVATAR_CLIENT_ID = "22222222-2222-4222-8222-222222222222";
 
 function jwtWithPayload(payload) {
   const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" }))
@@ -273,13 +276,68 @@ test("production chat requires an explicit one-write acknowledgement", async () 
   assert.equal(fetchCalls, 0);
 });
 
-test("production chat verifies the fixed operator before any write", async () => {
+test("production modes require the expected user before any request", async () => {
+  for (const [name, run] of [
+    ["read", runProductionReadProbe],
+    ["chat", runProductionChatProbe],
+  ]) {
+    let fetchCalls = 0;
+    const env = name === "chat"
+      ? { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" }
+      : {};
+    await assert.rejects(
+      run({
+        token: jwtWithPayload({ iat: 100, exp: 160 }),
+        env,
+        fetchImpl: async () => {
+          fetchCalls += 1;
+          throw new Error("must not run");
+        },
+      }),
+      { message: "production_user_id_missing" },
+    );
+    assert.equal(fetchCalls, 0, name);
+  }
+});
+
+test("production configuration controls read destinations and identity", async () => {
+  const observedUrls = [];
+  const result = await runProductionReadProbe({
+    token: jwtWithPayload({ iat: 100, exp: 160 }),
+    env: productionEnv({
+      AC2_PRODUCTION_BASE_URL: "https://nyxid.example.test",
+      AC2_AEVATAR_CLIENT_ID: TEST_AEVATAR_CLIENT_ID,
+    }),
+    fetchImpl: async (url) => {
+      observedUrls.push(url);
+      return jsonResponse(
+        200,
+        url.pathname === "/api/v1/users/me" ? { id: TEST_PRODUCTION_USER_ID } : {},
+      );
+    },
+  });
+
+  assert.equal(observedUrls.length, 8);
+  assert.equal(observedUrls.every((url) => url.origin === "https://nyxid.example.test"), true);
+  assert.equal(
+    observedUrls.some(
+      (url) =>
+        url.pathname ===
+        `/api/v1/users/me/consents/${TEST_AEVATAR_CLIENT_ID}/authorization`,
+    ),
+    true,
+  );
+  assert.equal(result.nyxid_base, "https://nyxid.example.test");
+  assert.equal(result.expected_user_matched, true);
+});
+
+test("production chat verifies the configured operator before any write", async () => {
   const writeMethods = [];
 
   await assert.rejects(
     runProductionChatProbe({
       token: jwtWithPayload({ iat: 100, exp: 160 }),
-      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      env: productionEnv(),
       fetchImpl: async (_url, init) => {
         if (init.method !== "GET") {
           writeMethods.push(init.method);
@@ -299,12 +357,10 @@ test("production chat never deletes an id that existed before the turn", async (
   await assert.rejects(
     runProductionChatProbe({
       token: jwtWithPayload({ iat: 100, exp: 160 }),
-      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      env: productionEnv(),
       fetchImpl: async (url, init) => {
         if (url.pathname === "/api/v1/users/me") {
-          return jsonResponse(200, {
-            id: "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b",
-          });
+          return jsonResponse(200, { id: TEST_PRODUCTION_USER_ID });
         }
         if (url.pathname === "/api/v1/keys") {
           return jsonResponse(200, {
@@ -340,13 +396,11 @@ test("production chat cleans up its new conversation after a body read failure",
   await assert.rejects(
     runProductionChatProbe({
       token: jwtWithPayload({ iat: 100, exp: 160 }),
-      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      env: productionEnv(),
       fetchImpl: async (url, init) => {
         observedPaths.push(`${init.method} ${url.pathname}`);
         if (url.pathname === "/api/v1/users/me") {
-          return jsonResponse(200, {
-            id: "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b",
-          });
+          return jsonResponse(200, { id: TEST_PRODUCTION_USER_ID });
         }
         if (url.pathname === "/api/v1/keys") {
           return jsonResponse(200, {
@@ -401,12 +455,10 @@ test("production chat reports a fixed error when cleanup is not confirmed", asyn
   await assert.rejects(
     runProductionChatProbe({
       token: jwtWithPayload({ iat: 100, exp: 160 }),
-      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      env: productionEnv(),
       fetchImpl: async (url, init) => {
         if (url.pathname === "/api/v1/users/me") {
-          return jsonResponse(200, {
-            id: "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b",
-          });
+          return jsonResponse(200, { id: TEST_PRODUCTION_USER_ID });
         }
         if (url.pathname === "/api/v1/keys") {
           return jsonResponse(200, {
@@ -463,6 +515,14 @@ function localEnv(overrides = {}) {
     AC2_RESTRICTED_DELEGATED_BEARER: restricted,
     AC2_GATEWAY_MODEL: "local-probe-model",
     AC2_ACK_LOCAL_POSTS: "ac2-local-only",
+    ...overrides,
+  };
+}
+
+function productionEnv(overrides = {}) {
+  return {
+    AC2_PRODUCTION_USER_ID: TEST_PRODUCTION_USER_ID,
+    AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete",
     ...overrides,
   };
 }

--- a/scripts/tests/probe-aevatar-chat-authority.test.mjs
+++ b/scripts/tests/probe-aevatar-chat-authority.test.mjs
@@ -184,6 +184,7 @@ test("serialization rejects secret-shaped content in allowed string fields", () 
 
 test("safe upstream-code parsing never returns response prose", () => {
   assert.equal(extractSafeUpstreamCode({ code: 8001 }), 8001);
+  assert.equal(extractSafeUpstreamCode({ error_code: 1002 }), 1002);
   assert.equal(
     extractSafeUpstreamCode({ error: { code: "identity_assertion_replayed" } }),
     "identity_assertion_replayed",

--- a/scripts/tests/probe-aevatar-chat-authority.test.mjs
+++ b/scripts/tests/probe-aevatar-chat-authority.test.mjs
@@ -1,0 +1,475 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decodeJwtClaimSummary,
+  extractSafeUpstreamCode,
+  runProductionChatProbe,
+  runSevenRowProbe,
+  sanitizeReceipt,
+  serializeReceipts,
+} from "../probe-aevatar-chat-authority.mjs";
+
+const ROW_IDS = [
+  "identity_only",
+  "identity_plus_capability_bearer",
+  "identity_plus_delegation_header",
+  "replayed_identity_jti",
+  "bridge_bearer_mcp_config",
+  "restricted_bearer_llm_gateway",
+  "restricted_bearer_proxy_slug",
+];
+
+function jwtWithPayload(payload) {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+    .toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.test-signature`;
+}
+
+function safeRow(rowId) {
+  return {
+    row_id: rowId,
+    surface: "pinned-source",
+    deployment_version: "e5bba2e9719ad5132004b882744caa3875db1123",
+    request_shape: "identity assertion only",
+    http_status: null,
+    upstream_code: null,
+    claim_summary: {
+      delegated: false,
+      actor_present: true,
+      client_id_present: false,
+      allow_all_services: null,
+      allowed_service_ids_count: 0,
+      resource_count: 0,
+      scope_names: ["account:read"],
+      expiry_window_seconds: 60,
+    },
+    verdict: "capability_required",
+    observation_kind: "source-proven-not-runtime-observed",
+  };
+}
+
+test("JWT parsing returns only the allowlisted summary", () => {
+  const token = jwtWithPayload({
+    sub: "user-secret",
+    act: { sub: "actor-secret" },
+    client_id: "client-secret",
+    jti: "replay-secret",
+    delegated: true,
+    allow_all_services: false,
+    allowed_service_ids: ["service-a", "service-b"],
+    resources: ["resource-a"],
+    scope: "proxy:read account:read proxy:read",
+    iat: 1_000,
+    exp: 1_300,
+    unknown_secret: "must-not-survive",
+  });
+
+  assert.deepEqual(decodeJwtClaimSummary(token), {
+    delegated: true,
+    actor_present: true,
+    client_id_present: true,
+    allow_all_services: false,
+    allowed_service_ids_count: 2,
+    resource_count: 1,
+    scope_names: ["account:read", "proxy:read"],
+    expiry_window_seconds: 300,
+  });
+});
+
+test("JWT parsing normalizes absent and wrongly typed claims", () => {
+  const token = jwtWithPayload({
+    act: { sub: 42 },
+    client_id: [],
+    delegated: "true",
+    allow_all_services: "false",
+    allowed_service_ids: "service-a",
+    resources: null,
+    scope: [" proxy:write ", "account:read", "proxy:write", 7],
+    iat: "1000",
+    exp: 1300,
+  });
+
+  assert.deepEqual(decodeJwtClaimSummary(token), {
+    delegated: false,
+    actor_present: false,
+    client_id_present: false,
+    allow_all_services: null,
+    allowed_service_ids_count: 0,
+    resource_count: 0,
+    scope_names: ["account:read", "proxy:write"],
+    expiry_window_seconds: null,
+  });
+});
+
+test("malformed JWT failures never include token fragments", () => {
+  const secretFragment = "sensitive-fragment";
+
+  assert.throws(
+    () => decodeJwtClaimSummary(`header.${secretFragment}.signature`),
+    (error) => {
+      assert.equal(error.message, "invalid_jwt_payload");
+      assert.equal(error.message.includes(secretFragment), false);
+      return true;
+    },
+  );
+  assert.throws(
+    () => decodeJwtClaimSummary("not-a-jwt"),
+    { message: "invalid_jwt_shape" },
+  );
+});
+
+test("receipt sanitization reconstructs the schema and drops unknown fields", () => {
+  const candidate = {
+    ...safeRow("identity_only"),
+    authorization: "must-not-survive",
+    cookie: "must-not-survive",
+    refresh_token: "must-not-survive",
+    jti: "must-not-survive",
+    claim_summary: {
+      ...safeRow("identity_only").claim_summary,
+      sub: "must-not-survive",
+      resources: ["must-not-survive"],
+    },
+  };
+
+  const sanitized = sanitizeReceipt(candidate);
+
+  assert.deepEqual(Object.keys(sanitized), [
+    "row_id",
+    "surface",
+    "deployment_version",
+    "request_shape",
+    "http_status",
+    "upstream_code",
+    "claim_summary",
+    "verdict",
+    "observation_kind",
+  ]);
+  assert.deepEqual(Object.keys(sanitized.claim_summary), [
+    "delegated",
+    "actor_present",
+    "client_id_present",
+    "allow_all_services",
+    "allowed_service_ids_count",
+    "resource_count",
+    "scope_names",
+    "expiry_window_seconds",
+  ]);
+  assert.equal(JSON.stringify(sanitized).includes("must-not-survive"), false);
+});
+
+test("serialization rejects secret-shaped content in allowed string fields", () => {
+  const secretShapes = [
+    ["eyJhbGciOiJSUzI1NiJ9", "eyJzdWIiOiJ4In0", "signature"].join("."),
+    ["nyx", "secret_material"].join("_"),
+    ["nyxid", "ag", "secret_material"].join("_"),
+    ["Authorization", "Bearer secret-material"].join(": "),
+    ["Cookie", "session=secret-material"].join(": "),
+    ["Set-Cookie", "session=secret-material"].join(": "),
+  ];
+
+  for (const secretShape of secretShapes) {
+    const row = safeRow("identity_only");
+    row.verdict = secretShape;
+    assert.throws(() => serializeReceipts([row]), {
+      message: "secret_barrier_triggered",
+    });
+  }
+});
+
+test("safe upstream-code parsing never returns response prose", () => {
+  assert.equal(extractSafeUpstreamCode({ code: 8001 }), 8001);
+  assert.equal(
+    extractSafeUpstreamCode({ error: { code: "identity_assertion_replayed" } }),
+    "identity_assertion_replayed",
+  );
+  assert.equal(extractSafeUpstreamCode({ code: "safe-code_12" }), "safe-code_12");
+  assert.equal(extractSafeUpstreamCode({ code: "contains spaces and prose" }), null);
+  assert.equal(extractSafeUpstreamCode({ message: "sensitive response body" }), null);
+  assert.equal(extractSafeUpstreamCode(null), null);
+});
+
+test("missing local acknowledgement performs no requests", async () => {
+  let fetchCalls = 0;
+  await assert.rejects(
+    runSevenRowProbe({
+      env: localEnv({ AC2_ACK_LOCAL_POSTS: undefined }),
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        throw new Error("must not run");
+      },
+    }),
+    { message: "local_posts_not_acknowledged" },
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test("non-loopback targets perform no requests", async () => {
+  let fetchCalls = 0;
+  await assert.rejects(
+    runSevenRowProbe({
+      env: localEnv({ AC2_NYXID_BASE_URL: "https://nyx-api.example.test" }),
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        throw new Error("must not run");
+      },
+    }),
+    { message: "local_base_url_not_loopback" },
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test("network failures use a fixed error without exposing rejection messages", async () => {
+  const secretFragment = "network-secret-fragment";
+  await assert.rejects(
+    runSevenRowProbe({
+      env: localEnv(),
+      fetchImpl: async () => {
+        throw new Error(secretFragment);
+      },
+    }),
+    (error) => {
+      assert.equal(error.message, "network_failure");
+      assert.equal(error.message.includes(secretFragment), false);
+      return true;
+    },
+  );
+});
+
+test("the fixed probe emits exactly seven rows in stable order", async () => {
+  const responses = [
+    jsonResponse(403, { code: 1003 }),
+    jsonResponse(200, { id: "discarded" }),
+    jsonResponse(403, { code: 1003, message: "discarded" }),
+  ];
+  const rows = await runSevenRowProbe({
+    env: localEnv(),
+    fetchImpl: async () => responses.shift(),
+  });
+  const output = serializeReceipts(rows);
+  const parsed = JSON.parse(output);
+
+  assert.equal(parsed.length, 7);
+  assert.deepEqual(parsed.map((row) => row.row_id), ROW_IDS);
+  assert.equal(output.endsWith("\n"), true);
+  assert.equal(output.includes("discarded"), false);
+});
+
+test("production chat requires an explicit one-write acknowledgement", async () => {
+  let fetchCalls = 0;
+  await assert.rejects(
+    runProductionChatProbe({
+      token: jwtWithPayload({ iat: 100, exp: 160 }),
+      env: {},
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        throw new Error("must not run");
+      },
+    }),
+    { message: "production_chat_not_acknowledged" },
+  );
+  assert.equal(fetchCalls, 0);
+});
+
+test("production chat verifies the fixed operator before any write", async () => {
+  const writeMethods = [];
+
+  await assert.rejects(
+    runProductionChatProbe({
+      token: jwtWithPayload({ iat: 100, exp: 160 }),
+      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      fetchImpl: async (_url, init) => {
+        if (init.method !== "GET") {
+          writeMethods.push(init.method);
+        }
+        return jsonResponse(200, { id: "different-user" });
+      },
+    }),
+    { message: "production_user_mismatch" },
+  );
+  assert.deepEqual(writeMethods, []);
+});
+
+test("production chat never deletes an id that existed before the turn", async () => {
+  const existingId = "nyxid-chat-existing";
+  const deletePaths = [];
+
+  await assert.rejects(
+    runProductionChatProbe({
+      token: jwtWithPayload({ iat: 100, exp: 160 }),
+      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      fetchImpl: async (url, init) => {
+        if (url.pathname === "/api/v1/users/me") {
+          return jsonResponse(200, {
+            id: "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b",
+          });
+        }
+        if (url.pathname === "/api/v1/keys") {
+          return jsonResponse(200, {
+            keys: [{ id: "service-id", slug: "service-slug", is_active: true }],
+          });
+        }
+        if (url.pathname === "/api/v1/assistant/conversations") {
+          return jsonResponse(200, { conversations: [{ id: existingId }] });
+        }
+        if (url.pathname === "/api/v1/assistant/chat") {
+          return new Response(`data: ${JSON.stringify({ conversationId: existingId })}\n\n`, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        if (init.method === "DELETE") {
+          deletePaths.push(url.pathname);
+          return jsonResponse(200, { ok: true });
+        }
+        return jsonResponse(404, { code: 1000 });
+      },
+    }),
+    { message: "production_conversation_identity_ambiguous" },
+  );
+  assert.deepEqual(deletePaths, []);
+});
+
+test("production chat cleans up its new conversation after a body read failure", async () => {
+  const conversationId = "nyxid-chat-new";
+  const observedPaths = [];
+  let conversationReads = 0;
+
+  await assert.rejects(
+    runProductionChatProbe({
+      token: jwtWithPayload({ iat: 100, exp: 160 }),
+      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      fetchImpl: async (url, init) => {
+        observedPaths.push(`${init.method} ${url.pathname}`);
+        if (url.pathname === "/api/v1/users/me") {
+          return jsonResponse(200, {
+            id: "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b",
+          });
+        }
+        if (url.pathname === "/api/v1/keys") {
+          return jsonResponse(200, {
+            keys: [{ id: "service-id", slug: "service-slug", is_active: true }],
+          });
+        }
+        if (url.pathname === "/api/v1/assistant/conversations") {
+          conversationReads += 1;
+          return conversationReads === 1
+            ? jsonResponse(200, { conversations: [] })
+            : jsonResponse(200, { conversations: [{ id: conversationId }] });
+        }
+        if (url.pathname === "/api/v1/assistant/chat") {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.error(new Error("sensitive stream failure"));
+              },
+            }),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          );
+        }
+        if (
+          init.method === "DELETE" &&
+          url.pathname === `/api/v1/assistant/conversations/${conversationId}`
+        ) {
+          return jsonResponse(200, { ok: true });
+        }
+        if (
+          init.method === "GET" &&
+          (url.pathname === `/api/v1/assistant/conversations/${conversationId}` ||
+            url.pathname === `/api/v1/assistant/conversations/${conversationId}/state`)
+        ) {
+          return jsonResponse(404, { code: 1000 });
+        }
+        return jsonResponse(404, { code: 1000 });
+      },
+    }),
+    { message: "response_read_failed" },
+  );
+  assert.deepEqual(observedPaths.slice(-3), [
+    `DELETE /api/v1/assistant/conversations/${conversationId}`,
+    `GET /api/v1/assistant/conversations/${conversationId}`,
+    `GET /api/v1/assistant/conversations/${conversationId}/state`,
+  ]);
+});
+
+test("production chat reports a fixed error when cleanup is not confirmed", async () => {
+  const conversationId = "nyxid-chat-new";
+  let conversationReads = 0;
+
+  await assert.rejects(
+    runProductionChatProbe({
+      token: jwtWithPayload({ iat: 100, exp: 160 }),
+      env: { AC2_ACK_PRODUCTION_CHAT: "post-one-chat-and-delete" },
+      fetchImpl: async (url, init) => {
+        if (url.pathname === "/api/v1/users/me") {
+          return jsonResponse(200, {
+            id: "10ddeeb3-9e40-4ee7-b58c-dbd9af615c3b",
+          });
+        }
+        if (url.pathname === "/api/v1/keys") {
+          return jsonResponse(200, {
+            keys: [{ id: "service-id", slug: "service-slug", is_active: true }],
+          });
+        }
+        if (url.pathname === "/api/v1/assistant/conversations") {
+          conversationReads += 1;
+          return conversationReads === 1
+            ? jsonResponse(200, { conversations: [] })
+            : jsonResponse(200, { conversations: [{ id: conversationId }] });
+        }
+        if (url.pathname === "/api/v1/assistant/chat") {
+          return new Response("data: done\n\n", { status: 200 });
+        }
+        if (init.method === "DELETE") {
+          return jsonResponse(200, { ok: true });
+        }
+        return jsonResponse(200, { id: conversationId });
+      },
+    }),
+    { message: "production_conversation_cleanup_failed" },
+  );
+});
+
+function localEnv(overrides = {}) {
+  const identity = jwtWithPayload({
+    act: { sub: "actor" },
+    iat: 100,
+    exp: 160,
+  });
+  const bridge = jwtWithPayload({
+    delegated: true,
+    act: { sub: "actor" },
+    allow_all_services: true,
+    allowed_service_ids: [],
+    iat: 100,
+    exp: 160,
+  });
+  const restricted = jwtWithPayload({
+    delegated: true,
+    act: { sub: "actor" },
+    allow_all_services: false,
+    allowed_service_ids: ["service"],
+    iat: 100,
+    exp: 160,
+  });
+
+  return {
+    AC2_NYXID_BASE_URL: "http://127.0.0.1:3187",
+    AC2_LOCAL_VERSION: "3fbae40a7b9526afdc97b3fdc005c1a543dabaaf",
+    AC2_IDENTITY_ASSERTION: identity,
+    AC2_BRIDGE_BEARER: bridge,
+    AC2_RESTRICTED_DELEGATED_BEARER: restricted,
+    AC2_GATEWAY_MODEL: "local-probe-model",
+    AC2_ACK_LOCAL_POSTS: "ac2-local-only",
+    ...overrides,
+  };
+}
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a dependency-free Node probe for Aevatar identity and capability transport, with deterministic offline parser and redaction tests.
- Records the seven-row AC-2 probe outcome and selects consent-derived delegated restrictions as the Aevatar access-review authority model.
- Defines the three security-gated AC-3 enabling changes: a live-grant-bound `GET /api/v1/mcp/config` allowance, a narrow live-grant-bound `chrono-llm-public` callback exemption, and a validated `delegated_authority_client_id` link.
- Corrects the assistant transport documentation to reflect Aevatar's identity assertion plus capability credential sequence.
- Changes no product behavior.

## Stack position

This lands after PR #1520 (AC-0) and PR #1524 (AC-1). Every phase PR targets `main` so CI Pipeline evaluates its exact head.

This branch is based on the published plan commit `ecdcd66890e3abc7fe99a079db9a3f428ff84e1c`, so the PR against `main` contains only the AC-2 commits. It touches doc comments in `backend/src/handlers/assistant.rs` and `backend/src/services/assistant_service.rs` that AC-1 also edits; the root coordinator will rebase before landing.

## Security review

AC-2 passed three independent security-review rounds. Final verdict: **APPROVE**. Reviewer: `opus-5`.

The detailed runtime receipts were stored under `/tmp` and were lost in a host reboot. The committed decision record is the durable AC-2 artifact and states the evidence classification, observed results, limitations, threat model, deployment preconditions, rollback order, and exact AC-3 symbol map.

## Verification

- `node --test scripts/tests/probe-aevatar-chat-authority.test.mjs`: 17 passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- Plan checker: 8 sections, 0 problems
- `git diff --check`: passed
- Secret-pattern scan: zero unexpected matches

Round three changed documentation only, so its final-head rerun covered the Node tests, plan checker, diff check, evidence-provenance check, and secret scan. Rust formatting and Clippy had already passed for the AC-2 Rust doc-comment changes. CI Pipeline is the authoritative exact-head verification.

## Risks

- The accepted authority model must remain disabled until AC-3 implements and independently reviews all three enabling changes and proves both caller identity and the replacement capability reach Aevatar.
- `forward_access_token=true` and unrestricted forwarding remain the deployed posture until that proof succeeds.
- The linked Aevatar OAuth client must permit both `proxy:*` and `mcp:catalog:read` for actor and receiver; link-time and mint-time validation must fail closed.
- The new REST catalog allowance must remain exact-GET-only and bound to a verified live `CatalogDelegationGrant`; all other delegated `/api/v1/mcp` routes remain denied.
- The legacy platform-row exemption must be limited to the active `chrono-llm-public` callback row and the verified assistant capability tuple described in the decision record.
- AC-1 overlaps the two Rust doc comments, so the coordinator must resolve that overlap by rebasing before landing.
