### PR TITLE
fix(approvals): surface active grants consistently

### DIFF
--- a/backend/src/services/approval_service.rs
+++ b/backend/src/services/approval_service.rs
@@ -1450,6 +1450,13 @@ pub async fn get_request(db: &Database, request_id: &str) -> AppResult<ApprovalR
         .ok_or_else(|| AppError::NotFound("Approval request not found".to_string()))
 }
 
+fn service_config_supports_grants(config: &ServiceApprovalConfig) -> bool {
+    config.approval_mode == ApprovalMode::Grant
+        || config.rules.iter().any(|rule| {
+            rule.effect == ApprovalEffect::RequireApproval && rule.mode == ApprovalMode::Grant
+        })
+}
+
 /// Build the Mongo filter for listing approval grants. Empty
 /// `admin_branches` preserves the legacy per-user shape. When
 /// non-empty, branches are emitted as `$or` alternatives. Each
@@ -1459,9 +1466,10 @@ pub async fn get_request(db: &Database, request_id: &str) -> AppResult<ApprovalR
 /// also intersected with the mode set so a scoped admin never sees
 /// rows outside their `allowed_service_ids`.
 ///
-/// `grant_mode_by_owner` maps an owner `user_id` → its grant-mode
-/// service ids. An owner missing from the map has no services in
-/// grant mode and contributes no grants.
+/// `grant_mode_by_owner` maps an owner `user_id` → service ids with
+/// grant capability, whether from the top-level mode or a rule. An
+/// owner missing from the map has no grant-capable services and
+/// contributes no grants.
 fn build_grants_filter(
     user_id: &str,
     admin_branches: &[OrgFilterBranch],
@@ -1546,12 +1554,13 @@ fn build_grants_filter(
 
 /// List active approval grants for a user.
 ///
-/// Only returns grants for services currently in `Grant` mode.
-/// Grants for services in `PerRequest` mode (or with no config,
-/// which defaults to `PerRequest`) are excluded even if they
-/// haven't been revoked yet. This read-time filter acts as a
-/// safety net for any write-time race conditions or partial
-/// failures during mode switches (see #146).
+/// Only returns grants for services with current grant capability.
+/// Capability may come from top-level `Grant` mode (including legacy
+/// configs with a missing field) or a `require_approval` rule whose
+/// mode is `Grant`. Services with no config default to `PerRequest`
+/// and remain excluded. This read-time filter acts as a safety net
+/// for write-time races or partial failures during policy changes
+/// (see #146).
 ///
 /// `admin_branches` widens the listing to also include org-scoped
 /// grants owned by each supplied admin org, with per-branch scope
@@ -1581,18 +1590,18 @@ pub async fn list_grants(
     for id in &config_owner_ids {
         ids_bson.push(bson::Bson::String(id.clone()));
     }
+    // Load the owners' complete configs and resolve grant capability in Rust.
+    // Filtering on raw BSON `approval_mode` would miss both legacy documents
+    // where the field is absent and rule-level grant modes.
     let configs: Vec<ServiceApprovalConfig> = db
         .collection::<ServiceApprovalConfig>(SERVICE_APPROVAL_CONFIGS)
-        .find(doc! {
-            "user_id": { "$in": ids_bson },
-            "approval_mode": "grant",
-        })
+        .find(doc! { "user_id": { "$in": ids_bson } })
         .await?
         .try_collect()
         .await?;
     let mut grant_mode_by_owner: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
-    for c in configs {
+    for c in configs.into_iter().filter(service_config_supports_grants) {
         grant_mode_by_owner
             .entry(c.user_id)
             .or_default()
@@ -1741,15 +1750,7 @@ pub async fn set_service_approval_config(
 
         match config {
             Ok(Some(cfg)) => {
-                // When the persisted mode is per_request, clean up stale state:
-                // 1. Revoke active grants so they no longer authorize proxy calls (#146)
-                // 2. Cancel pending grant-mode requests so they can't be approved (#153)
-                // Both operations are idempotent, so retries after partial failure
-                // still clean up.
-                if cfg.approval_mode == ApprovalMode::PerRequest {
-                    revoke_grants_for_service(db, user_id, service_id).await?;
-                    cancel_pending_grant_requests(db, user_id, service_id).await?;
-                }
+                reconcile_grant_state_for_config(db, user_id, service_id, &cfg).await?;
                 return Ok(cfg);
             }
             Ok(None) => {
@@ -1761,10 +1762,7 @@ pub async fn set_service_approval_config(
                 // Concurrent upserts can race on the unique (user_id, service_id) index.
                 // Read-after-write resolves to the winning document.
                 if let Some(existing) = collection.find_one(filter.clone()).await? {
-                    if existing.approval_mode == ApprovalMode::PerRequest {
-                        revoke_grants_for_service(db, user_id, service_id).await?;
-                        cancel_pending_grant_requests(db, user_id, service_id).await?;
-                    }
+                    reconcile_grant_state_for_config(db, user_id, service_id, &existing).await?;
                     return Ok(existing);
                 }
                 continue;
@@ -1797,8 +1795,8 @@ pub async fn delete_service_approval_config(
     // of deleted_count. If a previous attempt deleted the config but failed on
     // cleanup, this retry still cleans up. Both operations are no-ops when
     // nothing matches.
-    revoke_grants_for_service(db, user_id, service_id).await?;
-    cancel_pending_grant_requests(db, user_id, service_id).await?;
+    revoke_grants_for_service(db, user_id, service_id, false).await?;
+    cancel_pending_grant_requests(db, user_id, service_id, false).await?;
 
     if result.deleted_count == 0 {
         return Err(AppError::NotFound(
@@ -1907,9 +1905,37 @@ fn resolve_service_config_update(
     ))
 }
 
-/// Cancel all pending grant-mode approval requests for a (user, service) pair.
-/// Called when a service switches to `per_request` mode so stale grant requests
-/// are no longer actionable (see #153).
+/// Reconcile persisted grants and pending grant-mode requests after a policy
+/// update. Top-level grant mode retains service-wide and scoped state. With a
+/// rule-only grant capability, service-wide legacy state is invalid but scoped
+/// state remains eligible for the current evaluator to check operation by
+/// operation. `evaluate_and_check` consults a stored grant only after the live
+/// policy selects `Grant` for that operation, so a retained scope cannot bypass
+/// a newly selected `PerRequest` rule. The trade-off is stale scoped rows: when
+/// one grant rule remains, scopes created by removed or narrowed grant rules
+/// stay stored and visible until expiry or explicit revocation. Comparing two
+/// wildcard scope languages is not expressible through `grant_scope_covers`,
+/// which checks one concrete operation. When no grant capability remains, all
+/// grant state is invalid.
+async fn reconcile_grant_state_for_config(
+    db: &Database,
+    user_id: &str,
+    service_id: &str,
+    config: &ServiceApprovalConfig,
+) -> AppResult<()> {
+    if config.approval_mode == ApprovalMode::Grant {
+        return Ok(());
+    }
+
+    let unscoped_only = service_config_supports_grants(config);
+    revoke_grants_for_service(db, user_id, service_id, unscoped_only).await?;
+    cancel_pending_grant_requests(db, user_id, service_id, unscoped_only).await?;
+    Ok(())
+}
+
+/// Cancel pending grant-mode approval requests for a (user, service) pair.
+/// When `unscoped_only` is true, scoped requests remain eligible for live
+/// rule-level evaluation and only service-wide legacy requests are cancelled.
 ///
 /// Uses `$in: ["grant", null]` to also catch legacy requests that pre-date the
 /// `approval_mode` field -- those deserialize as `Grant` via
@@ -1918,39 +1944,48 @@ async fn cancel_pending_grant_requests(
     db: &Database,
     user_id: &str,
     service_id: &str,
+    unscoped_only: bool,
 ) -> AppResult<()> {
     let now = bson::DateTime::from_chrono(Utc::now());
+    let mut filter = doc! {
+        "user_id": user_id,
+        "service_id": service_id,
+        "status": "pending",
+        "approval_mode": { "$in": ["grant", null] },
+    };
+    if unscoped_only {
+        // `{ field: null }` matches both explicit null and a missing field,
+        // which covers every service-wide legacy request representation.
+        filter.insert("grant_scope", bson::Bson::Null);
+    }
     db.collection::<ApprovalRequest>(REQUESTS)
         .update_many(
-            doc! {
-                "user_id": user_id,
-                "service_id": service_id,
-                "status": "pending",
-                "approval_mode": { "$in": ["grant", null] },
-            },
+            filter,
             doc! { "$set": { "status": "expired", "decided_at": now } },
         )
         .await?;
     Ok(())
 }
 
-/// Revoke all active (non-revoked) grants for a (user, service) pair.
-/// Called after switching a service to `per_request` mode so stale grants
-/// no longer appear in the UI (see #146).
+/// Revoke active grants for a (user, service) pair. When `unscoped_only` is
+/// true, scoped grants remain eligible for live rule-level evaluation and only
+/// service-wide legacy grants are revoked.
 async fn revoke_grants_for_service(
     db: &Database,
     user_id: &str,
     service_id: &str,
+    unscoped_only: bool,
 ) -> AppResult<()> {
+    let mut filter = doc! {
+        "user_id": user_id,
+        "service_id": service_id,
+        "revoked": false,
+    };
+    if unscoped_only {
+        filter.insert("scope", bson::Bson::Null);
+    }
     db.collection::<ApprovalGrant>(GRANTS)
-        .update_many(
-            doc! {
-                "user_id": user_id,
-                "service_id": service_id,
-                "revoked": false,
-            },
-            doc! { "$set": { "revoked": true } },
-        )
+        .update_many(filter, doc! { "$set": { "revoked": true } })
         .await?;
     Ok(())
 }
@@ -2552,6 +2587,31 @@ mod tests {
         let id_clause = filter.get_document("_id").unwrap();
         let in_arr = id_clause.get_array("$in").unwrap();
         assert_eq!(in_arr.len(), 0);
+    }
+
+    #[test]
+    fn service_config_grant_capability_includes_rule_level_grant_mode() {
+        let mut config = ServiceApprovalConfig {
+            id: "cfg-1".to_string(),
+            user_id: "user-1".to_string(),
+            service_id: "svc-1".to_string(),
+            service_name: "Service".to_string(),
+            approval_required: true,
+            approval_mode: ApprovalMode::PerRequest,
+            rules: vec![],
+            default_effect: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        config.rules.push(ApprovalRule {
+            methods: vec!["POST".to_string()],
+            resource_pattern: "/v1/chat/**".to_string(),
+            verbs: vec![],
+            effect: ApprovalEffect::RequireApproval,
+            mode: ApprovalMode::Grant,
+        });
+
+        assert!(service_config_supports_grants(&config));
     }
 
     // ================================================================
@@ -3356,6 +3416,173 @@ mod tests {
         assert!(!still_valid);
     }
 
+    #[tokio::test]
+    async fn set_service_approval_config_reconciles_rule_scoped_and_service_wide_grants() {
+        let Some(db) = connect_test_database("appr_svc_set_cfg_rule_grants").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let scope = "v1:http:post:write:/v1/chat/**";
+
+        let mut rule_scoped = make_grant(
+            &user_id,
+            &service_id,
+            "api_key",
+            "rule-requester",
+            false,
+            30,
+        );
+        rule_scoped.scope = Some(scope.to_string());
+        let service_wide = make_grant(
+            &user_id,
+            &service_id,
+            "api_key",
+            "legacy-requester",
+            false,
+            30,
+        );
+        insert_grant(&db, &rule_scoped).await;
+        insert_grant(&db, &service_wide).await;
+
+        let grant_rule = ApprovalRule {
+            methods: vec!["POST".to_string()],
+            resource_pattern: "/v1/chat/**".to_string(),
+            verbs: vec![],
+            effect: ApprovalEffect::RequireApproval,
+            mode: ApprovalMode::Grant,
+        };
+        set_service_approval_config(
+            &db,
+            &user_id,
+            &service_id,
+            "Test Service",
+            Some(true),
+            Some(&ApprovalMode::PerRequest),
+            Some(std::slice::from_ref(&grant_rule)),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let grants = db.collection::<ApprovalGrant>(GRANTS);
+        let retained = grants
+            .find_one(doc! { "_id": &rule_scoped.id })
+            .await
+            .unwrap()
+            .unwrap();
+        let revoked_legacy = grants
+            .find_one(doc! { "_id": &service_wide.id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!retained.revoked, "rule-scoped grant should remain active");
+        assert!(
+            revoked_legacy.revoked,
+            "service-wide grant requires top-level grant mode"
+        );
+
+        set_service_approval_config(
+            &db,
+            &user_id,
+            &service_id,
+            "Test Service",
+            Some(true),
+            Some(&ApprovalMode::PerRequest),
+            Some(&[]),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let revoked_rule = grants
+            .find_one(doc! { "_id": &rule_scoped.id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            revoked_rule.revoked,
+            "scoped grant should be revoked after grant capability is removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_scoped_grant_cannot_bypass_current_per_request_rule() {
+        let Some(db) = connect_test_database("appr_svc_stale_scope_policy_gate").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let requester_id = "rule-requester";
+
+        let mut stale_grant = make_grant(&user_id, &service_id, "api_key", requester_id, false, 30);
+        stale_grant.scope = Some("v1:http:*:*:*".to_string());
+        insert_grant(&db, &stale_grant).await;
+
+        let rules = vec![
+            ApprovalRule {
+                methods: vec!["DELETE".to_string()],
+                resource_pattern: "/v1/admin/**".to_string(),
+                verbs: vec![],
+                effect: ApprovalEffect::RequireApproval,
+                mode: ApprovalMode::PerRequest,
+            },
+            ApprovalRule {
+                methods: vec!["POST".to_string()],
+                resource_pattern: "/v1/chat/**".to_string(),
+                verbs: vec![],
+                effect: ApprovalEffect::RequireApproval,
+                mode: ApprovalMode::Grant,
+            },
+        ];
+        set_service_approval_config(
+            &db,
+            &user_id,
+            &service_id,
+            "Test Service",
+            Some(true),
+            Some(&ApprovalMode::PerRequest),
+            Some(&rules),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let retained = db
+            .collection::<ApprovalGrant>(GRANTS)
+            .find_one(doc! { "_id": &stale_grant.id })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!retained.revoked, "conservative cleanup retains the scope");
+
+        let operation = crate::services::operation_descriptor::build_http_descriptor(
+            "DELETE",
+            "/v1/admin/users/42",
+            None,
+        );
+        let outcome = evaluate_and_check(
+            &db,
+            &user_id,
+            &user_id,
+            &service_id,
+            &operation,
+            Some("api_key"),
+            requester_id,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let ApprovalOutcome::NeedsApproval(pending) = outcome else {
+            panic!("current per-request rule must not reuse the stale grant");
+        };
+        assert_eq!(pending.resolution.mode, ApprovalMode::PerRequest);
+    }
+
     // --- delete_service_approval_config ---
 
     #[tokio::test]
@@ -3689,6 +3916,59 @@ mod tests {
         let (grants, total) = list_grants(&db, &user_id, &[], 1, 10).await.unwrap();
         assert_eq!(total, 1);
         assert_eq!(grants.len(), 1);
+        assert_eq!(grants[0].id, grant.id);
+    }
+
+    #[tokio::test]
+    async fn list_grants_includes_legacy_config_without_stored_approval_mode() {
+        let Some(db) = connect_test_database("appr_svc_list_grants_legacy_mode").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let config = make_service_config(&user_id, &service_id, true, ApprovalMode::Grant);
+        insert_config(&db, &config).await;
+        db.collection::<bson::Document>(SERVICE_APPROVAL_CONFIGS)
+            .update_one(
+                doc! { "_id": &config.id },
+                doc! { "$unset": { "approval_mode": "" } },
+            )
+            .await
+            .unwrap();
+
+        let grant = make_grant(&user_id, &service_id, "sa", "req-1", false, 30);
+        insert_grant(&db, &grant).await;
+
+        let (grants, total) = list_grants(&db, &user_id, &[], 1, 10).await.unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(grants[0].id, grant.id);
+    }
+
+    #[tokio::test]
+    async fn list_grants_includes_rule_level_grant_mode_service() {
+        let Some(db) = connect_test_database("appr_svc_list_grants_rule_mode").await else {
+            eprintln!("skipping: no MongoDB");
+            return;
+        };
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let service_id = uuid::Uuid::new_v4().to_string();
+        let mut config = make_service_config(&user_id, &service_id, true, ApprovalMode::PerRequest);
+        config.rules.push(ApprovalRule {
+            methods: vec!["POST".to_string()],
+            resource_pattern: "/v1/chat/**".to_string(),
+            verbs: vec![],
+            effect: ApprovalEffect::RequireApproval,
+            mode: ApprovalMode::Grant,
+        });
+        insert_config(&db, &config).await;
+
+        let mut grant = make_grant(&user_id, &service_id, "sa", "req-1", false, 30);
+        grant.scope = Some("v1:http:post:write:/v1/chat/**".to_string());
+        insert_grant(&db, &grant).await;
+
+        let (grants, total) = list_grants(&db, &user_id, &[], 1, 10).await.unwrap();
+        assert_eq!(total, 1);
         assert_eq!(grants[0].id, grant.id);
     }
 

--- a/frontend/src/components/orgs/org-approval-configs.tsx
+++ b/frontend/src/components/orgs/org-approval-configs.tsx
@@ -623,7 +623,9 @@ interface OrgApprovalGrantsProps {
  * user_id, so without this admin-only panel they would be unreachable.
  */
 function OrgApprovalGrants({ orgId }: OrgApprovalGrantsProps) {
-  const { data, isLoading, error, refetch } = useApprovalGrants(1, 50, orgId);
+  const { data, isLoading, error, refetch } = useApprovalGrants(1, 50, {
+    orgId,
+  });
   const revokeMutation = useRevokeGrant();
   const grants = data?.grants ?? [];
 

--- a/frontend/src/hooks/use-approvals.test.tsx
+++ b/frontend/src/hooks/use-approvals.test.tsx
@@ -161,12 +161,36 @@ describe("useApprovalGrants query string", () => {
   });
 
   it("appends org_id when listing an org's grants", async () => {
-    const { result } = renderHook(() => useApprovalGrants(1, 20, "org-1"), {
-      wrapper: wrapperFactory(),
-    });
+    const { result } = renderHook(
+      () => useApprovalGrants(1, 20, { orgId: "org-1" }),
+      {
+        wrapper: wrapperFactory(),
+      },
+    );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockGet).toHaveBeenCalledWith(
       "/approvals/grants?page=1&per_page=20&org_id=org-1",
+    );
+  });
+
+  it("sends include_admin_orgs and keeps the option in the query key", async () => {
+    const { result, rerender } = renderHook(
+      ({ includeAdminOrgs }: { includeAdminOrgs: boolean }) =>
+        useApprovalGrants(1, 20, { includeAdminOrgs }),
+      {
+        initialProps: { includeAdminOrgs: false },
+        wrapper: wrapperFactory(),
+      },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith(
+      "/approvals/grants?page=1&per_page=20",
+    );
+
+    rerender({ includeAdminOrgs: true });
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+    expect(mockGet).toHaveBeenLastCalledWith(
+      "/approvals/grants?page=1&per_page=20&include_admin_orgs=true",
     );
   });
 });

--- a/frontend/src/hooks/use-approvals.ts
+++ b/frontend/src/hooks/use-approvals.ts
@@ -167,24 +167,37 @@ export function useDecideApproval() {
 // --- Approval Grants ---
 
 /**
- * List active approval grants. When `orgId` is set, list grants owned by
- * the org instead of the caller's personal scope -- caller must be an
- * admin of that org. Org-policy approvals create grants under the org
- * user_id, so this is the only way for org admins to manage them.
+ * List active approval grants. `orgId` scopes the list to one org, while
+ * `includeAdminOrgs` unions the personal list with every org the caller
+ * currently administers.
  */
+export interface ApprovalGrantListOptions {
+  readonly orgId?: string;
+  readonly includeAdminOrgs?: boolean;
+}
+
 export function useApprovalGrants(
   page: number = 1,
   perPage: number = 20,
-  orgId?: string,
+  options: ApprovalGrantListOptions = {},
 ) {
+  const { orgId, includeAdminOrgs = false } = options;
   return useQuery({
-    queryKey: ["approvals", "grants", page, perPage, orgId ?? "personal"],
+    queryKey: [
+      "approvals",
+      "grants",
+      page,
+      perPage,
+      orgId ?? "personal",
+      includeAdminOrgs,
+    ],
     queryFn: async (): Promise<ApprovalGrantListResponse> => {
       const params = new URLSearchParams({
         page: String(page),
         per_page: String(perPage),
       });
       if (orgId) params.set("org_id", orgId);
+      if (includeAdminOrgs) params.set("include_admin_orgs", "true");
       return api.get<ApprovalGrantListResponse>(
         `/approvals/grants?${params.toString()}`,
       );
@@ -209,9 +222,8 @@ export function useRevokeGrant() {
       return api.delete<RevokeGrantResponse>(path);
     },
     onSuccess: () => {
-      // Broad invalidate -- the grants query key already varies by
-      // [page, perPage, orgId|"personal"], so this nukes both the org
-      // and personal lists rather than reasoning about the exact key.
+      // Broad invalidate so personal, combined-admin-org, and single-org
+      // grant lists all refresh after a revoke.
       void queryClient.invalidateQueries({
         queryKey: ["approvals", "grants"],
       });

--- a/frontend/src/pages/approval-grants.test.tsx
+++ b/frontend/src/pages/approval-grants.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ApprovalGrantItem } from "@/types/approvals";
+import type { ReactNode } from "react";
+import type {
+  ApprovalGrantItem,
+  DominantOrgPolicy,
+  ServiceApprovalConfigItem,
+} from "@/types/approvals";
 
 const {
   fixtures,
   mockUseApprovalGrants,
+  mockUseServiceApprovalConfigs,
   mockRevokeMutateAsync,
   mockRefetch,
   mockToastError,
@@ -16,18 +22,41 @@ const {
     total: 0,
     isLoading: false,
     error: null as unknown,
+    configs: [] as ServiceApprovalConfigItem[],
+    dominantOrgPolicies: [] as DominantOrgPolicy[],
+    configsLoading: false,
+    configsError: null as unknown,
     revokeRejection: null as Error | null,
   },
   mockUseApprovalGrants: vi.fn(),
+  mockUseServiceApprovalConfigs: vi.fn(),
   mockRevokeMutateAsync: vi.fn(),
   mockRefetch: vi.fn(),
   mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
 }));
 
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+  }: {
+    readonly children: ReactNode;
+    readonly to: string;
+  }) => (
+    <a href={to} data-router-link="true">
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock("@/hooks/use-approvals", () => ({
-  useApprovalGrants: (page: number, perPage: number) =>
-    mockUseApprovalGrants(page, perPage),
+  useApprovalGrants: (
+    page: number,
+    perPage: number,
+    options?: { includeAdminOrgs?: boolean; orgId?: string },
+  ) => mockUseApprovalGrants(page, perPage, options),
+  useServiceApprovalConfigs: () => mockUseServiceApprovalConfigs(),
   useRevokeGrant: () => ({
     mutateAsync: mockRevokeMutateAsync,
     isPending: false,
@@ -58,7 +87,9 @@ vi.mock("sonner", () => ({
 import { ApiError } from "@/lib/api-client";
 import { ApprovalGrantsPage } from "./approval-grants";
 
-function makeGrant(overrides: Partial<ApprovalGrantItem> = {}): ApprovalGrantItem {
+function makeGrant(
+  overrides: Partial<ApprovalGrantItem> = {},
+): ApprovalGrantItem {
   return {
     id: "grant-1",
     service_id: "svc-1",
@@ -66,6 +97,7 @@ function makeGrant(overrides: Partial<ApprovalGrantItem> = {}): ApprovalGrantIte
     requester_type: "api_key",
     requester_id: "key-1",
     requester_label: "coding-agent",
+    org_scoped: false,
     granted_at: "2026-05-01T00:00:00Z",
     // Far future so isExpiringSoon() is false unless a test overrides it.
     expires_at: "2099-01-01T00:00:00Z",
@@ -79,6 +111,10 @@ beforeEach(() => {
   fixtures.total = 0;
   fixtures.isLoading = false;
   fixtures.error = null;
+  fixtures.configs = [];
+  fixtures.dominantOrgPolicies = [];
+  fixtures.configsLoading = false;
+  fixtures.configsError = null;
   fixtures.revokeRejection = null;
   mockRevokeMutateAsync.mockImplementation(() =>
     fixtures.revokeRejection
@@ -86,23 +122,64 @@ beforeEach(() => {
       : Promise.resolve({}),
   );
   mockUseApprovalGrants.mockImplementation(() => ({
-    data: { grants: fixtures.grants, total: fixtures.total, page: 1, per_page: 20 },
+    data: {
+      grants: fixtures.grants,
+      total: fixtures.total,
+      page: 1,
+      per_page: 20,
+    },
     isLoading: fixtures.isLoading,
     error: fixtures.error,
     refetch: mockRefetch,
   }));
+  mockUseServiceApprovalConfigs.mockImplementation(() => ({
+    data: {
+      configs: fixtures.configs,
+      dominant_org_policies: fixtures.dominantOrgPolicies,
+    },
+    isLoading: fixtures.configsLoading,
+    error: fixtures.configsError,
+  }));
 });
+
+function makeConfig(
+  overrides: Partial<ServiceApprovalConfigItem> = {},
+): ServiceApprovalConfigItem {
+  return {
+    service_id: "svc-1",
+    service_name: "OpenAI",
+    approval_required: true,
+    approval_mode: "per_request",
+    rules: [],
+    default_effect: null,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
 
 describe("ApprovalGrantsPage", () => {
   it("requests the first page with a perPage of 20", () => {
     render(<ApprovalGrantsPage />);
-    expect(mockUseApprovalGrants).toHaveBeenCalledWith(1, 20);
+    expect(mockUseApprovalGrants).toHaveBeenCalledWith(1, 20, {
+      includeAdminOrgs: true,
+    });
   });
 
   it("renders a row per grant with service name, requester label, and type", () => {
     fixtures.grants = [
-      makeGrant({ id: "g1", service_name: "OpenAI", requester_label: "coding-agent", requester_type: "api_key" }),
-      makeGrant({ id: "g2", service_name: "GitHub", requester_label: null, requester_type: "user" }),
+      makeGrant({
+        id: "g1",
+        service_name: "OpenAI",
+        requester_label: "coding-agent",
+        requester_type: "api_key",
+      }),
+      makeGrant({
+        id: "g2",
+        service_name: "GitHub",
+        requester_label: null,
+        requester_type: "user",
+      }),
     ];
     fixtures.total = 2;
 
@@ -158,14 +235,54 @@ describe("ApprovalGrantsPage", () => {
 
     const dialog = await screen.findByRole("dialog");
     // Confirmation copy names the targeted service.
-    expect(within(dialog).getByText(/Revoke the grant for "OpenAI"/i)).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/Revoke the grant for "OpenAI"/i),
+    ).toBeInTheDocument();
 
-    await user.click(within(dialog).getByRole("button", { name: "Revoke Grant" }));
+    await user.click(
+      within(dialog).getByRole("button", { name: "Revoke Grant" }),
+    );
 
     await waitFor(() => {
-      expect(mockRevokeMutateAsync).toHaveBeenCalledWith({ grantId: "grant-42" });
+      expect(mockRevokeMutateAsync).toHaveBeenCalledWith({
+        grantId: "grant-42",
+      });
     });
     expect(mockToastSuccess).toHaveBeenCalledWith("Grant revoked");
+  });
+
+  it("renders an org badge in both layouts and revokes with the owning org id", async () => {
+    const user = userEvent.setup();
+    fixtures.grants = [
+      makeGrant({
+        id: "org-grant",
+        service_name: "GitHub",
+        org_scoped: true,
+        org_id: "org-42",
+        org_name: "Acme",
+      }),
+    ];
+    fixtures.total = 1;
+
+    render(<ApprovalGrantsPage />);
+
+    expect(screen.getAllByText("Org: Acme")).toHaveLength(2);
+    const revokeButtons = screen.getAllByRole("button", {
+      name: "Revoke grant for GitHub",
+    });
+    expect(revokeButtons).toHaveLength(2);
+    await user.click(revokeButtons[0]!);
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Revoke Grant" }),
+    );
+
+    await waitFor(() => {
+      expect(mockRevokeMutateAsync).toHaveBeenCalledWith({
+        grantId: "org-grant",
+        orgId: "org-42",
+      });
+    });
   });
 
   it("surfaces the ApiError message via toast.error when revoke fails", async () => {
@@ -185,7 +302,9 @@ describe("ApprovalGrantsPage", () => {
       .filter((b) => b.querySelector("svg.lucide-trash2") !== null);
     await user.click(trashTriggers[0]!);
     const dialog = await screen.findByRole("dialog");
-    await user.click(within(dialog).getByRole("button", { name: "Revoke Grant" }));
+    await user.click(
+      within(dialog).getByRole("button", { name: "Revoke Grant" }),
+    );
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Grant already revoked");
@@ -193,14 +312,62 @@ describe("ApprovalGrantsPage", () => {
     expect(mockToastSuccess).not.toHaveBeenCalled();
   });
 
-  it("renders the empty state and no table when there are no grants", () => {
+  it("links to approval settings when no service supports grant mode", () => {
     fixtures.grants = [];
     fixtures.total = 0;
 
     render(<ApprovalGrantsPage />);
 
-    expect(screen.getByText("No Active Grants")).toBeInTheDocument();
+    expect(screen.getByText("Grant Mode Is Off")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Configure approval policies" }),
+    ).toHaveAttribute("data-router-link", "true");
+    expect(
+      screen.getByRole("link", { name: "Configure approval policies" }),
+    ).toHaveAttribute("href", "/approvals/settings");
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes grant-enabled services with no active grants", () => {
+    fixtures.grants = [];
+    fixtures.total = 0;
+    fixtures.configs = [makeConfig({ approval_mode: "grant" })];
+
+    render(<ApprovalGrantsPage />);
+
+    expect(screen.getByText("No Active Grants")).toBeInTheDocument();
+    expect(
+      screen.getByText(/grant-enabled services have no active grants/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("explains dominant org policies and links members to policy settings", () => {
+    fixtures.dominantOrgPolicies = [
+      { org_id: "org-1", service_id: "svc-1" },
+    ];
+
+    render(<ApprovalGrantsPage />);
+
+    expect(screen.getByText("No Active Grants")).toBeInTheDocument();
+    expect(screen.getByText(/managed by an org admin/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Configure approval policies" }),
+    ).toHaveAttribute("data-router-link", "true");
+  });
+
+  it("distinguishes an unavailable approval-policy response", () => {
+    fixtures.configsError = new Error("config response failed");
+
+    render(<ApprovalGrantsPage />);
+
+    expect(screen.getByText("Policy Status Unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(/approval policy status could not be loaded/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Configure approval policies" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders skeletons (no table, no empty state) while loading", () => {
@@ -265,7 +432,9 @@ describe("ApprovalGrantsPage", () => {
     await user.click(screen.getByRole("button", { name: "Next page" }));
 
     await waitFor(() => {
-      expect(mockUseApprovalGrants).toHaveBeenCalledWith(2, 20);
+      expect(mockUseApprovalGrants).toHaveBeenCalledWith(2, 20, {
+        includeAdminOrgs: true,
+      });
     });
   });
 });

--- a/frontend/src/pages/approval-grants.tsx
+++ b/frontend/src/pages/approval-grants.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { useApprovalGrants, useRevokeGrant } from "@/hooks/use-approvals";
+import { Link } from "@tanstack/react-router";
+import {
+  useApprovalGrants,
+  useRevokeGrant,
+  useServiceApprovalConfigs,
+} from "@/hooks/use-approvals";
 import { ApiError } from "@/lib/api-client";
 import { formatDate } from "@/lib/utils";
 import { ErrorBanner } from "@/components/shared/error-banner";
@@ -32,19 +37,47 @@ export function ApprovalGrantsPage() {
   const [revokeGrantId, setRevokeGrantId] = useState<string | null>(null);
 
   const perPage = 20;
-  const { data, isLoading, error, refetch } = useApprovalGrants(page, perPage);
+  const { data, isLoading, error, refetch } = useApprovalGrants(page, perPage, {
+    includeAdminOrgs: true,
+  });
+  const {
+    data: configData,
+    isLoading: configsLoading,
+    error: configsError,
+  } = useServiceApprovalConfigs();
   const revokeMutation = useRevokeGrant();
 
   const grants = data?.grants ?? [];
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / perPage));
+  const hasGrantModeService = (configData?.configs ?? []).some(
+    (config) =>
+      config.approval_mode === "grant" ||
+      config.rules.some(
+        (rule) => rule.effect === "require_approval" && rule.mode === "grant",
+      ),
+  );
+  const hasDominantOrgPolicies =
+    (configData?.dominant_org_policies?.length ?? 0) > 0;
+  const grantModeStatusUnavailable = Boolean(configsError);
+  const grantModeKnownOff =
+    !hasGrantModeService && !hasDominantOrgPolicies && !grantModeStatusUnavailable;
 
   const revokeTarget = grants.find((g) => g.id === revokeGrantId);
 
   async function handleRevoke() {
     if (!revokeGrantId) return;
+    if (revokeTarget?.org_scoped && !revokeTarget.org_id) {
+      toast.error("This organization grant is missing its owner information");
+      setRevokeGrantId(null);
+      return;
+    }
     try {
-      await revokeMutation.mutateAsync({ grantId: revokeGrantId });
+      await revokeMutation.mutateAsync(
+        revokeTarget?.org_scoped
+          ? { grantId: revokeGrantId, orgId: revokeTarget.org_id }
+          : { grantId: revokeGrantId },
+      );
       toast.success("Grant revoked");
     } catch (err) {
       toast.error(
@@ -68,23 +101,42 @@ export function ApprovalGrantsPage() {
         description="Manage active approval grants. Revoking a grant will require re-approval on the next request."
       />
 
-      {isLoading ? (
+      {isLoading || (grants.length === 0 && configsLoading) ? (
         <div className="space-y-2">
           {Array.from({ length: 5 }).map((_, i) => (
             <Skeleton key={`grant-skel-${String(i)}`} className="h-12 w-full" />
           ))}
         </div>
       ) : error ? (
-        <ErrorBanner message="Failed to load grants. Please try again." onRetry={refetch} />
+        <ErrorBanner
+          message="Failed to load grants. Please try again."
+          onRetry={refetch}
+        />
       ) : grants.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-1 py-12 text-center">
           <SmartLockIcon className="h-64 w-64 text-muted-foreground" />
-          <div className="max-w-md space-y-1">
-            <p className="text-[12px] font-medium text-muted-foreground">No Active Grants</p>
-            <p className="text-[12px] text-muted-foreground">
-              Services using per-request approval do not create grants. Only
-              services set to time-based grant mode will appear here.
+          <div className="max-w-md space-y-2">
+            <p className="text-[12px] font-medium text-muted-foreground">
+              {grantModeStatusUnavailable
+                ? "Policy Status Unavailable"
+                : grantModeKnownOff
+                  ? "Grant Mode Is Off"
+                  : "No Active Grants"}
             </p>
+            <p className="text-[12px] text-muted-foreground">
+              {grantModeStatusUnavailable
+                ? "No grants are active, but approval policy status could not be loaded."
+                : hasGrantModeService
+                ? "Your grant-enabled services have no active grants. Grants appear here after an approval is granted."
+                : grantModeKnownOff
+                  ? "All configured services use per-request approval. Enable time-based grant mode for a service to create standing approvals."
+                  : "No grants are active. Organization policies are managed by an org admin and may define grant mode separately."}
+            </p>
+            {(grantModeKnownOff || hasDominantOrgPolicies) && (
+              <Button asChild variant="outline" className="mt-2">
+                <Link to="/approvals/settings">Configure approval policies</Link>
+              </Button>
+            )}
           </div>
         </div>
       ) : (
@@ -92,14 +144,38 @@ export function ApprovalGrantsPage() {
           {/* Mobile card view */}
           <div className="flex flex-col gap-3 md:hidden">
             {grants.map((grant) => (
-              <div key={grant.id} className="relative rounded-xl border border-border/50 bg-card p-4">
+              <div
+                key={grant.id}
+                className="relative rounded-xl border border-border/50 bg-card p-4"
+              >
                 <div className="absolute right-3 top-3">
-                  <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setRevokeGrantId(grant.id)}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label={`Revoke grant for ${grant.service_name}`}
+                    onClick={() => setRevokeGrantId(grant.id)}
+                  >
                     <Trash2 className="h-3.5 w-3.5 text-destructive" />
                   </Button>
                 </div>
-                <p className="pr-10 text-[13px] font-semibold text-foreground truncate">{grant.service_name}</p>
-                <p className="text-[11px] text-muted-foreground">{grant.requester_label ?? grant.requester_type}</p>
+                <div className="flex min-w-0 items-center gap-2 pr-10">
+                  <p className="truncate text-[13px] font-semibold text-foreground">
+                    {grant.service_name}
+                  </p>
+                  {grant.org_scoped && (
+                    <Badge
+                      variant="info"
+                      className="max-w-[12rem] shrink-0 truncate"
+                      title={grant.org_name ?? "Organization"}
+                    >
+                      Org: {grant.org_name ?? "Organization"}
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-[11px] text-muted-foreground">
+                  {grant.requester_label ?? grant.requester_type}
+                </p>
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {isExpiringSoon(grant.expires_at) && (
                     <Badge variant="warning">Expiring soon</Badge>
@@ -129,7 +205,18 @@ export function ApprovalGrantsPage() {
                 {grants.map((grant) => (
                   <TableRow key={grant.id}>
                     <TableCell className="font-medium">
-                      {grant.service_name}
+                      <div className="flex items-center gap-2">
+                        <span>{grant.service_name}</span>
+                        {grant.org_scoped && (
+                          <Badge
+                            variant="info"
+                            className="max-w-[12rem] truncate"
+                            title={grant.org_name ?? "Organization"}
+                          >
+                            Org: {grant.org_name ?? "Organization"}
+                          </Badge>
+                        )}
+                      </div>
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-col gap-0.5">
@@ -161,6 +248,7 @@ export function ApprovalGrantsPage() {
                         variant="ghost"
                         size="icon"
                         className="h-8 w-8"
+                        aria-label={`Revoke grant for ${grant.service_name}`}
                         onClick={() => setRevokeGrantId(grant.id)}
                       >
                         <Trash2 className="h-4 w-4 text-destructive" />

--- a/frontend/src/types/approvals.ts
+++ b/frontend/src/types/approvals.ts
@@ -85,6 +85,9 @@ export interface ApprovalGrantItem {
   readonly requester_id: string;
   readonly requester_label: string | null;
   readonly scope?: string | null;
+  readonly org_scoped: boolean;
+  readonly org_id?: string;
+  readonly org_name?: string;
   readonly granted_at: string;
   readonly expires_at: string;
 }


### PR DESCRIPTION
## Summary

`/approvals/grants` rendered "No Active Grants" for accounts that had live, enforced grants. The read path was never broken — eligibility was. `list_grants` did not list grants; it listed grants whose service passed a second, independent re-derivation of *"is this service in grant mode?"*, and that re-derivation read exactly one field: `ServiceApprovalConfig.approval_mode`, top level, literal string `"grant"`. Enforcement (`check_approval`) never reads the config at all — it trusts the grant row. Wherever the two disagreed, a grant was minted, honoured at proxy time, and invisible in the UI — and therefore unrevokable, since `nyxid approval revoke-grant` needs an id the user has no way to obtain.

Three ways they disagreed:

- **Rule-level grant mode.** A granular rule carries its own `mode`, and `approval_policy::evaluate` returns *the rule's* mode. Top-level `per_request` plus an Advanced-tab rule set to "Time-based grant" mints and enforces grants the list query never saw. Worse, the next save of that policy blanket-revoked every grant for the service — including the ones its own rules had just created, so grants silently appeared and silently vanished.
- **Legacy configs.** Documents written before `approval_mode` existed deserialize as `Grant` by design (`legacy_approval_mode_default`) and behave as grant mode everywhere in the product — but the raw BSON predicate ran *before* deserialization, and `{"approval_mode": "grant"}` cannot match an absent field.
- **Org-owned grants.** An approved org-policy request mints the grant under the **org's** `user_id` (`docs/ORG_MODEL.md`, "Grant ownership"). The web page asked for personal scope only, while mobile already sent `include_admin_orgs=true` (`mobile/src/lib/api/http.ts:716`) — so the same account showed grants on the phone and none on the web.

### Backend

- `list_grants` loads the owners' full configs and resolves capability in Rust (`service_config_supports_grants`): top-level `Grant` — including legacy documents with no stored field — **or** any `require_approval` rule whose mode is `Grant`. A raw BSON predicate could express neither case; honouring the model's serde defaults requires deserializing.
- `build_grants_filter` keeps grant-capable service ids grouped **per owner**, so one owner's grant-mode config can never admit another owner's rows. Each admin branch intersects the org's own capability set with the admin's `allowed_service_ids` *inside* the Mongo filter, so scope is applied at query time and pagination stays correct. When no branch survives, the filter matches nothing via an `_id` sentinel rather than degenerating into a wide `$or`.
- Policy-save cleanup is now capability-aware (`reconcile_grant_state_for_config`). Top-level grant mode is untouched. With rule-only capability, service-wide legacy grants and pending requests are still revoked while scoped ones are retained for the live evaluator to judge operation by operation. With no capability left, everything is revoked exactly as before.

### Frontend

- The page sends `include_admin_orgs=true` (matching mobile), renders the `org_scoped` / `org_name` fields the API already emitted as an "Org: …" chip in **both** the desktop table and the mobile cards, and passes `orgId` to `useRevokeGrant` so org grants are actually revokable from the web.
- `useApprovalGrants`'s third argument becomes an options object (`{ orgId, includeAdminOrgs }`), both carried in the query key; `useRevokeGrant` takes `{ grantId, orgId? }`. Both in-tree callers updated.
- The empty state stops being one undifferentiated string. It now distinguishes **Grant Mode Is Off** (no grant-capable service, with a link to `/approvals/settings`), **No Active Grants** (capability exists, nothing live), the dominant-org variant (org policies exist and are managed by an org admin), and **Policy Status Unavailable** — so a failed policy lookup never renders as a confident "nothing here".

### Deliberate trade-off

Rule-scoped grants now survive a policy save whenever the service retains *any* grant capability. Runtime is the gate: `evaluate_and_check` consults `check_approval` only when the **current** policy resolves that operation to grant mode, so a retained grant cannot authorize an operation the live policy sends to per-request — covered by `stale_scoped_grant_cannot_bypass_current_per_request_rule`.

The cost is real and worth stating: removing or downgrading one grant rule no longer revokes the grants it produced while another grant rule remains on the service. Those grants are inert while no live rule sends their operations to grant mode, but if such a rule is later added back, a retained broad scope applies again without a fresh human approval. They are at least listed and revokable in the UI now, which they were not before. Narrowing retention to grants whose stored `scope` is still derivable from a live rule is the follow-up.

## Test plan

- [x] backend `approval_service` 103/103 against a live MongoDB, including new coverage for a config with `approval_mode` physically `$unset`, top-level `per_request` + a matching grant-mode rule, rule-scoped vs service-wide reconciliation, and the stale-scope runtime gate
- [x] `build_grants_filter` unit tests: per-owner isolation, scoped-admin ∩ capability, empty-match sentinel, legacy flat shape
- [x] frontend `approval-grants` + `use-approvals` 37/37; `eslint` and `tsc --noEmit` clean; `cargo check --tests` clean
- [ ] Full backend + frontend suites, `clippy` / `fmt`
- [ ] Live: as an org admin, approve an org-policy call in grant mode and confirm the row appears on `/approvals/grants` with the org chip and revokes cleanly

## Known gaps (follow-ups, not fixed here)

- The `include_admin_orgs` union has unit coverage of the filter *shape*, but every existing case collapses to zero or one branch — no test exercises the two-branch `$or`, and no Mongo-backed test asserts that a personal grant and an org grant come back together.
- Legacy org grants written before `org_scoped` existed are still honoured by `check_approval`'s legacy branch but are excluded from the union branch (they remain visible via the org settings panel's `?org_id=` listing).
- Rows do not render `scope`, so two rule-scoped grants on the same service and requester are visually identical.
- Non-admin org members still have no read path to org-owned grants; the empty state explains the ownership but cannot enumerate them.

Investigation and evidence trail: `docs/ACTIVE_GRANTS_INVESTIGATION.md`, `docs/ACTIVE_GRANTS_BUG_REPORT.md`.
